### PR TITLE
Deprecate ConfigureLayout callin.

### DIFF
--- a/cont/LuaUI/callins.lua
+++ b/cont/LuaUI/callins.lua
@@ -14,7 +14,7 @@
 CallInsList = {
 	"Shutdown",
 	"LayoutButtons",
-	"ConfigureLayout",
+	"GotChatMsg",
 	"ActiveCommandChanged",
 	"CameraRotationChanged",
 	"CameraPositionChanged",

--- a/cont/LuaUI/main.lua
+++ b/cont/LuaUI/main.lua
@@ -93,8 +93,8 @@ function Shutdown()
   return widgetHandler:Shutdown()
 end
 
-function ConfigureLayout(command)
-  return widgetHandler:ConfigureLayout(command)
+function GotChatMsg(command)
+  return widgetHandler:GotChatMsg(command)
 end
 
 function ActiveCommandChanged(id, cmdType)

--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -1145,6 +1145,33 @@ end
 
 
 function widgetHandler:GotChatMsg(command)
+  if (command == 'tweakgui') then
+    self.tweakKeys = {}
+    self.tweakMode = true
+    Spring.Log(section, LOG.INFO, "LuaUI TweakMode: ON")
+    return true
+  elseif (command == 'reconf') then
+    self:SendConfigData()
+    return true
+  elseif (command == 'selector') then
+    if (self:SelectorActive()) then
+      return true  -- there can only be one
+    end
+    local sw = self:LoadWidget(LUAUI_DIRNAME .. SELECTOR_BASENAME)
+    self:InsertWidget(sw)
+    self:RaiseWidget(sw)
+    return true
+  elseif (string.find(command, 'togglewidget') == 1) then
+    self:ToggleWidget(string.sub(command, 14))
+    return true
+  elseif (string.find(command, 'enablewidget') == 1) then
+    self:EnableWidget(string.sub(command, 14))
+    return true
+  elseif (string.find(command, 'disablewidget') == 1) then
+    self:DisableWidget(string.sub(command, 15))
+    return true
+  end
+
   if (self.actionHandler:TextAction(command)) then
     return true
   end

--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -1144,34 +1144,7 @@ function widgetHandler:Update()
 end
 
 
-function widgetHandler:ConfigureLayout(command)
-  if (command == 'tweakgui') then
-    self.tweakKeys = {}
-    self.tweakMode = true
-    Spring.Log(section, LOG.INFO, "LuaUI TweakMode: ON")
-    return true
-  elseif (command == 'reconf') then
-    self:SendConfigData()
-    return true
-  elseif (command == 'selector') then
-    if (self:SelectorActive()) then
-      return true  -- there can only be one
-    end
-    local sw = self:LoadWidget(LUAUI_DIRNAME .. SELECTOR_BASENAME)
-    self:InsertWidget(sw)
-    self:RaiseWidget(sw)
-    return true
-  elseif (string.find(command, 'togglewidget') == 1) then
-    self:ToggleWidget(string.sub(command, 14))
-    return true
-  elseif (string.find(command, 'enablewidget') == 1) then
-    self:EnableWidget(string.sub(command, 14))
-    return true
-  elseif (string.find(command, 'disablewidget') == 1) then
-    self:DisableWidget(string.sub(command, 15))
-    return true
-  end
-
+function widgetHandler:GotChatMsg(command)
   if (self.actionHandler:TextAction(command)) then
     return true
   end

--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -183,7 +183,6 @@ CALLIN_LIST = {
 
 	"ViewResize", -- FIXME ?
 	"LayoutButtons",
-	"ConfigureLayout",
 
 	"AddConsoleLine",
 	"GroupChanged",

--- a/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
+++ b/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
@@ -28,37 +28,7 @@ function hHookFuncs.Shutdown()
 end
 
 
-function hHookFuncs.ConfigureLayout(command)
-	if (command == 'reconf') then
-		handler:SendConfigData()
-		return true
-	elseif (command:find('togglewidget') == 1) then
-		handler:Toggle(string.sub(command, 14))
-		return true
-	elseif (command:find('enablewidget') == 1) then
-		handler:Enable(string.sub(command, 14))
-		return true
-	elseif (command:find('disablewidget') == 1) then
-		handler:Disable(string.sub(command, 15))
-		return true
-	elseif (command:find('callins') == 1) then
-		Spring.Log(LUA_NAME, "info", "known callins are:")
-		Spring.Log(LUA_NAME, "info", "  (NOTE: This list contains a few (e.g. cause of LOS checking) unhandled CallIns, too.)")
-		local o = {}
-		for i,v in pairs(handler.knownCallIns) do
-			local t = {}
-			for j,w in pairs(v) do
-				t[#t+1] = j .. "=" .. tostring(w)
-			end
-			o[#o+1] = ("  %-25s "):format(i .. ":") .. table.concat(t, ", ")
-		end
-		table.sort(o)
-		for i=1,#o do
-			Spring.Log(LUA_NAME, "info", o[i])
-		end
-		return true
-	end
-
+function hHookFuncs.GotChatMsg(command, playerID)
 	if (actionHandler.TextAction(command)) then
 		return true
 	end

--- a/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
+++ b/cont/base/springcontent/LuaHandler/Utilities/specialCallinHandlers.lua
@@ -29,6 +29,36 @@ end
 
 
 function hHookFuncs.GotChatMsg(command, playerID)
+	if (command == 'reconf') then
+		handler:SendConfigData()
+		return true
+	elseif (command:find('togglewidget') == 1) then
+		handler:Toggle(string.sub(command, 14))
+		return true
+	elseif (command:find('enablewidget') == 1) then
+		handler:Enable(string.sub(command, 14))
+		return true
+	elseif (command:find('disablewidget') == 1) then
+		handler:Disable(string.sub(command, 15))
+		return true
+	elseif (command:find('callins') == 1) then
+		Spring.Log(LUA_NAME, "info", "known callins are:")
+		Spring.Log(LUA_NAME, "info", "  (NOTE: This list contains a few (e.g. cause of LOS checking) unhandled CallIns, too.)")
+		local o = {}
+		for i,v in pairs(handler.knownCallIns) do
+			local t = {}
+			for j,w in pairs(v) do
+				t[#t+1] = j .. "=" .. tostring(w)
+			end
+			o[#o+1] = ("  %-25s "):format(i .. ":") .. table.concat(t, ", ")
+		end
+		table.sort(o)
+		for i=1,#o do
+			Spring.Log(LUA_NAME, "info", o[i])
+		end
+		return true
+	end
+
 	if (actionHandler.TextAction(command)) then
 		return true
 	end

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -584,7 +584,9 @@ bool CLuaHandle::GotChatMsg(const string& msg, int playerID)
 	}
 
 	if (!processed && (this == luaUI)) {
-		processed = luaUI->ConfigureLayout(msg); //FIXME deprecated
+		// TODO: remove at a future date, api users should move
+		// to GotChatMsg callin.
+		processed = luaUI->ConfigureLayout(msg);
 	}
 	return processed;
 }

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -297,6 +297,7 @@ bool CLuaUI::ConfigureLayout(const string& command)
 	static bool deprecatedMsgDone = false;
 	if (!deprecatedMsgDone) {
 		LOG_L(L_DEPRECATED, "ConfigureLayout callin is deprecated! Please use GotChatMsg(cmd, playerID) instead.");
+		deprecatedMsgDone = true;
 	}
 
 	lua_pushsstring(L, command);

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -284,6 +284,7 @@ bool CLuaUI::LoadCFunctions(lua_State* L)
 
 /***
  * @function UI:ConfigureLayout
+ * @deprecated
  */
 bool CLuaUI::ConfigureLayout(const string& command)
 {

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -293,6 +293,11 @@ bool CLuaUI::ConfigureLayout(const string& command)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false; // the call is not defined
 
+	static bool deprecatedMsgDone = false;
+	if (!deprecatedMsgDone) {
+		LOG_L(L_DEPRECATED, "ConfigureLayout callin is deprecated! Please use GotChatMsg(cmd, playerID) instead.");
+	}
+
 	lua_pushsstring(L, command);
 
 	// call the routine


### PR DESCRIPTION
### Work done

- Deprecate ConfigureLayout callin
- Remove ConfigureLayout from basecontent lua files

### Remarks

- Not sure what the original intent was here, but seems to be some confusion about the deprecation of `ConfigureLayout`
  - I see if `GotChatMsg` is defined at the lua handler, then ConfigureLayout won't get executed, that leads me to think the intent was to use GotChatMsg.
  - Investigated a bit, and the `FIXME DEPRECATED` survived spans many years and refactors, so who knows what was the idea.
  - GotChatMsg seems like a bad name, since it deals with Actions/Commands. It should probably be TextCommand, since in the end that's the actual callin widgets/gadgets will get.
  - Anyways posting this to spark discussion and see if we can reach any decision.
  - Worst case we can remove the `FIXME DEPRECATED` and be done with it :D
- Still unfinished:
  - Still needs some work on basecontent since unsure about how the duplicate implementation works completely. Adapted everything but might need review to ensure it works correctly.
  - If we decide on really deprecating and go this way, I'll review and finish.