### PR TITLE
Fix static ghost behaviours

### DIFF
--- a/cont/base/springcontent/LuaGadgets/Gadgets/mobile_ghost_transport.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/mobile_ghost_transport.lua
@@ -1,0 +1,32 @@
+function gadget:GetInfo()
+  return {
+    name      = "LeavesGhost Updater",
+    desc      = "Removes radar icon wobble for mobile units with leavesGhost",
+    layer     = 0,
+    enabled   = true
+  }
+end
+
+
+if (gadgetHandler:IsSyncedCode()) then
+  local isTransportable = {}
+  for unitDefID, unitDef in pairs(UnitDefs) do
+    if not unitDef.cantBeTransported and unitDef.isImmobile and unitDef.leavesGhost then
+      isTransportable[unitDefID] = true
+    end
+  end
+
+  function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+    if isTransportable[unitDefID] then
+      Spring.Echo("Pick up", unitID)
+      Spring.SetUnitLeavesGhost(unitID, false, true)
+    end
+  end
+  function gadget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
+    if isTransportable[unitDefID] then
+      Spring.Echo("Drop", unitID)
+      Spring.SetUnitLeavesGhost(unitID, true)
+    end
+  end
+end
+

--- a/cont/base/springcontent/LuaGadgets/Gadgets/mobile_ghost_transport.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/mobile_ghost_transport.lua
@@ -1,7 +1,7 @@
 function gadget:GetInfo()
   return {
     name      = "LeavesGhost Updater",
-    desc      = "Removes radar icon wobble for mobile units with leavesGhost",
+    desc      = "Removes radar icon wobble for mobile units with leavesGhost and makes them leave 'dead ghosts' behind",
     layer     = 0,
     enabled   = true
   }
@@ -19,12 +19,14 @@ if (gadgetHandler:IsSyncedCode()) then
   function gadget:UnitLoaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
     if isTransportable[unitDefID] then
       Spring.Echo("Pick up", unitID)
+      -- remove leavesGhost, and leave dead ghost behind (if no radar and had a live ghost)
       Spring.SetUnitLeavesGhost(unitID, false, true)
     end
   end
   function gadget:UnitUnloaded(unitID, unitDefID, unitTeam, transportID, transportTeam)
     if isTransportable[unitDefID] then
       Spring.Echo("Drop", unitID)
+      -- reinstate leavesGhost
       Spring.SetUnitLeavesGhost(unitID, true)
     end
   end

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2869,7 +2869,6 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
  * @function Spring.SetUnitLeavesGhost
  *
  * Set the radar ghost for the unit to have no drift.
- * Only for units where unitDef has leavesGhost enabled.
  *
  * @number unitID
  * @bool leavesGhost

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2873,6 +2873,7 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
  *
  * @number unitID
  * @bool staticRadarGhost
+ * @bool[opt] leaveDeadGhost leave a dead ghost behind if disabling and the unit had a live static ghost.
  * @treturn nil
  */
 int LuaSyncedCtrl::SetUnitStaticRadarGhost(lua_State* L)
@@ -2885,7 +2886,7 @@ int LuaSyncedCtrl::SetUnitStaticRadarGhost(lua_State* L)
 	bool prevValue = unit->staticRadarGhost;
 	unit->SetStaticRadarGhost(luaL_checkboolean(L, 2));
 	if (prevValue != unit->staticRadarGhost)
-		unitDrawer->SetUnitStaticRadarGhost(unit);
+		unitDrawer->SetUnitStaticRadarGhost(unit, luaL_optboolean(L, 3, false));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2868,7 +2868,9 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
 /***
  * @function Spring.SetUnitLeavesGhost
  *
- * Set the radar ghost for the unit to have no drift.
+ * Change the unit leavesGhost attribute.
+ *
+ * Controls unit having static radar ghosts.
  *
  * @number unitID
  * @bool leavesGhost

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2879,6 +2879,9 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
  */
 int LuaSyncedCtrl::SetUnitLeavesGhost(lua_State* L)
 {
+	if (!gameSetup->ghostedBuildings)
+		return 0;
+
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -181,6 +181,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitStealth);
 	REGISTER_LUA_CFUNC(SetUnitSonarStealth);
 	REGISTER_LUA_CFUNC(SetUnitSeismicSignature);
+	REGISTER_LUA_CFUNC(SetUnitStaticRadarGhost);
 	REGISTER_LUA_CFUNC(SetUnitAlwaysVisible);
 	REGISTER_LUA_CFUNC(SetUnitUseAirLos);
 	REGISTER_LUA_CFUNC(SetUnitMetalExtraction);
@@ -2860,6 +2861,27 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
 		return 0;
 
 	unit->seismicSignature = luaL_checkfloat(L, 2);
+	return 0;
+}
+
+/***
+ * @function Spring.SetUnitStaticRadarGhost
+ *
+ * Set the radar ghost for the unit to have no drift.
+ * Only for units where unitDef has leavesRadarGhost enabled.
+ *
+ * @number unitID
+ * @bool staticRadarGhost
+ * @treturn nil
+ */
+int LuaSyncedCtrl::SetUnitStaticRadarGhost(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	unit->SetStaticRadarGhost(luaL_checkboolean(L, 2));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2887,10 +2887,7 @@ int LuaSyncedCtrl::SetUnitLeavesGhost(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	bool prevValue = unit->leavesGhost;
-	unit->SetLeavesGhost(luaL_checkboolean(L, 2));
-	if (prevValue != unit->leavesGhost)
-		unitDrawer->UnitLeavesGhostChanged(unit, luaL_optboolean(L, 3, false));
+	unit->SetLeavesGhost(luaL_checkboolean(L, 2), luaL_optboolean(L, 3, false));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -28,6 +28,7 @@
 #include "Rendering/Env/GrassDrawer.h"
 #include "Rendering/Env/IGroundDecalDrawer.h"
 #include "Rendering/Models/IModelParser.h"
+#include "Rendering/Units/UnitDrawer.h"
 #include "Sim/Features/Feature.h"
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureDefHandler.h"
@@ -2881,7 +2882,10 @@ int LuaSyncedCtrl::SetUnitStaticRadarGhost(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
+	bool prevValue = unit->staticRadarGhost;
 	unit->SetStaticRadarGhost(luaL_checkboolean(L, 2));
+	if (prevValue != unit->staticRadarGhost)
+		unitDrawer->SetUnitStaticRadarGhost(unit);
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2887,7 +2887,7 @@ int LuaSyncedCtrl::SetUnitLeavesGhost(lua_State* L)
 	bool prevValue = unit->leavesGhost;
 	unit->SetLeavesGhost(luaL_checkboolean(L, 2));
 	if (prevValue != unit->leavesGhost)
-		unitDrawer->SetUnitLeavesGhost(unit, luaL_optboolean(L, 3, false));
+		unitDrawer->UnitLeavesGhostChanged(unit, luaL_optboolean(L, 3, false));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -182,7 +182,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitStealth);
 	REGISTER_LUA_CFUNC(SetUnitSonarStealth);
 	REGISTER_LUA_CFUNC(SetUnitSeismicSignature);
-	REGISTER_LUA_CFUNC(SetUnitStaticRadarGhost);
+	REGISTER_LUA_CFUNC(SetUnitLeavesGhost);
 	REGISTER_LUA_CFUNC(SetUnitAlwaysVisible);
 	REGISTER_LUA_CFUNC(SetUnitUseAirLos);
 	REGISTER_LUA_CFUNC(SetUnitMetalExtraction);
@@ -2866,27 +2866,27 @@ int LuaSyncedCtrl::SetUnitSeismicSignature(lua_State* L)
 }
 
 /***
- * @function Spring.SetUnitStaticRadarGhost
+ * @function Spring.SetUnitLeavesGhost
  *
  * Set the radar ghost for the unit to have no drift.
- * Only for units where unitDef has leavesRadarGhost enabled.
+ * Only for units where unitDef has leavesGhost enabled.
  *
  * @number unitID
- * @bool staticRadarGhost
+ * @bool leavesGhost
  * @bool[opt] leaveDeadGhost leave a dead ghost behind if disabling and the unit had a live static ghost.
  * @treturn nil
  */
-int LuaSyncedCtrl::SetUnitStaticRadarGhost(lua_State* L)
+int LuaSyncedCtrl::SetUnitLeavesGhost(lua_State* L)
 {
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)
 		return 0;
 
-	bool prevValue = unit->staticRadarGhost;
-	unit->SetStaticRadarGhost(luaL_checkboolean(L, 2));
-	if (prevValue != unit->staticRadarGhost)
-		unitDrawer->SetUnitStaticRadarGhost(unit, luaL_optboolean(L, 3, false));
+	bool prevValue = unit->leavesGhost;
+	unit->SetLeavesGhost(luaL_checkboolean(L, 2));
+	if (prevValue != unit->leavesGhost)
+		unitDrawer->SetUnitLeavesGhost(unit, luaL_optboolean(L, 3, false));
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -90,6 +90,7 @@ class LuaSyncedCtrl
 		static int SetUnitStealth(lua_State* L);
 		static int SetUnitSonarStealth(lua_State* L);
 		static int SetUnitSeismicSignature(lua_State* L);
+		static int SetUnitStaticRadarGhost(lua_State* L);
 		static int SetUnitAlwaysVisible(lua_State* L);
 		static int SetUnitUseAirLos(lua_State* L);
 		static int SetUnitResourcing(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -90,7 +90,7 @@ class LuaSyncedCtrl
 		static int SetUnitStealth(lua_State* L);
 		static int SetUnitSonarStealth(lua_State* L);
 		static int SetUnitSeismicSignature(lua_State* L);
-		static int SetUnitStaticRadarGhost(lua_State* L);
+		static int SetUnitLeavesGhost(lua_State* L);
 		static int SetUnitAlwaysVisible(lua_State* L);
 		static int SetUnitUseAirLos(lua_State* L);
 		static int SetUnitResourcing(lua_State* L);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -218,6 +218,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitIsActive);
 	REGISTER_LUA_CFUNC(GetUnitIsCloaked);
 	REGISTER_LUA_CFUNC(GetUnitSeismicSignature);
+	REGISTER_LUA_CFUNC(GetUnitStaticRadarGhost);
 	REGISTER_LUA_CFUNC(GetUnitSelfDTime);
 	REGISTER_LUA_CFUNC(GetUnitStockpile);
 	REGISTER_LUA_CFUNC(GetUnitSensorRadius);
@@ -3881,6 +3882,22 @@ int LuaSyncedRead::GetUnitSeismicSignature(lua_State* L)
 		return 0;
 
 	lua_pushnumber(L, unit->seismicSignature);
+	return 1;
+}
+
+/***
+ *
+ * @function Spring.GetUnitStaticRadarGhost
+ * @number unitID
+ * @treturn nil|number
+ */
+int LuaSyncedRead::GetUnitStaticRadarGhost(lua_State* L)
+{
+	const CUnit* const unit = ParseAllyUnit(L, __func__, 1);
+	if (unit == nullptr)
+		return 0;
+
+	lua_pushboolean(L, unit->staticRadarGhost);
 	return 1;
 }
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -218,7 +218,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitIsActive);
 	REGISTER_LUA_CFUNC(GetUnitIsCloaked);
 	REGISTER_LUA_CFUNC(GetUnitSeismicSignature);
-	REGISTER_LUA_CFUNC(GetUnitStaticRadarGhost);
+	REGISTER_LUA_CFUNC(GetUnitLeavesGhost);
 	REGISTER_LUA_CFUNC(GetUnitSelfDTime);
 	REGISTER_LUA_CFUNC(GetUnitStockpile);
 	REGISTER_LUA_CFUNC(GetUnitSensorRadius);
@@ -3887,17 +3887,17 @@ int LuaSyncedRead::GetUnitSeismicSignature(lua_State* L)
 
 /***
  *
- * @function Spring.GetUnitStaticRadarGhost
+ * @function Spring.GetUnitLeavesGhost
  * @number unitID
  * @treturn nil|number
  */
-int LuaSyncedRead::GetUnitStaticRadarGhost(lua_State* L)
+int LuaSyncedRead::GetUnitLeavesGhost(lua_State* L)
 {
 	const CUnit* const unit = ParseAllyUnit(L, __func__, 1);
 	if (unit == nullptr)
 		return 0;
 
-	lua_pushboolean(L, unit->staticRadarGhost);
+	lua_pushboolean(L, unit->leavesGhost);
 	return 1;
 }
 

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -122,6 +122,7 @@ class LuaSyncedRead {
 		static int GetUnitIsActive(lua_State* L);
 		static int GetUnitIsCloaked(lua_State* L);
 		static int GetUnitSeismicSignature(lua_State* L);
+		static int GetUnitStaticRadarGhost(lua_State* L);
 		static int GetUnitSelfDTime(lua_State* L);
 		static int GetUnitStockpile(lua_State* L);
 		static int GetUnitSensorRadius(lua_State* L);

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -122,7 +122,7 @@ class LuaSyncedRead {
 		static int GetUnitIsActive(lua_State* L);
 		static int GetUnitIsCloaked(lua_State* L);
 		static int GetUnitSeismicSignature(lua_State* L);
-		static int GetUnitStaticRadarGhost(lua_State* L);
+		static int GetUnitLeavesGhost(lua_State* L);
 		static int GetUnitSelfDTime(lua_State* L);
 		static int GetUnitStockpile(lua_State* L);
 		static int GetUnitSensorRadius(lua_State* L);

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -727,6 +727,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_FLOAT("seismicSignature", ud.seismicSignature);
 	ADD_BOOL("stealth",      ud.stealth);
 	ADD_BOOL("sonarStealth", ud.sonarStealth);
+	ADD_BOOL("leavesRadarGhost", ud.leavesRadarGhost);
 
 	ADD_FLOAT("mass", ud.mass);
 

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -727,7 +727,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_FLOAT("seismicSignature", ud.seismicSignature);
 	ADD_BOOL("stealth",      ud.stealth);
 	ADD_BOOL("sonarStealth", ud.sonarStealth);
-	ADD_BOOL("leavesRadarGhost", ud.leavesRadarGhost);
+	ADD_BOOL("leavesGhost", ud.leavesGhost);
 
 	ADD_FLOAT("mass", ud.mass);
 

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -54,7 +54,7 @@ public:
 	static const std::vector<CUnit*>& GetUnsortedUnits() { return modelDrawerData->GetUnsortedObjects(); }
 
 	static void ClearPreviousDrawFlags() { modelDrawerData->ClearPreviousDrawFlags(); }
-	static void SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost) { modelDrawerData->SetUnitStaticRadarGhost(unit, leaveDeadGhost); }
+	static void SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost) { modelDrawerData->SetUnitLeavesGhost(unit, leaveDeadGhost); }
 public:
 	// DrawUnit*
 	virtual void DrawUnitNoTrans(const CUnit* unit, uint32_t preList, uint32_t postList, bool lodCall, bool noLuaCall) const = 0;

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -54,7 +54,7 @@ public:
 	static const std::vector<CUnit*>& GetUnsortedUnits() { return modelDrawerData->GetUnsortedObjects(); }
 
 	static void ClearPreviousDrawFlags() { modelDrawerData->ClearPreviousDrawFlags(); }
-	static void SetUnitStaticRadarGhost(const CUnit* unit) { modelDrawerData->SetUnitStaticRadarGhost(unit); }
+	static void SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost) { modelDrawerData->SetUnitStaticRadarGhost(unit, leaveDeadGhost); }
 public:
 	// DrawUnit*
 	virtual void DrawUnitNoTrans(const CUnit* unit, uint32_t preList, uint32_t postList, bool lodCall, bool noLuaCall) const = 0;

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -54,6 +54,7 @@ public:
 	static const std::vector<CUnit*>& GetUnsortedUnits() { return modelDrawerData->GetUnsortedObjects(); }
 
 	static void ClearPreviousDrawFlags() { modelDrawerData->ClearPreviousDrawFlags(); }
+	static void SetUnitStaticRadarGhost(const CUnit* unit) { modelDrawerData->SetUnitStaticRadarGhost(unit); }
 public:
 	// DrawUnit*
 	virtual void DrawUnitNoTrans(const CUnit* unit, uint32_t preList, uint32_t postList, bool lodCall, bool noLuaCall) const = 0;

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -54,7 +54,7 @@ public:
 	static const std::vector<CUnit*>& GetUnsortedUnits() { return modelDrawerData->GetUnsortedObjects(); }
 
 	static void ClearPreviousDrawFlags() { modelDrawerData->ClearPreviousDrawFlags(); }
-	static void SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost) { modelDrawerData->SetUnitLeavesGhost(unit, leaveDeadGhost); }
+	static void UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost) { modelDrawerData->UnitLeavesGhostChanged(unit, leaveDeadGhost); }
 public:
 	// DrawUnit*
 	virtual void DrawUnitNoTrans(const CUnit* unit, uint32_t preList, uint32_t postList, bool lodCall, bool noLuaCall) const = 0;

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -596,11 +596,12 @@ void CUnitDrawerData::RenderUnitCreated(const CUnit* unit, int cloaked)
 	UpdateUnitIcon(unit, false, false);
 }
 
-void CUnitDrawerData::UpdateGhosts(const CUnit* unit, const bool addNewGhost)
+bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost)
 {
 	if (!gameSetup->ghostedBuildings)
-		return;
+		return false;
 
+	bool addedOwnAllyTeam = false;
 	CUnit* u = const_cast<CUnit*>(unit);
 
 	const UnitDef* unitDef = unit->unitDef;
@@ -647,10 +648,14 @@ void CUnitDrawerData::UpdateGhosts(const CUnit* unit, const bool addNewGhost)
 			// remove prevlos for unit
 			if (u->losStatus[allyTeam] & LOS_PREVLOS)
 				u->losStatus[allyTeam] ^= LOS_PREVLOS;
+			if (allyTeam == gu->myAllyTeam)
+				addedOwnAllyTeam = true;
+
 		}
 
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(u)], u);
 	}
+	return addedOwnAllyTeam;
 }
 
 void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
@@ -658,7 +663,7 @@ void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit);
 
-	UpdateGhosts(unit, unit->staticRadarGhost);
+	UpdateUnitGhosts(unit, unit->staticRadarGhost);
 
 	DelObject(unit, true);
 	UpdateUnitIcon(unit, false, true);
@@ -708,9 +713,8 @@ void CUnitDrawerData::SetUnitStaticRadarGhost(const CUnit* unit)
 	if (unit->staticRadarGhost)
 		return;
 
-	const bool addNewGhost = gameSetup->ghostedBuildings;
-
-	UpdateGhosts(unit, true);
+	if (UpdateUnitGhosts(unit, true))
+		UpdateUnitIcon(unit, false, true);
 }
 
 void CUnitDrawerData::PlayerChanged(int playerNum)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -266,7 +266,7 @@ const icon::CIconData* CUnitDrawerData::GetUnitIcon(const CUnit* unit)
 	// use the unit's custom icon if we can currently see it,
 	// or have seen it before and did not lose contact since
 	bool unitVisible = ((losStatus & (LOS_INLOS | LOS_INRADAR)) && ((losStatus & prevMask) == prevMask));
-	unitVisible |= gameSetup->ghostedBuildings && unit->unitDef->IsBuildingUnit() && (losStatus & LOS_PREVLOS);
+	unitVisible |= gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit() && (losStatus & LOS_PREVLOS);
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 
 	if (customIcon)
@@ -604,7 +604,7 @@ void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
 	const UnitDef* unitDef = unit->unitDef;
 	const UnitDef* decoyDef = unitDef->decoyDef;
 
-	const bool addNewGhost = unitDef->IsBuildingUnit() && gameSetup->ghostedBuildings;
+	const bool addNewGhost = unitDef->IsImmobileUnit() && gameSetup->ghostedBuildings;
 
 	// TODO - make ghosted buildings per allyTeam - so they are correctly dealt with
 	// when spectating
@@ -669,7 +669,7 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->IsBuildingUnit())
+	if (gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit())
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
 
 	if (allyTeam != gu->myAllyTeam)
@@ -683,7 +683,7 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->IsBuildingUnit())
+	if (gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit())
 		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
 
 	if (allyTeam != gu->myAllyTeam)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -241,14 +241,7 @@ void CUnitDrawerData::UpdateGhostedBuildings()
 				}
 
 				// obtained LOS on the ghost of a dead building
-				if (!gso->DecRef()) {
-					spring::VectorErase(unitsByIcon[gso->myIcon].second, const_cast<const GhostSolidObject*>(gso));
-					groundDecals->GhostDestroyed(gso);
-					ghostMemPool.free(gso);
-				}
-
-				dgb[i] = dgb.back();
-				dgb.pop_back();
+				RemoveDeadGhost(gso, dgb, i); // swaps element with last so counter shouldn't be increased.
 			}
 		}
 	}
@@ -751,18 +744,23 @@ void CUnitDrawerData::RemoveDeadGhosts(const CUnit* unit)
 		for (int i = 0; i < dgb.size(); /*no-op*/) {
 			GhostSolidObject* gso = dgb[i];
 			if (gso->pos == pos) {
-				if (!gso->DecRef()) {
-					spring::VectorErase(unitsByIcon[gso->myIcon].second, const_cast<const GhostSolidObject*>(gso));
-					groundDecals->GhostDestroyed(gso);
-					ghostMemPool.free(gso);
-				}
-				dgb[i] = dgb.back();
-				dgb.pop_back();
+				RemoveDeadGhost(gso, dgb, i); // swaps element with last so counter shouldn't be increased.
 			} else {
 				++i;
 			}
 		}
 	}
+}
+
+void CUnitDrawerData::RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index)
+{
+	if (!gso->DecRef()) {
+		spring::VectorErase(unitsByIcon[gso->myIcon].second, const_cast<const GhostSolidObject*>(gso));
+		groundDecals->GhostDestroyed(gso);
+		ghostMemPool.free(gso);
+	}
+	dgb[index] = dgb.back();
+	dgb.pop_back();
 }
 
 void CUnitDrawerData::PlayerChanged(int playerNum)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -614,7 +614,7 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 	S3DModel* gsoModel = (decoyDef == nullptr) ? u->model : decoyDef->LoadModel();
 
 	for (int allyTeam = 0; allyTeam < savedData.deadGhostBuildings.size(); ++allyTeam) {
-		const bool canSeeGhost = !(u->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR)) && (u->losStatus[allyTeam] & (LOS_PREVLOS));
+		const bool canSeeGhost = !(u->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR | LOS_INRADAR)) && (u->losStatus[allyTeam] & (LOS_PREVLOS));
 
 		if (addNewGhost && canSeeGhost) {
 			if (gso == nullptr) {

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -743,10 +743,7 @@ void CUnitDrawerData::RemoveDeadGhosts(const CUnit* unit)
 
 	CUnit* u = const_cast<CUnit*>(unit);
 
-	// TODO - make ghosted buildings per allyTeam - so they are correctly dealt with
-	// when spectating
 	GhostSolidObject* gso = nullptr;
-	// FIXME -- adjust decals for decoys? gets weird?
 	S3DModel* gsoModel = (decoyDef == nullptr) ? u->model : decoyDef->LoadModel();
 
 	for (int allyTeam = 0; allyTeam < savedData.deadGhostBuildings.size(); ++allyTeam) {

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -712,12 +712,9 @@ void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leave
 		return;
 	}
 
-	if (UpdateUnitGhosts(unit, leaveDeadGhost))
+	if (UpdateUnitGhosts(unit, leaveDeadGhost)) {
 		// left ghost
 		UpdateUnitIcon(unit, false, true);
-	else {
-		// no ghost was created so ensure no dead ghost remains below the unit
-		RemoveDeadGhosts(unit);
 	}
 }
 
@@ -730,28 +727,6 @@ void CUnitDrawerData::ReviewPrevLos(const CUnit* unit)
 		if (!(unit->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR))) {
 			CUnit* u = const_cast<CUnit*>(unit);
 			u->losStatus[allyTeam] &= ~LOS_PREVLOS;
-		}
-	}
-}
-
-void CUnitDrawerData::RemoveDeadGhosts(const CUnit* unit)
-{
-	const float3 pos = unit->pos;
-
-	CUnit* u = const_cast<CUnit*>(unit);
-
-	GhostSolidObject* gso = nullptr;
-	S3DModel* gsoModel = GetUnitModel(unit);
-
-	for (int allyTeam = 0; allyTeam < savedData.deadGhostBuildings.size(); ++allyTeam) {
-		auto& dgb = savedData.deadGhostBuildings[allyTeam][gsoModel->type];
-		for (int i = 0; i < dgb.size(); /*no-op*/) {
-			GhostSolidObject* gso = dgb[i];
-			if (gso->pos == pos) {
-				RemoveDeadGhost(gso, dgb, i); // swaps element with last so counter shouldn't be increased.
-			} else {
-				++i;
-			}
 		}
 	}
 }

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -589,6 +589,16 @@ void CUnitDrawerData::RenderUnitCreated(const CUnit* unit, int cloaked)
 	UpdateUnitIcon(unit, false, false);
 }
 
+S3DModel* CUnitDrawerData::GetUnitModel(const CUnit* unit) const
+{
+	const UnitDef* unitDef = unit->unitDef;
+	const UnitDef* decoyDef = unitDef->decoyDef;
+
+	// FIXME -- adjust decals for decoys? gets weird?
+	S3DModel* gsoModel = (decoyDef == nullptr) ? unit->model : decoyDef->LoadModel();
+	return gsoModel;
+}
+
 bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost)
 {
 	if (!gameSetup->ghostedBuildings)
@@ -597,14 +607,10 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 	bool addedOwnAllyTeam = false;
 	CUnit* u = const_cast<CUnit*>(unit);
 
-	const UnitDef* unitDef = unit->unitDef;
-	const UnitDef* decoyDef = unitDef->decoyDef;
-
 	// TODO - make ghosted buildings per allyTeam - so they are correctly dealt with
 	// when spectating
 	GhostSolidObject* gso = nullptr;
-	// FIXME -- adjust decals for decoys? gets weird?
-	S3DModel* gsoModel = (decoyDef == nullptr) ? u->model : decoyDef->LoadModel();
+	S3DModel* gsoModel = GetUnitModel(unit);
 
 	for (int allyTeam = 0; allyTeam < savedData.deadGhostBuildings.size(); ++allyTeam) {
 		const bool canSeeGhost = !(u->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR | LOS_INRADAR)) && (u->losStatus[allyTeam] & (LOS_PREVLOS));
@@ -731,13 +737,10 @@ void CUnitDrawerData::RemoveDeadGhosts(const CUnit* unit)
 {
 	const float3 pos = unit->pos;
 
-	const UnitDef* unitDef = unit->unitDef;
-	const UnitDef* decoyDef = unitDef->decoyDef;
-
 	CUnit* u = const_cast<CUnit*>(unit);
 
 	GhostSolidObject* gso = nullptr;
-	S3DModel* gsoModel = (decoyDef == nullptr) ? u->model : decoyDef->LoadModel();
+	S3DModel* gsoModel = GetUnitModel(unit);
 
 	for (int allyTeam = 0; allyTeam < savedData.deadGhostBuildings.size(); ++allyTeam) {
 		auto& dgb = savedData.deadGhostBuildings[allyTeam][gsoModel->type];

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -713,7 +713,7 @@ void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leave
 	}
 
 	if (UpdateUnitGhosts(unit, leaveDeadGhost)) {
-		// left ghost
+		// left decoy dead ghost for own team
 		UpdateUnitIcon(unit, false, true);
 	}
 }

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -716,6 +716,7 @@ void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leave
 		// left ghost
 		UpdateUnitIcon(unit, false, true);
 	else {
+		// no ghost was created so ensure no dead ghost remains below the unit
 		RemoveDeadGhosts(unit);
 	}
 }
@@ -723,7 +724,7 @@ void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leave
 void CUnitDrawerData::ReviewPrevLos(const CUnit* unit)
 {
 	// When reinstating leavesGhost, we need to check whether the unit is still in los or
-	// contradar, and disable PREVLOS, otherwise specs will see it after going in and
+	// contradar, and otherwise disable PREVLOS, otherwise specs will see it after going in and
 	// out of player mode.
 	for (int allyTeam = 0; allyTeam < savedData.liveGhostBuildings.size(); ++allyTeam) {
 		if (!(unit->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR))) {

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -685,7 +685,7 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost)
+	if (gameSetup->ghostedBuildings && unit->staticRadarGhost)
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
 
 	if (allyTeam != gu->myAllyTeam)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -708,12 +708,12 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	UpdateUnitIcon(unit, false, false);
 }
 
-void CUnitDrawerData::SetUnitStaticRadarGhost(const CUnit* unit)
+void CUnitDrawerData::SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost)
 {
 	if (unit->staticRadarGhost)
 		return;
 
-	if (UpdateUnitGhosts(unit, true))
+	if (UpdateUnitGhosts(unit, leaveDeadGhost))
 		UpdateUnitIcon(unit, false, true);
 }
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -266,7 +266,7 @@ const icon::CIconData* CUnitDrawerData::GetUnitIcon(const CUnit* unit)
 	// use the unit's custom icon if we can currently see it,
 	// or have seen it before and did not lose contact since
 	bool unitVisible = ((losStatus & (LOS_INLOS | LOS_INRADAR)) && ((losStatus & prevMask) == prevMask));
-	unitVisible |= gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost && (losStatus & LOS_PREVLOS);
+	unitVisible |= gameSetup->ghostedBuildings && unit->staticRadarGhost && (losStatus & LOS_PREVLOS);
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 
 	if (customIcon)
@@ -596,15 +596,15 @@ void CUnitDrawerData::RenderUnitCreated(const CUnit* unit, int cloaked)
 	UpdateUnitIcon(unit, false, false);
 }
 
-void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
+void CUnitDrawerData::UpdateGhosts(const CUnit* unit, const bool addNewGhost)
 {
-	RECOIL_DETAILED_TRACY_ZONE;
+	if (!gameSetup->ghostedBuildings)
+		return;
+
 	CUnit* u = const_cast<CUnit*>(unit);
 
 	const UnitDef* unitDef = unit->unitDef;
 	const UnitDef* decoyDef = unitDef->decoyDef;
-
-	const bool addNewGhost = unitDef->leavesRadarGhost && gameSetup->ghostedBuildings;
 
 	// TODO - make ghosted buildings per allyTeam - so they are correctly dealt with
 	// when spectating
@@ -644,10 +644,21 @@ void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
 			if (allyTeam == gu->myAllyTeam) {
 				unitsByIcon[u->myIcon].second.push_back(gso);
 			}
+			// remove prevlos for unit
+			if (u->losStatus[allyTeam] & LOS_PREVLOS)
+				u->losStatus[allyTeam] ^= LOS_PREVLOS;
 		}
 
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(u)], u);
 	}
+}
+
+void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	CUnit* u = const_cast<CUnit*>(unit);
+
+	UpdateGhosts(unit, unit->staticRadarGhost);
 
 	DelObject(unit, true);
 	UpdateUnitIcon(unit, false, true);
@@ -683,13 +694,23 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost)
+	if (gameSetup->ghostedBuildings && unit->staticRadarGhost)
 		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
 
 	if (allyTeam != gu->myAllyTeam)
 		return;
 
 	UpdateUnitIcon(unit, false, false);
+}
+
+void CUnitDrawerData::SetUnitStaticRadarGhost(const CUnit* unit)
+{
+	if (unit->staticRadarGhost)
+		return;
+
+	const bool addNewGhost = gameSetup->ghostedBuildings;
+
+	UpdateGhosts(unit, true);
 }
 
 void CUnitDrawerData::PlayerChanged(int playerNum)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -266,7 +266,7 @@ const icon::CIconData* CUnitDrawerData::GetUnitIcon(const CUnit* unit)
 	// use the unit's custom icon if we can currently see it,
 	// or have seen it before and did not lose contact since
 	bool unitVisible = ((losStatus & (LOS_INLOS | LOS_INRADAR)) && ((losStatus & prevMask) == prevMask));
-	unitVisible |= gameSetup->ghostedBuildings && unit->staticRadarGhost && (losStatus & LOS_PREVLOS);
+	unitVisible |= gameSetup->ghostedBuildings && unit->leavesGhost && (losStatus & LOS_PREVLOS);
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 
 	if (customIcon)
@@ -663,7 +663,7 @@ void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit);
 
-	UpdateUnitGhosts(unit, unit->staticRadarGhost);
+	UpdateUnitGhosts(unit, unit->leavesGhost);
 
 	DelObject(unit, true);
 	UpdateUnitIcon(unit, false, true);
@@ -685,7 +685,7 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->staticRadarGhost)
+	if (gameSetup->ghostedBuildings && unit->leavesGhost)
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
 
 	if (allyTeam != gu->myAllyTeam)
@@ -699,7 +699,7 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->staticRadarGhost)
+	if (gameSetup->ghostedBuildings && unit->leavesGhost)
 		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
 
 	if (allyTeam != gu->myAllyTeam)
@@ -708,9 +708,9 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	UpdateUnitIcon(unit, false, false);
 }
 
-void CUnitDrawerData::SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost)
+void CUnitDrawerData::SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost)
 {
-	if (unit->staticRadarGhost)
+	if (unit->leavesGhost)
 		return;
 
 	if (UpdateUnitGhosts(unit, leaveDeadGhost))

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -645,9 +645,7 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 			if (allyTeam == gu->myAllyTeam) {
 				unitsByIcon[u->myIcon].second.push_back(gso);
 			}
-			// remove prevlos for unit
-			if (u->losStatus[allyTeam] & LOS_PREVLOS)
-				u->losStatus[allyTeam] ^= LOS_PREVLOS;
+			u->losStatus[allyTeam] &= ~LOS_PREVLOS;
 			if (allyTeam == gu->myAllyTeam)
 				addedOwnAllyTeam = true;
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -708,11 +708,26 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 
 void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost)
 {
-	if (unit->leavesGhost)
+	if (unit->leavesGhost) {
+		ReviewPrevLos(unit);
 		return;
+	}
 
 	if (UpdateUnitGhosts(unit, leaveDeadGhost))
 		UpdateUnitIcon(unit, false, true);
+}
+
+void CUnitDrawerData::ReviewPrevLos(const CUnit* unit)
+{
+	// When reinstating leavesGhost, we need to check whether the unit is still in los or
+	// contradar, and disable PREVLOS, otherwise specs will see it after going in and
+	// out of player mode.
+	for (int allyTeam = 0; allyTeam < savedData.liveGhostBuildings.size(); ++allyTeam) {
+		if (!(unit->losStatus[allyTeam] & (LOS_INLOS | LOS_CONTRADAR))) {
+			CUnit* u = const_cast<CUnit*>(unit);
+			u->losStatus[allyTeam] &= ~LOS_PREVLOS;
+		}
+	}
 }
 
 void CUnitDrawerData::PlayerChanged(int playerNum)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -708,7 +708,7 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	UpdateUnitIcon(unit, false, false);
 }
 
-void CUnitDrawerData::SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost)
+void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost)
 {
 	if (unit->leavesGhost)
 		return;

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -266,7 +266,7 @@ const icon::CIconData* CUnitDrawerData::GetUnitIcon(const CUnit* unit)
 	// use the unit's custom icon if we can currently see it,
 	// or have seen it before and did not lose contact since
 	bool unitVisible = ((losStatus & (LOS_INLOS | LOS_INRADAR)) && ((losStatus & prevMask) == prevMask));
-	unitVisible |= gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit() && (losStatus & LOS_PREVLOS);
+	unitVisible |= gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost && (losStatus & LOS_PREVLOS);
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 
 	if (customIcon)
@@ -604,7 +604,7 @@ void CUnitDrawerData::RenderUnitDestroyed(const CUnit* unit)
 	const UnitDef* unitDef = unit->unitDef;
 	const UnitDef* decoyDef = unitDef->decoyDef;
 
-	const bool addNewGhost = unitDef->IsImmobileUnit() && gameSetup->ghostedBuildings;
+	const bool addNewGhost = unitDef->leavesRadarGhost && gameSetup->ghostedBuildings;
 
 	// TODO - make ghosted buildings per allyTeam - so they are correctly dealt with
 	// when spectating
@@ -669,7 +669,7 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit())
+	if (gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost)
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
 
 	if (allyTeam != gu->myAllyTeam)
@@ -683,7 +683,7 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->unitDef->IsImmobileUnit())
+	if (gameSetup->ghostedBuildings && unit->unitDef->leavesRadarGhost)
 		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
 
 	if (allyTeam != gu->myAllyTeam)

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -266,7 +266,7 @@ const icon::CIconData* CUnitDrawerData::GetUnitIcon(const CUnit* unit)
 	// use the unit's custom icon if we can currently see it,
 	// or have seen it before and did not lose contact since
 	bool unitVisible = ((losStatus & (LOS_INLOS | LOS_INRADAR)) && ((losStatus & prevMask) == prevMask));
-	unitVisible |= gameSetup->ghostedBuildings && unit->leavesGhost && (losStatus & LOS_PREVLOS);
+	unitVisible |= unit->leavesGhost && (losStatus & LOS_PREVLOS);
 	const bool customIcon = (unitVisible || gu->spectatingFullView);
 
 	if (customIcon)
@@ -685,7 +685,7 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->leavesGhost)
+	if (unit->leavesGhost)
 		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
 
 	if (allyTeam != gu->myAllyTeam)
@@ -699,7 +699,7 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (gameSetup->ghostedBuildings && unit->leavesGhost)
+	if (unit->leavesGhost)
 		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
 
 	if (allyTeam != gu->myAllyTeam)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -65,7 +65,7 @@ public:
 
 	void PlayerChanged(int playerNum) override;
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
-	void SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost);
+	void SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -64,6 +64,8 @@ public:
 	void UnitLeftLos(const CUnit* unit, int allyTeam) override;
 
 	void PlayerChanged(int playerNum) override;
+	void UpdateGhosts(const CUnit* unit, const bool addNewGhost);
+	void SetUnitStaticRadarGhost(const CUnit* unit);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -65,7 +65,7 @@ public:
 
 	void PlayerChanged(int playerNum) override;
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
-	void SetUnitStaticRadarGhost(const CUnit* unit);
+	void SetUnitStaticRadarGhost(const CUnit* unit, const bool leaveDeadGhost);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -64,7 +64,7 @@ public:
 	void UnitLeftLos(const CUnit* unit, int allyTeam) override;
 
 	void PlayerChanged(int playerNum) override;
-	void UpdateGhosts(const CUnit* unit, const bool addNewGhost);
+	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
 	void SetUnitStaticRadarGhost(const CUnit* unit);
 public:
 	class TempDrawUnit {

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -65,7 +65,7 @@ public:
 
 	void PlayerChanged(int playerNum) override;
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
-	void SetUnitLeavesGhost(const CUnit* unit, const bool leaveDeadGhost);
+	void UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -67,7 +67,6 @@ public:
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
 	void UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost);
 	void ReviewPrevLos(const CUnit* unit);
-	void RemoveDeadGhosts(const CUnit* unit);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -189,6 +189,7 @@ private:
 
 	std::vector<UnitDefImage> unitDefImages;
 
+	void RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index);
 
 
 	// icons

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -66,6 +66,7 @@ public:
 	void PlayerChanged(int playerNum) override;
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
 	void UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost);
+	void ReviewPrevLos(const CUnit* unit);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -67,6 +67,7 @@ public:
 	bool UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost);
 	void UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost);
 	void ReviewPrevLos(const CUnit* unit);
+	void RemoveDeadGhosts(const CUnit* unit);
 public:
 	class TempDrawUnit {
 		CR_DECLARE_STRUCT(TempDrawUnit)

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -189,6 +189,7 @@ private:
 
 	std::vector<UnitDefImage> unitDefImages;
 
+	S3DModel* GetUnitModel(const CUnit* unit) const;
 	void RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index);
 
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -33,6 +33,7 @@
 #include "Map/ReadMap.h"
 
 #include "Rendering/GroundFlash.h"
+#include "Rendering/Units/UnitDrawer.h"
 
 #include "Game/UI/Groups/Group.h"
 #include "Game/UI/Groups/GroupHandler.h"
@@ -538,9 +539,13 @@ void CUnit::ForcedMove(const float3& newPos)
 }
 
 
-void CUnit::SetLeavesGhost(bool newLeavesGhost)
+void CUnit::SetLeavesGhost(bool newLeavesGhost, bool leaveDeadGhost)
 {
+	bool prevValue = leavesGhost;
 	leavesGhost = newLeavesGhost;
+
+	if (prevValue != newLeavesGhost)
+		unitDrawer->UnitLeavesGhostChanged(this, leaveDeadGhost);
 }
 
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -289,7 +289,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	wantCloak |= unitDef->startCloaked;
 	decloakDistance = unitDef->decloakDistance;
 
-	staticRadarGhost = unitDef->leavesRadarGhost;
+	leavesGhost = unitDef->leavesGhost;
 
 	flankingBonusMode        = unitDef->flankingBonusMode;
 	flankingBonusDir         = unitDef->flankingBonusDir;
@@ -538,9 +538,9 @@ void CUnit::ForcedMove(const float3& newPos)
 }
 
 
-void CUnit::SetStaticRadarGhost(bool isStatic)
+void CUnit::SetLeavesGhost(bool isStatic)
 {
-	staticRadarGhost = isStatic && unitDef->leavesRadarGhost;
+	leavesGhost = isStatic && unitDef->leavesGhost;
 }
 
 
@@ -555,7 +555,7 @@ float3 CUnit::GetErrorVector(int argAllyTeam) const
 	const int atSightMask = losStatus[argAllyTeam];
 
 	const int isVisible = 2 * ((atSightMask & LOS_INLOS  ) != 0 ||                  teamHandler.Ally(argAllyTeam, allyteam)); // in LOS or allied, no error
-	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && staticRadarGhost); // seen ghosted immobiles, no error
+	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && leavesGhost); // seen ghosted immobiles, no error
 	const int isOnRadar = 8 * ((atSightMask & LOS_INRADAR) != 0                                                            ); // current radar contact
 
 	float errorMult = 0.0f;
@@ -3021,7 +3021,7 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(isCloaked),
 	CR_MEMBER(decloakDistance),
 
-	CR_MEMBER(staticRadarGhost),
+	CR_MEMBER(leavesGhost),
 
 	CR_MEMBER(lastTerrainType),
 	CR_MEMBER(curTerrainType),

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -540,7 +540,7 @@ void CUnit::ForcedMove(const float3& newPos)
 
 void CUnit::SetLeavesGhost(bool isStatic)
 {
-	leavesGhost = isStatic && unitDef->leavesGhost;
+	leavesGhost = isStatic;
 }
 
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -548,7 +548,7 @@ float3 CUnit::GetErrorVector(int argAllyTeam) const
 	const int atSightMask = losStatus[argAllyTeam];
 
 	const int isVisible = 2 * ((atSightMask & LOS_INLOS  ) != 0 ||                  teamHandler.Ally(argAllyTeam, allyteam)); // in LOS or allied, no error
-	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && unitDef->IsBuildingUnit()); // seen ghosted building, no error
+	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && unitDef->IsImmobileUnit()); // seen ghosted immobiles, no error
 	const int isOnRadar = 8 * ((atSightMask & LOS_INRADAR) != 0                                                            ); // current radar contact
 
 	float errorMult = 0.0f;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -538,9 +538,9 @@ void CUnit::ForcedMove(const float3& newPos)
 }
 
 
-void CUnit::SetLeavesGhost(bool isStatic)
+void CUnit::SetLeavesGhost(bool newLeavesGhost)
 {
-	leavesGhost = isStatic;
+	leavesGhost = newLeavesGhost;
 }
 
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -289,7 +289,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	wantCloak |= unitDef->startCloaked;
 	decloakDistance = unitDef->decloakDistance;
 
-	leavesGhost = unitDef->leavesGhost;
+	leavesGhost = gameSetup->ghostedBuildings && unitDef->leavesGhost;
 
 	flankingBonusMode        = unitDef->flankingBonusMode;
 	flankingBonusDir         = unitDef->flankingBonusDir;
@@ -555,7 +555,7 @@ float3 CUnit::GetErrorVector(int argAllyTeam) const
 	const int atSightMask = losStatus[argAllyTeam];
 
 	const int isVisible = 2 * ((atSightMask & LOS_INLOS  ) != 0 ||                  teamHandler.Ally(argAllyTeam, allyteam)); // in LOS or allied, no error
-	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && leavesGhost); // seen ghosted immobiles, no error
+	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && leavesGhost); // seen ghosted immobiles, no error
 	const int isOnRadar = 8 * ((atSightMask & LOS_INRADAR) != 0                                                            ); // current radar contact
 
 	float errorMult = 0.0f;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -289,6 +289,8 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	wantCloak |= unitDef->startCloaked;
 	decloakDistance = unitDef->decloakDistance;
 
+	staticRadarGhost = unitDef->leavesRadarGhost;
+
 	flankingBonusMode        = unitDef->flankingBonusMode;
 	flankingBonusDir         = unitDef->flankingBonusDir;
 	flankingBonusMobility    = unitDef->flankingBonusMobilityAdd * 1000;
@@ -536,6 +538,11 @@ void CUnit::ForcedMove(const float3& newPos)
 }
 
 
+void CUnit::SetStaticRadarGhost(bool isStatic)
+{
+	staticRadarGhost = isStatic && unitDef->leavesRadarGhost;
+}
+
 
 float3 CUnit::GetErrorVector(int argAllyTeam) const
 {
@@ -548,7 +555,7 @@ float3 CUnit::GetErrorVector(int argAllyTeam) const
 	const int atSightMask = losStatus[argAllyTeam];
 
 	const int isVisible = 2 * ((atSightMask & LOS_INLOS  ) != 0 ||                  teamHandler.Ally(argAllyTeam, allyteam)); // in LOS or allied, no error
-	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && unitDef->IsImmobileUnit()); // seen ghosted immobiles, no error
+	const int seenGhost = 4 * ((atSightMask & LOS_PREVLOS) != 0 && gameSetup->ghostedBuildings && staticRadarGhost); // seen ghosted immobiles, no error
 	const int isOnRadar = 8 * ((atSightMask & LOS_INRADAR) != 0                                                            ); // current radar contact
 
 	float errorMult = 0.0f;
@@ -3013,6 +3020,8 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(wantCloak),
 	CR_MEMBER(isCloaked),
 	CR_MEMBER(decloakDistance),
+
+	CR_MEMBER(staticRadarGhost),
 
 	CR_MEMBER(lastTerrainType),
 	CR_MEMBER(curTerrainType),

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -193,7 +193,7 @@ public:
 	unsigned short CalcLosStatus(int allyTeam);
 	void UpdateLosStatus(int allyTeam);
 
-	void SetLeavesGhost(bool newLeavesGhost);
+	void SetLeavesGhost(bool newLeavesGhost, bool leaveDeadGhost);
 
 	void UpdateWeapons();
 	void UpdateWeaponVectors();

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -193,7 +193,7 @@ public:
 	unsigned short CalcLosStatus(int allyTeam);
 	void UpdateLosStatus(int allyTeam);
 
-	void SetLeavesGhost(bool isStatic);
+	void SetLeavesGhost(bool newLeavesGhost);
 
 	void UpdateWeapons();
 	void UpdateWeaponVectors();

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -193,6 +193,8 @@ public:
 	unsigned short CalcLosStatus(int allyTeam);
 	void UpdateLosStatus(int allyTeam);
 
+	void SetStaticRadarGhost(bool isStatic);
+
 	void UpdateWeapons();
 	void UpdateWeaponVectors();
 
@@ -536,7 +538,8 @@ public:
 	bool isCloaked = false;
 	// true if the unit currently wants to be cloaked
 	bool wantCloak = false;
-
+	// true if unitDef leavesRadarGhost and the unit ghost will have no drift
+	bool staticRadarGhost = false;
 
 	// unsynced vars
 	bool noMinimap = false;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -193,7 +193,7 @@ public:
 	unsigned short CalcLosStatus(int allyTeam);
 	void UpdateLosStatus(int allyTeam);
 
-	void SetStaticRadarGhost(bool isStatic);
+	void SetLeavesGhost(bool isStatic);
 
 	void UpdateWeapons();
 	void UpdateWeaponVectors();
@@ -538,8 +538,8 @@ public:
 	bool isCloaked = false;
 	// true if the unit currently wants to be cloaked
 	bool wantCloak = false;
-	// true if unitDef leavesRadarGhost and the unit ghost will have no drift
-	bool staticRadarGhost = false;
+	// true if the unit leaves static ghosts
+	bool leavesGhost = false;
 
 	// unsynced vars
 	bool noMinimap = false;

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -106,6 +106,7 @@ UnitDef::UnitDef()
 	, seismicSignature(0.0f)
 	, stealth(false)
 	, sonarStealth(false)
+	, leavesRadarGhost(false)
 	, buildRange3D(false)
 	, buildDistance(16.0f) // 16.0f is the minimum distance between two 1x1 units
 	, buildSpeed(0.0f)
@@ -657,6 +658,8 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	buildingMask = (std::uint16_t)udTable.GetInt("buildingMask", 1); //1st bit set to 1 constitutes for "normal building"
 	if (IsImmobileUnit())
 		CreateYardMap(udTable.GetString("yardMap", ""));
+
+	leavesRadarGhost   = udTable.GetBool("leavesRadarGhost", IsBuildingUnit());
 
 	decalDef.Parse(udTable);
 

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -106,7 +106,7 @@ UnitDef::UnitDef()
 	, seismicSignature(0.0f)
 	, stealth(false)
 	, sonarStealth(false)
-	, leavesRadarGhost(false)
+	, leavesGhost(false)
 	, buildRange3D(false)
 	, buildDistance(16.0f) // 16.0f is the minimum distance between two 1x1 units
 	, buildSpeed(0.0f)
@@ -659,7 +659,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	if (IsImmobileUnit())
 		CreateYardMap(udTable.GetString("yardMap", ""));
 
-	leavesRadarGhost   = udTable.GetBool("leavesRadarGhost", IsBuildingUnit());
+	leavesGhost   = udTable.GetBool("leavesGhost", IsBuildingUnit());
 
 	decalDef.Parse(udTable);
 

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -168,7 +168,7 @@ public:
 	float seismicSignature;
 	bool stealth;
 	bool sonarStealth;
-	bool leavesRadarGhost;
+	bool leavesGhost;
 
 	bool  buildRange3D;
 	float buildDistance;

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -168,6 +168,7 @@ public:
 	float seismicSignature;
 	bool stealth;
 	bool sonarStealth;
+	bool leavesRadarGhost;
 
 	bool  buildRange3D;
 	float buildDistance;


### PR DESCRIPTION
### Work done

- Add `leavesGhost` unitdef.
  - defaults to true for IsBuildingUnits
  - controls what units get unit attribute `leavesGhost` set to true on creation.
- Add `leavesGhost` unit attribute.
  - defaults to unitDef->leavesGhost
  - per unit toggle for static radar ghosts
  - lua `Get/SetUnitLeavesGhost` allows changing this at any time
  - controls:
    - radar wobbling when under radar
    - leaving static ghosts when out of radar or los (and having been in los and contradar before)
  - leaves a dead ghost behind when leavesGhost gets disabled and the unit had a static ghost, this way no information is leaked about unit whereabouts (only if 3rd parameter to SetUnitRadarGhost set to true).
    - this allows immobile units hopping on transports and looking like they're still there
- Add sample gadget `mobile_ghost_transport.lua`.

### Related issues

- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3617
- Fixes radar wobbling for units with leavesGhost true
- Fixes static radar ghosts being available just for buildings
- Fixes ghost behavior for transported units

### Remarks

- This approach allows control of which units leave static live/dead ghosts, and also disabling the ghosts behavior when the unit is put in a transport for example
- Dead ghost icons fixed at separate PR: https://github.com/beyond-all-reason/spring/pull/1887
- Could rename gameSetup->ghostedBuildings to staticGhosts (and export/accept also ghostedBuildings alias for now).
- Could rename live/deadGhostBuildings to live/deadStaticGhosts since it's not special for buildings now.
  - maybe change these at a different PR to not complicate this further

### Pending

- Fix ghosts not being generated when losing radar coverage of an area. (is this really happening, can't reproduce it now?)
  - not sure this is possible as part of this pr
  - might need some mechanism to facilitate drawing helpers (like defenseranges) for ghosts
    - atm this isn't handled properly at least in bar, not sure about zk or engine
      - ex: when an llt moves the range stays with the ghost, and then, if the llt new pos is spotted it won't draw a range

### Reference

```LUA
IsImmobileUnit -> (pathType == -1U && !canfly && speed <= 0.0f)
IsBuildingUnit -> (IsImmobileUnit() && !yardmap.empty())
IsGroundUnit   -> (pathType != -1U && !canfly)
```

### Screenshots

<image src="https://github.com/user-attachments/assets/87ac241b-357c-40c5-ae1d-1f357200d55d"></image>
