### PR TITLE
yardmap + yardmap overlap testing for building

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1074,7 +1074,7 @@ bool CGameHelper::YardmapsOverlap(const BuildInfo& bi1, const BuildInfo& bi2)
 	int overlap_x2 = std::min(x2_bi1, x2_bi2);
 	int overlap_z2 = std::min(z2_bi1, z2_bi2);
 
-	// not overlaping bounding-rects
+	// not overlapping bounding-rects
 	if (overlap_x1 >= overlap_x2 || overlap_z1 >= overlap_z2)
 		return false;
 
@@ -1418,7 +1418,7 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 						const int cmdDistX = std::max(bc.pos.x - sqrPos.x - SQUARE_SIZE, sqrPos.x - bc.pos.x) * 2;
 						const int cmdDistZ = std::max(bc.pos.z - sqrPos.z - SQUARE_SIZE, sqrPos.z - bc.pos.z) * 2;
 
-						// bounding-rects overflap
+						// bounding-rects overlap
 						if (cmdDistX < cmdSizeX && cmdDistZ < cmdSizeZ) {
 							const UnitDef* queuedDef = bc.def;
 

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -92,6 +92,12 @@ public:
 		const int2& zrange
 	);
 
+	///< check if yardmaps overlap, used to block overlapping builds
+	static bool YardmapsOverlap(
+		const BuildInfo& bi1,
+		const BuildInfo& bi2
+	);
+
 	///< test whether a blocked map square has a build override
 	static bool TestBlockSquareForBuildOnly(
 		const CSolidObject *blockingObject,

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -10,6 +10,7 @@
 #include "Game/GlobalUnsynced.h"
 #include "Game/SelectedUnitsHandler.h"
 #include "Game/WaitCommandsAI.h"
+#include "Game/GameHelper.h"
 #include "Map/Ground.h"
 #include "Map/MapDamage.h"
 #include "Sim/Features/Feature.h"
@@ -1336,13 +1337,9 @@ CCommandQueue::const_iterator CCommandAI::GetCancelQueued(const Command& c, cons
 					const BuildInfo bc1(c);
 					const BuildInfo bc2(c2);
 
-					if (bc1.def == nullptr) continue;
-					if (bc2.def == nullptr) continue;
-
-					if (math::fabs(bc1.pos.x - bc2.pos.x) * 2 <= std::max(bc1.GetXSize(), bc2.GetXSize()) * SQUARE_SIZE &&
-					    math::fabs(bc1.pos.z - bc2.pos.z) * 2 <= std::max(bc1.GetZSize(), bc2.GetZSize()) * SQUARE_SIZE) {
+					// check yardsmaps for overlap instead of bounding-boxes
+					if (CGameHelper::YardmapsOverlap(bc1, bc2))
 						return ci;
-					}
 				} else {
 					// assume c and c2 are positional commands
 					const float3& c1p = c.GetPos(0);
@@ -1436,20 +1433,9 @@ std::vector<Command> CCommandAI::GetOverlapQueued(const Command& c, const CComma
 					// NOTE: uses a BuildInfo structure, but <t> can be ANY command
 					BuildInfo tbi;
 					if (tbi.Parse(t)) {
-						const float dist2X = 2.0f * math::fabs(cbi.pos.x - tbi.pos.x);
-						const float dist2Z = 2.0f * math::fabs(cbi.pos.z - tbi.pos.z);
-						const float addSizeX = SQUARE_SIZE * (cbi.GetXSize() + tbi.GetXSize());
-						const float addSizeZ = SQUARE_SIZE * (cbi.GetZSize() + tbi.GetZSize());
-						const float maxSizeX = SQUARE_SIZE * std::max(cbi.GetXSize(), tbi.GetXSize());
-						const float maxSizeZ = SQUARE_SIZE * std::max(cbi.GetZSize(), tbi.GetZSize());
-
-						if (cbi.def == NULL) continue;
-						if (tbi.def == NULL) continue;
-
-						if (((dist2X > maxSizeX) || (dist2Z > maxSizeZ)) &&
-						    ((dist2X < addSizeX) && (dist2Z < addSizeZ))) {
-							v.push_back(t);
-						}
+						// check yardsmaps for overlap instead of bounding-boxs
+						if (CGameHelper::YardmapsOverlap(cbi, tbi))
+						    v.push_back(t);
 					} else {
 						if ((cbi.pos - tbi.pos).SqLength2D() >= (COMMAND_CANCEL_DIST * COMMAND_CANCEL_DIST))
 							continue;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1337,7 +1337,7 @@ CCommandQueue::const_iterator CCommandAI::GetCancelQueued(const Command& c, cons
 					const BuildInfo bc1(c);
 					const BuildInfo bc2(c2);
 
-					// check yardsmaps for overlap instead of bounding-boxes
+					// check yardmaps for overlap instead of bounding-boxes
 					if (CGameHelper::YardmapsOverlap(bc1, bc2))
 						return ci;
 				} else {
@@ -1433,9 +1433,9 @@ std::vector<Command> CCommandAI::GetOverlapQueued(const Command& c, const CComma
 					// NOTE: uses a BuildInfo structure, but <t> can be ANY command
 					BuildInfo tbi;
 					if (tbi.Parse(t)) {
-						// check yardsmaps for overlap instead of bounding-boxs
+						// check yardmaps for overlap instead of bounding-boxes
 						if (CGameHelper::YardmapsOverlap(cbi, tbi))
-						    v.push_back(t);
+							v.push_back(t);
 					} else {
 						if ((cbi.pos - tbi.pos).SqLength2D() >= (COMMAND_CANCEL_DIST * COMMAND_CANCEL_DIST))
 							continue;


### PR DESCRIPTION
This makes blueprints and queueing work consistently with manually building. Adding yard+yard overlap detection rather than just bounding-rect + yard overlap detection.