### PR TITLE
Lightweight sync history log and dump system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,11 @@ if    (SYNCCHECK)
 	add_definitions(-DSYNCCHECK)
 endif (SYNCCHECK)
 
+option(SYNC_HISTORY "Save sync history (for semidebug builds)" FALSE)
+if    (SYNC_HISTORY)
+	add_definitions(-DSYNC_HISTORY)
+endif (SYNC_HISTORY)
+
 option(NO_CREG "Disable creg support" FALSE)
 if    (NO_CREG)
 	add_definitions(-DNOT_USING_CREG)

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -107,6 +107,7 @@
 #include "System/Sound/ISound.h"
 #include "System/Sound/ISoundChannels.h"
 #include "System/Sync/DumpState.h"
+#include "System/Sync/DumpHistory.h"
 
 #include <SDL_events.h>
 #include <SDL_video.h>
@@ -3610,7 +3611,10 @@ public:
 		std::vector<std::string> args = CSimpleParser::Tokenize(action.GetArgs());
 
 		switch (args.size()) {
-			case 1: { DumpState(StringToInt(args[0]), StringToInt(args[0]),                    1,                 false); } break;
+			case 1: {
+					int dumpId = DumpState(StringToInt(args[0]), StringToInt(args[0]), 1, false);
+					DumpHistory(dumpId, false);
+				} break;
 			case 2: { DumpState(StringToInt(args[0]), StringToInt(args[1]),                    1,                 false); } break;
 			case 3: { DumpState(StringToInt(args[0]), StringToInt(args[1]), StringToInt(args[2]),                 false); } break;
 			case 4: { DumpState(StringToInt(args[0]), StringToInt(args[1]), StringToInt(args[2]), StringToBool(args[3])); } break;

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -37,6 +37,7 @@
 #include "System/Net/UnpackPacket.h"
 #include "System/Sound/ISound.h"
 #include "System/Sync/DumpState.h"
+#include "System/Sync/DumpHistory.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -1571,7 +1572,8 @@ void CGame::ClientReadNet()
 			case NETMSG_GAMESTATE_DUMP: {
 				ZoneScopedN("Net::GamestateDump");
 				LOG("Collecting current game state information.");
-				DumpState(gs->frameNum, gs->frameNum, 1, true, true);
+				int dumpId = DumpState(gs->frameNum, gs->frameNum, 1, true, true);
+				DumpHistory(dumpId, true);
 				break;
 			}
 

--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -54,6 +54,7 @@ make_global_var(sources_engine_System_common
 		"${CMAKE_CURRENT_SOURCE_DIR}/SpringApp.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/StartScriptGen.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Sync/DumpState.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Sync/DumpHistory.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Sync/FPUCheck.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Sync/Logger.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Sync/SHA512.cpp"

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -34,9 +34,9 @@ void DumpHistory(int dumpId, bool serverRequest)
 	name += IntToString(dumpId);
 	name += "-[";
 	name += IntToString(gs->frameNum);
-	name += "].txt";
+	name += "].bin";
 
-	file.open(name.c_str(), std::ios::out);
+	file.open(name.c_str(), std::ios::out|std::ios::binary);
 
 	if (file.is_open()) {
 		unsigned version = 0;

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -1,73 +1,33 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#include <string>
 #include <fstream>
-#include <vector>
-#include <list>
-
-#include "fmt/format.h"
-#include "fmt/printf.h"
 
 #include "DumpHistory.h"
 #include "SyncChecker.h"
 
 #include "Game/Game.h"
-#include "Game/GameSetup.h"
 #include "Game/GlobalUnsynced.h"
-#include "Game/GameVersion.h"
 #include "Net/GameServer.h"
-#include "Rendering/Models/3DModel.h"
-#include "Rendering/Models/IModelParser.h"
-#include "Sim/Features/Feature.h"
-#include "Sim/Features/FeatureDef.h"
-#include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/SmoothHeightMesh.h"
-#include "Sim/MoveTypes/MoveType.h"
-#include "Sim/MoveTypes/GroundMoveType.h"
-#include "Sim/Projectiles/Projectile.h"
-#include "Sim/Projectiles/ProjectileHandler.h"
-#include "Sim/Units/CommandAI/CommandAI.h"
-#include "Sim/Units/Scripts/CobEngine.h"
-#include "Sim/Units/Unit.h"
-#include "Sim/Units/UnitDef.h"
-#include "Sim/Units/UnitHandler.h"
-#include "Sim/Units/UnitTypes/Builder.h"
-#include "Sim/Weapons/Weapon.h"
-#include "Sim/Weapons/WeaponDefHandler.h"
-#include "Map/ReadMap.h"
 #include "System/StringUtil.h"
-#include "System/FileSystem/ArchiveScanner.h"
 #include "System/Log/ILog.h"
-#include "System/SpringHash.h"
+
 
 void DumpHistory(int dumpId, bool serverRequest)
 {
 	
 #ifdef SYNC_HISTORY
 	auto history = CSyncChecker::GetHistory();
+
 	auto index = history.first;
 	auto data = history.second;
 
-	static std::fstream file;
-	static int gMinFrameNum = -1;
-	static int gMaxFrameNum = -1;
-	static int gFramePeriod =  1;
-
-	const int oldMinFrameNum = gMinFrameNum;
-	const int oldMaxFrameNum = gMaxFrameNum;
+	std::fstream file;
 
 	if (!gs->cheatEnabled && !serverRequest)
 		return;
 
 	LOG("[%s] dumping history (for %d)", __func__, gs->frameNum);
-
-	if (file.is_open()) {
-		file.flush();
-		file.close();
-	}
 
 	std::string name = (gameServer != nullptr)? "Server": "Client";
 	name += "GameHistory-";

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -46,7 +46,7 @@ void DumpHistory(int dumpId, bool serverRequest)
 		file.write((char *)game->gameID, sizeof(unsigned char)*16);
 
 		file.write((char *)&data[nextIndex], sizeof(unsigned)*(MAX_SYNC_HISTORY-nextIndex));
-		if (index > 0)
+		if (nextIndex > 0)
 			file.write((char *)data, sizeof(unsigned)*nextIndex);
 
 		LOG("[%s] finished dump-file \"%s\"", __func__, name.c_str());

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -79,7 +79,9 @@ void DumpHistory(int dumpId, bool serverRequest)
 	file.open(name.c_str(), std::ios::out);
 
 	if (file.is_open()) {
+		unsigned version = 0;
 		LOG("[%s] starting dump-file \"%s\"", __func__, name.c_str());
+		file.write((char *)&version, sizeof(unsigned));
 		file.write((char *)game->gameID, sizeof(unsigned char)*16);
 		file.write((char *)data, sizeof(unsigned)*MAX_SYNC_HISTORY);
 		LOG("[%s] finished dump-file \"%s\"", __func__, name.c_str());

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -1,0 +1,94 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <string>
+#include <fstream>
+#include <vector>
+#include <list>
+
+#include "fmt/format.h"
+#include "fmt/printf.h"
+
+#include "DumpHistory.h"
+#include "SyncChecker.h"
+
+#include "Game/Game.h"
+#include "Game/GameSetup.h"
+#include "Game/GlobalUnsynced.h"
+#include "Game/GameVersion.h"
+#include "Net/GameServer.h"
+#include "Rendering/Models/3DModel.h"
+#include "Rendering/Models/IModelParser.h"
+#include "Sim/Features/Feature.h"
+#include "Sim/Features/FeatureDef.h"
+#include "Sim/Features/FeatureHandler.h"
+#include "Sim/Misc/GlobalSynced.h"
+#include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/LosHandler.h"
+#include "Sim/Misc/SmoothHeightMesh.h"
+#include "Sim/MoveTypes/MoveType.h"
+#include "Sim/MoveTypes/GroundMoveType.h"
+#include "Sim/Projectiles/Projectile.h"
+#include "Sim/Projectiles/ProjectileHandler.h"
+#include "Sim/Units/CommandAI/CommandAI.h"
+#include "Sim/Units/Scripts/CobEngine.h"
+#include "Sim/Units/Unit.h"
+#include "Sim/Units/UnitDef.h"
+#include "Sim/Units/UnitHandler.h"
+#include "Sim/Units/UnitTypes/Builder.h"
+#include "Sim/Weapons/Weapon.h"
+#include "Sim/Weapons/WeaponDefHandler.h"
+#include "Map/ReadMap.h"
+#include "System/StringUtil.h"
+#include "System/FileSystem/ArchiveScanner.h"
+#include "System/Log/ILog.h"
+#include "System/SpringHash.h"
+
+void DumpHistory(int dumpId, bool serverRequest)
+{
+	
+#ifdef SYNC_HISTORY
+	auto history = CSyncChecker::GetHistory();
+	auto index = history.first;
+	auto data = history.second;
+
+	static std::fstream file;
+	static int gMinFrameNum = -1;
+	static int gMaxFrameNum = -1;
+	static int gFramePeriod =  1;
+
+	const int oldMinFrameNum = gMinFrameNum;
+	const int oldMaxFrameNum = gMaxFrameNum;
+
+	if (!gs->cheatEnabled && !serverRequest)
+		return;
+
+	LOG("[%s] dumping history (for %d)", __func__, gs->frameNum);
+
+	if (file.is_open()) {
+		file.flush();
+		file.close();
+	}
+
+	std::string name = (gameServer != nullptr)? "Server": "Client";
+	name += "GameHistory-";
+	name += IntToString(dumpId);
+	name += "-[";
+	name += IntToString(gs->frameNum);
+	name += "].txt";
+
+	file.open(name.c_str(), std::ios::out);
+
+	if (file.is_open()) {
+		LOG("[%s] starting dump-file \"%s\"", __func__, name.c_str());
+		file.write((char *)game->gameID, sizeof(unsigned char)*16);
+		file.write((char *)data, sizeof(unsigned)*MAX_SYNC_HISTORY);
+		LOG("[%s] finished dump-file \"%s\"", __func__, name.c_str());
+	}
+
+	if (file.bad() || !file.is_open())
+		return;
+
+	file.close();
+#endif // SYNC_HISTORY
+}
+

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -19,8 +19,8 @@ void DumpHistory(int dumpId, bool serverRequest)
 #ifdef SYNC_HISTORY
 	auto history = CSyncChecker::GetHistory();
 
-	auto index = history.first;
-	auto data = history.second;
+	unsigned nextIndex = history.first;
+	unsigned* data = history.second;
 
 	std::fstream file;
 
@@ -41,9 +41,14 @@ void DumpHistory(int dumpId, bool serverRequest)
 	if (file.is_open()) {
 		unsigned version = 0;
 		LOG("[%s] starting dump-file \"%s\"", __func__, name.c_str());
+
 		file.write((char *)&version, sizeof(unsigned));
 		file.write((char *)game->gameID, sizeof(unsigned char)*16);
-		file.write((char *)data, sizeof(unsigned)*MAX_SYNC_HISTORY);
+
+		file.write((char *)&data[nextIndex], sizeof(unsigned)*(MAX_SYNC_HISTORY-nextIndex));
+		if (index > 0)
+			file.write((char *)data, sizeof(unsigned)*nextIndex);
+
 		LOG("[%s] finished dump-file \"%s\"", __func__, name.c_str());
 	}
 

--- a/rts/System/Sync/DumpHistory.h
+++ b/rts/System/Sync/DumpHistory.h
@@ -3,9 +3,6 @@
 #ifndef DUMPHISTORY_H
 #define DUMPHISTORY_H
 
-#include <optional>
-
 extern void DumpHistory(int dumpId, bool serverRequest);
-//extern void DumpHistory(unsigned index, unsigned *data, bool serverRequest);
 
 #endif /* DUMPHISTORY_H */

--- a/rts/System/Sync/DumpHistory.h
+++ b/rts/System/Sync/DumpHistory.h
@@ -1,0 +1,11 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef DUMPHISTORY_H
+#define DUMPHISTORY_H
+
+#include <optional>
+
+extern void DumpHistory(int dumpId, bool serverRequest);
+//extern void DumpHistory(unsigned index, unsigned *data, bool serverRequest);
+
+#endif /* DUMPHISTORY_H */

--- a/rts/System/Sync/DumpState.h
+++ b/rts/System/Sync/DumpState.h
@@ -5,7 +5,7 @@
 
 #include <optional>
 
-extern void DumpState(int startFrameNum, int endFrameNum, int newFramePeriod, std::optional<bool> outputFloats, bool serverRequest = false);
+extern int DumpState(int startFrameNum, int endFrameNum, int newFramePeriod, std::optional<bool> outputFloats, bool serverRequest = false);
 extern void DumpRNG(int startFrameNum, int endFrameNum);
 
 #endif /* DUMPSTATE_H */

--- a/rts/System/Sync/SyncChecker.cpp
+++ b/rts/System/Sync/SyncChecker.cpp
@@ -13,18 +13,17 @@ unsigned CSyncChecker::g_checksum;
 int CSyncChecker::inSyncedCode;
 
 #ifdef SYNC_HISTORY
+
 unsigned CSyncChecker::nextHistoryIndex = 0;
 unsigned CSyncChecker::logs[MAX_SYNC_HISTORY];
 
 void CSyncChecker::LogHistory()
 {
 	logs[nextHistoryIndex++] = g_checksum;
-	if (nextHistoryIndex == MAX_SYNC_HISTORY) {
+	if (nextHistoryIndex == MAX_SYNC_HISTORY)
 		nextHistoryIndex = 0;
-		//LOG("[Sync::Checker] HISTORY chksum=%u\n", g_checksum);
-		printf("[Sync::Checker] HISTORY\n");
-	}
 }
+
 #endif // SYNC_HISTORY
 
 void CSyncChecker::debugSyncCheckThreading()

--- a/rts/System/Sync/SyncChecker.cpp
+++ b/rts/System/Sync/SyncChecker.cpp
@@ -12,6 +12,10 @@
 unsigned CSyncChecker::g_checksum;
 int CSyncChecker::inSyncedCode;
 
+#ifdef SYNC_HISTORY
+unsigned CSyncChecker::currentIndex = 0;
+unsigned CSyncChecker::logs[MAX_SYNC_HISTORY];
+#endif // SYNC_HISTORY
 
 void CSyncChecker::debugSyncCheckThreading()
 {

--- a/rts/System/Sync/SyncChecker.cpp
+++ b/rts/System/Sync/SyncChecker.cpp
@@ -16,7 +16,7 @@ int CSyncChecker::inSyncedCode;
 unsigned CSyncChecker::currentIndex = 0;
 unsigned CSyncChecker::logs[MAX_SYNC_HISTORY];
 
-static void CSyncChecker::LogSync()
+void CSyncChecker::LogHistory()
 {
 	logs[currentIndex++] = g_checksum;
 	if (currentIndex == MAX_SYNC_HISTORY) {

--- a/rts/System/Sync/SyncChecker.cpp
+++ b/rts/System/Sync/SyncChecker.cpp
@@ -13,14 +13,14 @@ unsigned CSyncChecker::g_checksum;
 int CSyncChecker::inSyncedCode;
 
 #ifdef SYNC_HISTORY
-unsigned CSyncChecker::currentIndex = 0;
+unsigned CSyncChecker::nextHistoryIndex = 0;
 unsigned CSyncChecker::logs[MAX_SYNC_HISTORY];
 
 void CSyncChecker::LogHistory()
 {
-	logs[currentIndex++] = g_checksum;
-	if (currentIndex == MAX_SYNC_HISTORY) {
-		currentIndex = 0;
+	logs[nextHistoryIndex++] = g_checksum;
+	if (nextHistoryIndex == MAX_SYNC_HISTORY) {
+		nextHistoryIndex = 0;
 		//LOG("[Sync::Checker] HISTORY chksum=%u\n", g_checksum);
 		printf("[Sync::Checker] HISTORY\n");
 	}

--- a/rts/System/Sync/SyncChecker.cpp
+++ b/rts/System/Sync/SyncChecker.cpp
@@ -15,6 +15,16 @@ int CSyncChecker::inSyncedCode;
 #ifdef SYNC_HISTORY
 unsigned CSyncChecker::currentIndex = 0;
 unsigned CSyncChecker::logs[MAX_SYNC_HISTORY];
+
+static void CSyncChecker::LogSync()
+{
+	logs[currentIndex++] = g_checksum;
+	if (currentIndex == MAX_SYNC_HISTORY) {
+		currentIndex = 0;
+		//LOG("[Sync::Checker] HISTORY chksum=%u\n", g_checksum);
+		printf("[Sync::Checker] HISTORY\n");
+	}
+}
 #endif // SYNC_HISTORY
 
 void CSyncChecker::debugSyncCheckThreading()

--- a/rts/System/Sync/SyncChecker.h
+++ b/rts/System/Sync/SyncChecker.h
@@ -53,7 +53,7 @@ class CSyncChecker {
 			#endif // SYNC_HISTORY
 		}
 		#ifdef SYNC_HISTORY
-		static std::pair<unsigned, unsigned*> GetHistory() { return std::make_pair(currentIndex, logs); };
+		static std::pair<unsigned, unsigned*> GetHistory() { return std::make_pair(nextHistoryIndex, logs); };
 		#endif // SYNC_HISTORY
 
 	private:
@@ -76,7 +76,7 @@ class CSyncChecker {
 		 */
 		static void LogHistory();
 
-		static unsigned currentIndex;
+		static unsigned nextHistoryIndex;
 		static unsigned logs[MAX_SYNC_HISTORY];
 #endif // SYNC_HISTORY
 };

--- a/rts/System/Sync/SyncChecker.h
+++ b/rts/System/Sync/SyncChecker.h
@@ -53,14 +53,7 @@ class CSyncChecker {
 			#endif // SYNC_HISTORY
 		}
 		#ifdef SYNC_HISTORY
-		static void LogSync() {
-			logs[currentIndex++] = g_checksum;
-			if (currentIndex == MAX_SYNC_HISTORY) {
-				currentIndex = 0;
-				//LOG("[Sync::Checker] HISTORY chksum=%u\n", g_checksum);
-				printf("[Sync::Checker] HISTORY\n");
-			}
-		}
+		static void LogSync();
 		static std::pair<unsigned, unsigned*> GetHistory() { return std::make_pair(currentIndex, logs); };
 		#endif // SYNC_HISTORY
 

--- a/rts/System/Sync/SyncChecker.h
+++ b/rts/System/Sync/SyncChecker.h
@@ -9,6 +9,8 @@
 
 #include <assert.h>
 
+#define MAX_SYNC_HISTORY 2500000 // 10MB, ~= 10 seconds of typical midgame
+
 /**
  * @brief sync checker class
  *
@@ -29,7 +31,12 @@ class CSyncChecker {
 		 * Keeps a running checksum over all assignments to synced variables.
 		 */
 		static unsigned GetChecksum() { return g_checksum; }
-		static void NewFrame() { g_checksum = 0xfade1eaf; }
+		static void NewFrame() {
+			g_checksum = 0xfade1eaf;
+			#ifdef SYNC_HISTORY
+			LogSync();
+			#endif // SYNC_HISTORY
+		}
 		static void debugSyncCheckThreading();
 		static void Sync(const void* p, unsigned size) {
 #ifdef DEBUG_SYNC_MT_CHECK
@@ -40,7 +47,22 @@ class CSyncChecker {
 			// simple xor is not enough to detect multiple zeroes, e.g.
 			g_checksum = spring::LiteHash(p, size, g_checksum);
 			//LOG("[Sync::Checker] chksum=%u\n", g_checksum);
+
+			#ifdef SYNC_HISTORY
+			LogSync();
+			#endif // SYNC_HISTORY
 		}
+		#ifdef SYNC_HISTORY
+		static void LogSync() {
+			logs[currentIndex++] = g_checksum;
+			if (currentIndex == MAX_SYNC_HISTORY) {
+				currentIndex = 0;
+				//LOG("[Sync::Checker] HISTORY chksum=%u\n", g_checksum);
+				printf("[Sync::Checker] HISTORY\n");
+			}
+		}
+		static std::pair<unsigned, unsigned*> GetHistory() { return std::make_pair(currentIndex, logs); };
+		#endif // SYNC_HISTORY
 
 	private:
 
@@ -55,6 +77,14 @@ class CSyncChecker {
 		 * Whether one thread (doesn't have to current thread!!!) is currently processing a SimFrame.
 		 */
 		static int inSyncedCode;
+
+#ifdef SYNC_HISTORY
+		/**
+		 * Sync hash logs
+		 */
+		static unsigned currentIndex;
+		static unsigned logs[MAX_SYNC_HISTORY];
+#endif // SYNC_HISTORY
 };
 
 #endif // SYNCDEBUG

--- a/rts/System/Sync/SyncChecker.h
+++ b/rts/System/Sync/SyncChecker.h
@@ -34,7 +34,7 @@ class CSyncChecker {
 		static void NewFrame() {
 			g_checksum = 0xfade1eaf;
 			#ifdef SYNC_HISTORY
-			LogSync();
+			LogHistory();
 			#endif // SYNC_HISTORY
 		}
 		static void debugSyncCheckThreading();
@@ -49,11 +49,10 @@ class CSyncChecker {
 			//LOG("[Sync::Checker] chksum=%u\n", g_checksum);
 
 			#ifdef SYNC_HISTORY
-			LogSync();
+			LogHistory();
 			#endif // SYNC_HISTORY
 		}
 		#ifdef SYNC_HISTORY
-		static void LogSync();
 		static std::pair<unsigned, unsigned*> GetHistory() { return std::make_pair(currentIndex, logs); };
 		#endif // SYNC_HISTORY
 
@@ -75,6 +74,8 @@ class CSyncChecker {
 		/**
 		 * Sync hash logs
 		 */
+		static void LogHistory();
+
 		static unsigned currentIndex;
 		static unsigned logs[MAX_SYNC_HISTORY];
 #endif // SYNC_HISTORY


### PR DESCRIPTION
**Note:** See https://github.com/beyond-all-reason/spring/pull/2202 for more advanced version and more of a high level overview. Refer to this for more internal details about the initial mechanism and format

### Work done

- System to maintain a binary in-memory stream of checksums, and dump when requested by server, or `/dumpstate`
- SYNC_HISTORY compile time option

### Pending work

- maybe add springsetting so it can be enabled/disabled.
- maybe dump just the frame of the desync, or a few frames, instead of the full memory stored period.
- maybe change the log at NewFrame since that gets called every 4096 game frames, it's not a real frame.
- review or remove the /dumpstate logic, just with networked command dump could be fine.

### Remarks

- Talked about this with @lostsquirrel1 at engine channel
- The idea is with this + statefile, we will know exactly at what point in the checksum generation it started to fail, not just what frame.
- The PR can be improved to dump exactly the log for the frame before the desync took place, or at least a range around it.
- PR still needs some work and tuning (maybe file format and /dumpstate logic), but basic mechanism is there to review.
- Also, since all players generate this on a desync (at the request of the server), it could give us more info about the unsynced player, since many times we can't replay at all, this can provide valuable information.
- Atm saving 2,500,000 records (see `MAX_SYNC_HISTORY`).
  - That's about 10MB file (and memory), around 10 seconds of typical midgame.
    - If the PR is improved to dump only the data for the desynced frame then it can go down to 30kB or so file size.
  - Otherwise maybe can dump just around 10 frames for 300kB.
  - It's a tradeoff about storing all frame starts in an extra array, probably worth it. 
- Probably needs a system to delete the dumps automatically otherwise they can fill up the HD eventually and nobody would like that :D (each desync == 10MB).
- Later on could add something to load the file (or files) with a replay and have it do something, like abort at some point or launch debugger.

### Dump Format

- Name format: `Client/ServerGameHistory-statefileid-[framenum].bin`
  - statefileid generated from the same random number as Client/ServerGameState file so they can be matched together.
  - could make them named like `Client/ServerGameState-statefileid-[hist-framenum].bin` so they're easier to match, maybe.
- Simple binary format (version 0): `<version:4bytes><gameid:16bytes><checksums:XXXbytes>`
  - will maybe add framenumber and statefileid
- Dumped on `/dumpstate XX`, and on `NETMSG_GAMESTATE_DUMP`, next to GameState.

Could store the number of values in the header, anyways the format is versioned so can always change it.

I don't think much more info is needed here, since together with the frame number and GameState file, it should be easy enough to find out exactly where it's failing. Newframes get naturally inserted as `0xfade1eaf` (the new frame checksum),  they don't get the number but should be fine.

So, after a dump you end with smth like:

- `ClientGameState-250398225-[3286-3286].txt`
- `ClientGameHistory-250398225-[3286].bin`

We could also compress it before storing.

### Overhead

The overhead doesn't seem to amount to much. Anyways the idea is this could be enabled specially for `release candidate` versions, although while there are 

I tested on game id 4bedff6760962345899ba41cf85cc683 and didn't see much difference with the replay, both with and without the system enabled I can replay at max speed in 4 min (the game is 28 min).

### Reading the format

Example in python

```python
import struct

name = "ServerGameHistory-2131290340-[140].txt"

with open(name, "rb") as f:
  version = struct.unpack('<I', f.read(4))
  gameid = f.read(16)

  print(version)
  print(gameid.hex())

  data = f.read(4)

  while data:
    print(data[::-1].hex())
    data = f.read(4)
```