### PR TITLE
Document `timeout` parameter.

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5489,7 +5489,7 @@ int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
 
  * @return boolean unitOrdered
  */
@@ -5529,7 +5529,7 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return integer unitsOrdered The number of units ordered.
  */
 int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
@@ -5573,7 +5573,7 @@ int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return integer unitsOrdered The number of units ordered.
  */
 int LuaSyncedCtrl::GiveOrderToUnitArray(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5489,7 +5489,7 @@ int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
 
  * @return boolean unitOrdered
  */
@@ -5529,7 +5529,7 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return integer unitsOrdered The number of units ordered.
  */
 int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
@@ -5573,7 +5573,7 @@ int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return integer unitsOrdered The number of units ordered.
  */
 int LuaSyncedCtrl::GiveOrderToUnitArray(lua_State* L)

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3284,7 +3284,7 @@ static bool CanGiveOrders(const lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return boolean
  */
 int LuaUnsyncedCtrl::GiveOrder(lua_State* L)
@@ -3309,7 +3309,7 @@ int LuaUnsyncedCtrl::GiveOrder(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return boolean
  */
 int LuaUnsyncedCtrl::GiveOrderToUnit(lua_State* L)
@@ -3343,7 +3343,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnit(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return boolean orderGiven
  */
 int LuaUnsyncedCtrl::GiveOrderToUnitMap(lua_State* L)
@@ -3377,7 +3377,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer? The frame after which the command will be ignored if unstarted.
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  * @return boolean ordersGiven `true` if any orders were sent, otherwise `false`.
  */
 int LuaUnsyncedCtrl::GiveOrderToUnitArray(lua_State* L)

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3284,7 +3284,7 @@ static bool CanGiveOrders(const lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return boolean
  */
 int LuaUnsyncedCtrl::GiveOrder(lua_State* L)
@@ -3309,7 +3309,7 @@ int LuaUnsyncedCtrl::GiveOrder(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return boolean
  */
 int LuaUnsyncedCtrl::GiveOrderToUnit(lua_State* L)
@@ -3343,7 +3343,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnit(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return boolean orderGiven
  */
 int LuaUnsyncedCtrl::GiveOrderToUnitMap(lua_State* L)
@@ -3377,7 +3377,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? The frame after which the command will be ignored if unstarted.
  * @return boolean ordersGiven `true` if any orders were sent, otherwise `false`.
  */
 int LuaUnsyncedCtrl::GiveOrderToUnitArray(lua_State* L)

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1108,7 +1108,7 @@ static bool ParseCommandTimeOut(
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
- * @param timeout integer?
+ * @param timeout integer? Absolute frame number. The command will be discarded after this frame. Only respected by mobile units.
  */
 Command LuaUtils::ParseCommand(lua_State* L, const char* caller, int idIndex)
 {


### PR DESCRIPTION
> Looks fine, btw looked at the `timeout` parameter, and it's a deadline frame number.
> 
> Seems like for MobileAI and AirCAI this makes the command be finished if it's in front of the queue and current frame number already greater. Probably related to not being able to reach the command destination logic.
> 
> Skirmish AI might also be using it but probably not relevant here.
> 
> Only seen it used in two places (other than skirmish ai), by looking for timeOut and GetTimeOut.
 
https://github.com/beyond-all-reason/spring/pull/2195#pullrequestreview-2771778767

**cc** @saurtron clear enough?