### PR TITLE
Command Documentation Standard

### DIFF
--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -115,7 +115,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * - `meta` Range/filter switch.
 	 * - `alt` Tag/Index or Tag/Id switch, depending on `meta`.
 	 * - `ctrl` Alternative queue selection.
-	 *   - For factories alternative queue is the factory command queue, default queue is the newUnitCommands queue.
+	 *   - For factories alternative queue is the factory command queue, default queue is the rally queue.
 	 *   - For other units no effect.
 	 *
 	 * ## Callins

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -74,15 +74,14 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	/***
 	 * @field CMD.STOP 0
 	 *
-	 * Stop the current action.
+	 * Stop the current action and clear the unit's command queue.
 	 *
 	 * For factories, this will cancel the new unit orders queue.
 	 * For units, this will cancel the current command and queue.
 	 *
 	 * Accepts no parameters.
 	 *
-	 * *Note:* This is actually a noop, but clears the queue when `shift` isn't used since
-	 * that's the standard behaviour when `shift` isn't used for all actions.
+	 * It won't do anything if used with `CMD.INSERT`, or the `shift` option.
 	 */
 	PUSH_CMD(STOP);
 	/*** @field CMD.INSERT 1 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -134,7 +134,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, 2, {'meta', 'ctrl', 'alt'})
 	 * ```
 	 *
-	 * Delete from 1st to 2nd:
+	 * Delete from 1st to 20th:
 	 * ```lua
 	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {1, 20}, {'meta', 'ctrl', 'alt'})
 	 * ```

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -99,9 +99,9 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * ### Filter by id or tag
 	 *
-	 * Removes all commands matching ids or tags from a provided array.
+	 * Removes any command with an id or tag included in params.
 	 *
-	 * - `params` {id1, id2 ...} or {tag1, tag2, ...} an array of ids or tags to look for, unless META is used too.
+	 * - `params` {id1, id2 ...} or {tag1, tag2, ...} an array of ids or tags to look for.
 	 * - With `alt`, remove by id, otherwise remove by tag.
 	 *
 	 * ### Remove by range

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -118,11 +118,11 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *   - For factories alternative queue is the factory command queue, default queue is the newUnitCommands queue.
 	 *   - For other units no effect.
 	 *
-	 * ## Callins:
+	 * ## Callins
 	 *
 	 *  - UnitCmdDone: Run when the command is finished.
 	 *
-	 * ## Examples:
+	 * ## Examples
 	 *
 	 * Delete everything:
 	 * ```lua
@@ -204,11 +204,11 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * - `modInfo.targetableTransportedUnits`: Controls whether transported units are targetable.
 	 *
-	 * ## Callins:
+	 * ## Callins
 	 *
 	 *  - UnitCmdDone: Run when the command is finished.
 	 *
-	 * ## Examples:
+	 * ## Examples
 	 *
 	 * Attack unit with id `targetID`.
 	 * ```lua
@@ -225,6 +225,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * Spring.GiveOrderToUnit(unitID, CMD.ATTACK, {1000,100,1000})
 	 * ```
 	 * @see Spring.GiveOrderToUnit
+	 * @see Callins:UnitCmdDone
 	 */
 	PUSH_CMD(ATTACK);
 	/*** @field CMD.AREA_ATTACK 21 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -203,13 +203,13 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * **Note:** this is different than CMD.AREA_ATTACK, since this initially finds the targets
 	 * but then doesn't consider the area any more.
 	 *
-	 * - `params` {r,x,y,z} when radius is greater than 0.
+	 * - `params` {x,y,z,r} when radius is greater than 0.
 	 *   - r: radius
 	 *   - x,y,z: map position
 	 *
 	 * ### Ground attack
 	 *
-	 * - `params` {0,x,y,z} or {x,y,z}
+	 * - `params` {x,y,z,0} or {x,y,z}
 	 *   - x,y,z: map position
 	 *
 	 * ## Command Options

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -109,7 +109,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * - `params` {start, end}. both are optional and if not set default to queue limits.
 	 *   - Start and end will be clamped to the biggest queue intersection.
 	 *   - For example `{2,100}` is be processed as `{2,5}` (or `{2}`) in a queue with 5 items).
-	 * - With `alt`, start and end are indexes, without ALT, they're tags.
+	 * - With `alt`, start and end are indexes, without `alt`, they're tags.
 	 *
 	 * ## Command Options
 	 * - `meta` Range/filter switch.

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -134,7 +134,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, 2, {'meta', 'ctrl', 'alt'})
 	 * ```
 	 *
-	 * Delete from 1st to 2th:
+	 * Delete from 1st to 2nd:
 	 * ```lua
 	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {1, 20}, {'meta', 'ctrl', 'alt'})
 	 * ```
@@ -144,6 +144,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {startTag, endTag}, {'meta', 'ctrl'})
 	 * ```
 	 * @see Spring.GiveOrderToUnit
+	 * @see Callins:UnitCmdDone
 	 */
 	PUSH_CMD(REMOVE);
 	/*** @field CMD.WAIT 5 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -18,6 +18,22 @@
  *   master list of command IDs.
  * - Also supports integer keys, and those perform reverse mapping of command IDs.
  *
+ * The table can be extended by games through lua, in order to define custom
+ * commands.
+ *
+ * To extend, do:
+ *
+ * ```LUA
+ * local MY_CUSTOM_COMMAND = 57600 -- avoid conflicts
+ * CMD['MY_CUSTOM_COMMAND'] = MY_CUSTOM_COMMAND
+ * CMD[MY_CUSTOM_COMMAND] = 'MY_CUSTOM_COMMAND'
+ * ```
+ *
+ * For now there is no mechanism to avoid id conflicts, so you will have
+ * to be careful. Also you should put this code in a place where both
+ * Synced, Unsynced, and all lua environments can import it, otherwise
+ * it won't be available everywhere.
+ *
  * @see Spring.GiveOrderToUnit
  * @see Spring.GiveOrderToUnitArray
  * @enum CMD

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -15,27 +15,13 @@
  * Table defining Command related constants.
  *
  * - Contains a mix of special constants like command options or move states, and the
- *   master list of command IDs.
+ *   list of engine command IDs.
  * - Also supports integer keys, and those perform reverse mapping of command IDs.
  *
- * The table can be extended by games through lua, in order to define custom
- * commands.
- *
- * To extend, do:
- *
- * ```LUA
- * local MY_CUSTOM_COMMAND = 57600 -- avoid conflicts
- * CMD['MY_CUSTOM_COMMAND'] = MY_CUSTOM_COMMAND
- * CMD[MY_CUSTOM_COMMAND] = 'MY_CUSTOM_COMMAND'
- * ```
- *
- * For now there is no mechanism to avoid id conflicts, so you will have
- * to be careful. Also you should put this code in a place where both
- * Synced, Unsynced, and all lua environments can import it, otherwise
- * it won't be available everywhere.
- *
  * @see Spring.GiveOrderToUnit
- * @see Spring.GiveOrderToUnitArray
+ * @see Spring.GiveOrderArrayToUnitArray
+ * @see Spring.GetUnitCurrentCommand
+ * @see Callins:AllowCommand
  * @enum CMD
  */
 

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -79,7 +79,8 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * Accepts no parameters.
 	 *
-	 * *Note:* If `shift` option is used it will be a noop in the queue.
+	 * *Note:* This is actually a noop, but clears the queue when `shift` isn't used since
+	 * that's the standard behaviour when `shift` isn't used for all actions.
 	 */
 	PUSH_CMD(STOP);
 	/*** @field CMD.INSERT 1 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -91,58 +91,55 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	/***
 	 * @field CMD.REMOVE 2
 	 *
-	 * Remove commands from a unit's queue.
-	 *
-	 * The behaviour can be modified with the following options:
+	 * Remove all commands from a unit's queue matching specific cmdIDs or tags.
 	 *
 	 * ## Modes of operation
 	 *
-	 * ### Filter by id or tag
+	 * ### Filter by tag
 	 *
-	 * Removes any command with an id or tag included in params.
+	 * Removes any command with a tag matching those included in params.
 	 *
-	 * - `params` {id1, id2 ...} or {tag1, tag2, ...} an array of ids or tags to look for.
-	 * - With `alt`, remove by id, otherwise remove by tag.
+	 * - `params` {tag1, tag2 ...} an array of tags to look for.
 	 *
-	 * ### Remove by range
+	 * This is the default mode of operation.
 	 *
-	 * Removes all commands with index in range [start, end], indexed by position in the queue, or command tag.
+	 * ### Filter by id
 	 *
-	 * - `params` {start, end}. both are optional and if not set default to queue limits.
-	 * - With `alt`, start and end are indexes, without `alt`, they're tags.
+	 * Removes any command with a `command id` matching those included in params.
+	 *
+	 * - `params` {id1, id2 ...} or {tag1, tag2, ...} an array of ids tags to look for.
+	 *
+	 * To use this mode you need to pass the `alt` option.
 	 *
 	 * ## Command Options
-	 * - `meta` Range/filter switch.
-	 * - `alt` Tag/Index or Tag/Id switch, depending on `meta`.
+	 *
+	 * - `alt` Tag/Id switch
 	 * - `ctrl` Alternative queue selection.
 	 *   - For factories alternative queue is the factory command queue, default queue is the rally queue.
 	 *   - For other units no effect.
 	 *
-	 * ## Callins
-	 *
-	 *  - UnitCmdDone: Run when the command is finished.
-	 *
 	 * ## Examples
 	 *
-	 * Delete everything:
+	 * Delete all attack orders from unit, or factory rally queue if factory:
 	 * ```lua
-	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, nil, {'meta', 'ctrl'})
+	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, CMD.ATTACK)
 	 * ```
 	 *
-	 * Delete all but the 1st element:
+	 * Delete all attack and fight orders from unit, or factory rally queue if factory:
 	 * ```lua
-	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, 2, {'meta', 'ctrl', 'alt'})
+	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {CMD.ATTACK, CMD.FIGHT}, CMD.OPT_ALT)
 	 * ```
 	 *
-	 * Delete from 1st to 20th:
+	 * Delete commands with specific tags:
 	 * ```lua
-	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {1, 20}, {'meta', 'ctrl', 'alt'})
+	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {tag1, tag2, tag3})
 	 * ```
 	 *
-	 * Delete from position of `startTag`, to `endTag`.
+	 * Delete all commands to build units with UnitDef ids unitDefId1 and unitDefId2 from factory queue:
 	 * ```lua
-	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {startTag, endTag}, {'meta', 'ctrl'})
+	 * Spring.GiveOrderToUnit(unitID, CMD.REMOVE, {-unitDefId1, -unitDefId2}, CMD.OPT_ALT + CMD.OPT_CTRL)
 	 * ```
+	 *
 	 * @see Spring.GiveOrderToUnit
 	 * @see Callins:UnitCmdDone
 	 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -141,7 +141,6 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * ```
 	 *
 	 * @see Spring.GiveOrderToUnit
-	 * @see Callins:UnitCmdDone
 	 */
 	PUSH_CMD(REMOVE);
 	/*** @field CMD.WAIT 5 */

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -106,11 +106,9 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * ### Remove by range
 	 *
-	 * Removes all commands in a given range, indexed by position in the queue, or command tag.
+	 * Removes all commands with index in range [start, end], indexed by position in the queue, or command tag.
 	 *
 	 * - `params` {start, end}. both are optional and if not set default to queue limits.
-	 *   - Start and end will be clamped to the biggest queue intersection.
-	 *   - For example `{2,100}` is be processed as `{2,5}` (or `{2}`) in a queue with 5 items).
 	 * - With `alt`, start and end are indexes, without `alt`, they're tags.
 	 *
 	 * ## Command Options

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -192,7 +192,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * ### Attack single target
 	 *
-	 * - `params` {unitID/featureID}: Attack a unit or feature.
+	 * - `params` {unitID}: Attack a unit
 	 *
 	 * The command will end once the target is dead or not valid any more.
 	 *

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -211,12 +211,12 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 * Spring.GiveOrderToUnit(unitID, CMD.ATTACK, targetID)
 	 * ```
 	 *
-	 * Area attack:
+	 * Area attack of radius 50 at map position 1000,1000 with height 100:
 	 * ```lua
-	 * Spring.GiveOrderToUnit(unitID, CMD.ATTACK, {100, 1000,100,1000})
+	 * Spring.GiveOrderToUnit(unitID, CMD.ATTACK, {1000,100,1000,50})
 	 * ```
 	 *
-	 * Ground attack:
+	 * Ground attack at map position 1000,1000 with height 100:
 	 * ```lua
 	 * Spring.GiveOrderToUnit(unitID, CMD.ATTACK, {1000,100,1000})
 	 * ```


### PR DESCRIPTION
### Work done

- Document STOP, ATTACK, REMOVE commands, and the CMD table.
- Set a standard for documenting Commands the project can use for the future.

### The Standard

The main idea here is about where to put the commands documentation, and best format to use, so please comment on that, specially if you have any objections.

We need to define:

1. Where to put the documentation
   - If doing it right, it will appear both in editor tooltips, and webpage
   - Seems the best place is rts/Lua/LuaConstCMD.cpp, as recommended by @rhys-vdw 
2. A standard "template" for documenting actions
   - The idea is do it through documenting a few actions in this PR
   - Some things will need developing of the LLS->html or LLS typing language.

### Remarks

- Talked with @rhys-vdw about what could be the best way to document commands, so they will appear at the webpage, and also provide inline documentation in editors.
- Automatically goes to: https://beyond-all-reason.github.io/spring/lua-api/types/CMD
- Open for discussion about the best place to put this, or the best format.
- The idea is to define a standard/template, that **should be enforced** in the future, so command changes will stay documented, as such, command behaviour modifying PRs should be editing the documentation too.
  - If we have some "best practices" document could put that there too.
  - Specially important the reviewers are aware of this.
- Please, also fact check the ATTACK command description specially, I tried to investigate and do a best effort attempt at documenting it, but it's a hard one to start with :D
- Adding the documentation for https://github.com/beyond-all-reason/spring/pull/2156 here already, if it's a problem I can remove that part and move it to that PR.
  - Just wanted to provide a few command examples.

### Screenshots

- Will add a screenshot soon, or else a link to generated documentation from this PR soon.