### PR TITLE
Add ALTQUEUE command modifier.

### DIFF
--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -979,6 +979,7 @@ int LuaUtils::PushUnitAndCommand(lua_State* L, const CUnit* unit, const Command&
 
 /***
  * @alias CommandOptionBit
+ * | 2 # Alternative queue order
  * | 4 # Meta (windows/mac/mod4) key.
  * | 8 # Internal order.
  * | 16 # Right mouse key.
@@ -994,6 +995,7 @@ int LuaUtils::PushUnitAndCommand(lua_State* L, const CUnit* unit, const Command&
  * | "ctrl" # Control key.
  * | "shift" # Shift key.
  * | "meta" # Meta key (space).
+ * | "altqueue" # Put order into the unit alternative queue.
  */
 
 /***
@@ -1045,6 +1047,9 @@ static bool ParseCommandOptions(
 					case hashString("meta"): {
 						cmd.SetOpts(cmd.GetOpts() | (META_KEY * value));
 					} break;
+					case hashString("altqueue"): {
+						cmd.SetOpts(cmd.GetOpts() | (ALTQUEUE * value));
+					} break;
 				}
 
 				continue;
@@ -1070,6 +1075,9 @@ static bool ParseCommandOptions(
 					} break;
 					case hashString("meta"): {
 						cmd.SetOpts(cmd.GetOpts() | META_KEY);
+					} break;
+					case hashString("altqueue"): {
+						cmd.SetOpts(cmd.GetOpts() | ALTQUEUE);
 					} break;
 				}
 			}

--- a/rts/Sim/Units/CommandAI/Command.h
+++ b/rts/Sim/Units/CommandAI/Command.h
@@ -86,6 +86,7 @@ static constexpr float CMD_WAITCODE_GATHERWAIT = 4.0f;
 //   be QUEUED_ORDER), ALT_KEY in most contexts means
 //   OVERRIDE_QUEUED_ORDER, etc.
 //
+static constexpr uint8_t ALTQUEUE        = (1 << 1); //   2
 static constexpr uint8_t META_KEY        = (1 << 2); //   4
 static constexpr uint8_t INTERNAL_ORDER  = (1 << 3); //   8
 static constexpr uint8_t RIGHT_MOUSE_KEY = (1 << 4); //  16

--- a/rts/Sim/Units/CommandAI/FactoryCAI.h
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.h
@@ -39,6 +39,7 @@ public:
 
 private:
 	void UpdateIconName(int id, const int& numQueued);
+	void ClearBuildQueue();
 };
 
 #endif // _FACTORY_AI_H_


### PR DESCRIPTION
### Work done

- New ALTQUEUE command modifier Makes command be placed into the alternative queue (ie, not default for that command).
  - Accessible as cmdOptions.altqueue in lua.
- Adds support for altqueue CMD_STOP in factories (completely clears the build queue).

### Related issues

- https://github.com/beyond-all-reason/spring/issues/1082
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2190

### How to test

- In BAR, substitute `cmd_factory_stop_production.lua::orderDequeue` code by `spGiveOrderToUnit(unitID, CMD.STOP, EMPTY, {'altqueue'})`

### Remarks

- Not final, but just to get some feedback about the mechanism used.
- This can be used in the future (or even added later in this PR) also for builders, so they can put orders into their own queue or the newUnitCommands queue.
- Relevant too if factories can assist construction in the future, or have other builder commands themselves.
- For "factory stop" could add a special command, but since in the future we need the ALTQUEUE modifier (already talked with @sprunk about this in the past, might as well do it directly.
  - It's the perfect simple test case for the modifier.
- Unsure how to place this at the unit's possibleCommands, not sure it's actually possible, so game has to send this commands itself, possibly by using an extra 'fake' command (like BAR's and possibly ZK's CMD_STOP_PRODUCTION).