### PR TITLE
feat(KeyBindings): More control to unbind commands

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -5,6 +5,16 @@ Spring changelog
 -- BAR105 --------------------------------------------------------
 
 BREAKING CHANGES & HOW TO GET BACK OLD BEHAVIOURS:
+ ! /unbind and /unbindaction now understand and operate on argument subsets.
+
+   /unbind key action arg1 arg2 now correctly removes the bindings that are bound to action
+   action and arguments "arg1 arg2.*". This is only breaking if you were relying on unbind
+   being noop when receiving action arguments.
+
+   /unbindaction action arg1 arg2 now correctly removes the bindings that are bound to action
+   action and arguments "arg1 arg2.*". This is only breaking if you relied on arguments being
+   ignored to unbind all keybindings bound to action.
+
  ! Add movetilt and movereset for previously hardcoded ALT and CTRL camera bindings.
    To get back old behaviour, make sure to rebind them (remember "Any+", as in "Any+Alt")
 

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -14,6 +14,42 @@ BREAKING CHANGES & HOW TO GET BACK OLD BEHAVIOURS:
    /unbindaction action arg1 arg2 now correctly removes the bindings that are bound to action
    action and arguments "arg1 arg2.*". This is only breaking if you relied on arguments being
    ignored to unbind all keybindings bound to action.
+   
+   To get back previous behaviours:
+
+   ```lua
+   local function unbind_back_compat(str)
+     local command, action, args = str:match("(%S+) ?(%S*) ?(.*)")
+     if command == "unbind" and args ~= "" then
+       return "" -- used to be no-op when args were provided
+     elseif command == "unbindaction" then
+       return "unbindaction " .. action -- used to remove all regardless of args
+     else
+       return str
+     end
+   end
+   
+   local function unbind_compat_table(t)
+     for i = 1, #t do
+       t[i] = unbind_back_compat(t[i])
+     end
+     return t
+   end
+ 
+   local originalSendCommands = Spring.SendCommands
+   Spring.SendCommands = function (param, ...)
+     local t
+     if type(param) == 'string' then
+       t = unbind_compat_table({...})
+       table.insert(t, 1, unbind_back_compat(param))
+     elseif type(param) == 'table' then
+       t = unbind_compat_table(param)
+     else
+       t = param
+     end
+     return originalSendCommands(t)
+   end
+   ```
 
  ! Add movetilt and movereset for previously hardcoded ALT and CTRL camera bindings.
    To get back old behaviour, make sure to rebind them (remember "Any+", as in "Any+Alt")

--- a/rts/Game/Action.cpp
+++ b/rts/Game/Action.cpp
@@ -31,3 +31,26 @@ Action::Action(const std::string& l)
 
 	line = command + extra;
 }
+
+const Action::Comparison Action::compareByTriggerOrder = [](const Action& a, const Action& b) {
+	bool selfAnyMod = a.keyChain.back().AnyMod();
+	bool actionAnyMod = b.keyChain.back().AnyMod();
+
+	if (selfAnyMod == actionAnyMod)
+		return a.bindingIndex < b.bindingIndex;
+	else
+		return actionAnyMod;
+};
+
+const Action::Comparison Action::compareByBindingOrder = [](const Action& a, const Action& b) {
+	return (a.bindingIndex < b.bindingIndex);
+};
+
+// Returns true when Action a is a subcommand of b.
+// Example:
+//     compareBySubset(Action("somecommand"), Action("somecommand arg")) == false
+//     compareBySubset(Action("somecommand arg"), Action("somecommand")) == true
+//     compareBySubset(Action("somecommand arg"), Action("somecommand arg")) == true
+const Action::Comparison Action::compareBySubset = [](const Action& a, const Action& b) {
+	return b.line.find(a.line) == 0;
+};

--- a/rts/Game/Action.h
+++ b/rts/Game/Action.h
@@ -12,7 +12,7 @@ public:
 	Action() {}
 	Action(const std::string& line);
 
-	typedef std::function<bool (Action, Action)> Comparison;
+	typedef std::function<bool (const Action &, const Action &)> Comparison;
 
 	int         bindingIndex; ///< the order for the action trigger
 	std::string command;      ///< first word, lowercase

--- a/rts/Game/Action.h
+++ b/rts/Game/Action.h
@@ -12,6 +12,8 @@ public:
 	Action() {}
 	Action(const std::string& line);
 
+	typedef std::function<bool (Action, Action)> Comparison;
+
 	int         bindingIndex; ///< the order for the action trigger
 	std::string command;      ///< first word, lowercase
 	std::string extra;        ///< everything but the first word, stripped of comments (//)
@@ -19,6 +21,11 @@ public:
 	std::string rawline;      ///< includes the command, case preserved
 	std::string boundWith;    ///< the string that defined the binding keyset
 	CKeyChain   keyChain;     ///< the bound keychain/keyset
+
+public:
+	static const Comparison compareByTriggerOrder;
+	static const Comparison compareByBindingOrder;
+	static const Comparison compareBySubset;
 };
 
 typedef std::vector<Action> ActionList;

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1265,7 +1265,7 @@ bool CGame::UpdateUnsynced(const spring_time currentTime)
 
 			// if we have a new sim frame, then check when the time and CTO of the previous draw frame was. 
 			drawsimratio = std::fmin(drawsimratio, 1.0);  // Clamp it otherwise we will accumulate delay when < 30 FPS
-			float oldCTO = globalRendering->timeOffset;
+			// float oldCTO = globalRendering->timeOffset;
 			float newCTO = globalRendering->timeOffset;
 
 			if (newSimFrame) { 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -753,8 +753,7 @@ bool CKeyBindings::RemoveActionFromList(ActionList& al, const Action& action, co
 	auto it = al.begin();
 
 	while (it != al.end()) {
-		const auto a = it.base();
-		if (comparison(action, *a)) {
+		if (comparison(action, *it)) {
 			it = al.erase(it);
 			success = true;
 		} else {

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -17,7 +17,6 @@ class CKeyBindings : public CommandReceiver
 {
 	public:
 		typedef std::vector<std::string> HotkeyList;
-		typedef std::function<bool (Action, Action)> ActionComparison;
 
 	protected:
 		struct KeySetHash {
@@ -61,7 +60,8 @@ class CKeyBindings : public CommandReceiver
 		void DebugActionList(const ActionList& actionList) const;
 
 		void AddActionToKeyMap(KeyMap& bindings, Action& action);
-		static bool RemoveActionFromKeyMap(const std::string& command, KeyMap& bindings);
+		static bool RemoveActionFromKeyMap(const Action& command, KeyMap& bindings);
+		static bool RemoveActionFromList(ActionList& al, const Action& action, const Action::Comparison& comparison = Action::compareBySubset);
 
 		bool Bind(const std::string& keystring, const std::string& action);
 		bool UnBind(const std::string& keystring, const std::string& action);
@@ -69,8 +69,6 @@ class CKeyBindings : public CommandReceiver
 		bool UnBindAction(const std::string& action);
 		bool SetFakeMetaKey(const std::string& keystring);
 		bool AddKeySymbol(const std::string& keysym, const std::string& code);
-
-		static bool RemoveCommandFromList(ActionList& al, const std::string& command);
 
 		bool FileSave(FILE* file) const;
 


### PR DESCRIPTION
Previously for /unbind and /unbindall commands and uikeys keywords these were the actual behaviors:

- `/unbind <key> <action> <args>`: Wound unbind nothing if any args were passed. Engine would try to compare only the action name itself against the whole action + args.
- `/unbind <key> <action>`: Wound unbind all instances of action bound to the keyset regardless of any arguments bound to it.
- `/unbindaction <action> <args>`: Wound unbind all instances of action regardless of any arguments, either passed to the unbindaction command or bound to the keybinding.

This would be a considerable headache for game developers what use action arguments extensively and need a finer control over keybindings.

This PR does not change anything for the behavior above when no action arguments are provided.

If action arguments are provided, for both /unbindaction and /unbind, keybindings will only be unbound if their action arguments are equal to or contain the passed action arguments to the keybinding. For example:

    /unbindaction a a1
    /unbind   <k> a a1
    -> Unbinds any keybinding in the form of `bind <k> a a1 <whatever>`
    -> Does not unbind keybindings in the form of `bind <k> a <not 'a1 '>`

The reason for non equal argument matching, which is still lacking, is for providing better control on unbind behavior for those who need it while maintaining compatibility with most, if not all, cases seen in the wild.

The motivation for this feature, apart from having to work around current behavior, is that it is a foundational requirement for further unhardcoding of engine keyboard modifiers in a sane manner, without requiring definition of an ever expanding set of action names with some 'smart' matching. For example:

    bind Any+ctrl modifier cam_move_fast
    bind Any+ctrl modifier cam_move_tilt

    If for some reason the game developer wanted to programmatically
    unbind to only one of the modifiers he would have to iterate on the
    currently bound modifiers on the same key, unbind all actions on
    that same key then bind all actions again except for the one unbind
    he wanted in the first place.
    
    Instead of:
    
    bind Any+ctrl movefast
    bind Any+ctrl movetilt
    
    And having to unbind specifically each action name if a certain
    modifier is not desirable, for the cases where widgets or the game
    itself can't or don't want to unbindall and start from a fresh slate.
    
 Additionally we refactor action comparisons and remove an unused variable assignment.