### PR TITLE
Unify AI resourcemap analyzer(s)

### DIFF
--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -2011,17 +2011,13 @@ EXPORT(int) skirmishAiCallback_Map_getResourceMapRaw(
 	return resourcesSize;
 }
 
-static inline const CResourceMapAnalyzer* getResourceMapAnalyzer(int resourceId) {
-	return resourceHandler->GetResourceMapAnalyzer(resourceId);
-}
-
 EXPORT(int) skirmishAiCallback_Map_getResourceMapSpotsPositions(
 	int skirmishAIId,
 	int resourceId,
 	float* spots,
 	int spotsMaxSize
 ) {
-	const std::vector<float3>& intSpots = getResourceMapAnalyzer(resourceId)->GetSpots();
+	const std::vector<float3>& intSpots = resourceHandler->GetResourceMapAnalyzer()->GetSpots();
 	const int spotsRealSize = intSpots.size() * 3;
 
 	size_t spotsSize = spotsRealSize;
@@ -2041,7 +2037,7 @@ EXPORT(int) skirmishAiCallback_Map_getResourceMapSpotsPositions(
 }
 
 EXPORT(float) skirmishAiCallback_Map_getResourceMapSpotsAverageIncome(int skirmishAIId, int resourceId) {
-	return getResourceMapAnalyzer(resourceId)->GetAverageIncome();
+	return resourceHandler->GetResourceMapAnalyzer()->GetAverageIncome();
 }
 
 EXPORT(void) skirmishAiCallback_Map_getResourceMapSpotsNearest(
@@ -2050,7 +2046,7 @@ EXPORT(void) skirmishAiCallback_Map_getResourceMapSpotsNearest(
 	float* pos_posF3,
 	float* return_posF3_out
 ) {
-	getResourceMapAnalyzer(resourceId)->GetNearestSpot(pos_posF3, AI_TEAM_IDS[skirmishAIId]).copyInto(return_posF3_out);
+	resourceHandler->GetResourceMapAnalyzer()->GetNearestSpot(pos_posF3, AI_TEAM_IDS[skirmishAIId]).copyInto(return_posF3_out);
 }
 
 EXPORT(int) skirmishAiCallback_Map_getHash(int skirmishAIId) {

--- a/rts/Sim/Misc/Resource.cpp
+++ b/rts/Sim/Misc/Resource.cpp
@@ -8,9 +8,7 @@ CR_BIND(CResourceDescription, )
 CR_REG_METADATA(CResourceDescription, (
 	CR_MEMBER(name),
 	CR_MEMBER(description),
-	CR_MEMBER(optimum),
-	CR_MEMBER(extractorRadius),
-	CR_MEMBER(maxWorth)
+	CR_MEMBER(optimum)
 ))
 
 
@@ -36,8 +34,6 @@ CR_REG_METADATA(SResourceOrder,(
 CResourceDescription::CResourceDescription()
 : name("UNNAMED_RESOURCE")
 , optimum(FLT_MAX)
-, extractorRadius(0.0f)
-, maxWorth(0.0f)
 {
 }
 

--- a/rts/Sim/Misc/Resource.h
+++ b/rts/Sim/Misc/Resource.h
@@ -142,12 +142,6 @@ public:
 
 	/// The optimum value for this resource, eg. 0 for "Waste" or FLT_MAX for "Metal"
 	float optimum;
-
-	/// The default extractor radius for the resource map, 0.0f if non applicable
-	float extractorRadius;
-
-	/// What value 255 in the resource map is worth
-	float maxWorth;
 };
 
 

--- a/rts/Sim/Misc/ResourceHandler.cpp
+++ b/rts/Sim/Misc/ResourceHandler.cpp
@@ -85,11 +85,8 @@ int CResourceHandler::GetResourceId(const std::string& resourceName) const
 	return ((iter == resourceDescriptions.end())? -1: (iter - resourceDescriptions.cbegin()));
 }
 
-const CResourceMapAnalyzer* CResourceHandler::GetResourceMapAnalyzer(int resourceId)
+const CResourceMapAnalyzer* CResourceHandler::GetResourceMapAnalyzer()
 {
-	if (!IsValidId(resourceId))
-		return nullptr;
-
 	CResourceMapAnalyzer* rma = &resourceMapAnalyzer.value();
 
 	if (rma->GetNumSpots() < 0)

--- a/rts/Sim/Misc/ResourceHandler.cpp
+++ b/rts/Sim/Misc/ResourceHandler.cpp
@@ -2,10 +2,8 @@
 
 #include "ResourceHandler.h"
 #include "ResourceMapAnalyzer.h"
-#include "Map/MapInfo.h" // for the metal extractor radius
-#include "Map/ReadMap.h" // for the metal map
-#include "Map/MetalMap.h"
 
+#include <algorithm>
 #include <cfloat>
 
 
@@ -41,15 +39,11 @@ void CResourceHandler::AddResources() {
 	CResourceDescription rMetal;
 	rMetal.name = "Metal";
 	rMetal.optimum = FLT_MAX;
-	rMetal.extractorRadius = mapInfo->map.extractorRadius;
-	rMetal.maxWorth = mapInfo->map.maxMetal;
 	metalResourceId = AddResource(rMetal);
 
 	CResourceDescription rEnergy;
 	rEnergy.name = "Energy";
 	rEnergy.optimum = FLT_MAX;
-	rEnergy.extractorRadius = 0.0f;
-	rEnergy.maxWorth = 0.0f;
 	energyResourceId = AddResource(rEnergy);
 }
 
@@ -65,7 +59,7 @@ int CResourceHandler::AddResource(const CResourceDescription& resource)
 	 * contain everything needed regardless. Keep in mind object lifetime issues
 	 * when dealing with things like save/load, or reloading a different map tho. */
 	if (!resourceMapAnalyzer)
-		resourceMapAnalyzer.emplace(0);
+		resourceMapAnalyzer.emplace();
 
 	return (resourceDescriptions.size() - 1);
 }
@@ -89,38 +83,6 @@ int CResourceHandler::GetResourceId(const std::string& resourceName) const
 	const auto pred = [&](const CResourceDescription& rd) { return (resourceName == rd.name); };
 	const auto iter = std::find_if(resourceDescriptions.cbegin(), resourceDescriptions.cend(), pred);
 	return ((iter == resourceDescriptions.end())? -1: (iter - resourceDescriptions.cbegin()));
-}
-
-const unsigned char* CResourceHandler::GetResourceMap(int resourceId) const
-{
-	if (resourceId == GetMetalId())
-		return (metalMap.GetDistributionMap());
-
-	return nullptr;
-}
-
-size_t CResourceHandler::GetResourceMapSize(int resourceId) const
-{
-	if (resourceId == GetMetalId())
-		return (GetResourceMapWidth(resourceId) * GetResourceMapHeight(resourceId));
-
-	return 0;
-}
-
-size_t CResourceHandler::GetResourceMapWidth(int resourceId) const
-{
-	if (resourceId == GetMetalId())
-		return mapDims.hmapx;
-
-	return 0;
-}
-
-size_t CResourceHandler::GetResourceMapHeight(int resourceId) const
-{
-	if (resourceId == GetMetalId())
-		return mapDims.hmapy;
-
-	return 0;
 }
 
 const CResourceMapAnalyzer* CResourceHandler::GetResourceMapAnalyzer(int resourceId)

--- a/rts/Sim/Misc/ResourceHandler.h
+++ b/rts/Sim/Misc/ResourceHandler.h
@@ -3,6 +3,7 @@
 #ifndef _RESOURCEHANDLER_H
 #define _RESOURCEHANDLER_H
 
+#include <optional>
 #include <vector>
 
 #include "System/Misc/NonCopyable.h"
@@ -24,7 +25,7 @@ public:
 	void Init() { AddResources(); }
 	void Kill() {
 		resourceDescriptions.clear();
-		resourceMapAnalyzers.clear();
+		resourceMapAnalyzer.reset();
 	}
 
 	void PostLoad() { AddResources(); }
@@ -113,7 +114,7 @@ public:
 
 private:
 	std::vector<CResourceDescription> resourceDescriptions;
-	std::vector<CResourceMapAnalyzer> resourceMapAnalyzers;
+	std::optional<CResourceMapAnalyzer> resourceMapAnalyzer;
 
 	int metalResourceId = -1;
 	int energyResourceId = -1;

--- a/rts/Sim/Misc/ResourceHandler.h
+++ b/rts/Sim/Misc/ResourceHandler.h
@@ -65,38 +65,6 @@ public:
 	int GetResourceId(const std::string& resourceName) const;
 
 	/**
-	 * @brief	resource map
-	 * @param	resourceId index of the resource whichs map to fetch
-	 * @return	the resource values for all the pixels of the map
-	 *
-	 * Returns a resource map by index.
-	 */
-	const unsigned char* GetResourceMap(int resourceId) const;
-	/**
-	 * @brief	resource map size
-	 * @param	resourceId index of the resource whichs map size to fetch
-	 * @return	the number of values in the resource map
-	 *
-	 * Returns the resource map size by index.
-	 */
-	size_t GetResourceMapSize(int resourceId) const;
-	/**
-	 * @brief	resource map width
-	 * @param	resourceId index of the resource whichs map width to fetch
-	 * @return	width of values in the resource map
-	 *
-	 * Returns the resource map width by index.
-	 */
-	size_t GetResourceMapWidth(int resourceId) const;
-	/**
-	 * @brief	resource map height
-	 * @param	resourceId index of the resource whichs map height to fetch
-	 * @return	height of values in the resource map
-	 *
-	 * Returns the resource map height by index.
-	 */
-	size_t GetResourceMapHeight(int resourceId) const;
-	/**
 	 * @brief	resource map analyzer
 	 * @param	resourceId index of the resource whichs map analyzer to fetch
 	 * @return	resource map analyzer

--- a/rts/Sim/Misc/ResourceHandler.h
+++ b/rts/Sim/Misc/ResourceHandler.h
@@ -66,12 +66,11 @@ public:
 
 	/**
 	 * @brief	resource map analyzer
-	 * @param	resourceId index of the resource whichs map analyzer to fetch
 	 * @return	resource map analyzer
 	 *
-	 * Returns the resource map analyzer by index.
+	 * Returns the resource map analyzer.
 	 */
-	const CResourceMapAnalyzer* GetResourceMapAnalyzer(int resourceId);
+	const CResourceMapAnalyzer* GetResourceMapAnalyzer();
 
 	size_t GetNumResources() const { return resourceDescriptions.size(); }
 

--- a/rts/Sim/Misc/ResourceMapAnalyzer.h
+++ b/rts/Sim/Misc/ResourceMapAnalyzer.h
@@ -11,7 +11,7 @@ struct UnitDef;
 
 class CResourceMapAnalyzer {
 public:
-	CResourceMapAnalyzer(int resourceId);
+	CResourceMapAnalyzer();
 
 	// deferred to ResourceHandler
 	void Init();
@@ -39,10 +39,7 @@ private:
 
 	std::string GetCacheFileName() const;
 
-	int resourceId;
 	int numSpotsFound;
-
-	float extractorRadius;
 	float averageIncome;
 
 	bool stopMe;


### PR DESCRIPTION
The skirmish AI interface exposes resource analyzers to find resource spots.
Each resource type has its own analyzer instance. But only metal has a map
with distribution. Energy doesn't (geo spots aren't built into the map, but
are actually features), and hypothetical future extra resource types also
wouldn't.

Future commits will make it so that other resource types can be extracted,
but will still use the "metalmap", which will become a generic resource map.

This commit removes the energymap analyser and makes it so that asking about
energy (and other future resources) returns generic resource distribution,
i.e. the metal map.

It maintains the logic around object lifetime etc very closely (hence the
std::optional) because I am scared of things like save/load interaction.
Anybody is free to improve that part.

This is a logic change but I don't expect any AI to actually ask about the
energy map (because why would they, it's empty). Circuit at least doesn't.
So there should be no observed change in practice.