### PR TITLE
Mouse button binds.

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1208,7 +1208,7 @@ bool CGame::MousePress(int x, int y, int button)
 
 	// try our list of actions
 	for (const Action& action: lastActionList) {
-		if (ActionPressed(keyCode, scanCode, action, isRepeat)) {
+		if (ActionPressed(action, isRepeat)) {
 			return true;
 		}
 	}

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1219,13 +1219,13 @@ bool CGame::MousePress(int x, int y, int button)
 
 	if (luaUI != nullptr) {
 		for (const Action& action: lastActionList) {
-			handled = luaUI->GotChatMsg(action.rawline, false);
+			handled |= luaUI->GotChatMsg(action.rawline, false);
 		}
 	}
 
 	if (luaMenu != nullptr) {
 		for (const Action& action: lastActionList) {
-			handled = luaMenu->GotChatMsg(action.rawline, false);
+			handled |= luaMenu->GotChatMsg(action.rawline, false);
 		}
 	}
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1201,8 +1201,9 @@ bool CGame::MousePress(int x, int y, int button)
 	const CKeySet ks(scanCode, CKeySet::KSScanCode);
 	bool isRepeat = false;
 
-	curKeyCodeChain.push_back(kc, spring_gettime(), isRepeat);
-	curScanCodeChain.push_back(ks, spring_gettime(), isRepeat);
+	const auto now = spring_gettime();
+	curKeyCodeChain.push_back(kc, now, isRepeat);
+	curScanCodeChain.push_back(ks, now, isRepeat);
 
 	lastActionList = keyBindings.GetActionList(curKeyCodeChain, curScanCodeChain);
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1213,7 +1213,23 @@ bool CGame::MousePress(int x, int y, int button)
 		}
 	}
 
-	return false;
+	// maybe a widget is interested?
+	// allowing all listeners to process for backwards compatibility.
+	bool handled = false;
+
+	if (luaUI != nullptr) {
+		for (const Action& action: lastActionList) {
+			handled = luaUI->GotChatMsg(action.rawline, false);
+		}
+	}
+
+	if (luaMenu != nullptr) {
+		for (const Action& action: lastActionList) {
+			handled = luaMenu->GotChatMsg(action.rawline, false);
+		}
+	}
+
+	return handled;
 }
 
 bool CGame::MouseRelease(int x, int y, int button)

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -135,7 +135,6 @@
 #include "System/TimeProfiler.h"
 #include "System/LoadLock.h"
 
-
 #include "System/Misc/TracyDefs.h"
 
 
@@ -1213,7 +1212,6 @@ bool CGame::MousePress(int x, int y, int button)
 			return true;
 		}
 	}
-
 
 	return false;
 }

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -123,6 +123,10 @@ private:
 	int KeyReleased(int keyCode, int scanCode) override;
 	/// Called when the key is pressed by the user (can be called several times due to key repeat)
 	int KeyPressed(int keyCode, int scanCode, bool isRepeat) override;
+
+	bool MousePress(int x, int y, int button) override;
+	bool MouseRelease(int x, int y, int button) override;
+
 	/// Called when the keymap changes (language or keyboard switch)
 	int KeyMapChanged() override;
 	///

--- a/rts/Game/GameController.h
+++ b/rts/Game/GameController.h
@@ -21,6 +21,8 @@ public:
 	virtual int TextInput(const std::string& utf8Text) { return 0; }
 	virtual int TextEditing(const std::string& utf8Text, unsigned int start, unsigned int length) { return 0; }
 	virtual void ResizeEvent() {}
+	virtual bool MousePress(int x, int y, int button) { return 0; }
+	virtual bool MouseRelease(int x, int y, int button) { return 0; }
 };
 
 extern CGameController* activeController;

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -184,6 +184,7 @@ void CKeyCodes::Reset()
 
 int CKeyCodes::GetMouseButtonSymbol(int button)
 {
+	// magic number here chosen so it won't conflict with SDL reserved values.
 	return 1024+button;
 }
 

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -184,8 +184,9 @@ void CKeyCodes::Reset()
 
 int CKeyCodes::GetMouseButtonSymbol(int button)
 {
-	// magic number here chosen so it won't conflict with SDL reserved values.
-	return 1024+button;
+	// magic number here chosen so it won't conflict with SDL or unicode reserved values.
+	// choosing a private part of unicode range.
+	return 0xE000+button;
 }
 
 

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -182,6 +182,7 @@ void CKeyCodes::Reset()
 	std::copy(codeToName.begin(), codeToName.end(), defaultCodeToName.begin());
 }
 
+
 int CKeyCodes::GetMouseButtonSymbol(int button)
 {
 	// magic number here chosen so it won't conflict with SDL or unicode reserved values.

--- a/rts/Game/UI/KeyCodes.cpp
+++ b/rts/Game/UI/KeyCodes.cpp
@@ -4,6 +4,7 @@
 #include <SDL_keycode.h>
 
 #include "KeyCodes.h"
+#include "Game/UI/MouseHandler.h"
 #include "System/Log/ILog.h"
 #include "System/Platform/SDL1_keysym.h"
 #include "System/StringUtil.h"
@@ -159,6 +160,10 @@ void CKeyCodes::Reset()
 	//AddPair("euro", SDLK_EURO);       // Some european keyboards
 	//AddPair("undo", SDLK_UNDO);       // Atari keyboard has Undo
 
+	for (int i = ACTION_BUTTON_MIN; i <= NUM_BUTTONS; i++) {
+		AddPair("mouse" + IntToString(i), CKeyCodes::GetMouseButtonSymbol(i));
+	}
+
 	std::sort(nameToCode.begin(), nameToCode.end(), namePred);
 	std::sort(codeToName.begin(), codeToName.end(), codePred);
 	std::sort(printableCodes.begin(), printableCodes.end());
@@ -175,6 +180,11 @@ void CKeyCodes::Reset()
 
 	std::copy(nameToCode.begin(), nameToCode.end(), defaultNameToCode.begin());
 	std::copy(codeToName.begin(), codeToName.end(), defaultCodeToName.begin());
+}
+
+int CKeyCodes::GetMouseButtonSymbol(int button)
+{
+	return 1024+button;
 }
 
 

--- a/rts/Game/UI/KeyCodes.h
+++ b/rts/Game/UI/KeyCodes.h
@@ -18,6 +18,7 @@ public:
 
 	static std::string GetCodeString(int code);
 	static int GetNormalizedSymbol(int sym);
+	static int GetMouseButtonSymbol(int button);
 };
 
 extern CKeyCodes keyCodes;

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -375,6 +375,14 @@ void CMouseHandler::MousePress(int x, int y, int button)
 			}
 		}
 
+	}
+
+	if (button >= ACTION_BUTTON_MIN && activeController->MousePress(x, y, button)) {
+		return;
+	}
+
+	if (game != nullptr && !game->hideInterface) {
+		// skip guihandler in this case
 		return;
 	}
 
@@ -513,6 +521,10 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 		if (!buttons[SDL_BUTTON_LEFT].pressed && !buttons[SDL_BUTTON_MIDDLE].pressed && !buttons[SDL_BUTTON_RIGHT].pressed)
 			activeReceiver = nullptr;
 
+		return;
+	}
+
+	if (button >= ACTION_BUTTON_MIN && activeController->MouseRelease(x, y, button)) {
 		return;
 	}
 

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -377,7 +377,7 @@ void CMouseHandler::MousePress(int x, int y, int button)
 
 	}
 
-	if (button >= ACTION_BUTTON_MIN && activeController->MousePress(x, y, button)) {
+	if (button >= ACTION_BUTTON_MIN && activeController != nullptr && activeController->MousePress(x, y, button)) {
 		return;
 	}
 
@@ -524,7 +524,7 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 		return;
 	}
 
-	if (button >= ACTION_BUTTON_MIN && activeController->MouseRelease(x, y, button)) {
+	if (button >= ACTION_BUTTON_MIN && activeController != nullptr && activeController->MouseRelease(x, y, button)) {
 		return;
 	}
 

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -371,7 +371,7 @@ void CMouseHandler::MousePress(int x, int y, int button)
 				if (activeReceiver == nullptr)
 					activeReceiver = recv;
 
-				break;
+				return;
 			}
 		}
 

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -13,6 +13,7 @@
 #include "MouseCursor.h"
 
 static const int NUM_BUTTONS = 10;
+static const int ACTION_BUTTON_MIN = 4;
 
 class CInputReceiver;
 class CCameraController;

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -245,12 +245,14 @@ void CScanCodes::Reset()
 	std::copy(codeToName.begin(), codeToName.end(), defaultCodeToName.begin());
 }
 
+
 int CScanCodes::GetMouseButtonSymbol(int button)
 {
 	// magic number here chosen so it won't conflict with SDL reserved values.
 	// just in case taking a value from private unicode area.
 	return 0x100000+button;
 }
+
 
 std::string CScanCodes::GetCodeString(int code)
 {

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -247,6 +247,7 @@ void CScanCodes::Reset()
 
 int CScanCodes::GetMouseButtonSymbol(int button)
 {
+	// magic number here chosen so it won't conflict with SDL reserved values.
 	return 512+button;
 }
 

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -248,7 +248,8 @@ void CScanCodes::Reset()
 int CScanCodes::GetMouseButtonSymbol(int button)
 {
 	// magic number here chosen so it won't conflict with SDL reserved values.
-	return 512+button;
+	// just in case taking a value from private unicode area.
+	return 0x100000+button;
 }
 
 std::string CScanCodes::GetCodeString(int code)

--- a/rts/Game/UI/ScanCodes.cpp
+++ b/rts/Game/UI/ScanCodes.cpp
@@ -4,6 +4,7 @@
 #include <SDL_scancode.h>
 
 #include "ScanCodes.h"
+#include "Game/UI/MouseHandler.h"
 #include "System/Log/ILog.h"
 #include "System/StringUtil.h"
 
@@ -213,6 +214,10 @@ void CScanCodes::Reset()
 	AddPair("sc_alt",   SDL_SCANCODE_LALT);
 	AddPair("sc_meta",  SDL_SCANCODE_LGUI);
 
+	for (int i = ACTION_BUTTON_MIN; i <= NUM_BUTTONS; i++) {
+		AddPair("sc_mouse" + IntToString(i), CScanCodes::GetMouseButtonSymbol(i));
+	}
+
 	// Miscellaneous function keys
 	AddPair("sc_help", SDL_SCANCODE_HELP);
 	AddPair("sc_printscreen", SDL_SCANCODE_PRINTSCREEN);
@@ -240,6 +245,10 @@ void CScanCodes::Reset()
 	std::copy(codeToName.begin(), codeToName.end(), defaultCodeToName.begin());
 }
 
+int CScanCodes::GetMouseButtonSymbol(int button)
+{
+	return 512+button;
+}
 
 std::string CScanCodes::GetCodeString(int code)
 {

--- a/rts/Game/UI/ScanCodes.h
+++ b/rts/Game/UI/ScanCodes.h
@@ -18,6 +18,8 @@ public:
 
 	static std::string GetCodeString(int code);
 	static int GetNormalizedSymbol(int sym);
+
+	static int GetMouseButtonSymbol(int button);
 };
 
 extern CScanCodes scanCodes;


### PR DESCRIPTION
### Work done

- Allow binding of mouse buttons to actions.
- Enable binding for buttons 4+.

#### Related issues

- Fixes https://github.com/beyond-all-reason/spring/issues/2059

(see at the bottom for other issue and PR references)

### Remarks

- Talked to both @badosu and @MasterBel2 about this, since they're interested in the issue and particularly @MasterBel2 did some [overlapping work](https://github.com/beyond-all-reason/spring/pull/893)
  - They seem to be ok with going the route this PR starts, but pls voice your ideas/complaints otherwise.
  - Was specially worried about @MasterBel2's patch overlap, but I think we both agree that one needs splitting anyways, and we can incrementally add code to try to fix/support any use cases he has, possibly taking code from his PR in the future.
- PR'ing this simplistic version since I think it's best to start discussion, but see below for additional code possibly improving behaviour and code organization, but also complicating review/discussion somewhat.
- I'm choosing here to input the events as KeyCode and ScanCode so we don't need a lot of adapting for Action processing code.
  - Choosing some "safe" values SDL shouldn't be using, but we can look better, otherwise could make the keycode/scancode internal representation larger, so we can fit all possible SDL values, while having extra bits for ourselves (ie, from int to long).
  - Might be better to just allow scancode `or` keycode here, to avoid having to support both when chains support merged codes later. Still, they could have a meaning if buttons are remapped with some os facility, or some weird mouse formfactor also makes users having left and right buttons not in positions 1 and 3.
- This simplistic PR could need a couple tweaks:
  - Move the action processing code in MouseHandler a bit up so it has more priority (already done in "step 2" below).
  - For now just allowing mouse buttons 4+, but allowing others will be just a matter of changing MouseHandler::ACTION_BUTTON_MIN to the buttons we like. (if doing non consecutive would need some "special" code tho, like allowing buttons 2 and 4+ for now)
   - Might want to at least PR with "step two" below, but since we're early in engine release cycle likely not a problem to commit code incrementally. Could go directly to step 3 just as well imo.

### Next steps

- (2). https://github.com/beyond-all-reason/spring/pull/2164
  - Adds a simple proxy game InputReceiver, and rehooks some minimap behaviour so button 2 can already be bound
  - minimal receiver so we can 'lock' PressRelease button, allowing override of middle button engine behaviours, also likely making it more correct.
  - moves action processing to top of MouseHandler:PressRelease.
  - still a very simple change
- (3). https://github.com/beyond-all-reason/spring/pull/2165
  - fully go the InputReceiver route, moving code from Game.cpp into GameInputReceiver.
  - simplifies Game.cpp, while having main action input callbacks in one place (and out of Game.cpp).
  - while not really adding much new code, it complicates the PR since it has a lot of refactoring.
  - makes the whole thing nicer imo.
 - After that, there is likely other work to be done:
   -  Review engine code to see hardcoded behaviours that need to be unhardcoded or overridable, so rebind of default actions for buttons 1, 3 will be possible. Till that's done probably most that can be done is override them (but not rebind), and some cases not even that because of hardcoded behaviours not directly controlled through MousePress/MouseRelease.
   - Review of scancode/keycode in chains, possibly unifying them.
   - Add wheel support too


### Other References

Some may not be directly related, but they add to domain knowledge.

- https://github.com/beyond-all-reason/spring/pull/893
- https://github.com/beyond-all-reason/spring/issues/910
- https://github.com/beyond-all-reason/spring/issues/911
- https://github.com/beyond-all-reason/spring/issues/1071
  - https://github.com/beyond-all-reason/spring/pull/1074
- https://wiki.libsdl.org/SDL2/SDL_Keycode
- https://wiki.libsdl.org/SDL2/SDL_Scancode
- https://wiki.libsdl.org/SDL3/SDL_Keycode
- https://wiki.libsdl.org/SDL3/SDL_Scancode