### PR TITLE
Enable deferred rendering by default

### DIFF
--- a/rts/Map/SMF/SMFGroundDrawer.cpp
+++ b/rts/Map/SMF/SMFGroundDrawer.cpp
@@ -43,9 +43,9 @@ CONFIG(int, MaxDynamicMapLights)
 	.minimumValue(0).description("Maximum number of map-global dynamic lights that will be rendered at once. High numbers of lights cost performance, as they affect every map fragment.");
 
 CONFIG(bool, AdvMapShading).defaultValue(true).safemodeValue(false).description("Enable shaders for terrain rendering.");
-CONFIG(bool, AllowDeferredMapRendering).defaultValue(false).safemodeValue(false).description("Enable rendering the map to the map deferred buffers.");
-CONFIG(bool, AllowDrawMapPostDeferredEvents).defaultValue(false).description("Enable DrawGroundPostDeferred Lua callin.");
-CONFIG(bool, AllowDrawMapDeferredEvents).defaultValue(false).description("Enable DrawGroundDeferred Lua callin.");
+CONFIG(bool, AllowDeferredMapRendering).defaultValue(true).safemodeValue(false).description("Enable rendering the map to the map deferred buffers.");
+CONFIG(bool, AllowDrawMapPostDeferredEvents).defaultValue(true).safemodeValue(false).description("Enable DrawGroundPostDeferred Lua callin.");
+CONFIG(bool, AllowDrawMapDeferredEvents).defaultValue(true).safemodeValue(false).description("Enable DrawGroundDeferred Lua callin.");
 
 
 CONFIG(int, ROAM)

--- a/rts/Rendering/LuaObjectDrawer.cpp
+++ b/rts/Rendering/LuaObjectDrawer.cpp
@@ -28,7 +28,7 @@
 #define USE_OBJECT_RENDERING_BUCKETS
 
 // applies to both units and features
-CONFIG(bool, AllowDeferredModelRendering).defaultValue(false).safemodeValue(false).description("Allows the rendering of model deferred buffers.");
+CONFIG(bool, AllowDeferredModelRendering).defaultValue(true).safemodeValue(false).description("Allows the rendering of model deferred buffers.");
 CONFIG(bool, AllowDeferredModelBufferClear).defaultValue(false).safemodeValue(false);
 CONFIG(bool, AllowDrawModelPostDeferredEvents).defaultValue(true).description("Enable Draw{Units,Features}PostDeferred Lua callins.");
 CONFIG(bool, AllowMultiSampledFrameBuffers).defaultValue(false).description("Enable FBOs that can have multisampled anti-aliasing.");;


### PR DESCRIPTION
Note, I don't actually know what the risks/tradeoffs are here! I'm working off the assumption that if a game's Lua code doesn't use these facilities then there's no downside, but I am not 100% sure if that's actually true. Anyway, the upside is that new gamedevs won't need to know about these somewhat-obscure toggles for things to work. The safemode values are still false.