### PR TITLE
Lua time offset

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1399,6 +1399,7 @@ bool CGame::UpdateUnsynced(const spring_time currentTime)
 		lastFrameTime = currentTime;
 	}
 
+	eventHandler.UpdateTimeOffset(globalRendering->timeOffset, gu->simFPS * gu->avgFrameTime * 0.001f);
 	if ((currentTime - frameStartTime).toMilliSecsf() >= 1000.0f) {
 		globalRendering->FPS = (numDrawFrames * 1000.0f) / std::max(0.01f, (currentTime - frameStartTime).toMilliSecsf());
 

--- a/rts/Game/GlobalUnsynced.cpp
+++ b/rts/Game/GlobalUnsynced.cpp
@@ -53,7 +53,8 @@ CR_REG_METADATA(CGlobalUnsynced, (
 	CR_MEMBER(spectatingFullSelect),
 	CR_IGNORED(fpsMode),
 	CR_IGNORED(globalQuit),
-	CR_IGNORED(globalReload)
+	CR_IGNORED(globalReload),
+	CR_IGNORED(lastSimFrameStartTime)
 ))
 
 

--- a/rts/Game/GlobalUnsynced.h
+++ b/rts/Game/GlobalUnsynced.h
@@ -7,6 +7,7 @@
 
 #include "System/creg/creg_cond.h"
 #include "System/GlobalRNG.h"
+#include "System/Misc/SpringTime.h"
 
 class CPlayer;
 class CGameSetup;
@@ -168,6 +169,14 @@ public:
 	*/
 	std::atomic<bool> globalQuit = {false};
 	std::atomic<bool> globalReload = {false};
+
+	/**
+	* @brief lastSimFrameStartTime
+	*
+	* Global spring_time which tells us when we started the last sim frame 
+	* in local or demo mode. Used for GameServer new frame timing
+	*/
+	spring_time lastSimFrameStartTime;
 };
 
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3546,6 +3546,31 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 }
 
 
+ *
+ * @function UpdateTimeOffset
+ * @number timeOffset
+ * @number drawSimRatio
+ * @return new timeOffset
+ */
+void CLuaHandle::UpdateTimeOffset(float timeOffset, float drawSimRatio)
+{
+	LUA_CALL_IN_CHECK(L, false);
+	luaL_checkstack(L, 4, __func__);
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return ;
+
+	int args = 2;
+
+	lua_pushnumber(L, timeOffset);
+	lua_pushnumber(L, drawSimRatio);
+
+	// call the routine
+	RunCallIn(L, cmdStr, args, 0);
+	return;
+}
+
+
 /***
  *
  * @function GameSetup

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3545,7 +3545,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 	return retval;
 }
 
-
+/*** Called at the start of each update, to determine what the timeOffset should be. 
  *
  * @function UpdateTimeOffset
  * @number timeOffset

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -235,6 +235,8 @@ class CLuaHandle : public CEventClient
 			const std::string* label
 		) override;
 
+		void UpdateTimeOffset(float timeOffset, float drawSimRatio) override;
+
 		void ViewResize() override;
 
 		void FontsChanged() override;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -216,6 +216,8 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetTimer);
 	REGISTER_LUA_CFUNC(GetTimerMicros);
 	REGISTER_LUA_CFUNC(GetFrameTimer);
+	REGISTER_LUA_CFUNC(GetLastSwapBuffersEnd);
+	REGISTER_LUA_CFUNC(GetLastSwapBuffersDuration);
 	REGISTER_LUA_CFUNC(DiffTimers);
 
 	REGISTER_LUA_CFUNC(GetDrawSeconds);
@@ -737,6 +739,36 @@ int LuaUnsyncedRead::GetFrameTimer(lua_State* L)
 	return 1;
 }
 
+
+/*** Get a timer for  when the last SwapBuffers finished
+ *
+ * @function Spring.GetLastSwapBuffersEnd
+ *
+ * For tracking vsync, and calculating frame and camera offsets.
+ * 
+ * @bool[opt=false] micros Get a microsecond accurate timer
+ * @treturn Timer
+ */
+int LuaUnsyncedRead::GetLastSwapBuffersEnd(lua_State* L)
+{
+	PushTimer(L, globalRendering->lastSwapBuffersEnd, luaL_optboolean(L, 2, false));
+	return 1;
+}
+
+
+/*** Get a timer for how long the last swapbuffers took (in milliseconds)
+ *
+ * @function Spring.GetLastSwapBuffersDuration
+ *
+ * For tracking vsync, and calculating frame and camera offsets.
+ * 
+ * @treturn number
+ */
+int LuaUnsyncedRead::GetLastSwapBuffersDuration(lua_State* L)
+{
+	lua_pushnumber(L, globalRendering->lastSwapBuffersDuration.toMilliSecsf());
+	return 1;
+}
 
 /***
  *

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -727,14 +727,16 @@ int LuaUnsyncedRead::GetTimerMicros(lua_State* L)
  * This should give better results for camera interpolations
  *
  * @bool[opt=false] lastFrameTime whether to use last frame time instead of last frame start
+ * @bool[opt=false] micros Get a microsecond accurate timer
  * @treturn Timer
  */
 int LuaUnsyncedRead::GetFrameTimer(lua_State* L)
 {
+	bool micros = luaL_optboolean(L, 2, false);
 	if (luaL_optboolean(L, 1, false)) {
-		PushTimer(L, game->lastFrameTime, false);
+		PushTimer(L, game->lastFrameTime, micros);
 	} else {
-		PushTimer(L, globalRendering->lastFrameStart, false);
+		PushTimer(L, globalRendering->lastFrameStart, micros);
 	}
 	return 1;
 }

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -130,6 +130,8 @@ class LuaUnsyncedRead {
 		static int GetTimer(lua_State* L);
 		static int GetTimerMicros(lua_State* L);
 		static int GetFrameTimer(lua_State* L);
+		static int GetLastSwapBuffersEnd(lua_State* L);
+		static int GetLastSwapBuffersDuration(lua_State* L);
 		static int DiffTimers(lua_State* L);
 
 		static int GetDrawSeconds(lua_State* L);

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -66,7 +66,7 @@
 
 #define ALLOW_DEMO_GODMODE
 
-//#define DEBUG_SERVERSYNCGAMETIMING // uncomment to enable debug output for serverSyncGameTiming
+#define DEBUG_SERVERSYNCGAMETIMING // uncomment to enable debug output for serverSyncGameTiming
 const char* const tracyFrameTimeLeft = "FrameTimeLeft";
 const char* const tracyDrawSimRatio = "DrawSimRatio2";
 
@@ -2658,7 +2658,9 @@ void CGameServer::CreateNewFrame(bool fromServerThread, bool fixedFrameTime)
 				// this number is positive if we are issuing the sim frame too late
 				// ideally this number is about -2 ms
 				timeFromNextExpectedSimMs = timeFromNextExpectedSimMs - simFramePeriodms;
+				TracyPlot("timeFromNextExpectedSimMs", timeFromNextExpectedSimMs);
 				if (internalSpeed >= 0.45 && internalSpeed <= 2.1){
+				
 					if (timeFromNextExpectedSimMs > -2.0) {
 						frameTimeLeft += 2.0 * simFramePeriodms/2000.0f;
 						TracyMessageL("Hurrying up Gameserver");
@@ -2670,7 +2672,7 @@ void CGameServer::CreateNewFrame(bool fromServerThread, bool fixedFrameTime)
 				}
 
 			}
-			{
+			
 			#ifdef DEBUG_SERVERSYNCGAMETIMING
 				char msgBuf[512];
 
@@ -2680,8 +2682,12 @@ void CGameServer::CreateNewFrame(bool fromServerThread, bool fixedFrameTime)
 
 				TracyMessage(msgBuf, sizeof(msgBuf));
 				TracyPlot(tracyFrameTimeLeft,frameTimeLeft);
+				TracyPlot("timeFromNextExpectedSimMs",timeFromNextExpectedSimMs);
+				TracyPlot("tracyTimeElapsed",timeElapsed.toMilliSecsf());
+
+	
 			#endif
-			}
+			
 		#endif
 
 
@@ -2731,6 +2737,7 @@ void CGameServer::CreateNewFrame(bool fromServerThread, bool fixedFrameTime)
 			++serverFrameNum;
 			#ifdef DEBUG_SERVERSYNCGAMETIME
 				TracyMessageL("CGameServer::CreateNewFrame::NewFrameCreated");
+				ZoneScopedN("CGameServer::CreateNewFrame::NewFrameCreated");
 			#endif
 
 			// Send out new frame messages.

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -2717,10 +2717,11 @@ void CGameServer::UpdateLoop()
 		Threading::SetAffinity(~0);
 
 		while (!quitServer) {
-			spring_msecs(loopSleepTime).sleep(true);
 
 			if (udpListener != nullptr)
-				udpListener->Update();
+				udpListener->Update(loopSleepTime);
+			else
+				spring_msecs(loopSleepTime).sleep(true);
 
 			std::lock_guard<spring::recursive_mutex> scoped_lock(gameServerMutex);
 			ServerReadNet();

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -795,6 +795,7 @@ float CGameServer::GetDemoTime() const {
 
 void CGameServer::Update()
 {
+	ZoneScopedN("CGameServer::Update");
 	const float tdif = spring_tomsecs(spring_gettime() - lastUpdate) * 0.001f;
 
 	gameTime += tdif;
@@ -1942,6 +1943,7 @@ void CGameServer::HandleConnectionAttempts()
 
 void CGameServer::ServerReadNet()
 {
+	ZoneScopedN("CGameServer::ServerReadNet");
 	// handle new connections
 	HandleConnectionAttempts();
 
@@ -2571,6 +2573,7 @@ bool CGameServer::HasFinished() const
 
 void CGameServer::CreateNewFrame(bool fromServerThread, bool fixedFrameTime)
 {
+	ZoneScopedN("CGameServer::CreateNewFrame");
 	if (demoReader != nullptr) {
 		CheckSync();
 		SendDemoData(-1);

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -57,6 +57,8 @@
 #include "System/Platform/Threading.h"
 #include "System/Threading/SpringThreading.h"
 
+#include "System/Misc/TracyDefs.h"
+
 #ifndef DEDICATED
 #include "lib/luasocket/src/restrictions.h"
 #endif

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -819,8 +819,8 @@ float CGameServer::GetDemoTime() const {
 void CGameServer::Update()
 {
 	ZoneScopedN("CGameServer::Update");
-	const float tdif = spring_tomsecs(spring_gettime() - lastUpdate) * 0.001f;
 
+	const float tdif = (spring_gettime() - lastUpdate).toMilliSecsf() * 0.001f;
 	gameTime += tdif;
 	lastUpdate = spring_gettime();
 

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -109,6 +109,8 @@ public:
 	}
 
 	std::string GetPlayerNames(const std::vector<int>& indices) const;
+	
+	void ConfigNotify(const std::string& key, const std::string& value);
 
 	const std::shared_ptr<const ClientSetup> GetClientSetup() const { return myClientSetup; }
 	const std::shared_ptr<const    GameData> GetGameData() const { return myGameData; }
@@ -249,6 +251,8 @@ private:
 	int medianPing = 0;
 	int curSpeedCtrl = 0;
 	int loopSleepTime = 0;
+	bool serverSyncGameTiming = false;
+	int vSync = 0;
 
 
 	int serverFrameNum = -1;

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -614,6 +614,8 @@ void CGame::ClientReadNet()
 				msgProcTimeLeft -= 1000.0f;
 				lastSimFrameNetPacketTime = spring_gettime();
 
+				gu->lastSimFrameStartTime = spring_gettime();
+
 				SimFrame();
 
 #ifdef SYNCCHECK

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -119,6 +119,8 @@ CR_REG_METADATA(CGlobalRendering, (
 	CR_MEMBER(lastFrameTime),
 	CR_MEMBER(lastFrameStart),
 	CR_MEMBER(lastSwapBuffersEnd),
+	CR_MEMBER(lastSwapBuffersStart),
+	CR_MEMBER(lastSwapBuffersDuration),
 	CR_MEMBER(weightedSpeedFactor),
 	CR_MEMBER(drawFrame),
 	CR_MEMBER(FPS),
@@ -668,6 +670,8 @@ void CGlobalRendering::SwapBuffers(bool allowSwapBuffers, bool clearErrors)
 	// exclude debug from SCOPED_TIMER("Misc::SwapBuffers");
 	eventHandler.DbgTimingInfo(TIMING_SWAP, pre, spring_now());
 	globalRendering->lastSwapBuffersEnd = spring_now();
+	globalRendering->lastSwapBuffersStart = pre;
+	globalRendering->lastSwapBuffersDuration = globalRendering->lastSwapBuffersEnd - pre;
 }
 
 void CGlobalRendering::SetGLTimeStamp(uint32_t queryIdx) const

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -136,6 +136,11 @@ public:
 	spring_time lastFrameStart;
 
 	spring_time lastSwapBuffersEnd;
+	spring_time lastSwapBuffersStart;
+
+	//The duration of the swapbuffers gives us a hint of wether triple buffering is being used
+	//and if the windows Desktop Compositor (DWM) is being enforced 
+	spring_time lastSwapBuffersDuration; 
 
 	/// 0.001f * gu->simFPS, used for rendering
 	float weightedSpeedFactor;

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -420,7 +420,7 @@ public:
 	/**
 	 * @brief Forces Window's desktop compositing before each glSwapWindow
 	 */
-	bool forceDWMFlush;
+	int forceDWMFlush;
 
 	#ifdef _WIN32
 		DwmApiLoader& dwmLoader  = DwmApiLoader::getInstance();

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -321,6 +321,8 @@ class CEventClient
 		                        const float3* pos1,
 		                        const std::string* label);
 
+		virtual void UpdateTimeOffset(float timeOffset, float drawSimRatio) {}
+
 		virtual void SunChanged();
 
 		virtual void ViewResize();

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -943,6 +943,10 @@ bool CEventHandler::MapDrawCmd(
 	return ControlReverseIterateDefTrue(listMapDrawCmd, &CEventClient::MapDrawCmd, playerID, type, pos0, pos1, label);
 }
 
+void CEventHandler::UpdateTimeOffset(float timeOffset, float drawSimRatio)
+{
+	ITERATE_EVENTCLIENTLIST(UpdateTimeOffset, timeOffset, drawSimRatio);
+}
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -259,6 +259,8 @@ class CEventHandler
 		                const float3* pos0,
 		                const float3* pos1,
 		                const std::string* label);
+		
+		void UpdateTimeOffset(float timeOffset, float drawSimRatio);
 
 		void SunChanged();
 

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -236,6 +236,8 @@
 	SETUP_EVENT(Pong,            MANAGED_BIT | UNSYNCED_BIT)
 	SETUP_EVENT(MetalMapChanged, MANAGED_BIT)
 
+	SETUP_EVENT(UpdateTimeOffset,   MANAGED_BIT | UNSYNCED_BIT) // informs about video-/sim-frame start & end times
+
 
 #ifndef SETUP_EVENT
 	#pragma pop_macro("SETUP_EVENT")

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -235,9 +235,7 @@
 	SETUP_EVENT(DbgTimingInfo,   MANAGED_BIT | UNSYNCED_BIT) // informs about video-/sim-frame start & end times
 	SETUP_EVENT(Pong,            MANAGED_BIT | UNSYNCED_BIT)
 	SETUP_EVENT(MetalMapChanged, MANAGED_BIT)
-
-	SETUP_EVENT(UpdateTimeOffset,   MANAGED_BIT | UNSYNCED_BIT) // informs about video-/sim-frame start & end times
-
+	SETUP_EVENT(UpdateTimeOffset,   MANAGED_BIT | UNSYNCED_BIT) // calculates timeOffset for the next draw frame
 
 #ifndef SETUP_EVENT
 	#pragma pop_macro("SETUP_EVENT")

--- a/rts/System/Net/UDPListener.h
+++ b/rts/System/Net/UDPListener.h
@@ -52,8 +52,9 @@ public:
 	 * @brief Run this from time to time
 	 * Recieve data from the socket and hand it to the associated UDPConnection,
 	 * or open a new UDPConnection. It also Updates all of its connections.
+	 * Sleeps for loopSleepTime is desired. This is needed for windows because min sleep there is 1/64th second
 	 */
-	void Update();
+	void Update(int loopSleepTime = 0);
 
 	/**
 	 * Set if we are accepting new connections
@@ -75,6 +76,7 @@ public:
 	void RejectConnection() { waiting.pop(); }
 	void UpdateConnections(); // Updates connections when the endpoint has been reconnected
 
+	auto& GetSocket() { return socket; }
 private:
 	/**
 	 * @brief Do we accept packets from unknown sources?


### PR DESCRIPTION
This PR fixes a few things regarding frame timing and pacing.

## ServerSyncGameTiming

Most importantly, it uses a blocking server socket to wait in the server thread, because windows default sleep duration is 15.6 ms, and we need a more accurate time to be able to sync the generation of gameframes from the server thread to be accurately on time with rendering. This mitigates the jitter effect that result that manifests as an uneven count of draw frames being issues per sim frame.

## LuaTimeOffset
It also contains the lua backend that allows for the game to determine FrameTimeOffset from lua. Shifting this task to lua is not expensive, but the only way to develop sane logic to calculate sane and visually pleasing timeOffsets. Accurate timeoffsets will be even more nessesary with the upcoming gpu interplolated quaternion animations.

LuaTimeOffset should be calculated by the game, and is the first calling of the unsynced update loop. We need the timeOffset early, before any draw is done.

Also, calculating it is non trivial, as you need to know when the next frame you are drawing will actually hit the monitor.

TODO: Overwrite timeOffset from the return value of the calling

## DWMFlush support

Another addition is support for telling windows (before or after swapbuffers) to perform desktop window compositing. This is intended for the very sad case were plenty of frames get drawn, but they never make it to the monitor. This can be confirmed when sim load is high, and the BAR widget Jitter 