### PR TITLE
Split radar error params Lua API

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -348,7 +348,8 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetNoPause);
 	REGISTER_LUA_CFUNC(SetExperienceGrade);
 
-	REGISTER_LUA_CFUNC(SetRadarErrorParams);
+	REGISTER_LUA_CFUNC(SetAllyTeamRadarErrorParams);
+	REGISTER_LUA_CFUNC(SetBaseRadarErrorParams);
 
 	if (!LuaSyncedMoveCtrl::PushMoveCtrl(L))
 		return false;
@@ -6920,23 +6921,32 @@ int LuaSyncedCtrl::SetExperienceGrade(lua_State* L)
 
 /***
  *
- * @function Spring.SetRadarErrorParams
+ * @function Spring.SetAllyTeamRadarErrorParams
  * @number allyTeamID
  * @number allyteamErrorSize
- * @number[opt] baseErrorSize
- * @number[opt] baseErrorMult
  * @treturn nil
  */
-int LuaSyncedCtrl::SetRadarErrorParams(lua_State* L)
+int LuaSyncedCtrl::SetAllyTeamRadarErrorParams(lua_State* L)
 {
 	const int allyTeamID = lua_tonumber(L, 1);
-
 	if (!teamHandler.IsValidAllyTeam(allyTeamID))
 		return 0;
 
 	losHandler->SetAllyTeamRadarErrorSize(allyTeamID, luaL_checknumber(L, 2));
-	losHandler->SetBaseRadarErrorSize(luaL_optnumber(L, 3, losHandler->GetBaseRadarErrorSize()));
-	losHandler->SetBaseRadarErrorMult(luaL_optnumber(L, 4, losHandler->GetBaseRadarErrorMult()));
+	return 0;
+}
+
+/***
+ *
+ * @function Spring.SetBaseRadarErrorParams
+ * @number[opt] baseErrorSize
+ * @number[opt] baseErrorMult
+ * @treturn nil
+ */
+int LuaSyncedCtrl::SetBaseRadarErrorParams(lua_State* L)
+{
+	losHandler->SetBaseRadarErrorSize(luaL_optnumber(L, 1, losHandler->GetBaseRadarErrorSize()));
+	losHandler->SetBaseRadarErrorMult(luaL_optnumber(L, 2, losHandler->GetBaseRadarErrorMult()));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -242,7 +242,8 @@ class LuaSyncedCtrl
 		static int SetNoPause(lua_State* L);
 		static int SetExperienceGrade(lua_State* L);
 
-		static int SetRadarErrorParams(lua_State* L);
+		static int SetBaseRadarErrorParams(lua_State* L);
+		static int SetAllyTeamRadarErrorParams(lua_State* L);
 };
 
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -377,7 +377,9 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetFeaturePiecePosDir);
 	REGISTER_LUA_CFUNC(GetFeaturePieceMatrix);
 
-	REGISTER_LUA_CFUNC(GetRadarErrorParams);
+	REGISTER_LUA_CFUNC(GetRadarErrorParams); // deprecated
+	REGISTER_LUA_CFUNC(GetAllyTeamRadarErrorParams);
+	REGISTER_LUA_CFUNC(GetBaseRadarErrorParams);
 
 	if (!LuaMetalMap::PushReadEntries(L))
 		return false;
@@ -8439,15 +8441,13 @@ int LuaSyncedRead::GetUnitScriptNames(lua_State* L)
 
 /***
  *
- * @function Spring.GetRadarErrorParams
+ * @function Spring.GetAllyTeamRadarErrorParams
  *
  * @number allyTeamID
  *
- * @treturn nil|number radarErrorSize actual radar error size (when allyTeamID is allied to current team) or base radar error size
- * @treturn number baseRadarErrorSize
- * @treturn number baseRadarErrorMult
+ * @treturn number radarErrorSize actual radar error size (when allyTeamID is allied to current team) or base radar error size
  */
-int LuaSyncedRead::GetRadarErrorParams(lua_State* L)
+int LuaSyncedRead::GetAllyTeamRadarErrorParams(lua_State* L)
 {
 	const int allyTeamID = lua_tonumber(L, 1);
 
@@ -8459,9 +8459,29 @@ int LuaSyncedRead::GetRadarErrorParams(lua_State* L)
 	} else {
 		lua_pushnumber(L, losHandler->GetBaseRadarErrorSize());
 	}
+	return 1;
+}
+
+
+// no docs, deprecated and same as GetAllyTeamRadarErrorParams
+int LuaSyncedRead::GetRadarErrorParams(lua_State* L)
+{
+	return GetAllyTeamRadarErrorParams(L);
+}
+
+
+/***
+ *
+ * @function Spring.GetBaseRadarErrorParams
+ *
+ * @treturn number baseRadarErrorSize
+ * @treturn number baseRadarErrorMult
+ */
+int LuaSyncedRead::GetBaseRadarErrorParams(lua_State* L)
+{
 	lua_pushnumber(L, losHandler->GetBaseRadarErrorSize());
 	lua_pushnumber(L, losHandler->GetBaseRadarErrorMult());
-	return 3;
+	return 2;
 }
 
 

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -286,7 +286,9 @@ class LuaSyncedRead {
 		static int GetFeaturePiecePosDir(lua_State* L);
 		static int GetFeaturePieceMatrix(lua_State* L);
 
-		static int GetRadarErrorParams(lua_State* L);
+		static int GetRadarErrorParams(lua_State* L); // deprecated, same as GetAllyTeamRadarErrorParams
+		static int GetAllyTeamRadarErrorParams(lua_State* L);
+		static int GetBaseRadarErrorParams(lua_State* L);
 
 		static int TraceRay(lua_State* L);           //TODO: not implemented
 		static int TraceRayUnits(lua_State* L);      //TODO: not implemented


### PR DESCRIPTION
Separate functions per-allyteam and base. No known game used the setter; getter was exclusively used for the allyteam so kept as an alias for that.