### PR TITLE
Map damage area merging and deferring of notifications

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5836,7 +5836,7 @@ int LuaSyncedCtrl::LevelHeightMap(lua_State* L)
 		}
 	}
 
-	mapDamage->RecalcArea(x1, x2, z1, z2);
+	mapDamage->PushRecalcArea(x1, x2, z1, z2);
 	return 0;
 }
 
@@ -5868,7 +5868,7 @@ int LuaSyncedCtrl::AdjustHeightMap(lua_State* L)
 		}
 	}
 
-	mapDamage->RecalcArea(x1, x2, z1, z2);
+	mapDamage->PushRecalcArea(x1, x2, z1, z2);
 	return 0;
 }
 
@@ -5916,7 +5916,7 @@ int LuaSyncedCtrl::RevertHeightMap(lua_State* L)
 		}
 	}
 
-	mapDamage->RecalcArea(x1, x2, z1, z2);
+	mapDamage->PushRecalcArea(x1, x2, z1, z2);
 	return 0;
 }
 
@@ -6077,7 +6077,7 @@ int LuaSyncedCtrl::SetHeightMapFunc(lua_State* L)
 	}
 
 	if (heightMapx2 > -1) {
-		mapDamage->RecalcArea(heightMapx1, heightMapx2, heightMapz1, heightMapz2);
+		mapDamage->PushRecalcArea(heightMapx1, heightMapx2, heightMapz1, heightMapz2);
 	}
 
 	lua_pushnumber(L, heightMapAmountChanged);

--- a/rts/Map/BasicMapDamage.cpp
+++ b/rts/Map/BasicMapDamage.cpp
@@ -325,8 +325,6 @@ void CBasicMapDamage::Update()
 
 	}
 
-	ProcessRecalcs();
-
 
 	// pop explosions that are no longer being processed
 	while (explUpdateQueueIdx < explosionUpdateQueue.size()) {

--- a/rts/Map/BasicMapDamage.h
+++ b/rts/Map/BasicMapDamage.h
@@ -6,6 +6,7 @@
 #include "MapDamage.h"
 
 #include <vector>
+#include "System/Rectangle.h"
 
 class CBasicMapDamage : public IMapDamage
 {
@@ -60,6 +61,7 @@ private:
 
 	std::vector<float> explosionSquaresPool;
 	std::vector<Explo> explosionUpdateQueue;
+	std::vector<SRectangle> damageRects;
 
 	static constexpr unsigned int CRATER_TABLE_SIZE = 200;
 	static constexpr unsigned int EXPLOSION_LIFETIME = 10;

--- a/rts/Map/BasicMapDamage.h
+++ b/rts/Map/BasicMapDamage.h
@@ -13,6 +13,8 @@ class CBasicMapDamage : public IMapDamage
 public:
 	void Explosion(const float3& pos, float strength, float radius, float& maxHeightDiff) override;
 	void RecalcArea(int x1, int x2, int y1, int y2) override;
+	virtual void PushRecalcArea(int x1, int x2, int y1, int y2) override;
+	virtual void ProcessRecalcs() override;
 	void TerrainTypeHardnessChanged(int ttIndex) override;
 	void TerrainTypeSpeedModChanged(int ttIndex) override;
 

--- a/rts/Map/MapDamage.h
+++ b/rts/Map/MapDamage.h
@@ -18,6 +18,8 @@ public:
 	virtual void RecalcArea(int x1, int x2, int y1, int y2) = 0;
 	virtual void TerrainTypeHardnessChanged(int ttIndex) {}
 	virtual void TerrainTypeSpeedModChanged(int ttIndex) {}
+	virtual void PushRecalcArea(int x1, int x2, int y1, int y2) {}
+	virtual void ProcessRecalcs() {}
 
 	virtual void Init() = 0;
 	virtual void Update() = 0;

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -11,6 +11,7 @@
 #include "UnitTypes/Factory.h"
 
 #include "CommandAI/BuilderCAI.h"
+#include "Map/MapDamage.h"
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/ModInfo.h"
@@ -438,6 +439,7 @@ void CUnitHandler::Update()
 	QueueDeleteUnits();
 	UpdateUnitLosStates();
 	SlowUpdateUnits();
+	mapDamage->ProcessRecalcs();
 	UpdateUnits();
 	UpdateUnitWeapons();
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -560,7 +560,7 @@ void CBuilder::SlowUpdate()
   RECOIL_DETAILED_TRACY_ZONE;
 	if (terraforming) {
 		constexpr int tsr = TERRA_SMOOTHING_RADIUS;
-		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
+		mapDamage->PushRecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
 	}
 
 	CUnit::SlowUpdate();
@@ -707,7 +707,7 @@ void CBuilder::StopBuild(bool callScript)
 
 	if (terraforming) {
 		constexpr int tsr = TERRA_SMOOTHING_RADIUS;
-		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
+		mapDamage->PushRecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
 	}
 
 	terraforming = false;


### PR DESCRIPTION
### Work done

- Introduce and apply a mechanism so map damaged areas can be merged and updates deferred to apply all at one.

### Related issues

- https://github.com/beyond-all-reason/RecoilEngine/issues/1839

### Remarks

- Not sure this is wanted like this, so posting as draft for comments.
- Can merge some explosion damage, but specially useful for many builders terraforming the same area.
- See [this comment](https://github.com/beyond-all-reason/RecoilEngine/pull/2240#issuecomment-2841502665) for rationale of why I'm placing the ProcessDamage between unit SlowUpdate and Update.
  - basically because that's when terraforming is RecalcArea'd atm, so all terraforming should be done by that.
- Rect merging atm is very basic (simply merges any overlapping rects), could be tweaked.
- Alternative branch on top of 2025.03.9 [here](https://github.com/saurtron/spring/tree/map-damage-merging)