### PR TITLE
Fonts textwrap prescan for glyphs

### DIFF
--- a/rts/Rendering/Fonts/TextWrap.cpp
+++ b/rts/Rendering/Fonts/TextWrap.cpp
@@ -429,6 +429,9 @@ void CTextWrap::SplitTextInWords(const spring::u8string& text, std::list<word>* 
 	const unsigned int length = (unsigned int)text.length();
 	const float spaceAdvance = GetGlyph(spaceUTF16).advance;
 
+	// Scan in advance so we avoid calls on every step of splitting.
+	ScanForWantedGlyphs(text);
+
 	words->push_back(word());
 	word* w = &(words->back());
 

--- a/rts/Rendering/Fonts/TextWrap.h
+++ b/rts/Rendering/Fonts/TextWrap.h
@@ -27,6 +27,7 @@ protected:
 	virtual ~CTextWrap() {}
 public:
 	virtual float GetTextWidth(const std::string& text) = 0;
+	virtual void ScanForWantedGlyphs(const spring::u8string& str) = 0;
 private:
 	struct colorcode {
 		colorcode() : resetColor(false),color(1.f,1.f,1.f,1.f),pos(0) {};

--- a/rts/Rendering/Fonts/glFont.h
+++ b/rts/Rendering/Fonts/glFont.h
@@ -131,10 +131,10 @@ private:
 		int& numLines
 	);
 private:
-	void ScanForWantedGlyphs(const spring::u8string& str);
 	float GetTextWidth_(const spring::u8string& text);
 	float GetTextHeight_(const spring::u8string& text, float* descender = nullptr, int* numLines = nullptr);
 public:
+	void ScanForWantedGlyphs(const spring::u8string& str) override;
 	static auto GetLoadedFonts() -> const decltype(allFonts)& {
 		return allFonts;
 	}


### PR DESCRIPTION
### Work done

- Added a leading call to ScanForWantedGlyphs inside TextWrap::SplitTextInWords.

### Remarks

This avoids repeated calls into `CFontTexture::LoadWantedGlyphs` for every letter, thus potentially saving a lot of researching for glyphs/fallbacks.