### PR TITLE
Better chasing while on MOVESTATE_HOLDPOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ Spring.VC.VC.opendb
 toolchain
 compile_commands.json
 build-*
+/dev_engine/AI
+/rts/lib/entt

--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -110,6 +110,7 @@ CALLIN_LIST = {
 	"AllowUnitCloak",
 	"AllowUnitDecloak",
 	"AllowUnitKamikaze",
+	"AllowUnitChase",
 	"AllowFeatureBuildStep",
 	"AllowFeatureCreation",
 	"AllowResourceLevel",

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1242,6 +1242,15 @@ function gadgetHandler:AllowUnitKamikaze(unitID, targetID)
   return true
 end
 
+function gadgetHandler:AllowUnitChase(unitID, targetID)
+  for _,g in r_ipairs(self.AllowUnitChaseList) do
+    if (not g:AllowUnitChase(unitID, targetID)) then
+      return false
+    end
+  end
+
+  return true
+end
 
 function gadgetHandler:AllowFeatureBuildStep(builderID, builderTeam, featureID, featureDefID, part)
   for _,g in r_ipairs(self.AllowFeatureBuildStepList) do

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1025,6 +1025,34 @@ bool CSyncedLuaHandle::AllowUnitKamikaze(const CUnit* unit, const CUnit* target,
 	return allow;
 }
 
+/***
+ *
+ * @function AllowUnitChase
+ * @number unitID
+ * @number targetID
+ * @treturn bool whether unit is allowed to default engine chase behavior
+ */
+bool CSyncedLuaHandle::AllowUnitChase(const CUnit* unit, const CUnit* target)
+{
+	LUA_CALL_IN_CHECK(L, true);
+	luaL_checkstack(L, 2 + 2, __func__);
+
+	static const LuaHashString cmdStr(__func__);
+
+	if (!cmdStr.GetGlobalFunc(L))
+		return true;
+
+	lua_pushnumber(L, unit->id);
+	lua_pushnumber(L, target->id);
+
+	if (!RunCallIn(L, cmdStr, 2, 1))
+		return true;
+
+	const bool allow = luaL_optboolean(L, -1, true);
+	lua_pop(L, 1);
+	return allow;
+}
+
 
 /*** Called just before feature is created.
  *

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -64,6 +64,7 @@ class CSyncedLuaHandle : public CLuaHandle
 		bool AllowUnitCloak(const CUnit* unit, const CUnit* enemy) override;
 		bool AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon) override;
 		bool AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed) override;
+		bool AllowUnitChase(const CUnit* unit, const CUnit* target) override;
 		bool AllowFeatureCreation(const FeatureDef* featureDef, int allyTeamID, const float3& pos) override;
 		bool AllowFeatureBuildStep(const CUnit* builder, const CFeature* feature, float part) override;
 		bool AllowResourceLevel(int teamID, const std::string& type, float level) override;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -716,7 +716,7 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 	// also make sure that we're not locked in close-in/in-range state
 	// loop due to rotates invoked by in-range or out-of-range states
 	if (tryTargetRotate) {
-		const bool canChaseTarget = (!owner->unitDef->stopToAttack) && (owner->moveState != MOVESTATE_HOLDPOS);
+		const bool canChaseTarget = (!owner->unitDef->stopToAttack) && (!tempOrder || (owner->moveState != MOVESTATE_HOLDPOS));
 		const bool targetBehind = (targetMidPosVec.dot(orderTarget->speed) < 0.0f);
 
 		if (canChaseTarget && tryTargetHeading && targetBehind && !owner->unitDef->IsHoveringAirUnit()) {
@@ -766,9 +766,9 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 			goalDiff += orderTarget->pos;
 
 			SetGoal(goalDiff, owner->pos);
+			return;
 		}
 
-		return;
 	}
 
 	// not a temporary order or not on hold-position; close in on target more

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -662,7 +662,9 @@ void CMobileCAI::ExecuteStop(Command& c)
 }
 
 
-
+// debug print includes
+#include<iostream>
+#include<string>
 
 void CMobileCAI::ExecuteObjectAttack(Command& c)
 {
@@ -715,19 +717,29 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 	// in range with our biggest (?) weapon, so stop moving
 	// also make sure that we're not locked in close-in/in-range state
 	// loop due to rotates invoked by in-range or out-of-range states
+	std::cout << "Chase Logic: Frame: " << gs->frameNum << std::endl;
+	std::cout << "tryTargetRotate = " << tryTargetRotate << std::endl;
 	if (tryTargetRotate) {
-		const bool canChaseTarget = (!owner->unitDef->stopToAttack) && (!tempOrder || (owner->moveState != MOVESTATE_HOLDPOS));
-		const bool targetBehind = (targetMidPosVec.dot(orderTarget->speed) < 0.0f);
+		//(!tempOrder || (owner->moveState != MOVESTATE_HOLDPOS));
+		//ask game if we use should use below engine chase behavior
 
-		if (canChaseTarget && tryTargetHeading && targetBehind && !owner->unitDef->IsHoveringAirUnit()) {
-			SetGoal(owner->pos + (orderTarget->speed * 80), owner->pos, SQUARE_SIZE, orderTarget->speed.w * 1.1f);
-		} else {
-			StopMove();
+		//std::cout << "Chase Logic: Frame: " << gs->frameNum << std::endl;
+		if (eventHandler.AllowUnitChase(owner, orderTarget))
+		{
+			std::cout << "Chase Logic: Allowed" << std::endl;
+			const bool canChaseTarget = (!owner->unitDef->stopToAttack) && (owner->moveState != MOVESTATE_HOLDPOS);
+			const bool targetBehind = (targetMidPosVec.dot(orderTarget->speed) < 0.0f);
 
-			if (gs->frameNum > (lastCloseInTry + MAX_CLOSE_IN_RETRY_TICKS))
-				owner->moveType->KeepPointingTo(orderTarget->midPos, minPointingDist, true);
+			if (canChaseTarget && tryTargetHeading && targetBehind && !owner->unitDef->IsHoveringAirUnit()) {
+				SetGoal(owner->pos + (orderTarget->speed * 80), owner->pos, SQUARE_SIZE, orderTarget->speed.w * 1.1f);
+			}
+			else {
+				StopMove();
+
+				if (gs->frameNum > (lastCloseInTry + MAX_CLOSE_IN_RETRY_TICKS))
+					owner->moveType->KeepPointingTo(orderTarget->midPos, minPointingDist, true);
+			}
 		}
-
 		owner->AttackUnit(orderTgtInfo.unit, orderTgtInfo.isUserTarget, orderTgtInfo.isManualFire);
 		return;
 	}
@@ -854,6 +866,7 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		}
 	}
 
+	std::cout << "inCommand = " << inCommand << std::endl;
 	if (!inCommand) {
 		switch (c.GetNumParams()) {
 			case 0: {
@@ -880,6 +893,7 @@ void CMobileCAI::ExecuteAttack(Command& c)
 				const float3 tgtPosDir = (tgtErrPos - owner->pos).Normalize();
 
 				// FIXME: don't call SetGoal() if target is already in range of some weapon?
+				std::cout << "Set Goal Line 1 Frame: " << gs->frameNum << std::endl;
 				SetGoal(tgtErrPos - tgtPosDir * CalcTargetRadius(targetUnit, targetUnit->radius, 1.0f), owner->pos);
 				SetOrderTarget(targetUnit);
 				owner->AttackUnit(targetUnit, !c.IsInternalOrder(), c.GetID() == CMD_MANUALFIRE);

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -212,6 +212,7 @@ class CEventClient
 		virtual bool AllowUnitCloak(const CUnit* unit, const CUnit* enemy) { return true; }
 		virtual bool AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon) { return true; }
 		virtual bool AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed) { return true; }
+		virtual bool AllowUnitChase(const CUnit* unit, const CUnit* target) { return true; }
 		virtual bool AllowFeatureCreation(const FeatureDef* featureDef, int allyTeamID, const float3& pos) { return true; }
 		virtual bool AllowFeatureBuildStep(const CUnit* builder, const CFeature* feature, float part) { return true; }
 		virtual bool AllowResourceLevel(int teamID, const string& type, float level) { return true; }

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -330,6 +330,12 @@ bool CEventHandler::AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bo
 	return ControlIterateDefTrue(listAllowUnitKamikaze, &CEventClient::AllowUnitKamikaze, unit, target, allowed);
 }
 
+bool CEventHandler::AllowUnitChase(const CUnit* unit, const CUnit* target)
+{
+	ZoneScoped;
+	return ControlIterateDefTrue(listAllowUnitChase, &CEventClient::AllowUnitChase, unit, target);
+}
+
 
 bool CEventHandler::AllowFeatureCreation(const FeatureDef* featureDef, int allyTeamID, const float3& pos)
 {

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -150,6 +150,7 @@ class CEventHandler
 		bool AllowUnitCloak(const CUnit* unit, const CUnit* enemy);
 		bool AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon);
 		bool AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed);
+		bool AllowUnitChase(const CUnit* unit, const CUnit* target);
 		bool AllowFeatureCreation(const FeatureDef* featureDef, int allyTeamID, const float3& pos);
 		bool AllowFeatureBuildStep(const CUnit* builder, const CFeature* feature, float part);
 		bool AllowResourceLevel(int teamID, const string& type, float level);

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -183,6 +183,7 @@
 	SETUP_EVENT(AllowUnitCloak,           MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowUnitDecloak,         MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowUnitKamikaze,        MANAGED_BIT | CONTROL_BIT)
+	SETUP_EVENT(AllowUnitChase,           MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowFeatureCreation,     MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowFeatureBuildStep,    MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowResourceLevel,       MANAGED_BIT | CONTROL_BIT)


### PR DESCRIPTION
Add a check for tempOrder, so that units on MOVESTATE_HOLDPOS can set correct move goals when manually told to attack a moving target. 

Also move a return statement, so that units with a longer ranged secondary AA weapon (BAR armlatnk, armmar), correctly try to close in on target more.

This will address this issue I raised
https://github.com/beyond-all-reason/spring/issues/978