### PR TITLE
fixed the weapon types that misuse `size` vs `collisionSize`

### DIFF
--- a/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
@@ -57,7 +57,7 @@ void CFireBallProjectile::Draw()
 	unsigned char col[4] = {255, 150, 100, 1};
 
 	const float3 interPos = mix(pos, drawPos, checkCol);
-	const float size = radius * 1.3f;
+	const float size = drawRadius;
 
 	const unsigned int numFire = std::min(10u, numSparks);
 	const unsigned int maxCol = mix(numFire, 10u, checkCol);

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -62,7 +62,7 @@ void CFlameProjectile::Update()
 	}
 
 	UpdateInterception();
-	drawRadius = radius + weaponDef->sizeGrowth;
+	drawRadius += weaponDef->sizeGrowth;
 
 	curTime = std::min(curTime + invttl, 1.0f);
 	checkCol &= (curTime <= physLife);

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -62,8 +62,7 @@ void CFlameProjectile::Update()
 	}
 
 	UpdateInterception();
-
-	drawRadius = radius;
+	drawRadius = radius + weaponDef->sizeGrowth;
 
 	curTime = std::min(curTime + invttl, 1.0f);
 	checkCol &= (curTime <= physLife);

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -34,7 +34,7 @@ CFlameProjectile::CFlameProjectile(const ProjectileParams& params): CWeaponProje
 
 	if (weaponDef != nullptr) {
 		SetRadiusAndHeight(weaponDef->collisionSize, 0.0f);
-
+		
 		drawRadius = weaponDef->size;
 		physLife = 1.0f / weaponDef->duration;
 	}

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -63,7 +63,6 @@ void CFlameProjectile::Update()
 
 	UpdateInterception();
 
-	sqRadius = radius * radius;
 	drawRadius = radius;
 
 	curTime = std::min(curTime + invttl, 1.0f);

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -33,7 +33,7 @@ CFlameProjectile::CFlameProjectile(const ProjectileParams& params): CWeaponProje
 	projectileType = WEAPON_FLAME_PROJECTILE;
 
 	if (weaponDef != nullptr) {
-		SetRadiusAndHeight(weaponDef->size * weaponDef->collisionSize, 0.0f);
+		SetRadiusAndHeight(weaponDef->collisionSize, 0.0f);
 
 		drawRadius = weaponDef->size;
 		physLife = 1.0f / weaponDef->duration;
@@ -63,9 +63,8 @@ void CFlameProjectile::Update()
 
 	UpdateInterception();
 
-	radius = radius + weaponDef->sizeGrowth;
 	sqRadius = radius * radius;
-	drawRadius = radius * weaponDef->collisionSize;
+	drawRadius = radius;
 
 	curTime = std::min(curTime + invttl, 1.0f);
 	checkCol &= (curTime <= physLife);


### PR DESCRIPTION
I am not 100% sure about the last part of my fix, can someone check that to make sure that its correct