### PR TITLE
Use same version of lua-doc-extractor on all workflows

### DIFF
--- a/.github/workflows/check-lua.yml
+++ b/.github/workflows/check-lua.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate Lua library
         run: |
-          npm install -g lua-doc-extractor@3.1
+          npm install -g lua-doc-extractor@3
           lua-doc-extractor rts/Lua/*.cpp \
             --dest rts/Lua/library/generated \
             --repo https://github.com/${{ github.repository }}/blob/${{ github.sha }} \


### PR DESCRIPTION
Other workflows only require major version of `lua-doc-extractor`. This change syncs the check workflow with the others ([`publish-site.yml`](https://github.com/beyond-all-reason/spring/blob/604f00d290a2e3ddbc2fae9f27f10b9c8efedc0a/.github/workflows/publish-site.yml#L30), [`generate-lua-library.yml`](https://github.com/beyond-all-reason/spring/blob/604f00d290a2e3ddbc2fae9f27f10b9c8efedc0a/.github/workflows/generate-lua-library.yml#L30)).

This is safe because I control the version numbers and won't bump major version unless it actually breaks back-compat.