### PR TITLE
Draft: use conan for dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ endif (RECOIL_DETAILED_TRACY_ZONING)
 
 # Note the missing REQUIRED, as headless & dedi may not depend on those.
 #  So req. checks are done in the build target's CMakeLists.txt.
-find_package(SDL2)
+find_package(SDL2 MODULE)
 
 find_package_static(DevIL 1.8.0 REQUIRED)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -41,8 +41,12 @@ class RecoilConan(ConanFile):
         self.requires("ogg/1.3.5")
         self.requires("vorbis/1.3.7")
         self.requires("sdl/2.0.20")
+        self.requires("libcurl/7.88.1")
+        self.requires("openal-soft/1.23.1")
 
     def configure(self):
+        self.options["glew"].with_glu = "system"
+        self.options["openal-soft"].shared = True
         if self.settings.os == "Linux":
             self.options["sdl"].wayland = False # Disable wayland build for now
             self.options["sdl"].pulse = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,85 @@
+from conan import ConanFile, __version__ as conan_version
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.files import load
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.0.0"
+
+class RecoilConan(ConanFile):
+    name = "recoil"
+    license = "GPL-2.0-or-later"
+    homepage = "https://github.com/beyond-all-reason/spring"
+    description = "Recoil is an open source real time strategy game engine."
+    topics = ("game-engine", "open-source")
+    package_type = "application"
+    version="105.0"
+
+    exports_sources = "CMakeLists.txt", "src/*", "cmake/*", "cpack/*", "docs/*", "examples/*", "share/*", "tests/*",\
+                      "VERSION", "README.md"
+    no_copy_source = True
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+    }
+    default_options = {
+    }
+
+    @property
+    def _testing_enabled(self):
+        return not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
+
+    def requirements(self):
+        self.requires("opengl/system")
+        self.requires("glew/2.2.0")
+        self.requires("zlib/1.2.13")
+        self.requires("devil/1.8.0")
+        self.requires("libunwind/1.8.1", force=True)
+        self.requires("zstd/1.5.6", override=True)
+        #self.requires("libpng/1.6.37")
+        #self.requires("giflib/5.2.1")
+        self.requires("ogg/1.3.5")
+        self.requires("vorbis/1.3.7")
+        self.requires("sdl/2.0.20")
+
+    def configure(self):
+        if self.settings.os == "Linux":
+            self.options["sdl"].wayland = False # Disable wayland build for now
+            self.options["sdl"].pulse = False
+            self.options["sdl"].alsa = False
+
+    def build_requirements(self):
+        pass
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.user_presets_path = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def validate(self):
+        check_min_cppstd(self, "20")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+        if self._testing_enabled:
+            cmake.test()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def layout(self):
+        cmake_layout(self)
+        build_folder = self.conf.get("user.cmake.cmake_layout:build_folder",
+                                     default=f"cmake-build-{str(self.settings.build_type).lower()}")
+
+        self.folders.build = build_folder
+        self.folders.generators = f"{build_folder}/conan"
+        self.folders.source = "."
+        self.cpp.source.includedirs = "src"

--- a/docker-build-v2/amd64-linux/Dockerfile
+++ b/docker-build-v2/amd64-linux/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update \
  && add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
  && apt-get update \
  && apt-get install --no-install-recommends --yes \
-    curl gcc-13 g++-13 git ninja-build curl p7zip-full python3.8 python3.8-distutils \
+    curl gcc-13 g++-13 git ninja-build p7zip-full python3.8 python3.8-distutils \
     xz-utils build-essential \
     libgl-dev \
+    libglu-dev \
     xorg-dev \
     libxcb1-dev \
     libxcb-util-dev \
@@ -53,7 +54,7 @@ RUN git clone --depth 1 --branch v1.5.6 https://github.com/facebook/zstd.git \
 RUN pip3 install --upgrade pip \
  && pip3 install scikit-build \
  && pip3 install cmake==3.27.* \
- && pip3 install conan==2.9.1
+ && pip3 install conan==2.10.2
 
 WORKDIR /build
 RUN mkdir src cache out artifacts && chmod a+rwx cache out artifacts

--- a/docker-build-v2/amd64-linux/Dockerfile
+++ b/docker-build-v2/amd64-linux/Dockerfile
@@ -9,12 +9,31 @@ RUN apt-get update \
  && add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
  && apt-get update \
  && apt-get install --no-install-recommends --yes \
-    curl gcc-13 g++-13 git ninja-build curl p7zip-full python3-pip python3-setuptools \
-    libsdl2-dev libopenal-dev libfreetype6-dev libfontconfig1-dev \
+    curl gcc-13 g++-13 git ninja-build curl p7zip-full python3.8 python3.8-distutils \
+    xz-utils build-essential \
+    libgl-dev \
+    xorg-dev \
+    libxcb1-dev \
+    libxcb-util-dev \
+    libxcb-render-util0-dev \
+    libxcb-xkb-dev \
+    libxcb-icccm4-dev \
+    libxcb-image0-dev \
+    libxcb-keysyms1-dev \
+    libxcb-xinerama0-dev \
+    libxcb-cursor-dev \
+    libxcb-composite0-dev \
+    libxcb-ewmh-dev \
+    libxcb-res0-dev \
+    uuid-dev \
  && apt-get remove --purge --yes software-properties-common \
  && apt-get autoremove --purge --yes \
  && apt-get upgrade --yes \
  && rm -rf /var/lib/apt/lists/*
+
+# pip for python3.8
+RUN curl -L -O https://bootstrap.pypa.io/get-pip.py && python3.8 get-pip.py && rm get-pip.py
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10
 
 # We need a newer ccache for compression support
 ARG CCACHE_VERSION="4.10.2"
@@ -33,16 +52,17 @@ RUN git clone --depth 1 --branch v1.5.6 https://github.com/facebook/zstd.git \
 
 RUN pip3 install --upgrade pip \
  && pip3 install scikit-build \
- && pip3 install cmake==3.27.*
+ && pip3 install cmake==3.27.* \
+ && pip3 install conan==2.9.1
 
 WORKDIR /build
 RUN mkdir src cache out artifacts && chmod a+rwx cache out artifacts
 
 # Fetch library dependencies and configure resolution
-RUN git clone --depth=1 https://github.com/beyond-all-reason/spring-static-libs.git -b 18.04 spring-static-libs
-ENV PKG_CONFIG_LIBDIR=/build/spring-static-libs/lib/pkgconfig
-ENV PKG_CONFIG="pkg-config --define-prefix --static"
-ENV CMAKE_PREFIX_PATH=/build/spring-static-libs/
+#RUN git clone --depth=1 https://github.com/beyond-all-reason/spring-static-libs.git -b 18.04 spring-static-libs
+#ENV PKG_CONFIG_LIBDIR=/build/spring-static-libs/lib/pkgconfig
+#ENV PKG_CONFIG="pkg-config --define-prefix --static"
+#ENV CMAKE_PREFIX_PATH=/build/spring-static-libs/
 ENV PREFER_STATIC_LIBS=TRUE
 
 # Set up default cmake toolchain
@@ -54,3 +74,4 @@ COPY ccache.conf .
 ENV CCACHE_CONFIGPATH=/build/ccache.conf
 ENV CMAKE_CXX_COMPILER_LAUNCHER=ccache
 ENV CMAKE_C_COMPILER_LAUNCHER=ccache
+ENV CONAN_HOME=/build/.conan2

--- a/docker-build-v2/amd64-linux/conan_build_profile
+++ b/docker-build-v2/amd64-linux/conan_build_profile
@@ -1,0 +1,12 @@
+[settings]
+arch=x86_64
+build_type=RelWithDebInfo
+compiler=gcc
+compiler.cppstd=gnu20
+compiler.libcxx=libstdc++11
+compiler.version=13
+os=Linux
+
+[conf]
+tools.build:compiler_executables={'c': '/usr/bin/gcc-13', 'cpp': '/usr/bin/g++13' }
+user.cmake.cmake_layout:build_folder=/build/out

--- a/docker-build-v2/amd64-linux/conan_build_profile
+++ b/docker-build-v2/amd64-linux/conan_build_profile
@@ -8,5 +8,7 @@ compiler.version=13
 os=Linux
 
 [conf]
-tools.build:compiler_executables={'c': '/usr/bin/gcc-13', 'cpp': '/usr/bin/g++13' }
+tools.build:compiler_executables={'c': '/usr/bin/gcc-13', 'cpp': '/usr/bin/g++-13' }
+tools.cmake.cmaketoolchain:user_toolchain+=/build/toolchain.cmake
 user.cmake.cmake_layout:build_folder=/build/out
+tools.build.cross_building:cross_build=True

--- a/docker-build-v2/conan_profile
+++ b/docker-build-v2/conan_profile
@@ -9,4 +9,6 @@ os=Linux
 
 [conf]
 tools.build:compiler_executables={'c': '/usr/bin/gcc-13', 'cpp': '/usr/bin/g++-13' }
+tools.cmake.cmaketoolchain:user_toolchain+=/build/toolchain.cmake
 user.cmake.cmake_layout:build_folder=/build/out
+tools.build.cross_building:cross_build=True

--- a/docker-build-v2/conan_profile
+++ b/docker-build-v2/conan_profile
@@ -1,0 +1,12 @@
+[settings]
+arch=x86_64
+build_type=RelWithDebInfo
+compiler=gcc
+compiler.cppstd=gnu20
+compiler.libcxx=libstdc++11
+compiler.version=13
+os=Linux
+
+[conf]
+tools.build:compiler_executables={'c': '/usr/bin/gcc-13', 'cpp': '/usr/bin/g++-13' }
+user.cmake.cmake_layout:build_folder=/build/out

--- a/docker-build-v2/scripts/configure.sh
+++ b/docker-build-v2/scripts/configure.sh
@@ -7,5 +7,6 @@ cmake --fresh -S /build/src -B /build/out \
     -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG" \
     -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG" \
+    -DCMAKE_TOOLCHAIN_FILE="conan/conan_toolchain.cmake"
     -G Ninja \
     "$@"

--- a/docker-build-v2/scripts/configure.sh
+++ b/docker-build-v2/scripts/configure.sh
@@ -4,9 +4,10 @@ cmake --fresh -S /build/src -B /build/out \
     -DCMAKE_INSTALL_PREFIX:PATH=/build/out/install \
     -DAI_EXCLUDE_REGEX="^CppTestAI$" \
     -DUSERDOCS_PLAIN=ON \
+    -DPR_DOWNLOADER_FIND_CURL_NO_PKGCONFIG=ON \
     -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG" \
     -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O3 -g -DNDEBUG" \
-    -DCMAKE_TOOLCHAIN_FILE="conan/conan_toolchain.cmake"
+    -DCMAKE_TOOLCHAIN_FILE="conan/conan_toolchain.cmake" \
     -G Ninja \
     "$@"

--- a/docker-build-v2/scripts/deps.sh
+++ b/docker-build-v2/scripts/deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export CMAKE_TOOLCHAIN_FILE=
+
+conan install \
+  -u \
+  -r conancenter \
+  -pr:h conan_profile \
+  -pr:b conan_build_profile \
+  --build=missing \
+  /build/src

--- a/docker-build-v2/scripts/graph-deps.sh
+++ b/docker-build-v2/scripts/graph-deps.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+conan graph info \
+  -u \
+  -r conancenter \
+  -pr:h conan_profile \
+  -pr:b conan_build_profile \
+  --format=html \
+  /build/src > /build/out/graph.html

--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -86,7 +86,6 @@ endif (UNIX AND NOT MINGW)
 
 find_package_static(ZLIB 1.2.7 REQUIRED)
 list(APPEND engineCommonLibraries DevIL::IL)
-
 list(APPEND engineCommonLibraries 7zip prd::jsoncpp ${SPRING_MINIZIP_LIBRARY} ZLIB::ZLIB Tracy::TracyClient)
 list(APPEND engineCommonLibraries lua luasocket archives assimp
 	gflags_nothreads_static)

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -156,6 +156,9 @@ add_library(engineSim STATIC
 
 target_link_libraries(engineSim SDL2::SDL2 Tracy::TracyClient)
 
+find_package_static(GLEW 2.2.0 REQUIRED)
+target_link_libraries(engineSim $<COMPILE_ONLY:GLEW::GLEW>)
+
 if( CMAKE_COMPILER_IS_GNUCXX)
 	# FIXME: hack to avoid linkers to remove not referenced symbols. required because of
 	# https://springrts.com/mantis/view.php?id=4511

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -154,9 +154,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Weapons/WeaponTarget.cpp"
 	)
 
-target_include_directories(engineSim
-	PRIVATE ${SDL2_INCLUDE_DIR})
-target_link_libraries(engineSim Tracy::TracyClient)
+target_link_libraries(engineSim SDL2::SDL2 Tracy::TracyClient)
 
 if( CMAKE_COMPILER_IS_GNUCXX)
 	# FIXME: hack to avoid linkers to remove not referenced symbols. required because of

--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -46,7 +46,8 @@ if    (NOT NO_SOUND)
 
 	find_package_static(OpenAL 1.18.2 REQUIRED)
 	find_package_static(OggVorbis 1.3.4 REQUIRED)
-
+	
+	find_package_static(GLEW 2.2.0 REQUIRED)
 	find_package(SDL2 MODULE REQUIRED)
 
 	include_directories(${CMAKE_SOURCE_DIR}/include/)
@@ -57,4 +58,5 @@ if    (NOT NO_SOUND)
 	target_link_libraries(sound vorbis::vorbisfile vorbis::vorbis Ogg::ogg)
 	target_link_libraries(sound OpenAL::OpenAL)
 	target_link_libraries(sound Tracy::TracyClient)
+	target_link_libraries(sound $<COMPILE_ONLY:GLEW::GLEW>)
 endif (NOT NO_SOUND)

--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -48,13 +48,13 @@ if    (NOT NO_SOUND)
 	include_directories(${OPENAL_INCLUDE_DIR})
 	find_package_static(OggVorbis 1.3.4 REQUIRED)
 
-	find_package(SDL2 REQUIRED)
-	include_directories(${SDL2_INCLUDE_DIR})
+	find_package(SDL2 MODULE REQUIRED)
 
 	include_directories(${CMAKE_SOURCE_DIR}/include/)
 	include_directories(${CMAKE_SOURCE_DIR}/include/AL)
 
 	add_library(sound STATIC EXCLUDE_FROM_ALL ${soundSources})
+	target_link_libraries(sound SDL2::SDL2)
 	target_link_libraries(sound vorbis::vorbisfile vorbis::vorbis Ogg::ogg)
 	target_link_libraries(sound ${OPENAL_LIBRARY})
 	target_link_libraries(sound Tracy::TracyClient)

--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -44,8 +44,7 @@ if    (NOT NO_SOUND)
 			OpenAL/VorbisShared.cpp
 		)
 
-	find_package_static(OpenAL REQUIRED)
-	include_directories(${OPENAL_INCLUDE_DIR})
+	find_package_static(OpenAL 1.18.2 REQUIRED)
 	find_package_static(OggVorbis 1.3.4 REQUIRED)
 
 	find_package(SDL2 MODULE REQUIRED)
@@ -56,6 +55,6 @@ if    (NOT NO_SOUND)
 	add_library(sound STATIC EXCLUDE_FROM_ALL ${soundSources})
 	target_link_libraries(sound SDL2::SDL2)
 	target_link_libraries(sound vorbis::vorbisfile vorbis::vorbis Ogg::ogg)
-	target_link_libraries(sound ${OPENAL_LIBRARY})
+	target_link_libraries(sound OpenAL::OpenAL)
 	target_link_libraries(sound Tracy::TracyClient)
 endif (NOT NO_SOUND)

--- a/rts/build/cmake/FindSDL2.cmake
+++ b/rts/build/cmake/FindSDL2.cmake
@@ -1,196 +1,24 @@
-# Locate SDL2 library
-# This module defines
-# SDL2_LIBRARY, the name of the library to link against
-# SDL2_FOUND, if false, do not try to link to SDL2
-# SDL2_INCLUDE_DIR, where to find SDL.h
-# SDL2_VERSION_STRING the version found
-#
-# This module responds to the the flag:
-# SDL2_BUILDING_LIBRARY
-# If this is defined, then no SDL2_main will be linked in because
-# only applications need main().
-# Otherwise, it is assumed you are building an application and this
-# module will attempt to locate and set the the proper link flags
-# as part of the returned SDL2_LIBRARY variable.
-#
-# Don't forget to include SDL2main.h and SDL2main.m your project for the
-# OS X framework based version. (Other versions link to -lSDL2main which
-# this module will try to find on your behalf.) Also for OS X, this
-# module will automatically add the -framework Cocoa on your behalf.
-#
-#
-# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
-# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
-# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
-# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
-# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
-# as appropriate. These values are used to generate the final SDL2_LIBRARY
-# variable, but when these values are unset, SDL2_LIBRARY does not get created.
-#
-#
-# $SDL2DIR is an environment variable that would
-# correspond to the ./configure --prefix=$SDL2DIR
-# used in building SDL2.
-# l.e.galup  9-20-02
-#
-# Modified by Eric Wing.
-# Added code to assist with automated building by using environmental variables
-# and providing a more controlled/consistent search behavior.
-# Added new modifications to recognize OS X frameworks and
-# additional Unix paths (FreeBSD, etc).
-# Also corrected the header search path to follow "proper" SDL2 guidelines.
-# Added a search for SDL2main which is needed by some platforms.
-# Added a search for threads which is needed by some platforms.
-# Added needed compile switches for MinGW.
-#
-# On OSX, this will prefer the Framework version (if found) over others.
-# People will have to manually change the cache values of
-# SDL2_LIBRARY to override this selection or set the CMake environment
-# CMAKE_INCLUDE_PATH to modify the search paths.
-#
-# Note that the header path has changed from SDL2/SDL.h to just SDL.h
-# This needed to change because "proper" SDL2 convention
-# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
-# reasons because not all systems place things in SDL2/ (see FreeBSD).
-#
-# Ported by Johnny Patterson. This is a literal port for SDL2 of the FindSDL.cmake
-# module with the minor edit of changing "SDL" to "SDL2" where necessary. This
-# was not created for redistribution, and exists temporarily pending official
-# SDL2 CMake modules.
+# The version of SDL we have is too old
+# and doesn't provide a proper config file.
+# We need to create imported targets for the config
 
+find_package(SDL2 QUIET CONFIG)
 
-#=============================================================================
-# Copyright 2003-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
-
-
-FIND_PATH(SDL2_INCLUDE_DIR SDL.h
-  HINTS
-  $ENV{SDL2DIR}
-  PATH_SUFFIXES include/SDL2 include
-  PATHS
-  ~/Library/Frameworks
-  /Library/Frameworks
-  /usr/local/include/SDL2
-  /usr/include/SDL2
-  /sw # Fink
-  /opt/local # DarwinPorts
-  /opt/csw # Blastwave
-  /opt
+find_library(SDL2_LIBRARY
+             NAMES
+              SDL2
+             PATHS
+              ${SDL2_LIBDIR}
 )
 
-if(SDL2_INCLUDE_DIR AND EXISTS "${SDL2_INCLUDE_DIR}/SDL_version.h")
-  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+[0-9]+$")
-  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MINOR_VERSION[ \t]+[0-9]+$")
-  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_PATCHLEVEL[ \t]+[0-9]+$")
-  string(REGEX REPLACE "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MAJOR "${SDL2_VERSION_MAJOR_LINE}")
-  string(REGEX REPLACE "^#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL_VERSION_MINOR "${SDL2_VERSION_MINOR_LINE}")
-  string(REGEX REPLACE "^#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL_VERSION_PATCH "${SDL2_VERSION_PATCH_LINE}")
-  set(SDL2_VERSION_STRING ${SDL_VERSION_MAJOR}.${SDL_VERSION_MINOR}.${SDL_VERSION_PATCH})
-  unset(SDL2_VERSION_MAJOR_LINE)
-  unset(SDL2_VERSION_MINOR_LINE)
-  unset(SDL2_VERSION_PATCH_LINE)
-  unset(SDL2_VERSION_MAJOR)
-  unset(SDL2_VERSION_MINOR)
-  unset(SDL2_VERSION_PATCH)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2 DEFAULT_MSG SDL2_INCLUDE_DIRS SDL2_LIBRARIES SDL2_LIBRARY)
+mark_as_advanced(SDL2_LIBRARIES SDL2_LIBRARY)
+
+if (SDL2_FOUND AND NOT TARGET SDL2::SDL2)
+  add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+  set_target_properties(SDL2::SDL2 PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+                        IMPORTED_LOCATION ${SDL2_LIBRARY}
+  )
 endif()
-
-
-
-FIND_LIBRARY(SDL2_LIBRARY_TEMP
-  NAMES SDL2
-  HINTS
-  $ENV{SDL2DIR}
-  PATH_SUFFIXES lib64 lib
-  PATHS
-  /sw
-  /opt/local
-  /opt/csw
-  /opt
-)
-
-IF(NOT SDL2_BUILDING_LIBRARY)
-  IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-    # Non-OS X framework versions expect you to also dynamically link to
-    # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
-    # seem to provide SDL2main for compatibility even though they don't
-    # necessarily need it.
-    FIND_LIBRARY(SDL2MAIN_LIBRARY
-      NAMES SDL2main
-      HINTS
-      $ENV{SDL2DIR}
-      PATH_SUFFIXES lib64 lib
-      PATHS
-      /sw
-      /opt/local
-      /opt/csw
-      /opt
-    )
-  ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
-ENDIF(NOT SDL2_BUILDING_LIBRARY)
-
-
-# SDL2 may require threads on your system.
-# The Apple build may not need an explicit flag because one of the
-# frameworks may already provide it.
-# But for non-OSX systems, I will use the CMake Threads package.
-IF(NOT APPLE)
-  FIND_PACKAGE(Threads)
-ENDIF(NOT APPLE)
-
-SET(SDL2_FOUND "NO")
-IF(SDL2_LIBRARY_TEMP)
-  SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
-  SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} CACHE INTERNAL "")
-
-  # For SDL2main
-  IF(NOT SDL2_BUILDING_LIBRARY)
-    IF(SDL2MAIN_LIBRARY)
-      SET(SDL2_LIBRARY ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY})
-    ENDIF(SDL2MAIN_LIBRARY)
-  ENDIF(NOT SDL2_BUILDING_LIBRARY)
-
-
-  # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
-  # CMake doesn't display the -framework Cocoa string in the UI even
-  # though it actually is there if I modify a pre-used variable.
-  # I think it has something to do with the CACHE STRING.
-  # So I use a temporary variable until the end so I can set the
-  # "real" variable in one-shot.
-  IF(APPLE)
-    SET(SDL2_LIBRARY ${SDL2_LIBRARY} "-framework Cocoa")
-  ENDIF(APPLE)
-
-
-  # For threads, as mentioned Apple doesn't need this.
-  # In fact, there seems to be a problem if I used the Threads package
-  # and try using this line, so I'm just skipping it entirely for OS X.
-  IF(NOT APPLE)
-    SET(SDL2_LIBRARY ${SDL2_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-  ENDIF(NOT APPLE)
-
-
-  # For MinGW library
-  IF(MINGW)
-    SET(SDL2_LIBRARY ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
-  ENDIF(MINGW)
-
-  SET(SDL2_FOUND "YES")
-ENDIF(SDL2_LIBRARY_TEMP)
-
-
-INCLUDE(FindPackageHandleStandardArgs)
-
-
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
-				  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR
-				  VERSION_VAR SDL2_VERSION_STRING)

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -54,12 +54,6 @@ if    (UNIX AND NOT MINGW)
 	endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 endif (UNIX AND NOT MINGW)
 
-find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR})
-if("${SDL2_VERSION_STRING}" VERSION_LESS "2")
-	message(FATAL_ERROR "Found SDL v${SDL2_VERSION_STRING} while 2 is required!")
-endif()
-
 ### Assemble the incude dirs
 include_directories(${ENGINE_SRC_ROOT_DIR}/)
 include_directories(${ENGINE_SRC_ROOT_DIR}/lib/lua/include)

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -15,8 +15,6 @@ set(OpenGL_GL_PREFERENCE LEGACY)
 include_directories(${OPENAL_INCLUDE_DIR})
 
 find_package(OpenGL 3.0 REQUIRED)
-find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR})
 
 # headlessstubs are our stubs that replace libGL, libGLU, libGLEW, libSDL (yes really!)
 list(APPEND engineHeadlessLibraries headlessStubs)

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -12,7 +12,6 @@ add_definitions(-DNO_SOUND)
 remove_definitions(-DAVI_CAPTURING)
 
 set(OpenGL_GL_PREFERENCE LEGACY)
-include_directories(${OPENAL_INCLUDE_DIR})
 
 find_package(OpenGL 3.0 REQUIRED)
 

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -55,7 +55,6 @@ list(APPEND engineLibraries RmlUi::Debugger)
 list(APPEND engineLibraries lunasvg)
 
 ### Assemble external incude dirs
-list(APPEND engineIncludes ${OPENAL_INCLUDE_DIR})
 list(APPEND engineIncludes ${ENGINE_SRC_ROOT_DIR}/lib/asio/include)
 list(APPEND engineIncludes ${ENGINE_SRC_ROOT_DIR}/lib/slimsig/include)
 list(APPEND engineIncludes ${ENGINE_SRC_ROOT_DIR}/lib/cereal/include)

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -9,12 +9,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
 
 ### Assemble libraries
-find_package(SDL2 REQUIRED)
-set(engineIncludes ${SDL2_INCLUDE_DIR})
-set(engineLibraries ${SDL2_LIBRARY})
-if("${SDL2_VERSION_STRING}" VERSION_LESS "2")
-	message(FATAL_ERROR "Found SDL v${SDL2_VERSION_STRING} while 2 is required!")
-endif()
+find_package(SDL2 MODULE REQUIRED)
+set(engineLibraries SDL2::SDL2)
 
 set(OpenGL_GL_PREFERENCE LEGACY)
 find_package_static(OpenGL 3.0 REQUIRED)

--- a/rts/lib/headlessStubs/CMakeLists.txt
+++ b/rts/lib/headlessStubs/CMakeLists.txt
@@ -7,5 +7,5 @@ SET(headlessStubsSources
 find_package(SDL2 MODULE REQUIRED)
 
 ADD_LIBRARY(headlessStubs STATIC EXCLUDE_FROM_ALL ${headlessStubsSources})
-target_link_libraries(headlessStubs PUBLIC SDL2::SDL2)
+target_link_libraries(headlessStubs PUBLIC $<COMPILE_ONLY:SDL2::SDL2>)
 SET_TARGET_PROPERTIES(headlessStubs PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")

--- a/rts/lib/headlessStubs/CMakeLists.txt
+++ b/rts/lib/headlessStubs/CMakeLists.txt
@@ -5,7 +5,8 @@ SET(headlessStubsSources
 	)
 
 find_package(SDL2 MODULE REQUIRED)
+find_package(OpenGL REQUIRED)
 
 ADD_LIBRARY(headlessStubs STATIC EXCLUDE_FROM_ALL ${headlessStubsSources})
-target_link_libraries(headlessStubs PUBLIC $<COMPILE_ONLY:SDL2::SDL2>)
+target_link_libraries(headlessStubs PUBLIC $<COMPILE_ONLY:SDL2::SDL2> $<COMPILE_ONLY:OpenGL::GL> $<COMPILE_ONLY:OpenGL::GLU>)
 SET_TARGET_PROPERTIES(headlessStubs PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")

--- a/rts/lib/headlessStubs/CMakeLists.txt
+++ b/rts/lib/headlessStubs/CMakeLists.txt
@@ -4,9 +4,8 @@ SET(headlessStubsSources
 		"sdlstub.c"
 	)
 
-FIND_PACKAGE(SDL2 REQUIRED)
-INCLUDE_DIRECTORIES(${SDL2_INCLUDE_DIR})
+find_package(SDL2 MODULE REQUIRED)
 
 ADD_LIBRARY(headlessStubs STATIC EXCLUDE_FROM_ALL ${headlessStubsSources})
+target_link_libraries(headlessStubs PUBLIC SDL2::SDL2)
 SET_TARGET_PROPERTIES(headlessStubs PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")
-

--- a/test/headercheck/CMakeLists.txt
+++ b/test/headercheck/CMakeLists.txt
@@ -7,7 +7,6 @@ include_directories(
 		${Spring_SOURCE_DIR}/include
 		${Spring_SOURCE_DIR}/rts/lib
 		${Spring_SOURCE_DIR}/rts/lib/lua/include
-		${SDL2_INCLUDE_DIR}
 		${OPENAL_INCLUDE_DIR}
 	)
 

--- a/test/headercheck/CMakeLists.txt
+++ b/test/headercheck/CMakeLists.txt
@@ -7,7 +7,6 @@ include_directories(
 		${Spring_SOURCE_DIR}/include
 		${Spring_SOURCE_DIR}/rts/lib
 		${Spring_SOURCE_DIR}/rts/lib/lua/include
-		${OPENAL_INCLUDE_DIR}
 	)
 
 file(GLOB_RECURSE headers

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -23,8 +23,8 @@ if (WIN32)
 	list(APPEND unitsync_libs ${WINMM_LIBRARY})
 endif (WIN32)
 
-find_package(SDL2 REQUIRED)
-include_directories(${SDL2_INCLUDE_DIR})
+find_package(SDL2 MODULE REQUIRED)
+list(APPEND unitsync_libs SDL2::SDL2)
 
 if    (MINGW)
 	#list(APPEND unitsync_lib_flags -static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread)


### PR DESCRIPTION
This is gonna be a draft because there are still some things that need to be worked out. But this should be a decent proof of concept.

Note this is based on top of https://github.com/beyond-all-reason/spring/pull/1746 so the file diff will be against that

I would love feedback and if y'all are on linux try this PR out (note you have to rebuild the docker image locally).

### Goal of this work

The goal of this work is to make the numerous dependencies of Recoil consistent across platforms. Right now Linux, Windows MinGW, and Windows MSVC all use different dependency versions. As part of this, the intent is to make it very easy to add new dependencies instead of having to wrangle them into the build system as submodules or add them to a completely different repo (e.g. spring-static-libs).

A secondary goal is to make it significantly easier for new developers to get started. The ideal workflow is:

1. Clone repo
2. Run `conan install .`
3. Run `cmake` and `cmake --build`

### Caveats

* Right now I've only tested this on the linux docker v2 build. It probably won't work in any other way
* You need to patch `pr-downloader` (see below)
* If you are trying out this PR you need to build the docker image locally
* Our compiler/flag configuration means that no binaries are available in the conan remote and so unless you have them cached the build process will build all dependencies from source. This should just be a one-time thing but we should look into hosting conan binary packages (gitlab and gitea support this for example. I don't think github does).
* This only replaces dependencies found in spring-static-libs. Once this PR is complete we won't need that repo anymore, or the two windows based ones :)
* Submodule dependencies are left untouched -- for now
* This requires a very recent version of conan, or needs a version of conan configured on using the new conan2 center remote. In the docker v2 build I install conan so you don't need to on your host machine if you are using the docker build
* I'm not 100% sure the build as is can generated releases properly, as I'm not familiar with the release process.
* I haven't generated a conan lockfile yet, but plan on doing so before the PR is merged.
* It goes without saying that CI right now will fail horribly.

### Patch required for pr-downloader

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
--- a/CMakeLists.txt	(revision bdac30330eccb5ec73da299922491f3f4ee8debe)
+++ b/CMakeLists.txt	(date 1734107372971)
@@ -31,7 +31,7 @@
 find_package(Threads REQUIRED)
 
 # CURL
-if(UNIX)
+if(UNIX AND NOT PR_DOWNLOADER_FIND_CURL_NO_PKGCONFIG)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(libcurl REQUIRED IMPORTED_TARGET libcurl>=7.84)
     add_library(prd::libcurl ALIAS PkgConfig::libcurl)
```

### More information

The docker image will generate (and mount as a volume) a new directory alongside `.cache` called `.conan2-{linux|windows}`. This is the Conan home directory and will persist so you don't have to rebuild binaries all the time. Deleting this folder will make conan to rebuild all dependencies the next time you run a build.

The conan "build folder" (i.e. that contains all the cmake scripts and so on) is in `build-{linux|windows}/conan`.

There is a new stage in the docker v2 build script called "deps". You can pass in the `--deps` flag to just install conan dependencies. This will re-use any binaries of dependencies that are cached.

I'll make a PR for the tool