### PR TITLE
Prevent rezbot from chasing unrepaired units in area resurrection

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -1149,10 +1149,14 @@ void CBuilderCAI::ExecuteResurrect(Command& c)
 
 				if (ownerBuilder->lastResurrected && unitHandler.GetUnitUnsafe(ownerBuilder->lastResurrected) != nullptr && owner->unitDef->canRepair) {
 					// resurrection finished, start repair (by overwriting the current order)
-					float3 pos = c.GetPos(1);
-					float radius = c.GetParam(4);
-					c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected, pos);
-					c.PushParam(radius);
+					if (c.GetNumParams() == 5) {
+						float3 pos = c.GetPos(1);
+						float radius = c.GetParam(4);
+						c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected, pos);
+						c.PushParam(radius);
+					} else {
+						c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected);
+					}
 					ownerBuilder->lastResurrected = 0;
 					inCommand = CMD_STOP;
 					SlowUpdate();

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -1129,7 +1129,7 @@ void CBuilderCAI::ExecuteResurrect(Command& c)
 	if (!owner->unitDef->canResurrect)
 		return;
 
-	if (c.GetNumParams() == 1) {
+	if (c.GetNumParams() == 1 || c.GetNumParams() == 5) {
 		const unsigned int id = (unsigned int) c.GetParam(0);
 
 		if (id >= unitHandler.MaxUnits()) { // resurrect feature
@@ -1149,8 +1149,10 @@ void CBuilderCAI::ExecuteResurrect(Command& c)
 
 				if (ownerBuilder->lastResurrected && unitHandler.GetUnitUnsafe(ownerBuilder->lastResurrected) != nullptr && owner->unitDef->canRepair) {
 					// resurrection finished, start repair (by overwriting the current order)
-					c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected);
-
+					float3 pos = c.GetPos(1);
+					float radius = c.GetParam(4);
+					c = Command(CMD_REPAIR, c.GetOpts() | INTERNAL_ORDER, ownerBuilder->lastResurrected, pos);
+					c.PushParam(radius);
 					ownerBuilder->lastResurrected = 0;
 					inCommand = CMD_STOP;
 					SlowUpdate();
@@ -1551,7 +1553,9 @@ bool CBuilderCAI::FindResurrectableFeatureAndResurrect(
 	}
 
 	if (best != nullptr) {
-		commandQue.push_front(Command(CMD_RESURRECT, options | INTERNAL_ORDER, unitHandler.MaxUnits() + best->id));
+		Command c(CMD_RESURRECT, options | INTERNAL_ORDER, unitHandler.MaxUnits() + best->id, pos);
+		c.PushParam(radius);
+		commandQue.push_front(c);
 		return true;
 	}
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -449,7 +449,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 
 			Command& c = resurrecterCAI->commandQue.front();
 
-			if (c.GetID() != CMD_RESURRECT || c.GetNumParams() != 1)
+			if (c.GetID() != CMD_RESURRECT || (c.GetNumParams() != 1 && c.GetNumParams() != 5))
 				continue;
 
 			if ((c.GetParam(0) - unitHandler.MaxUnits()) != curResurrectee->id)


### PR DESCRIPTION
The current behavior results in resurrected units within the resurrection area being chased indefinitely by the rezbot, when they are not fully repaired. This chase often leads to the rezbot reaching the front line, where it's often destroyed.

This patch modifies the behavior so that the rezbot stops repairing the resurrected unit when it exits the direct repair range of the rezbot, i.e., when the unit move. This solution is more preferred then repairing within resurrect area due to the fact that resurrection often happen near the front line. Fixes #986.