### PR TITLE
feature: add Patrolling FILTER to select command

### DIFF
--- a/doc/site/articles/select-command.markdown
+++ b/doc/site/articles/select-command.markdown
@@ -86,7 +86,7 @@ Here are the filters. Note that "units" generally means both buildings and mobil
 
 ### `Patrolling`
 
-  Keep only units that currently have a **Patrol** order.
+  Keep only units that have a **Patrol** order early in the queue (first 4 commands).
 
 ### `IdMatches_<string>`
 

--- a/doc/site/articles/select-command.markdown
+++ b/doc/site/articles/select-command.markdown
@@ -84,6 +84,10 @@ Here are the filters. Note that "units" generally means both buildings and mobil
 
   Keep only units that currently have a **Guard** order.
 
+### `Patrolling`
+
+  Keep only units that currently have a **Patrol** order.
+
 ### `IdMatches_<string>`
 
   Keep only units whose internal name (unitDef name) matches `<string>` **exactly**.

--- a/doc/site/articles/select-command.markdown
+++ b/doc/site/articles/select-command.markdown
@@ -86,7 +86,7 @@ Here are the filters. Note that "units" generally means both buildings and mobil
 
 ### `Patrolling`
 
-  Keep only units that have a **Patrol** order early in the queue (first 4 commands).
+  Keep only units that have a **Patrol** order early in the queue (first 4 commands, including sub-orders spawned by Patrol).
 
 ### `IdMatches_<string>`
 

--- a/rts/Game/UI/SelectionKeyHandler.cpp
+++ b/rts/Game/UI/SelectionKeyHandler.cpp
@@ -12,7 +12,9 @@
 #include "Game/UI/Groups/GroupHandler.h"
 #include "Map/Ground.h"
 #include "Sim/Misc/CategoryHandler.h"
+#include "Sim/Units/CommandAI/Command.h"
 #include "Sim/Units/CommandAI/CommandAI.h"
+#include "Sim/Units/CommandAI/CommandQueue.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitHandler.h"
@@ -124,7 +126,12 @@ namespace {
 	DECLARE_FILTER(Idle, unit->commandAI->commandQue.empty())
 	DECLARE_FILTER(Waiting, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_WAIT))
 	DECLARE_FILTER(Guarding, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_GUARD))
-	DECLARE_FILTER(Patrolling, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_PATROL))
+  DECLARE_FILTER(Patrolling, !unit->commandAI->commandQue.empty() && (
+                     (unit->commandAI->commandQue.size() == 1 && unit->commandAI->commandQue.at(0).GetID() == CMD_PATROL) ||
+                     (unit->commandAI->commandQue.size() == 2 && unit->commandAI->commandQue.at(1).GetID() == CMD_PATROL) ||
+                     (unit->commandAI->commandQue.size() == 3 && unit->commandAI->commandQue.at(2).GetID() == CMD_PATROL) ||
+                     unit->commandAI->commandQue.at(3).GetID() == CMD_PATROL
+                   ))
 	DECLARE_FILTER(InHotkeyGroup, unit->GetGroup() != nullptr)
 	DECLARE_FILTER(Radar, (unit->radarRadius > 0 || unit->sonarRadius > 0))
 	DECLARE_FILTER(Jammer, (unit->jammerRadius > 0))

--- a/rts/Game/UI/SelectionKeyHandler.cpp
+++ b/rts/Game/UI/SelectionKeyHandler.cpp
@@ -124,6 +124,7 @@ namespace {
 	DECLARE_FILTER(Idle, unit->commandAI->commandQue.empty())
 	DECLARE_FILTER(Waiting, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_WAIT))
 	DECLARE_FILTER(Guarding, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_GUARD))
+	DECLARE_FILTER(Patrolling, !unit->commandAI->commandQue.empty() && (unit->commandAI->commandQue.front().GetID() == CMD_PATROL))
 	DECLARE_FILTER(InHotkeyGroup, unit->GetGroup() != nullptr)
 	DECLARE_FILTER(Radar, (unit->radarRadius > 0 || unit->sonarRadius > 0))
 	DECLARE_FILTER(Jammer, (unit->jammerRadius > 0))


### PR DESCRIPTION
This PR is an extension of https://github.com/beyond-all-reason/spring/pull/1060

This PR adds support for filtering units based on whether they are patrolling or not when using select commands.

The benefit of this change is that it becomes possible to exclude units with long-running patrol tasks (e.g. defending expansions without LLTs) from select commands. For example, `AllMap+_Not_Builder_Not_Building_Not_Patrolling+_ClearSelection_SelectAll+`.

For some small addition context/discussion, see [this](https://discord.com/channels/549281623154229250/1018861299939168288/1169735003630997524) Discord thread.

Tested with 5000 armpw in different command queue sizes, didn't notice a perceivable latency issuing the command.