### PR TITLE
StaticMoveType follow ground

### DIFF
--- a/rts/Map/BasicMapDamage.cpp
+++ b/rts/Map/BasicMapDamage.cpp
@@ -14,6 +14,7 @@
 #include "Sim/Path/IPathManager.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "System/TimeProfiler.h"
+#include "Sim/MoveTypes/StaticMoveType.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -241,6 +242,7 @@ void CBasicMapDamage::RecalcArea(int x1, int x2, int y1, int y2)
 
 	readMap->UpdateHeightMapSynced(updRect);
 	featureHandler.TerrainChanged(x1, y1, x2, y2);
+	CStaticMoveType::TerrainChanged(x1, y1, x2, y2);
 	smoothGround.MapChanged(x1, y1, x2, y2);
 	{
 		SCOPED_TIMER("Sim::BasicMapDamage::Los");

--- a/rts/Sim/MoveTypes/StaticMoveType.cpp
+++ b/rts/Sim/MoveTypes/StaticMoveType.cpp
@@ -52,7 +52,7 @@ bool CStaticMoveType::FitToGround()
 	if (owner->FloatOnWater() && owner->IsInWater()) {
 		change = -waterline - owner->pos.y;
 	} else {
-		/* Using GetHeightReal gives smoother result, but desyncs with ground drawing and also needs
+		/* Using GetHeightReal gives smoother result, but makes it draw off the ground and also needs
 		 * needsUpdate above to be set to the result of FitToGround. */
 		change = CGround::GetApproximateHeight(owner->pos.x, owner->pos.z) - owner->pos.y;
 	}

--- a/rts/Sim/MoveTypes/StaticMoveType.cpp
+++ b/rts/Sim/MoveTypes/StaticMoveType.cpp
@@ -56,7 +56,7 @@ bool CStaticMoveType::FitToGround()
 		 * needsUpdate above to be set to the result of FitToGround. */
 		change = CGround::GetApproximateHeight(owner->pos.x, owner->pos.z) - owner->pos.y;
 	}
-	if (std::abs(change) > 1e-04f) {
+	if (std::abs(change) > float3::cmp_eps()) {
 		owner->Move(UpVector * change, true);
 		return true;
 	}

--- a/rts/Sim/MoveTypes/StaticMoveType.cpp
+++ b/rts/Sim/MoveTypes/StaticMoveType.cpp
@@ -51,11 +51,14 @@ void CStaticMoveType::FitToGround()
 	// NOTE:
 	//   static buildings don't have any MoveDef instance, hence we need
 	//   to get the ground height instead of calling CMoveMath::yLevel()
+	float change;
 	if (owner->FloatOnWater() && owner->IsInWater()) {
-		owner->Move(UpVector * (-waterline - owner->pos.y), true);
+		change = -waterline - owner->pos.y;
 	} else {
-		owner->Move(UpVector * (CGround::GetHeightReal(owner->pos.x, owner->pos.z) - owner->pos.y), true);
+		change = CGround::GetHeightReal(owner->pos.x, owner->pos.z) - owner->pos.y;
 	}
+	if (std::abs(change) > 1e-04f)
+		owner->Move(UpVector * change, true);
 }
 
 void CStaticMoveType::TerrainChanged(int x1, int y1, int x2, int y2)

--- a/rts/Sim/MoveTypes/StaticMoveType.h
+++ b/rts/Sim/MoveTypes/StaticMoveType.h
@@ -22,11 +22,12 @@ public:
 	void KeepPointingTo(float3 pos, float distance, bool aggressive) override {}
 
 	bool Update() override { return false; }
-	void SlowUpdate() override;
+	void UpdateGroundFit();
 	static void TerrainChanged(int x1, int y1, int x2, int y2);
+
+	bool needsUpdate;
 private:
-	void FitToGround();
-	bool firstUpdate;
+	bool FitToGround();
 };
 
 #endif // STATICMOVETYPE_H

--- a/rts/Sim/MoveTypes/StaticMoveType.h
+++ b/rts/Sim/MoveTypes/StaticMoveType.h
@@ -23,6 +23,10 @@ public:
 
 	bool Update() override { return false; }
 	void SlowUpdate() override;
+	static void TerrainChanged(int x1, int y1, int x2, int y2);
+private:
+	void FitToGround();
+	bool firstUpdate;
 };
 
 #endif // STATICMOVETYPE_H

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -52,6 +52,7 @@
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
 #include "Sim/MoveTypes/MoveTypeFactory.h"
+#include "Sim/MoveTypes/StaticMoveType.h"
 #include "Sim/MoveTypes/ScriptMoveType.h"
 #include "Sim/Projectiles/FlareProjectile.h"
 #include "Sim/Projectiles/ProjectileMemPool.h"
@@ -653,6 +654,10 @@ void CUnit::Update()
 	RECOIL_DETAILED_TRACY_ZONE;
 	ASSERT_SYNCED(pos);
 
+
+	auto staticMoveType = dynamic_cast<CStaticMoveType*>(moveType);
+	if unlikely(staticMoveType && staticMoveType->needsUpdate)
+		staticMoveType->UpdateGroundFit();
 	UpdatePhysicalState(0.1f);
 	UpdatePosErrorParams(true, false);
 	UpdateTransportees(); // none if already dead


### PR DESCRIPTION
### Work done

- Make StaticMoveType units follow ground right after heightmap is changed instead of polling all the time inside SlowUpdate.
- Optimize out uneeded Move() calls by checking for required change size.

### Related issues

- Fixes slow reaction to terrain change as described here: https://github.com/beyond-all-reason/RecoilEngine/pull/2182#issuecomment-2801775086

### Remarks

- May still need some work on update method
- pros: Can likely avoid some processing when https://github.com/beyond-all-reason/RecoilEngine/pull/2182#issuecomment-2839318561 is used.
- cons: Will make terrain deformation a bit more expensive.
  - will be helped by merging damage areas before notifying, rn situation is a bit bad related to that, since could get lots of updates with same or very similar rects (sometimes in same frame, but very often in consecutive frames, maybe due to projectile slowUpdate?).
  - can be helped too by reusing the quadField query among other damage listeners (like the featureHandler)
- Haven't been able to fully test, but I think this will be a net benefit in perf, as well as more correct.
  - can maybe merge update+terrain update request through updating (and renaming) current `firstUpdate` flag.
- Maintaining an initial `SlowUpdate` with `FitToGround` call, but I think it shouldn't be needed.

### Screenshots

with this change

![terraform3](https://github.com/user-attachments/assets/6450a68a-7ab7-41d3-9caf-a5b01f779bc6)

see the previous situation here: https://github.com/beyond-all-reason/RecoilEngine/pull/2182#issuecomment-2801775086

the above version (the one in this PR v1), updates on TerrainUpdated, potentially generating lots of sync events, and also somewhat lags behind where buildings can go below the floor at times.

other interpolation options (not yet in PR, **still evaluating**) with somewhat reduced sync events, also with smoother update via `moveType->Update` instead of moveType->SlowUpdate (with SlowUpdate will always lag behind).

`CGround::GetHeightReal` on update:

![det-interpolation](https://github.com/user-attachments/assets/777c500a-21a1-48f8-bb32-fe71c914992a)

`CGround::GetApproximateHeight` update, and skip `preFramePos`:

![det-nointerpolation](https://github.com/user-attachments/assets/7c74c73e-5532-4d8e-890f-05557d4e98ca)
