### PR TITLE
Sensors (Ugly attempt at #1000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ Spring.VC.VC.opendb
 toolchain
 compile_commands.json
 build-*
+/out/build/x64-Debug

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ progress.make
 
 # Windows libraries used by spring when compiling with Visual Studio
 /vclibs
+/vclibs64
+/out
 
 # Installer files
 /external

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,6 @@ progress.make
 
 # Windows libraries used by spring when compiling with Visual Studio
 /vclibs
-/vclibs64
-/out
 
 # Installer files
 /external

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,42 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "JAVA_AWT_INCLUDE_PATH",
+          "value": "C:\\Program Files\\Java\\jdk-21\\include\\",
+          "type": "PATH"
+        },
+        {
+          "name": "JAVA_INCLUDE_PATH",
+          "value": "C:\\Program Files\\Java\\jdk-21\\include\\",
+          "type": "PATH"
+        },
+        {
+          "name": "JAVA_AWT_LIBRARY",
+          "value": "C:\\Program Files\\Java\\jdk-21\\lib",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "JAVA_JVM_LIBRARY",
+          "value": "C:\\Program Files\\Java\\jdk-21\\bin",
+          "type": "FILEPATH"
+        },
+        {
+          "name": "AI_TYPES",
+          "value": "NONE",
+          "type": "STRING"
+        }
+      ]
+    }
+  ]
+}

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -33,8 +33,13 @@
         },
         {
           "name": "AI_TYPES",
-          "value": "NONE",
+          "value": "NATIVE",
           "type": "STRING"
+        },
+        {
+          "name": "TRACY_ENABLE",
+          "value": "True",
+          "type": "BOOL"
         }
       ]
     }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -33,13 +33,8 @@
         },
         {
           "name": "AI_TYPES",
-          "value": "NATIVE",
+          "value": "NONE",
           "type": "STRING"
-        },
-        {
-          "name": "TRACY_ENABLE",
-          "value": "True",
-          "type": "BOOL"
         }
       ]
     }

--- a/rts/ExternalAI/SkirmishAIHandler.cpp
+++ b/rts/ExternalAI/SkirmishAIHandler.cpp
@@ -284,7 +284,7 @@ const SkirmishAIKey* CSkirmishAIHandler::GetLocalSkirmishAILibraryKey(const size
 	const SkirmishAIData* aiData = GetSkirmishAI(skirmishAIId);
 	const SkirmishAIKey& resKey = aiLibManager->ResolveSkirmishAIKey(SkirmishAIKey(aiData->shortName, aiData->version));
 
-	assert(!resKey.IsUnspecified());
+	//assert(!resKey.IsUnspecified());
 
 	aiLibraryKeys[skirmishAIId] = resKey;
 	return &aiLibraryKeys[skirmishAIId];

--- a/rts/ExternalAI/SkirmishAIHandler.cpp
+++ b/rts/ExternalAI/SkirmishAIHandler.cpp
@@ -284,7 +284,7 @@ const SkirmishAIKey* CSkirmishAIHandler::GetLocalSkirmishAILibraryKey(const size
 	const SkirmishAIData* aiData = GetSkirmishAI(skirmishAIId);
 	const SkirmishAIKey& resKey = aiLibManager->ResolveSkirmishAIKey(SkirmishAIKey(aiData->shortName, aiData->version));
 
-	//assert(!resKey.IsUnspecified());
+	assert(!resKey.IsUnspecified());
 
 	aiLibraryKeys[skirmishAIId] = resKey;
 	return &aiLibraryKeys[skirmishAIId];

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -76,6 +76,7 @@
 #include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/InterceptHandler.h"
 #include "Sim/Misc/QuadField.h"
+#include "Sim/Misc/SensorHandler.h"
 #include "Sim/Misc/SideParser.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
 #include "Sim/Misc/TeamHandler.h"
@@ -670,6 +671,7 @@ void CGame::PostLoadSimulation(LuaParser* defsParser)
 	featureHandler.Init();
 	projectileHandler.Init();
 	CLosHandler::InitStatic();
+	sensorHandler.Init();
 
 	readMap->InitHeightMapDigestVectors(losHandler->los.size);
 
@@ -1012,6 +1014,7 @@ void CGame::KillSimulation()
 	featureHandler.Kill(); // depends on unitHandler (via ~CFeature)
 	unitHandler.Kill();
 	projectileHandler.Kill();
+	sensorHandler.Kill();
 
 	LOG("[Game::%s][3]", __func__);
 	IPathManager::FreeInstance(pathManager);
@@ -1777,6 +1780,7 @@ void CGame::SimFrame() {
 			unitScriptEngine->Tick(tickMs);
 		}
 		envResHandler.Update();
+		sensorHandler.Update();
 		losHandler->Update();
 		// dead ghosts have to be updated in sim, after los,
 		// to make sure they represent the current knowledge correctly.

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -7176,12 +7176,14 @@ int LuaSyncedCtrl::RemoveUnitCmdDesc(lua_State* L)
  *
  * Offmap positions are clamped! Use MoveCtrl to move to such positions.
  *
- * @tparam string|number unitDefName or unitDefID
+ * @number teamID
  * @number x
  * @number y
  * @number z
- * @number teamID
- * @treturn number|nil unitID meaning unit was created
+ * @number LOSType (flag for los, radar, sonar, or combination)
+ * @number LOSDistance (distance of sensor)
+ * @number duration (number of frames)
+ * @treturn number|nil sensorID meaning sensor was created
  ***/
 int LuaSyncedCtrl::CreateSensor(lua_State* L)
 {
@@ -7217,6 +7219,7 @@ int LuaSyncedCtrl::CreateSensor(lua_State* L)
 
 	ASSERT_SYNCED(pos);
 
+	// reusing this...?
 	inCreateUnit++;
 
 	CSensor* sensor = sensorHandler.NewSensor(teamID, pos, LOSType, LOSDistance, duration);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -38,6 +38,7 @@
 #include "Sim/Misc/DamageArrayHandler.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/SensorHandler.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
 #include "Sim/Misc/Team.h"
 #include "Sim/Misc/TeamHandler.h"
@@ -554,6 +555,23 @@ static void ParseUnitDefArray(lua_State* L, const char* caller,
 
 		unitDefs.push_back(ud);
 	}
+}
+
+static inline CSensor* ParseSensor(lua_State* L, const char* caller, int index)
+{
+	CSensor* sensor = sensorHandler.GetSensor(luaL_checkint(L, index));
+	if (sensor == nullptr)
+		return nullptr;
+
+	const int ctrlTeam = CtrlTeam(L);
+
+	if (ctrlTeam < 0 && ctrlTeam == CEventClient::AllAccessTeam)
+		return sensor;
+
+	if (ctrlTeam == sensor->team)
+		return sensor;
+
+	return nullptr;
 }
 
 static int SetSolidObjectCollisionVolumeData(lua_State* L, CSolidObject* o)
@@ -7151,3 +7169,126 @@ int LuaSyncedCtrl::RemoveUnitCmdDesc(lua_State* L)
 }
 
 
+
+/***
+ * @function Spring.CreateSensor
+ * @see Spring.DestroySensor
+ *
+ * Offmap positions are clamped! Use MoveCtrl to move to such positions.
+ *
+ * @tparam string|number unitDefName or unitDefID
+ * @number x
+ * @number y
+ * @number z
+ * @number teamID
+ * @treturn number|nil unitID meaning unit was created
+ ***/
+int LuaSyncedCtrl::CreateSensor(lua_State* L)
+{
+	CheckAllowGameChanges(L);
+
+	if (inCreateUnit >= MAX_CMD_RECURSION_DEPTH) {
+		luaL_error(L, "[%s()]: recursion is not permitted, max depth: %d", __func__, MAX_CMD_RECURSION_DEPTH);
+		return 0;
+	}
+
+	//int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_
+	const int teamID = luaL_checkinteger(L, 1);
+	if (!teamHandler.IsValidTeam(teamID)) {
+		luaL_error(L, "[%s()]: invalid team number (%d)", __func__, teamID);
+		return 0;
+	}
+	if (!FullCtrl(L) && (CtrlTeam(L) != teamID)) {
+		luaL_error(L, "[%s()]: not a controllable team (%d)", __func__, teamID);
+		return 0;
+	}
+	if (!sensorHandler.CanBuildSensor(teamID))
+		return 0; // unit limit reached
+
+	const float3 pos(
+		luaL_checkfloat(L, 2),
+		luaL_checkfloat(L, 3),
+		luaL_checkfloat(L, 4)
+	);
+
+	const int LOSType = luaL_checkinteger(L, 5);
+	const float LOSDistance = luaL_checkfloat(L, 6);
+	const int duration = luaL_checkinteger(L, 7);
+
+	ASSERT_SYNCED(pos);
+
+	inCreateUnit++;
+
+	CSensor* sensor = sensorHandler.NewSensor(teamID, pos, LOSType, LOSDistance, duration);
+	inCreateUnit--;
+
+	if (sensor == nullptr)
+		return 0;
+
+	sensorHandler.AddSensor(sensor);
+
+	lua_pushnumber(L, sensor->id);
+	return 1;
+}
+
+
+/***
+ * @function Spring.DestroySensor
+ * @see Spring.CreateSensor
+ * @number sensorID
+ * @treturn nil
+ ***/
+int LuaSyncedCtrl::DestroySensor(lua_State* L)
+{
+	CheckAllowGameChanges(L); // FIXME -- recursion protection
+	CSensor* sensor = ParseSensor(L, __func__, 1);
+
+	if (sensor == nullptr)
+		return 0;
+
+	if (inDestroyUnit >= MAX_CMD_RECURSION_DEPTH)
+		luaL_error(L, "DestroySensor() recursion is not permitted, max depth: %d", MAX_CMD_RECURSION_DEPTH);
+
+	inDestroyUnit++;
+
+	ASSERT_SYNCED(sensor->id);
+	sensor->Kill();
+
+	inDestroyUnit--;
+
+	return 0;
+}
+
+
+/***
+ * @function Spring.TransferSensor
+ * @number sensorID
+ * @number newTeamID
+ * @treturn nil
+ ***/
+int LuaSyncedCtrl::TransferSensor(lua_State* L)
+{
+	CheckAllowGameChanges(L);
+	CSensor* sensor = ParseSensor(L, __func__, 1);
+
+	if (sensor == nullptr)
+		return 0;
+
+	const int newTeam = luaL_checkint(L, 2);
+	if (!teamHandler.IsValidTeam(newTeam))
+		return 0;
+
+	const CTeam* team = teamHandler.Team(newTeam);
+	if (team == nullptr)
+		return 0;
+
+	if (inTransferUnit >= MAX_CMD_RECURSION_DEPTH)
+		luaL_error(L, "TransferSensor() recursion is not permitted, max depth: %d", MAX_CMD_RECURSION_DEPTH);
+
+	++inTransferUnit;
+	ASSERT_SYNCED(sensor->id);
+	ASSERT_SYNCED((int)newTeam);
+	sensor->ChangeTeam(newTeam);
+	--inTransferUnit;
+	return 0;
+}

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -68,6 +68,10 @@ class LuaSyncedCtrl
 		static int DestroyUnit(lua_State* L);
 		static int TransferUnit(lua_State* L);
 
+		static int CreateSensor(lua_State* L);
+		static int DestroySensor(lua_State* L);
+		static int TransferSensor(lua_State* L);
+
 		static int CreateFeature(lua_State* L);
 		static int DestroyFeature(lua_State* L);
 		static int TransferFeature(lua_State* L);

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/Resource.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/ResourceHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/ResourceMapAnalyzer.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/Sensor.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/SensorHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/SideParser.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/SimObjectIDPool.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/SmoothHeightMesh.cpp"

--- a/rts/Sim/Misc/GlobalConstants.h
+++ b/rts/Sim/Misc/GlobalConstants.h
@@ -79,10 +79,10 @@ static constexpr int MAX_PLAYERS = 251;
 static constexpr int MAX_AIS = 255;
 
 /**
- * @brief max units / features / projectiles
+ * @brief max units / features / projectiles / sensors
  *
  * Defines the absolute global maximum number of simulation objects
- * (units, features, projectiles) that are allowed to exist in a game
+ * (units, features, projectiles, sensors) that are allowed to exist in a game
  * at any time.
  *
  * NOTE:
@@ -97,9 +97,10 @@ static constexpr int MAX_AIS = 255;
 static constexpr int MAX_UNITS       =  32000;
 static constexpr int MAX_FEATURES    =  32000;
 static constexpr int MAX_PROJECTILES = 128000;
+static constexpr int MAX_SENSORS     =   320;
 
-static_assert(MAX_UNITS + MAX_FEATURES < std::numeric_limits<uint16_t>::max(),
-	"MAX_UNITS + MAX_FEATURES must fit in a 16-bit type because the network protocol packs them both there");
+static_assert(MAX_UNITS + MAX_FEATURES + MAX_SENSORS < std::numeric_limits<uint16_t>::max(),
+	"MAX_UNITS + MAX_FEATURES + MAX_SENSORS must fit in a 16-bit type because the network protocol packs them both there");
 
 /**
  * @brief max weapons per unit

--- a/rts/Sim/Misc/GlobalConstants.h
+++ b/rts/Sim/Misc/GlobalConstants.h
@@ -79,10 +79,10 @@ static constexpr int MAX_PLAYERS = 251;
 static constexpr int MAX_AIS = 255;
 
 /**
- * @brief max units / features / projectiles / sensors
+ * @brief max units / features / projectiles
  *
  * Defines the absolute global maximum number of simulation objects
- * (units, features, projectiles, sensors) that are allowed to exist in a game
+ * (units, features, projectiles) that are allowed to exist in a game
  * at any time.
  *
  * NOTE:
@@ -97,10 +97,10 @@ static constexpr int MAX_AIS = 255;
 static constexpr int MAX_UNITS       =  32000;
 static constexpr int MAX_FEATURES    =  32000;
 static constexpr int MAX_PROJECTILES = 128000;
-static constexpr int MAX_SENSORS     =   320;
+static constexpr int MAX_SENSORS     =   3200;
 
-static_assert(MAX_UNITS + MAX_FEATURES + MAX_SENSORS < std::numeric_limits<uint16_t>::max(),
-	"MAX_UNITS + MAX_FEATURES + MAX_SENSORS must fit in a 16-bit type because the network protocol packs them both there");
+static_assert(MAX_UNITS + MAX_FEATURES < std::numeric_limits<uint16_t>::max(),
+	"MAX_UNITS + MAX_FEATURES must fit in a 16-bit type because the network protocol packs them both there");
 
 /**
  * @brief max weapons per unit

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -1,3 +1,6 @@
+#include "LosHandler.h"
+#include "LosHandler.h"
+#include "LosHandler.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "LosHandler.h"
@@ -7,6 +10,8 @@
 #include "Sim/Units/UnitHandler.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/Sensor.h"
+#include "Sim/Misc/SensorHandler.h"
 #include "Map/ReadMap.h"
 #include "System/Log/ILog.h"
 #include "System/SpringHash.h"
@@ -128,7 +133,7 @@ void ILosType::Kill()
 }
 
 
-float ILosType::GetRadius(const CUnit* unit) const
+float ILosType::GetUnitRadius(const CUnit* unit) const
 {
 	switch (type) {
 		case LOS_TYPE_LOS:          return (unit->losRadius      / SQUARE_SIZE) >> mipLevel;
@@ -144,8 +149,24 @@ float ILosType::GetRadius(const CUnit* unit) const
 	return 0.0f;
 }
 
+float ILosType::GetSensorRadius(const CSensor* sensor) const
+{
+	switch (type) {
+	case LOS_TYPE_LOS:          return (sensor->losRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_AIRLOS:       return (sensor->airLosRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_RADAR:        return (sensor->radarRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_SONAR:        return (sensor->sonarRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_JAMMER:       return (sensor->jammerRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_SEISMIC:      return (sensor->seismicRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_SONAR_JAMMER: return (sensor->sonarJamRadius / SQUARE_SIZE) >> mipLevel;
+	case LOS_TYPE_COUNT:        break; //make the compiler happy
+	}
+	assert(false);
+	return 0.0f;
+}
 
-float ILosType::GetHeight(const CUnit* unit) const
+
+float ILosType::GetUnitHeight(const CUnit* unit) const
 {
 	if (algoType == LOS_ALGO_CIRCLE)
 		return 0.0f;
@@ -153,6 +174,19 @@ float ILosType::GetHeight(const CUnit* unit) const
 	const float emitHeight = (type == LOS_TYPE_LOS || type == LOS_TYPE_AIRLOS) ? unit->unitDef->losHeight : unit->unitDef->radarHeight;
 	const float losHeight  = std::max(unit->midPos.y + emitHeight, 0.0f);
 	const int bucketSize   = 1 << (mipLevel + 2);
+	const float iLosHeight = (int(losHeight) / bucketSize + 0.5f) * bucketSize; // save losHeight in buckets
+	return iLosHeight;
+}
+
+
+float ILosType::GetSensorHeight(const CSensor* sensor) const
+{
+	if (algoType == LOS_ALGO_CIRCLE)
+		return 0.0f;
+
+	const float emitHeight = (type == LOS_TYPE_LOS || type == LOS_TYPE_AIRLOS) ? sensor->losHeight : sensor->radarHeight;
+	const float losHeight = std::max(sensor->pos.y + emitHeight, 0.0f);
+	const int bucketSize = 1 << (mipLevel + 2);
 	const float iLosHeight = (int(losHeight) / bucketSize + 0.5f) * bucketSize; // save losHeight in buckets
 	return iLosHeight;
 }
@@ -195,8 +229,8 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 	#endif
 
 	const float3 losPos = unit->midPos;
-	const float radius = GetRadius(unit);
-	const float height = GetHeight(unit);
+	const float radius = GetUnitRadius(unit);
+	const float height = GetUnitHeight(unit);
 	const int2 baseLos = PosToSquare(losPos);
 	      int allyteam = unit->allyteam;
 
@@ -254,6 +288,99 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 	unit->los[type] = li;
 	instanceHashes[hash].push_back(li);
 	UpdateInstanceStatus(li, SLosInstance::TLosStatus::NEW);
+}
+
+
+inline void ILosType::UpdateSensor(CSensor* sensor, bool ignore)
+{
+
+	if (sensor->isDead || sensor->isExpired)
+		return;
+
+	SLosInstance* sli = sensor->los[type];
+
+#if (USE_STAGGERED_UPDATES == 1)
+	if (ignore && sli != nullptr) {
+		// make sure ILosType::Update will do nothing with this instance
+		sli->status = SLosInstance::TLosStatus::NONE;
+		return;
+	}
+#endif
+
+	const float3 losPos = sensor->pos;
+	const float radius = GetSensorRadius(sensor);
+	const float height = GetSensorHeight(sensor);
+	const int2 baseLos = PosToSquare(losPos);
+	int allyteam = sensor->allyteam;
+
+	// jammers share all the same map independent of the allyTeam
+	if (type == LOS_TYPE_JAMMER || type == LOS_TYPE_SONAR_JAMMER)
+		allyteam *= modInfo.separateJammers;
+
+	if (radius <= 0.0f) {
+		if (sli != nullptr) {
+			sensor->los[type] = nullptr;
+			UnrefInstance(sli);
+		}
+		return;
+	}
+
+	const auto CanRefInstance = [&](SLosInstance* li) -> bool {
+		return (li != nullptr
+			&& (li->basePos == baseLos)
+			&& (li->baseHeight == height)
+			&& (li->radius == radius)
+			&& (li->allyteam == allyteam)
+			);
+		};
+
+	// unchanged?
+	if (CanRefInstance(sli))
+		return;
+
+	if (sli != nullptr) {
+		sensor->los[type] = nullptr;
+		UnrefInstance(sli);
+	}
+
+	const int hash = GetHashNum(sli->allyteam, baseLos, radius);
+
+	// Cache - search if there is already an instance with same properties
+	auto vit = instanceHashes.find(hash);
+
+	if (vit != instanceHashes.end()) {
+		for (SLosInstance* li : vit->second) {
+			if (CanRefInstance(li)) {
+				cacheHits += (algoType == LOS_ALGO_RAYCAST);
+				sensor->los[type] = li;
+				RefInstance(li);
+				return;
+			}
+		}
+	}
+
+	// New - create a new one
+	cacheFails += (algoType == LOS_ALGO_RAYCAST);
+	SLosInstance* li = CreateInstance();
+	li->Init(radius, allyteam, baseLos, height, hash);
+	li->refCount++;
+	sensor->los[type] = li;
+	instanceHashes[hash].push_back(li);
+	UpdateInstanceStatus(li, SLosInstance::TLosStatus::NEW);
+}
+
+void ILosType::RemoveSensor(CSensor* sensor, bool delayed)
+{
+	if (sensor->los[type] == nullptr)
+		return;
+
+	if (delayed) {
+		DelayedUnrefInstance(sensor->los[type]);
+	}
+	else {
+		UnrefInstance(sensor->los[type]);
+	}
+	sensor->los[type] = nullptr;
 }
 
 
@@ -786,12 +913,20 @@ void CLosHandler::UnitLoaded(const CUnit* unit, const CUnit* transport)
 	}
 }
 
+void CLosHandler::SensorExpired(const CSensor* sensor)
+{
+	for (ILosType* lt : losTypes) {
+		lt->RemoveSensor(const_cast<CSensor*>(sensor), true);
+	}
+}
+
 
 void CLosHandler::Update()
 {
 	SCOPED_TIMER("Sim::Los");
 
 	const std::vector<CUnit*>& activeUnits = unitHandler.GetActiveUnits();
+	const std::vector<CSensor*>& activeSensors = sensorHandler.GetActiveSensors();
 
 	#if (USE_STAGGERED_UPDATES == 1)
 	const size_t losBatchRate = UNIT_SLOWUPDATE_RATE;
@@ -815,6 +950,9 @@ void CLosHandler::Update()
 			ZoneScopedN("Sim::Los::UpdateLosTypeMT");
 			for (CUnit* u : activeUnits) {
 				lt->UpdateUnit(u, false);
+			}
+			for (CSensor* s : activeSensors) {
+				lt->UpdateSensor(s, false);
 			}
 		}
 		#endif

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -1,6 +1,3 @@
-#include "LosHandler.h"
-#include "LosHandler.h"
-#include "LosHandler.h"
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "LosHandler.h"

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -343,7 +343,7 @@ inline void ILosType::UpdateSensor(CSensor* sensor, bool ignore)
 		UnrefInstance(sli);
 	}
 
-	const int hash = GetHashNum(sli->allyteam, baseLos, radius);
+	const int hash = GetHashNum(sensor->allyteam, baseLos, radius);
 
 	// Cache - search if there is already an instance with same properties
 	auto vit = instanceHashes.find(hash);

--- a/rts/Sim/Misc/LosHandler.h
+++ b/rts/Sim/Misc/LosHandler.h
@@ -133,6 +133,9 @@ public:
 	void RemoveUnit(CUnit* unit, bool delayed = false);
 	void UpdateUnit(CUnit* unit, bool ignore = false);
 
+	void UpdateSensor(CSensor* sensor, bool ignore);
+	void RemoveSensor(CSensor* sensor, bool delayed = false);
+
 private:
 	//void PostLoad();
 
@@ -153,8 +156,10 @@ private:
 private:
 	int GetHashNum(const int allyteam, const int2 baseLos, const float radius) const;
 
-	float GetRadius(const CUnit* unit) const;
-	float GetHeight(const CUnit* unit) const;
+	float GetUnitRadius(const CUnit* unit) const;
+	float GetSensorRadius(const CSensor* sensor) const;
+	float GetUnitHeight(const CUnit* unit) const;
+	float GetSensorHeight(const CSensor* sensor) const;
 
 public:
 	int   mipLevel = 0;
@@ -293,6 +298,8 @@ public:
 	void UnitTaken(const CUnit* unit, int oldTeam, int newTeam) override;
 	void UnitLoaded(const CUnit* unit, const CUnit* transport) override;
 	void UnitReverseBuilt(const CUnit* unit) override;
+
+	void SensorExpired(const CSensor* sensor);
 
 public:
 	void Update() override;

--- a/rts/Sim/Misc/Sensor.cpp
+++ b/rts/Sim/Misc/Sensor.cpp
@@ -1,0 +1,140 @@
+#include "Game/GameHelper.h"
+#include "Game/GameSetup.h"
+#include "Game/GlobalUnsynced.h"
+#include "Game/Players/Player.h"
+#include "Map/Ground.h"
+#include "Map/MapInfo.h"
+#include "Map/ReadMap.h"
+
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/LosHandler.h"
+#include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/SensorMemPool.h"
+#include "System/EventHandler.h"
+#include "System/Log/ILog.h"
+#include "System/Matrix44f.h"
+#include "System/SpringMath.h"
+#include "System/creg/DefTypes.h"
+#include "System/creg/STL_List.h"
+#include "System/Sound/ISoundChannels.h"
+#include "System/Sync/SyncedPrimitive.h"
+
+#include <tracy/Tracy.hpp>
+
+
+CSensor::CSensor()
+{
+	createdOn = gs->frameNum;
+	drawFlag = SO_NODRAW_FLAG;
+	isInit = false;
+	isExpired = false;
+	isDead = false;
+}
+
+CSensor::~CSensor()
+{
+	// Don't think anything is needed here...?
+}
+
+void CSensor::Init(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_)
+{
+	team = team_;
+	allyteam = teamHandler.AllyTeam(team);
+	pos = pos_;
+
+	switch (LOSType_) {
+	case 1: {
+		losRadius = LOSDistance_;
+		airLosRadius = LOSDistance_;
+		radarRadius = 0;
+		sonarRadius = 0;
+	};
+	case 2: {
+		losRadius = 0;
+		airLosRadius = 0;
+		radarRadius = LOSDistance_;
+		sonarRadius = LOSDistance_;
+	};
+	case 4: {
+		losRadius = LOSDistance_;
+		airLosRadius = LOSDistance_;
+		radarRadius = LOSDistance_;
+		sonarRadius = LOSDistance_;
+	};
+	default: {
+		losRadius = 0;
+		airLosRadius = 0;
+		radarRadius = 0;
+		sonarRadius = 0;
+	};
+	}
+
+	jammerRadius = 0;
+	seismicRadius = 0;
+	sonarJamRadius = 0;
+
+	losHeight = 0;
+	radarHeight = 0;
+
+	LOSDistance = LOSDistance_;
+
+	if (duration_ == -1) {
+		expiresOn = -1;
+	}
+	else {
+		expiresOn = createdOn + duration_;
+	}
+
+	eventHandler.SensorCreated(this);
+	isInit = true;
+}
+
+
+void CSensor::Update()
+{
+	if (expiresOn != -1 && gs->frameNum > expiresOn) {
+		isExpired = true;
+	}
+}
+
+void CSensor::Kill() 
+{
+	if (isDead)
+		return;
+
+	isExpired = true;
+	isDead = true;
+
+	eventHandler.SensorExpired(this);
+}
+
+bool CSensor::ChangeTeam(int newTeamID)
+{
+	if (isExpired || isDead)
+		return false;
+
+	eventHandler.SensorTaken(this, team, newTeamID);
+	teamHandler.Team(team)->RemoveSensor(this);
+	teamHandler.Team(team)->AddSensor(this);
+}
+
+//CR_BIND_DERIVED_POOL(CSensor, CWorldObject, , sensorMemPool.allocMem, sensorMemPool.freeMem)
+//CR_REG_METADATA(CSensor, (
+//	CR_MEMBER(LOSDistance),
+//	CR_MEMBER(createdOn),
+//	CR_MEMBER(expiresOn),
+//	CR_MEMBER(isInit),
+//	CR_MEMBER(isExpired),
+//	CR_MEMBER(isDead),
+//	CR_MEMBER(losRadius),
+//	CR_MEMBER(airLosRadius),
+//	CR_MEMBER(radarRadius),
+//	CR_MEMBER(sonarRadius),
+//	CR_MEMBER(jammerRadius),
+//	CR_MEMBER(seismicRadius),
+//	CR_MEMBER(sonarJamRadius),
+//	CR_MEMBER(losHeight),
+//	CR_MEMBER(radarHeight),
+//	CR_MEMBER(los)
+//	))

--- a/rts/Sim/Misc/Sensor.cpp
+++ b/rts/Sim/Misc/Sensor.cpp
@@ -44,30 +44,30 @@ void CSensor::Init(int team_, float3 pos_, int LOSType_, float LOSDistance_, int
 	pos = pos_;
 
 	switch (LOSType_) {
-	case 1: {
+	case 1: 
 		losRadius = LOSDistance_;
 		airLosRadius = LOSDistance_;
 		radarRadius = 0;
 		sonarRadius = 0;
-	};
-	case 2: {
+		break;
+	case 2: 
 		losRadius = 0;
 		airLosRadius = 0;
 		radarRadius = LOSDistance_;
 		sonarRadius = LOSDistance_;
-	};
-	case 4: {
+		break;
+	case 4: 
 		losRadius = LOSDistance_;
 		airLosRadius = LOSDistance_;
 		radarRadius = LOSDistance_;
 		sonarRadius = LOSDistance_;
-	};
-	default: {
+		break;
+	default: 
 		losRadius = 0;
 		airLosRadius = 0;
 		radarRadius = 0;
 		sonarRadius = 0;
-	};
+		break;
 	}
 
 	jammerRadius = 0;

--- a/rts/Sim/Misc/Sensor.h
+++ b/rts/Sim/Misc/Sensor.h
@@ -1,0 +1,52 @@
+
+#ifndef SENSOR_H
+#define SENSOR_H
+
+#include <vector>
+#include "System/type2.h"
+#include "Sim/Objects/WorldObject.h"
+#include "Sim/Misc/LosHandler.h"
+
+class CSensor : public CWorldObject
+{
+public:
+	//CR_DECLARE(CSensor)
+
+	CSensor();
+	virtual ~CSensor();
+
+	void Init(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_);
+	void Update();
+	void Kill();
+	bool ChangeTeam(int newTeamID);
+
+public:
+	int team;
+	int allyteam;
+
+	float LOSDistance;
+
+	int createdOn;
+	int expiresOn;
+
+	bool isInit;
+	bool isExpired;
+	bool isDead;
+
+	int losRadius;
+	int airLosRadius;
+	int radarRadius;
+	int sonarRadius;
+	int jammerRadius;
+	int seismicRadius;
+	int sonarJamRadius;
+
+	float losHeight;
+	float radarHeight;
+
+
+	// which squares the sensor can currently observe, per los-type
+	std::array<SLosInstance*, /*ILosType::LOS_TYPE_COUNT*/ 7> los{ {nullptr} };
+};
+
+#endif // SENSOR_H

--- a/rts/Sim/Misc/SensorHandler.cpp
+++ b/rts/Sim/Misc/SensorHandler.cpp
@@ -1,0 +1,208 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <cassert>
+
+#include "SensorHandler.h"
+#include "Sim/Misc/SensorMemPool.h"
+
+#include "Sim/Ecs/Registry.h"
+#include "Sim/Misc/GlobalSynced.h"
+#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/TeamHandler.h"
+#include "System/EventHandler.h"
+#include "System/Log/ILog.h"
+#include "System/SpringMath.h"
+#include "System/Threading/ThreadPool.h"
+#include "System/TimeProfiler.h"
+#include "System/creg/STL_Deque.h"
+#include "System/creg/STL_Set.h"
+
+
+//CR_BIND(CSensorHandler, )
+//CR_REG_METADATA(CSensorHandler, (
+//	CR_MEMBER(idPool),
+//
+//	CR_MEMBER(sensorsToBeRemoved),
+//	CR_MEMBER(activeUpdateSensor),
+//
+//	CR_MEMBER(maxSensors),
+//
+//	CR_MEMBER(inUpdateCall)
+//))
+
+
+SensorMemPool sensorMemPool;
+CSensorHandler sensorHandler;
+
+
+CSensor* CSensorHandler::NewSensor(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_)
+{
+	CSensor* sensor = sensorMemPool.alloc<CSensor>();
+	sensor->Init(team_, pos_, LOSType_, LOSDistance_, duration_);
+	return sensor;
+}
+
+
+
+void CSensorHandler::Init() {
+	{
+		maxSensors = MAX_SENSORS;
+	}
+	{
+		sensors.resize(maxSensors, nullptr);
+		activeSensors.reserve(maxSensors);
+
+		sensorMemPool.reserve(128);
+
+		idPool.Clear();
+		idPool.Expand(0, MAX_SENSORS);
+	}
+}
+
+
+void CSensorHandler::Kill()
+{
+	for (CSensor* s : activeSensors) {
+		sensorMemPool.free(s);
+	}
+	{
+		// do not clear in ctor because creg-loaded objects would be wiped out
+		sensorMemPool.clear();
+
+		sensors.clear();
+
+		activeSensors.clear();
+		sensorsToBeRemoved.clear();
+	}
+	{
+		maxSensors = 0;
+	}
+}
+
+void CSensorHandler::InsertActiveSensor(CSensor* sensor)
+{
+	idPool.AssignID(sensor);
+
+	assert(sensor->id < sensors.size());
+	assert(sensors[sensor->id] == nullptr);
+	sensors[sensor->id] = sensor;
+}
+
+
+bool CSensorHandler::AddSensor(CSensor* sensor)
+{
+	assert(CanAddSensor(sensor->id));
+
+	InsertActiveSensor(sensor);
+
+	teamHandler.Team(sensor->team)->AddSensor(sensor);
+
+	return true;
+}
+
+
+bool CSensorHandler::GarbageCollectSensor(unsigned int id)
+{
+	if (inUpdateCall)
+		return false;
+
+	assert(sensorsToBeRemoved.empty());
+
+	if (!QueueDeleteSensor(sensors[id]))
+		return false;
+
+	// only processes sensors[id]
+	DeleteSensors();
+
+	return (idPool.RecycleID(id));
+}
+
+void CSensorHandler::QueueDeleteSensors()
+{
+	ZoneScoped;
+	// gather up dead sensors
+	for (activeUpdateSensor = 0; activeUpdateSensor < activeSensors.size(); ++activeUpdateSensor) {
+		QueueDeleteSensor(activeSensors[activeUpdateSensor]);
+	}
+}
+
+
+bool CSensorHandler::QueueDeleteSensor(CSensor* sensor)
+{
+	if (!sensor->isExpired)
+		return false;
+	sensor->Kill();
+	sensorsToBeRemoved.push_back(sensor);
+	return true;
+}
+
+void CSensorHandler::DeleteSensors()
+{
+	while (!sensorsToBeRemoved.empty()) {
+		DeleteSensor(sensorsToBeRemoved.back());
+		sensorsToBeRemoved.pop_back();
+	}
+}
+
+
+void CSensorHandler::DeleteSensor(CSensor* delSensor)
+{
+	assert(delSensor->isDead);
+
+	const auto it = std::find(activeSensors.begin(), activeSensors.end(), delSensor);
+
+	if (it == activeSensors.end()) {
+		assert(false);
+		return;
+	}
+
+	const int delSensorTeam = delSensor->team;
+
+	teamHandler.Team(delSensorTeam)->RemoveSensor(delSensor);
+
+	activeSensors.erase(it);
+
+	idPool.FreeID(delSensor->id, true);
+
+	sensors[delSensor->id] = nullptr;
+
+	sensorMemPool.free(delSensor);
+}
+
+
+void CSensorHandler::Update()
+{
+	inUpdateCall = true;
+
+	DeleteSensors();
+	QueueDeleteSensors();
+	UpdateSensors();
+
+	inUpdateCall = false;
+}
+
+
+void CSensorHandler::UpdateSensors()
+{
+	SCOPED_TIMER("Sim::Sensor::Update");
+
+	size_t activeSensorCount = activeSensors.size();
+	for (size_t i = 0; i < activeSensorCount; ++i) {
+		CSensor* censor = activeSensors[i];
+		if (censor->isDead)
+			continue;
+
+		censor->Update();
+
+		assert(activeSensors[i] == censor);
+	}
+}
+
+
+bool CSensorHandler::CanBuildSensor(int team) const
+{
+	if (teamHandler.Team(team)->AtSensorLimit())
+		return false;
+
+	return true;
+}

--- a/rts/Sim/Misc/SensorHandler.cpp
+++ b/rts/Sim/Misc/SensorHandler.cpp
@@ -85,6 +85,8 @@ void CSensorHandler::InsertActiveSensor(CSensor* sensor)
 
 	assert(sensor->id < sensors.size());
 	assert(sensors[sensor->id] == nullptr);
+
+	activeSensors.push_back(sensor);
 	sensors[sensor->id] = sensor;
 }
 
@@ -133,6 +135,8 @@ bool CSensorHandler::QueueDeleteSensor(CSensor* sensor)
 		return false;
 	sensor->Kill();
 	sensorsToBeRemoved.push_back(sensor);
+	eventHandler.SensorExpired(sensor);
+	losHandler->SensorExpired(sensor);
 	return true;
 }
 
@@ -188,13 +192,13 @@ void CSensorHandler::UpdateSensors()
 
 	size_t activeSensorCount = activeSensors.size();
 	for (size_t i = 0; i < activeSensorCount; ++i) {
-		CSensor* censor = activeSensors[i];
-		if (censor->isDead)
+		CSensor* sensor = activeSensors[i];
+		if (sensor->isDead)
 			continue;
 
-		censor->Update();
+		sensor->Update();
 
-		assert(activeSensors[i] == censor);
+		assert(activeSensors[i] == sensor);
 	}
 }
 

--- a/rts/Sim/Misc/SensorHandler.h
+++ b/rts/Sim/Misc/SensorHandler.h
@@ -1,0 +1,80 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef SENSORHANDLER_H
+#define SENSORHANDLER_H
+
+#include <array>
+#include <vector>
+
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/SimObjectIDPool.h"
+#include "System/creg/STL_Map.h"
+
+class CSensor;
+
+class CSensorHandler
+{
+	//CR_DECLARE_STRUCT(CSensorHandler)
+
+public:
+	CSensorHandler() : idPool(MAX_SENSORS) {}
+
+	void Init();
+	void Kill();
+
+	void Update();
+	bool AddSensor(CSensor* sensor);
+
+	bool CanAddSensor(int id) const {
+		// do we want to be assigned a random ID and are any left in pool?
+		if (id < 0)
+			return (!idPool.IsEmpty());
+		// is this ID not already in use *and* has it been recycled by pool?
+		if (id < MaxSensors())
+			return (sensors[id] == nullptr && idPool.HasID(id));
+		// AddSensor will not make new room for us
+		return false;
+	}
+
+	unsigned int MaxSensors() const { return maxSensors; }
+
+	bool CanBuildSensor(int team) const;
+	bool GarbageCollectSensor(unsigned int id);
+
+	// note: negative ID's are implicitly converted
+	CSensor* GetSensor(unsigned int id) const { return ((id < MaxSensors()) ? sensors[id] : nullptr); }
+
+	static CSensor* NewSensor(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_);
+
+	const std::vector<CSensor*>& GetSensorsToBeRemoved() const { return sensorsToBeRemoved; }
+	const std::vector<CSensor*>& GetActiveSensors() const { return activeSensors; }
+	std::vector<CSensor*>& GetActiveSensors() { return activeSensors; }
+
+private:
+	void InsertActiveSensor(CSensor* sensor);
+	bool QueueDeleteSensor(CSensor* sensor);
+	void QueueDeleteSensors();
+	void DeleteSensor(CSensor* sensor);
+	void DeleteSensors();
+	void UpdateSensors();
+
+private:
+	SimObjectIDPool idPool;
+
+	std::vector<CSensor*> sensors;                                           ///< used to get units from IDs (0 if not created)
+
+	std::vector<CSensor*> activeSensors;                                     ///< used to get all active units
+	std::vector<CSensor*> sensorsToBeRemoved;                                ///< units that will be removed at start of next update
+
+	size_t activeUpdateSensor = 0;      ///< first Sensor of batch that will be updated
+
+	///< global unit-limit (derived from the per-team limit)
+	///< units.size() is equal to this and constant at runtime
+	unsigned int maxSensors = 0;
+
+	bool inUpdateCall = false;
+};
+
+extern CSensorHandler sensorHandler;
+
+#endif /* SENSORHANDLER_H */

--- a/rts/Sim/Misc/SensorMemPool.h
+++ b/rts/Sim/Misc/SensorMemPool.h
@@ -1,0 +1,19 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef SENSOR_MEMPOOL_H
+#define SENSOR_MEMPOOL_H
+
+#include "Sim/Misc/Sensor.h"
+#include "Sim/Misc/GlobalConstants.h"
+#include "System/MemPoolTypes.h"
+
+#if (defined(__x86_64) || defined(__x86_64__) || defined(_M_X64))
+typedef StaticMemPoolT<MAX_SENSORS, CSensor> SensorMemPool;
+#else
+typedef FixedDynMemPoolT<MAX_SENSORS / 10, MAX_SENSORS / 32, CSensor> SensorMemPool;
+#endif
+
+extern SensorMemPool sensorMemPool;
+
+#endif
+

--- a/rts/Sim/Misc/SimObjectIDPool.cpp
+++ b/rts/Sim/Misc/SimObjectIDPool.cpp
@@ -45,7 +45,7 @@ void SimObjectIDPool::Expand(uint32_t baseID, uint32_t numIDs) {
 
 
 
-void SimObjectIDPool::AssignID(CSolidObject* object) {
+void SimObjectIDPool::AssignID(CWorldObject* object) {
 	if (object->id < 0) {
 		object->id = ExtractID();
 	} else {

--- a/rts/Sim/Misc/SimObjectIDPool.h
+++ b/rts/Sim/Misc/SimObjectIDPool.h
@@ -4,6 +4,7 @@
 
 #include "System/creg/creg_cond.h"
 #include "System/UnorderedMap.hpp"
+#include "Sim/Objects/WorldObject.h"
 
 class CSolidObject;
 class SimObjectIDPool {
@@ -27,7 +28,7 @@ public:
 		tempIDs.clear();
 	}
 
-	void AssignID(CSolidObject* object);
+	void AssignID(CWorldObject* object);
 	void FreeID(uint32_t uid, bool delayed);
 
 	bool RecycleID(uint32_t uid);

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -14,6 +14,7 @@
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
+#include "Sim/Misc/Sensor.h"
 #include "System/ContainerUtil.h"
 #include "System/EventHandler.h"
 #include "System/MsgStrings.h"
@@ -28,6 +29,9 @@ CR_REG_METADATA(CTeam, (
 	CR_MEMBER(teamNum),
 	CR_MEMBER(numUnits),
 	CR_MEMBER(maxUnits),
+
+	CR_MEMBER(numSensors),
+	CR_MEMBER(maxSensors),
 
 	CR_MEMBER(isDead),
 	CR_MEMBER(gaia),
@@ -62,6 +66,9 @@ CTeam::CTeam():
 	teamNum(-1),
 	numUnits(0),
 	maxUnits(0),
+
+	numSensors(0),
+	maxSensors(0),
 
 	isDead(false),
 	gaia(false),
@@ -425,6 +432,18 @@ void CTeam::RemoveUnit(CUnit* unit, RemoveType type)
 			GetCurrentStats().unitsOutCaptured++;
 		} break;
 	}
+}
+
+
+void CTeam::AddSensor(CSensor* sensor)
+{
+	numSensors++;
+}
+
+
+void CTeam::RemoveSensor(CSensor* sensor)
+{
+	numSensors--;
 }
 
 void CTeam::UpdateControllerName() {

--- a/rts/Sim/Misc/Team.h
+++ b/rts/Sim/Misc/Team.h
@@ -15,6 +15,7 @@
 #include "Lua/LuaRulesParams.h"
 
 class CUnit;
+class CSensor;
 
 class CTeam : public TeamBase
 {
@@ -50,6 +51,12 @@ public:
 	unsigned int GetNumUnits() const { return numUnits; }
 	bool AtUnitLimit() const { return (numUnits >= maxUnits); }
 
+
+	void SetMaxSensors(unsigned int n) { maxSensors = n; }
+	unsigned int GetMaxSensors() const { return maxSensors; }
+	unsigned int GetNumSensors() const { return numSensors; }
+	bool AtSensorLimit() const { return (numSensors >= maxSensors); }
+
 	const TeamStatistics& GetCurrentStats() const { return statHistory.back(); }
 	      TeamStatistics& GetCurrentStats()       { return statHistory.back(); }
 
@@ -73,10 +80,16 @@ public:
 	void AddUnit(CUnit* unit, AddType type);
 	void RemoveUnit(CUnit* unit, RemoveType type);
 
+	void AddSensor(CSensor* sensor);
+	void RemoveSensor(CSensor* sensor);
+
 public:
 	int teamNum;
 	unsigned int numUnits; // number of units this team controls
 	unsigned int maxUnits; // maximum number of units this team can control
+
+	unsigned int numSensors;
+	unsigned int maxSensors;
 
 	bool isDead;
 	bool gaia;

--- a/rts/Sim/Misc/TeamHandler.cpp
+++ b/rts/Sim/Misc/TeamHandler.cpp
@@ -158,6 +158,7 @@ void CTeamHandler::UpdateTeamUnitLimitsPreSpawn(int liveTeamNum)
 	if (numRemainingActiveTeams == 0) {
 		// set default since we are the only team in our allyteam now
 		liveTeam->SetMaxUnits(std::min(gameSetup->maxUnitsPerTeam, int(MAX_UNITS / teams.size())));
+		liveTeam->SetMaxSensors(int(MAX_SENSORS / teams.size()));
 		return;
 	}
 
@@ -176,6 +177,7 @@ void CTeamHandler::UpdateTeamUnitLimitsPreSpawn(int liveTeamNum)
 
 	assert(tempTeam != nullptr);
 	liveTeam->SetMaxUnits(tempTeam->GetMaxUnits());
+	liveTeam->SetMaxSensors(tempTeam->GetMaxSensors());
 }
 
 void CTeamHandler::UpdateTeamUnitLimitsPreDeath(int deadTeamNum)

--- a/rts/Sim/Units/UnitLoader.cpp
+++ b/rts/Sim/Units/UnitLoader.cpp
@@ -23,6 +23,7 @@
 #include "Sim/Features/FeatureDefHandler.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/SensorHandler.h"
 
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
@@ -167,8 +168,25 @@ void CUnitLoader::ParseAndExecuteGiveUnitsCommand(const std::vector<std::string>
 		LOG_L(L_WARNING, "[%s] invalid object-name argument", __FUNCTION__);
 		return;
 	}
+	
+	if (objectName == "sensor") {
+		GiveSensor(team, pos, 4, amount, 60);
+	}
+	else {
+		GiveUnits(objectName, pos, amount, team, featureAllyTeam);
+	}
+}
 
-	GiveUnits(objectName, pos, amount, team, featureAllyTeam);
+int CUnitLoader::GiveSensor(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_)
+{
+	CSensor* sensor = sensorHandler.NewSensor(team_, pos_, LOSType_, LOSDistance_, duration_);
+
+	if (sensor == nullptr)
+		return 0;
+
+	sensorHandler.AddSensor(sensor);
+
+	return 1;
 }
 
 

--- a/rts/Sim/Units/UnitLoader.cpp
+++ b/rts/Sim/Units/UnitLoader.cpp
@@ -23,7 +23,6 @@
 #include "Sim/Features/FeatureDefHandler.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/SensorHandler.h"
 
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
@@ -168,25 +167,8 @@ void CUnitLoader::ParseAndExecuteGiveUnitsCommand(const std::vector<std::string>
 		LOG_L(L_WARNING, "[%s] invalid object-name argument", __FUNCTION__);
 		return;
 	}
-	
-	if (objectName == "sensor") {
-		GiveSensor(team, pos, 4, amount, 60);
-	}
-	else {
-		GiveUnits(objectName, pos, amount, team, featureAllyTeam);
-	}
-}
 
-int CUnitLoader::GiveSensor(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_)
-{
-	CSensor* sensor = sensorHandler.NewSensor(team_, pos_, LOSType_, LOSDistance_, duration_);
-
-	if (sensor == nullptr)
-		return 0;
-
-	sensorHandler.AddSensor(sensor);
-
-	return 1;
+	GiveUnits(objectName, pos, amount, team, featureAllyTeam);
 }
 
 

--- a/rts/Sim/Units/UnitLoader.h
+++ b/rts/Sim/Units/UnitLoader.h
@@ -43,6 +43,7 @@ public:
 
 	void ParseAndExecuteGiveUnitsCommand(const std::vector<std::string>& args, int team);
 	void GiveUnits(const std::string& objectName, float3 pos, int amount, int team, int allyTeamFeatures);
+	int GiveSensor(int team_, float3 pos_, int LOSType_, float LOSDistance_, int duration_);
 
 	void FlattenGround(const CUnit* unit);
 	void RestoreGround(const CUnit* unit);

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -25,6 +25,7 @@ class CUnit;
 class CWeapon;
 class CFeature;
 class CProjectile;
+class CSensor;
 struct Command;
 class IArchive;
 struct SRectangle;
@@ -193,6 +194,10 @@ class CEventClient
 
 		virtual void RenderProjectileCreated(const CProjectile* proj) {}
 		virtual void RenderProjectileDestroyed(const CProjectile* proj) {}
+
+		virtual void SensorCreated(const CSensor* sensor) {}
+		virtual void SensorExpired(const CSensor* sensor) {}
+		virtual void SensorTaken(const CSensor* sensor, int oldTeam, int newTeam) {}
 
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -10,6 +10,7 @@
 #include "Sim/Units/Unit.h"
 #include "Sim/Features/Feature.h"
 #include "Sim/Projectiles/Projectile.h"
+#include "Sim/Misc/Sensor.h"
 
 class CWeapon;
 struct Command;
@@ -132,6 +133,10 @@ class CEventHandler
 
 		void ProjectileCreated(const CProjectile* proj, int allyTeam);
 		void ProjectileDestroyed(const CProjectile* proj, int allyTeam);
+
+		void SensorCreated(const CSensor* sensor);
+		void SensorExpired(const CSensor* sensor);
+		void SensorTaken(const CSensor* sensor, int oldTeam, int newTeam);
 
 		bool Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner);
 
@@ -764,6 +769,21 @@ inline void CEventHandler::RenderProjectileCreated(const CProjectile* proj)
 inline void CEventHandler::RenderProjectileDestroyed(const CProjectile* proj)
 {
 	ITERATE_EVENTCLIENTLIST(RenderProjectileDestroyed, proj)
+}
+
+inline void CEventHandler::SensorCreated(const CSensor* sensor)
+{
+	ITERATE_EVENTCLIENTLIST(SensorCreated, sensor)
+}
+
+inline void CEventHandler::SensorExpired(const CSensor* sensor)
+{
+	ITERATE_EVENTCLIENTLIST(SensorExpired, sensor)
+}
+
+inline void CEventHandler::SensorTaken(const CSensor* sensor, int oldTeam, int newTeam)
+{
+	ITERATE_EVENTCLIENTLIST(SensorTaken, sensor, oldTeam, newTeam)
 }
 
 

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -88,6 +88,11 @@
 
 	SETUP_EVENT(StockpileChanged, MANAGED_BIT)
 
+	SETUP_EVENT(SensorCreated, MANAGED_BIT)
+	SETUP_EVENT(SensorExpired, MANAGED_BIT)
+	SETUP_EVENT(SensorTaken,   MANAGED_BIT)
+
+
 	// unsynced call-ins
 	SETUP_EVENT(Save,           MANAGED_BIT | UNSYNCED_BIT)
 


### PR DESCRIPTION
Draft, ugly implementation of #1000... A lot should change.

Pretty garbage code, but it works. In BAR, try "/give 1000 sensor" after turning cheats on and a Sensor should spawn at your mouse with vision range =1000 and despawn after about 2 seconds. (That's a quick hack of the "/give" command that should be reverted eventually, I just wanted an easy way to test without writing a widget).

I'm posting this as a draft just so you all see. There is tons of redundant code from Unit, UnitHandler, etc. all applied to Sensor. It needs serious thought about refactoring and how it should actually be implemented. Definitely consider merging Handlers, centralizing ID assignment so there is not overlap between different types of IDs, and potentially using the WorldObject class for a lot of the commands with redundant "Set<X>Position()" (related to #717).

That being said, this is just a proof of concept that works fine.

Also, I had issues with getting creg to work for Sensors, I might need help there.