### PR TITLE
MT the LosHandlers UpdateHeightMapSynced call

### DIFF
--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -16,6 +16,11 @@
 #include "System/TimeProfiler.h"
 #include "System/Threading/ThreadPool.h"
 
+#include "System/Config/ConfigHandler.h"
+// TODO: Remove this once its validated to not cause major issues downstream
+CONFIG(int, LosHandlerUpdateHeightMapSyncedMT).defaultValue(1).safemodeValue(0).minimumValue(0).description("MTs  LosHandler::UpdateHeightMapSynced. Should be safe to toggle ingame as well.");
+
+
 #define USE_STAGGERED_UPDATES 0
 
 
@@ -824,10 +829,23 @@ void CLosHandler::Update()
 
 void CLosHandler::UpdateHeightMapSynced(SRectangle rect)
 {
-	for (ILosType* lt: losTypes) {
-		ZoneScopedN("LosHandler::UpdateHeightMapSynced");
-		lt->UpdateHeightMapSynced(rect);
+	int losHandlerUpdateHeightMapSyncedMT = configHandler->GetInt("LosHandlerUpdateHeightMapSyncedMT");
+	if (losHandlerUpdateHeightMapSyncedMT == 0) {
+
+		for (ILosType* lt : losTypes) {
+			ZoneScopedN("LosHandler::UpdateHeightMapSyncedST");
+			lt->UpdateHeightMapSynced(rect);
+		}
 	}
+	else {
+		for_mt(0, losTypes.size(), [&](const int idx) {
+			ILosType* lt = losTypes[idx];
+			ZoneScopedN("LosHandler::UpdateHeightMapSyncedMT");
+			lt->UpdateHeightMapSynced(rect);
+		});
+
+	}
+
 }
 
 


### PR DESCRIPTION
This isnt a very good use, as most of the time there are only 2 calls within this for loop that actually take a significant amount of time. Even then, the time distrubution of these calls is usually 3:1. Overall, lategame this section is about 2% of all cpu load, so its still worth having a look at this.

For testing, this can be toggled with the config int LosHandlerUpdateHeightMapSyncedMT .

Minor mitigation of #316 