### PR TITLE
Dont draw surface and ballistic circles if their alpha is set to 0.0

### DIFF
--- a/cont/cmdcolors.txt
+++ b/cont/cmdcolors.txt
@@ -84,6 +84,9 @@ deathWatch  0.5  0.5  0.5  0.4
 //
 //  Selected Range Rendering
 //
+// This section controls the colors assigned to ground circles that are drawn for selected units
+// The numbers below are RGBA values
+// If the alpha of any circle color is 0.0, that circle type will be completely skipped. 
 
 selectedLineWidth  2.0
 selectedBlendSrc   src_alpha

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -112,6 +112,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "hwConfig", Platform::GetHardwareStr());
 	LuaPushNamedNumber(L, "cpuLogicalCores", Threading::GetLogicalCpuCores());
 	LuaPushNamedNumber(L, "cpuPhysicalCores", Threading::GetPhysicalCpuCores());
+	LuaPushNamedString(L, "cpuBrand", Threading::GetCPUBrand());
 	LuaPushNamedNumber(L, "totalRAM", Platform::TotalRAM()/1e6);
 
 	LuaPushNamedString(L, "sysInfoHash", Platform::GetSysInfoHash());

--- a/rts/Rendering/GL/glExtra.cpp
+++ b/rts/Rendering/GL/glExtra.cpp
@@ -36,6 +36,7 @@ void glSurfaceCircle(const float3& center, float radius, const SColor& col, uint
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float4 fColor = col;
+	if (fColor.a == 0.0f) return;
 
 	auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_0>();
 	rb.AssertSubmission();
@@ -147,6 +148,7 @@ void glBallisticCircle(const CWeapon* weapon, const WeaponDef* weaponDef, const 
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float4 fColor = color;
+	if (fColor.a == 0.0f) return;
 
 	auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_0>();
 	rb.AssertSubmission();

--- a/rts/Rendering/GL/glExtra.cpp
+++ b/rts/Rendering/GL/glExtra.cpp
@@ -36,7 +36,8 @@ void glSurfaceCircle(const float3& center, float radius, const SColor& col, uint
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float4 fColor = col;
-	if (fColor.a == 0.0f) return;
+	if (fColor.a == 0.0f)
+		return;
 
 	auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_0>();
 	rb.AssertSubmission();
@@ -148,7 +149,8 @@ void glBallisticCircle(const CWeapon* weapon, const WeaponDef* weaponDef, const 
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float4 fColor = color;
-	if (fColor.a == 0.0f) return;
+	if (fColor.a == 0.0f)
+		return;
 
 	auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_0>();
 	rb.AssertSubmission();

--- a/rts/System/Platform/CpuID.cpp
+++ b/rts/System/Platform/CpuID.cpp
@@ -120,5 +120,28 @@ namespace springproc {
 
 		smtDetected = !!( processorMasks.hyperThreadLowMask | processorMasks.hyperThreadHighMask );
 	}
+	std::string CPUID::GetCPUBrandString() {
+        // Check if the CPU supports the extended CPUID leaves for the brand string
+        unsigned int eax = 0x80000000, ebx, ecx, edx;
+        ExecCPUID(&eax, &ebx, &ecx, &edx);
+        if (eax < 0x80000004) {
+            return "Unknown CPU";
+        }
+
+        // Buffer to hold the 48-byte brand string
+        char brand[49] = {0};
+        unsigned int regs[REG_CNT];
+
+        // Query leaves 0x80000002, 0x80000003, and 0x80000004
+        for (int i = 0; i < 3; ++i) {
+            regs[REG_EAX] = 0x80000002 + i;
+            regs[REG_ECX] = 0; // Subleaf is 0
+            ExecCPUID(&regs[REG_EAX], &regs[REG_EBX], &regs[REG_ECX], &regs[REG_EDX]);
+            std::memcpy(&brand[i * 16], regs, 16);
+        }
+
+        // Return the brand string as a std::string
+        return std::string(brand);
+    }
 
 }

--- a/rts/System/Platform/CpuID.h
+++ b/rts/System/Platform/CpuID.h
@@ -12,6 +12,8 @@
 #endif
 
 #include <cstdint>
+#include <cstring>
+#include <string> 
 
 namespace springproc {
 	_noinline void ExecCPUID(unsigned int* a, unsigned int* b, unsigned int* c, unsigned int* d);
@@ -49,6 +51,8 @@ namespace springproc {
 		int GetNumLogicalCores() const { return numLogicalCores; }
 
 		bool HasHyperThreading() const { return smtDetected; };
+
+		std::string GetCPUBrandString();
 
 		cpu_topology::ProcessorMasks GetAvailableProcessorAffinityMask() const { return processorMasks; };
 

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -290,6 +290,10 @@ namespace Threading {
 		return springproc::CPUID::GetInstance().HasHyperThreading();
 	}
 
+	std::string GetCPUBrand() {
+		return springproc::CPUID::GetInstance().GetCPUBrandString();
+	}
+
 
 	void SetThreadScheduler()
 	{

--- a/rts/System/Platform/Threading.h
+++ b/rts/System/Platform/Threading.h
@@ -124,6 +124,7 @@ namespace Threading {
 	int GetLogicalCpuCores();  /// physical + hyperthreading
 	int GetPerformanceCpuCores(); /// performance physical cores only (excluding hyperthreading or efficiency cores)
 	bool HasHyperThreading();
+	std::string GetCPUBrand();
 
 	uint32_t GetSystemAffinityMask();
 	uint32_t GetPreferredMainThreadMask();


### PR DESCRIPTION
There isn't much point in drawing them if their alpha is set to zero, right? This is relevant in BAR where attack range rings are fully widget-controlled.