### PR TITLE
New REMOVE_RANGE command for range removal

### DIFF
--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -142,6 +142,8 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	LuaInsertDualMapPair(L, "LOOPBACKATTACK", CMD_ATTACK); // backward compatibility (TODO: find a way to print a warning when used!)
 	/*** @field CMD.IDLEMODE 145  */
 	PUSH_CMD(IDLEMODE);
+	/*** @field CMD.REMOVE_RANGE 155 */
+	PUSH_CMD(REMOVE_RANGE);
 
 	return true;
 }

--- a/rts/Sim/Units/CommandAI/Command.h
+++ b/rts/Sim/Units/CommandAI/Command.h
@@ -51,6 +51,7 @@ static constexpr int CMD_CAPTURE             = 130;
 static constexpr int CMD_AUTOREPAIRLEVEL     = 135;
 static constexpr int CMD_IDLEMODE            = 145;
 static constexpr int CMD_FAILED              = 150;
+static constexpr int CMD_REMOVE_RANGE        = 155;
 
 static constexpr int CMDTYPE_ICON                      =  0;  // expect 0 parameters in return
 static constexpr int CMDTYPE_ICON_MODE                 =  5;  // expect 1 parameter in return (number selected mode)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1281,7 +1281,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		}
 	}
 
-	if ((c.GetNumParams() < 0) || (queue->size() <= 0))
+	if (queue->empty())
 		return;
 
 	repeatOrders = false;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1310,11 +1310,8 @@ void CCommandAI::ExecuteRemove(const Command& c)
 			}
 
 			if (!facCAI && (ci == queue->begin())) {
-				if (!active) {
-					active = true;
-					FinishCommand();
-					break;
-				}
+				FinishCommand();
+				break;
 			}
 
 			queue->erase(ci);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1240,7 +1240,7 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 			return std::nullopt;
 
 		if (c.GetNumParams() >= 2) {
-			auto lastTagIndex = FindTagIndex(queue, c.GetParam(1));
+			const auto lastTagIndex = FindTagIndex(queue, c.GetParam(1));
 			if (!lastTagIndex)
 				return std::nullopt;
 			lastIndex = *lastTagIndex;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1235,7 +1235,7 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 		if (c.GetNumParams() >= 2)
 			lastIndex = std::min<int>(c.GetParam(1)-1, lastIndex);
 	} else if (c.GetNumParams() >= 1) {
-		auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
+		const auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
 		if (!firstTagIndex)
 			return std::nullopt;
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1265,7 +1265,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	// disable repeating during the removals
 	const bool prevRepeat = repeatOrders;
 
-	// erase commands by a list of command types
 	bool facBuildQueue = false;
 
 	if (facCAI) {
@@ -1284,6 +1283,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	repeatOrders = false;
 
 	if (c.GetOpts() & META_KEY) {
+		// erase range by tag or (with ALT) index
 		const auto limits = GetRemoveLimitsFromOptions(c, *queue);
 		if (!limits) {
 			eventHandler.UnitCmdDone(owner, c);
@@ -1323,9 +1323,11 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	if (c.GetNumParams() <= 0)
 		return;
 
-	bool active = false;
+	// erase commands by a list of command types
 	// if false, remove commands by tag
 	const bool removeByID = (c.GetOpts() & ALT_KEY);
+
+	bool active = false;
 
 	for (unsigned int p = 0; p < c.GetNumParams(); p++) {
 		const int removeValue = c.GetParam(p); // tag or id

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1287,10 +1287,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 			--ci;
 		}
 		repeatOrders = prevRepeat;
-		// TODO following is maybe not needed and probably
-		// has unwanted side effects
-		commandQue.push_front(c);
-		FinishCommand();
+		eventHandler.UnitCmdDone(owner, c);
 		return;
 	}
 
@@ -1353,6 +1350,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	}
 
 	repeatOrders = prevRepeat;
+	eventHandler.UnitCmdDone(owner, c);
 }
 
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1243,7 +1243,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 
 	repeatOrders = false;
 
-	if (c.GetOpts() & META_KEY) {
+	if ((c.GetOpts() & META_KEY) && removeByID) {
 		int firstIndex = 0;
 		int lastIndex = queue->size()-1;
 		if (c.GetNumParams() >= 1)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1266,7 +1266,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	const bool prevRepeat = repeatOrders;
 
 	// erase commands by a list of command types
-	bool active = false;
 	bool facBuildQueue = false;
 
 	if (facCAI) {
@@ -1324,6 +1323,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	if (c.GetNumParams() <= 0)
 		return;
 
+	bool active = false;
 	// if false, remove commands by tag
 	const bool removeByID = (c.GetOpts() & ALT_KEY);
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1412,7 +1412,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	}
 
 	repeatOrders = prevRepeat;
-	eventHandler.UnitCmdDone(owner, c);
 }
 
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1223,9 +1223,9 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 		if (c.GetNumParams() >= 2)
 			lastIndex = std::min<int>(c.GetParam(1), lastIndex);
 	} else if (c.GetNumParams() > 0) {
+		bool foundStart = false, foundEnd = true;
 		unsigned int startTag = (unsigned int)c.GetParam(0);
 		unsigned int endTag = 0;
-		bool foundStart = false, foundEnd = true;
 		if (c.GetNumParams() >= 2) {
 			endTag = (unsigned int)c.GetParam(1);
 			foundEnd = false;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1315,7 +1315,8 @@ void CCommandAI::ExecuteRemove(const Command& c)
 			}
 
 			queue->erase(ci);
-			--ci;
+			// iterator may have been invalidated
+			ci = queue->begin() + firstIndex + nElements - 1;
 		}
 		repeatOrders = prevRepeat;
 		eventHandler.UnitCmdDone(owner, c);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1216,37 +1216,13 @@ void CCommandAI::ExecuteInsert(const Command& c, bool fromSynced)
 	SlowUpdate();
 }
 
-const std::optional<int> CCommandAI::FindTagIndex(const CCommandQueue& queue, unsigned int tag) const
-{
-	int i = 0;
-	for (const auto& qc: queue) {
-		if (qc.GetTag() == tag)
-			return i;
-		++i;
-	}
-	return std::nullopt;
-}
-
 
 const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const
 {
 	int firstIndex = 0;
 	int lastIndex = queue.size() - 1;
 
-	if (c.GetOpts() & ALT_KEY) {
-		const auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
-		if (!firstTagIndex)
-			return std::nullopt;
-
-		if (c.GetNumParams() >= 2) {
-			const auto lastTagIndex = FindTagIndex(queue, c.GetParam(1));
-			if (!lastTagIndex)
-				return std::nullopt;
-			lastIndex = *lastTagIndex;
-		}
-
-		firstIndex = *firstTagIndex;
-	} else if (c.GetNumParams() >= 1) {
+	if (c.GetNumParams() >= 1) {
 		if (c.GetNumParams() >= 1)
 			firstIndex = std::max<int>(c.GetParam(0) - 1, 0);
 		if (c.GetNumParams() >= 2)
@@ -1286,7 +1262,7 @@ void CCommandAI::ExecuteRemoveRange(const Command& c)
 
 	repeatOrders = false;
 
-	// erase range by index or (with ALT) tag
+	// erase range by index
 	const auto limits = GetRemoveLimitsFromOptions(c, *queue);
 	if (!limits) {
 		eventHandler.UnitCmdDone(owner, c);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1304,8 +1304,8 @@ void CCommandAI::ExecuteRemove(const Command& c)
 			}
 
 			if (facBuildQueue) {
-				// if ci == queue->begin() and !queue->empty(), this pop_front()'s
-				// via CFAI::ExecuteStop; otherwise only modifies *ci (not <queue>)
+				// only true when ci == queue->begin(), does pop_front()
+				// via CFAI::ExecuteStop. otherwise converts to CMD_STOP.
 				if (facCAI->RemoveBuildCommand(ci)) {
 					break;
 				}

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1227,7 +1227,7 @@ const std::optional<int> CCommandAI::FindTagIndex(const CCommandQueue& queue, un
 const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const
 {
 	int firstIndex = 0;
-	int lastIndex = queue.size()-1;
+	int lastIndex = queue.size() - 1;
 
 	if (c.GetOpts() & ALT_KEY) {
 		if (c.GetNumParams() >= 1)
@@ -1293,7 +1293,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		const auto [firstIndex, lastIndex] = *limits;
 		int nElements = lastIndex - firstIndex + 1;
 
-		CCommandQueue::iterator ci = queue->begin()+lastIndex;
+		CCommandQueue::iterator ci = queue->begin() + lastIndex;
 		while(nElements > 0) {
 			--nElements;
 			const Command& qc = *ci;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1262,8 +1262,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	CCommandQueue* queue = &commandQue;
 	CFactoryCAI* facCAI = dynamic_cast<CFactoryCAI*>(this);
 
-	// if false, remove commands by tag
-	const bool removeByID = (c.GetOpts() & ALT_KEY);
 	// disable repeating during the removals
 	const bool prevRepeat = repeatOrders;
 
@@ -1327,6 +1325,9 @@ void CCommandAI::ExecuteRemove(const Command& c)
 
 	if (c.GetNumParams() <= 0)
 		return;
+
+	// if false, remove commands by tag
+	const bool removeByID = (c.GetOpts() & ALT_KEY);
 
 	for (unsigned int p = 0; p < c.GetNumParams(); p++) {
 		const int removeValue = c.GetParam(p); // tag or id

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1230,10 +1230,13 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 	int lastIndex = queue.size() - 1;
 
 	if (c.GetOpts() & ALT_KEY) {
-		if (c.GetNumParams() >= 1)
-			firstIndex = std::max<int>(c.GetParam(0)-1, firstIndex);
+		if (c.GetNumParams() >= 1) {
+			firstIndex = std::max<int>(c.GetParam(0) - 1, 0);
+		}
 		if (c.GetNumParams() >= 2)
-			lastIndex = std::min<int>(c.GetParam(1)-1, lastIndex);
+			lastIndex = std::clamp<int>(c.GetParam(1) - 1, 0, queue.size() - 1);
+		if (lastIndex < firstIndex || firstIndex >= queue.size())
+			return std::nullopt;
 	} else if (c.GetNumParams() >= 1) {
 		const auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
 		if (!firstTagIndex)
@@ -1247,10 +1250,10 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 		}
 
 		firstIndex = *firstTagIndex;
-	}
 
-	if (lastIndex < firstIndex)
-		std::swap(lastIndex, firstIndex);
+		if (lastIndex < firstIndex)
+			std::swap(lastIndex, firstIndex);
+	}
 
 	return std::make_pair(firstIndex, lastIndex);
 }

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1231,9 +1231,9 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 
 	if (c.GetOpts() & ALT_KEY) {
 		if (c.GetNumParams() >= 1)
-			firstIndex = std::max<int>(c.GetParam(0), firstIndex);
+			firstIndex = std::max<int>(c.GetParam(0)-1, firstIndex);
 		if (c.GetNumParams() >= 2)
-			lastIndex = std::min<int>(c.GetParam(1), lastIndex);
+			lastIndex = std::min<int>(c.GetParam(1)-1, lastIndex);
 	} else if (c.GetNumParams() > 0) {
 		auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
 		if (!firstTagIndex)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1286,7 +1286,7 @@ void CCommandAI::ExecuteRemoveRange(const Command& c)
 
 	repeatOrders = false;
 
-	// erase range by tag or (with ALT) index
+	// erase range by index or (with ALT) tag
 	const auto limits = GetRemoveLimitsFromOptions(c, *queue);
 	if (!limits) {
 		eventHandler.UnitCmdDone(owner, c);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1291,8 +1291,10 @@ void CCommandAI::ExecuteRemove(const Command& c)
 
 	if (c.GetOpts() & META_KEY) {
 		const auto limits = GetRemoveLimitsFromOptions(c, *queue);
-		if (!limits)
+		if (!limits) {
+			eventHandler.UnitCmdDone(owner, c);
 			return;
+		}
 		const auto [firstIndex, lastIndex] = *limits;
 		int nElements = lastIndex - firstIndex + 1;
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1288,14 +1288,14 @@ void CCommandAI::ExecuteRemove(const Command& c)
 
 	if (c.GetOpts() & META_KEY) {
 		const auto limits = GetRemoveLimitsFromOptions(c, *queue);
-		if (!limits.has_value())
+		if (!limits)
 			return;
-		const auto [firstIndex, lastIndex] = limits.value();
+		const auto [firstIndex, lastIndex] = *limits;
 		int nElements = lastIndex - firstIndex + 1;
 
 		CCommandQueue::iterator ci = queue->begin()+lastIndex;
 		while(nElements > 0) {
-			nElements -= 1;
+			--nElements;
 			const Command& qc = *ci;
 			if (qc.GetID() == CMD_WAIT) {
 				waitCommandsAI.RemoveWaitCommand(owner, qc);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1230,13 +1230,10 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 	int lastIndex = queue.size() - 1;
 
 	if (c.GetOpts() & ALT_KEY) {
-		if (c.GetNumParams() >= 1) {
+		if (c.GetNumParams() >= 1)
 			firstIndex = std::max<int>(c.GetParam(0) - 1, 0);
-		}
 		if (c.GetNumParams() >= 2)
 			lastIndex = std::clamp<int>(c.GetParam(1) - 1, 0, queue.size() - 1);
-		if (lastIndex < firstIndex || firstIndex >= queue.size())
-			return std::nullopt;
 	} else if (c.GetNumParams() >= 1) {
 		const auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
 		if (!firstTagIndex)
@@ -1250,10 +1247,10 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 		}
 
 		firstIndex = *firstTagIndex;
-
-		if (lastIndex < firstIndex)
-			std::swap(lastIndex, firstIndex);
 	}
+
+	if (lastIndex < firstIndex || firstIndex >= queue.size())
+		return std::nullopt;
 
 	return std::make_pair(firstIndex, lastIndex);
 }

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1238,10 +1238,62 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		}
 	}
 
-	if ((c.GetNumParams() <= 0) || (queue->size() <= 0))
+	if ((c.GetNumParams() < 0) || (queue->size() <= 0))
 		return;
 
 	repeatOrders = false;
+
+	if (c.GetOpts() & META_KEY) {
+		int firstIndex = 0;
+		int lastIndex = queue->size()-1;
+		if (c.GetNumParams() >= 1)
+			firstIndex = (int)c.GetParam(0);
+		if (c.GetNumParams() >= 2) {
+			lastIndex = (int)c.GetParam(1);
+			if (lastIndex > queue->size()-1)
+				lastIndex = queue->size()-1;
+		}
+
+		int nElements = lastIndex - firstIndex + 1 ;
+		CCommandQueue::iterator ci = queue->begin()+lastIndex;
+		while(nElements > 0) {
+			nElements -= 1;
+			const Command& qc = *ci;
+			if (qc.GetID() == CMD_WAIT) {
+				waitCommandsAI.RemoveWaitCommand(owner, qc);
+			}
+
+			if (facBuildQueue) {
+				// if ci == queue->begin() and !queue->empty(), this pop_front()'s
+				// via CFAI::ExecuteStop; otherwise only modifies *ci (not <queue>)
+				if (facCAI->RemoveBuildCommand(ci)) {
+					ci = queue->begin()+firstIndex;
+					break;
+				}
+			}
+
+			if (!facCAI && (ci == queue->begin())) {
+				if (!active) {
+					active = true;
+					FinishCommand();
+					ci = queue->begin()+firstIndex;
+					break;
+				}
+			}
+
+			queue->erase(ci);
+			--ci;
+		}
+		repeatOrders = prevRepeat;
+		// TODO following is maybe not needed and probably
+		// has unwanted side effects
+		commandQue.push_front(c);
+		FinishCommand();
+		return;
+	}
+
+	if (c.GetNumParams() <= 0)
+		return;
 
 	for (unsigned int p = 0; p < c.GetNumParams(); p++) {
 		const int removeValue = c.GetParam(p); // tag or id

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1248,6 +1248,9 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 			return std::nullopt;
 	}
 
+	if (lastIndex < firstIndex)
+		std::swap(lastIndex, firstIndex);
+
 	return std::make_pair(firstIndex, lastIndex);
 }
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1248,6 +1248,8 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		int lastIndex = queue->size()-1;
 		if (c.GetNumParams() >= 1)
 			firstIndex = (int)c.GetParam(0);
+			if (firstIndex < 0)
+				firstIndex = 0;
 		if (c.GetNumParams() >= 2) {
 			lastIndex = (int)c.GetParam(1);
 			if (lastIndex > queue->size()-1)

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1294,7 +1294,7 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		int nElements = lastIndex - firstIndex + 1;
 
 		CCommandQueue::iterator ci = queue->begin() + lastIndex;
-		while(nElements > 0) {
+		while (nElements > 0) {
 			--nElements;
 			const Command& qc = *ci;
 			if (qc.GetID() == CMD_WAIT) {

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1303,7 +1303,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 				// if ci == queue->begin() and !queue->empty(), this pop_front()'s
 				// via CFAI::ExecuteStop; otherwise only modifies *ci (not <queue>)
 				if (facCAI->RemoveBuildCommand(ci)) {
-					ci = queue->begin()+firstIndex;
 					break;
 				}
 			}
@@ -1312,7 +1311,6 @@ void CCommandAI::ExecuteRemove(const Command& c)
 				if (!active) {
 					active = true;
 					FinishCommand();
-					ci = queue->begin()+firstIndex;
 					break;
 				}
 			}

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1330,9 +1330,13 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	CCommandQueue* queue = &commandQue;
 	CFactoryCAI* facCAI = dynamic_cast<CFactoryCAI*>(this);
 
+	// if false, remove commands by tag
+	const bool removeByID = (c.GetOpts() & ALT_KEY);
 	// disable repeating during the removals
 	const bool prevRepeat = repeatOrders;
 
+	// erase commands by a list of command types
+	bool active = false;
 	bool facBuildQueue = false;
 
 	if (facCAI) {
@@ -1345,16 +1349,10 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		}
 	}
 
-	if (queue->empty() || c.GetNumParams() <= 0)
+	if ((c.GetNumParams() <= 0) || (queue->size() <= 0))
 		return;
 
 	repeatOrders = false;
-
-	// erase commands by a list of command types
-	// if false, remove commands by tag
-	const bool removeByID = (c.GetOpts() & ALT_KEY);
-
-	bool active = false;
 
 	for (unsigned int p = 0; p < c.GetNumParams(); p++) {
 		const int removeValue = c.GetParam(p); // tag or id

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1234,7 +1234,7 @@ const std::optional<std::pair<int, int>> CCommandAI::GetRemoveLimitsFromOptions(
 			firstIndex = std::max<int>(c.GetParam(0)-1, firstIndex);
 		if (c.GetNumParams() >= 2)
 			lastIndex = std::min<int>(c.GetParam(1)-1, lastIndex);
-	} else if (c.GetNumParams() > 0) {
+	} else if (c.GetNumParams() >= 1) {
 		auto firstTagIndex = FindTagIndex(queue, c.GetParam(0));
 		if (!firstTagIndex)
 			return std::nullopt;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1297,16 +1297,14 @@ void CCommandAI::ExecuteRemove(const Command& c)
 		while (nElements > 0) {
 			--nElements;
 			const Command& qc = *ci;
-			if (qc.GetID() == CMD_WAIT) {
+			if (qc.GetID() == CMD_WAIT)
 				waitCommandsAI.RemoveWaitCommand(owner, qc);
-			}
 
 			if (facBuildQueue) {
 				// only true when ci == queue->begin(), does pop_front()
 				// via CFAI::ExecuteStop. otherwise converts to CMD_STOP.
-				if (facCAI->RemoveBuildCommand(ci)) {
+				if (facCAI->RemoveBuildCommand(ci))
 					break;
-				}
 			}
 
 			if (!facCAI && (ci == queue->begin())) {

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -108,7 +108,6 @@ public:
 	void ExecuteRemove(const Command& c);
 	void ExecuteRemoveRange(const Command& c);
 	const std::optional<std::pair<int, int>> GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const;
-	const std::optional<int> FindTagIndex(const CCommandQueue& queue, unsigned int tag) const;
 
 	void AddStockpileWeapon(CWeapon* weapon);
 	void StockpileChanged(CWeapon* weapon);

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -5,7 +5,6 @@
 
 #include <functional>
 #include <vector>
-#include <utility>
 
 #include "System/Object.h"
 #include "CommandDescription.h"

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <vector>
+#include <utility>
 
 #include "System/Object.h"
 #include "CommandDescription.h"
@@ -106,6 +107,7 @@ public:
 
 	void ExecuteInsert(const Command& c, bool fromSynced = true);
 	void ExecuteRemove(const Command& c);
+	const std::optional<std::pair<int, int>> GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const;
 
 	void AddStockpileWeapon(CWeapon* weapon);
 	void StockpileChanged(CWeapon* weapon);

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -108,6 +108,7 @@ public:
 	void ExecuteInsert(const Command& c, bool fromSynced = true);
 	void ExecuteRemove(const Command& c);
 	const std::optional<std::pair<int, int>> GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const;
+	const std::optional<int> FindTagIndex(const CCommandQueue& queue, unsigned int tag) const;
 
 	void AddStockpileWeapon(CWeapon* weapon);
 	void StockpileChanged(CWeapon* weapon);

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -106,6 +106,7 @@ public:
 
 	void ExecuteInsert(const Command& c, bool fromSynced = true);
 	void ExecuteRemove(const Command& c);
+	void ExecuteRemoveRange(const Command& c);
 	const std::optional<std::pair<int, int>> GetRemoveLimitsFromOptions(const Command& c, const CCommandQueue& queue) const;
 	const std::optional<int> FindTagIndex(const CCommandQueue& queue, unsigned int tag) const;
 

--- a/rts/Sim/Units/CommandAI/FactoryCAI.cpp
+++ b/rts/Sim/Units/CommandAI/FactoryCAI.cpp
@@ -174,7 +174,7 @@ void CFactoryCAI::GiveCommandReal(const Command& c, bool fromSynced)
 			return;
 		}
 
-		if (cmdID == CMD_INSERT || cmdID == CMD_REMOVE) {
+		if (cmdID == CMD_INSERT || cmdID == CMD_REMOVE || cmdID == CMD_REMOVE_RANGE) {
 			CCommandAI::GiveAllowedCommand(c);
 			return;
 		}


### PR DESCRIPTION
### Work done

- New REMOVE_RANGE command, removing ranges by cmdId or Tag.

### Work yet to be done in this PR

- Sort out callin behaviour, if any
  - kind of decided, but can still think about it.
- Maybe refactor to better share code with the cmdid/tag loop
  - not sure it's going to be pretty due to inverse looping and 'active' inside the cmdid/tag loop.

### Related issues

- https://github.com/beyond-all-reason/spring/issues/1082
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2190

Also see following "precursor" prs:
- https://github.com/beyond-all-reason/spring/pull/2137
- https://github.com/beyond-all-reason/spring/pull/2154

### Remarks

- It's a bit unclear how callins should react 
  - how is gui supposed to be notified? I don't see the other loop doing any callins, but gui needs them to be notified of changes, specially for factories, otherwise the gui queue numbers don't get updated without some special gui code.
  - for now decided on actually calling UnitCmdDone for the remove command.

### REMOVE_RANGE specs

- ALT: remove by index or tag switch
- CONTROL: alternative queue selection.
  - for factories alternative queue is the factory command queue, default queue is the newUnitCommands queue.
  - for other units no effect.

callins: After successful execution, it will call UnitCmdDone.

Examples:
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, nil, {'meta', 'ctrl'}) -- delete everything`
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, 2, {'meta', 'ctrl', 'alt'}) -- delete all but the 1st element`
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, {1, 20}, {'meta', 'ctrl', 'alt'}) -- delete from 1st to 2th`
  - `spGiveOrderToUnit(unitID, CMD.REMOVE, {startTag, endTag}, {'meta', 'ctrl'}) -- delete from position of startTag, to endTag` 