### PR TITLE
Fix desyncs caused by unsynced pathing requests

### DIFF
--- a/rts/ExternalAI/AICallback.cpp
+++ b/rts/ExternalAI/AICallback.cpp
@@ -694,7 +694,7 @@ bool CAICallback::IsUnitNeutral(int unitId) {
 int CAICallback::InitPath(const float3& start, const float3& end, int pathType, float goalRadius)
 {
 	assert(((size_t)pathType) < moveDefHandler.GetNumMoveDefs());
-	return pathManager->RequestPath(nullptr, moveDefHandler.GetMoveDefByPathType(pathType), start, end, goalRadius, false);
+	return pathManager->RequestPath(nullptr, moveDefHandler.GetMoveDefByPathType(pathType), start, end, goalRadius, false, true);
 }
 
 float3 CAICallback::GetNextWaypoint(int pathId)

--- a/rts/Lua/LuaPathFinder.cpp
+++ b/rts/Lua/LuaPathFinder.cpp
@@ -234,9 +234,8 @@ int LuaPathFinder::RequestPath(lua_State* L)
 
 	const float radius = luaL_optfloat(L, 8, 8.0f);
 
-	// Synced requests are batched, deferred, and linked to a unit; so straight up Lua calls cannot make them. However,
-	// it is perfectly safe for synced Lua code to make an unsynced pathing request.
-	const int pathID = pathManager->RequestPath(nullptr, moveDef, start, end, radius, false);
+	const bool synced = CLuaHandle::GetHandleSynced(L);
+	const int pathID = pathManager->RequestPath(nullptr, moveDef, start, end, radius, synced, true);
 
 	if (pathID == 0)
 		return 0;

--- a/rts/Sim/Ecs/Registry.cpp
+++ b/rts/Sim/Ecs/Registry.cpp
@@ -3,6 +3,6 @@
 #include "Registry.h"
 
 entt::registry Sim::registry;
-SystemGlobals::SystemGlobal Sim::systemGlobals(Sim::registry);
+SystemGlobals::SystemGlobal<> Sim::systemGlobals(Sim::registry);
 SystemUtils::SystemUtils Sim::systemUtils;
 Sim::SaveLoadUtils Sim::saveLoadUtils(Sim::registry, Sim::systemUtils, Sim::systemGlobals);

--- a/rts/Sim/Ecs/Registry.h
+++ b/rts/Sim/Ecs/Registry.h
@@ -10,7 +10,7 @@
 
 namespace Sim {
     extern entt::registry registry;
-    extern SystemGlobals::SystemGlobal systemGlobals;
+    extern SystemGlobals::SystemGlobal<> systemGlobals;
     extern SystemUtils::SystemUtils systemUtils;
     extern SaveLoadUtils saveLoadUtils;
 }

--- a/rts/Sim/Ecs/SaveLoadUtils.h
+++ b/rts/Sim/Ecs/SaveLoadUtils.h
@@ -18,7 +18,7 @@ public:
     SaveLoadUtils
         ( entt::registry& registryReference
         , SystemUtils::SystemUtils& systemUtilsReference
-        , SystemGlobals::SystemGlobal& systemGlobalsReference
+        , SystemGlobals::SystemGlobal<>& systemGlobalsReference
         )
         : registry(registryReference)
         , systemUtils(systemUtilsReference)
@@ -31,7 +31,7 @@ public:
 private:
     entt::registry& registry;
     SystemUtils::SystemUtils& systemUtils;
-    SystemGlobals::SystemGlobal& systemGlobals;
+    SystemGlobals::SystemGlobal<>& systemGlobals;
 };
 
 }

--- a/rts/Sim/Path/HAPFS/PathManager.cpp
+++ b/rts/Sim/Path/HAPFS/PathManager.cpp
@@ -434,14 +434,15 @@ unsigned int CPathManager::RequestPath(
 	float3 startPos,
 	float3 goalPos,
 	float goalRadius,
-	bool synced
+	bool synced,
+	bool immediateResult
 ) {
 	unsigned int pathId = 0;
 
 	if (!IsFinalized())
 		return 0;
 
-	if (synced) {
+	if (!immediateResult) {
 		assert(!ThreadPool::inMultiThreadedSection);
 
 		PathSearch* existingSearch = nullptr;

--- a/rts/Sim/Path/HAPFS/PathManager.h
+++ b/rts/Sim/Path/HAPFS/PathManager.h
@@ -144,7 +144,8 @@ public:
 		float3 startPos,
 		float3 goalPos,
 		float goalRadius,
-		bool synced
+		bool synced,
+		bool immediateResult = false
 	) override;
 
 	/**

--- a/rts/Sim/Path/IPathManager.h
+++ b/rts/Sim/Path/IPathManager.h
@@ -147,7 +147,8 @@ public:
 		float3 startPos,
 		float3 goalPos,
 		float goalRadius,
-		bool synced
+		bool synced,
+		bool immediateResult = false
 	) {
 		return 0;
 	}

--- a/rts/Sim/Path/QTPFS/Components/Path.h
+++ b/rts/Sim/Path/QTPFS/Components/Path.h
@@ -5,6 +5,8 @@
 
 #include <vector>
 
+#include "../Registry.h"
+
 #include "System/float3.h"
 #include "System/Ecs/Components/BaseComponents.h"
 
@@ -13,21 +15,21 @@ namespace QTPFS {
 struct SharedPathChain {
 	SharedPathChain() {}
 
-	SharedPathChain(entt::entity initPrev, entt::entity initNext)
+	SharedPathChain(QTPFS::entity initPrev, QTPFS::entity initNext)
 		: prev(initPrev), next(initNext) {}
 
-    entt::entity prev{entt::null};
-    entt::entity next{entt::null};
+    QTPFS::entity prev{entt::null};
+    QTPFS::entity next{entt::null};
 };
 
 struct PartialSharedPathChain {
 	PartialSharedPathChain() {}
 
-	PartialSharedPathChain(entt::entity initPrev, entt::entity initNext)
+	PartialSharedPathChain(QTPFS::entity initPrev, QTPFS::entity initNext)
 		: prev(initPrev), next(initNext) {}
 
-    entt::entity prev{entt::null};
-    entt::entity next{entt::null};
+    QTPFS::entity prev{entt::null};
+    QTPFS::entity next{entt::null};
 };
 
 VOID_COMPONENT(PathIsTemp);
@@ -36,7 +38,7 @@ VOID_COMPONENT(PathIsToBeUpdated);
 VOID_COMPONENT(PathUpdatedCounterIncrease);
 VOID_COMPONENT(ProcessPath);
 
-ALIAS_COMPONENT(PathSearchRef, entt::entity);
+ALIAS_COMPONENT(PathSearchRef, QTPFS::entity);
 ALIAS_COMPONENT(PathRequeueSearch, bool);
 
 }

--- a/rts/Sim/Path/QTPFS/Path.h
+++ b/rts/Sim/Path/QTPFS/Path.h
@@ -385,6 +385,12 @@ namespace QTPFS {
 
 		spring_time searchTime;
 	};
+
+	struct UnsyncedIPath : public IPath {
+		UnsyncedIPath() {
+			SetSynced(false); // Mark this path as unsynced explicitly
+		}
+	};
 }
 
 #endif

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -124,6 +124,7 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 		IPath* path = &pathView.get<IPath>(entity);
 
 		if (path->IsSynced() == false) { continue; }
+		assert(path->GetOwner() != nullptr);
 		if (path->GetPathType() != pathType) { continue; }
 
 		// LOG("%s: %x is processing", __func__, (int)entity);

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -1,5 +1,5 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-#undef NDEBUG
+// #undef NDEBUG
 
 #include <bit>
 #include <cassert>

--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -1,5 +1,5 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
-// #undef NDEBUG
+#undef NDEBUG
 
 #include <bit>
 #include <cassert>

--- a/rts/Sim/Path/QTPFS/PathCache.h
+++ b/rts/Sim/Path/QTPFS/PathCache.h
@@ -24,7 +24,7 @@ namespace QTPFS {
 	struct PathCache {
 
 		struct DirtyPathDetail {
-			entt::entity pathEntity;
+			QTPFS::entity pathEntity;
 			int autoRepathTrigger;
 			int nodesAreCleanFromNodeId;
 			bool clearSharing;

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -1434,7 +1434,8 @@ unsigned int QTPFS::PathManager::RequestPath(
 	float3 sourcePoint,
 	float3 targetPoint,
 	float radius,
-	bool synced
+	bool synced,
+	bool immediateResult
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	unsigned int returnPathId = 0;
@@ -1449,8 +1450,8 @@ unsigned int QTPFS::PathManager::RequestPath(
 	// if (object != nullptr && 30809 == object->id)
 	// 	LOG("%s: RequestPath (%d).", __func__, returnPathId);
 
-	if (!synced && returnPathId != 0) {
-		// Unsynced calls are expected to resolve immediately.
+	if (immediateResult && returnPathId != 0) {
+		// immediateResult calls are expected to resolve immediately.
 		returnPathId = ExecuteUnsyncedSearch(returnPathId);
 	}
 

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -129,6 +129,15 @@ namespace QTPFS {
 
 	unsigned int PathManager::LAYERS_PER_UPDATE;
 	unsigned int PathManager::MAX_TEAM_SEARCHES;
+
+	IPath* GetPath(QTPFS::entity entityId) {
+		if (!registry.valid(entityId)) return nullptr;
+
+		IPath* path = registry.try_get<IPath>(entityId);
+		if (path != nullptr) return path;
+
+		return registry.try_get<UnsyncedIPath>(entityId);
+	};
 }
 
 QTPFS::PathManager::PathManager() {
@@ -156,9 +165,14 @@ QTPFS::PathManager::~PathManager() {
 	// print out anything still left in the registry - there should be nothing
 	registry.each([this](auto entity) {
 		bool isPath = registry.all_of<IPath>(entity);
+		bool isUnsyncedPath = registry.all_of<UnsyncedIPath>(entity);
 		bool isSearch = registry.all_of<PathSearch>(entity);
 		if (isPath) {
 			const IPath& path = registry.get<IPath>(entity);
+			registry.destroy(entity);
+		}
+		if (isUnsyncedPath) {
+			const IPath& path = registry.get<UnsyncedIPath>(entity);
 			registry.destroy(entity);
 		}
 		if (isSearch) {
@@ -238,6 +252,9 @@ void QTPFS::PathManager::InitStatic() {
 	}
 	{ auto view = registry.view<IPath>();
 	  if (view.size() > 0) { LOG("%s: IPath is unexpectedly greater than 0.", __func__); }
+	}
+	{ auto view = registry.view<UnsyncedIPath>();
+	  if (view.size() > 0) { LOG("%s: UnsyncedIPath is unexpectedly greater than 0.", __func__); }
 	}
 	// Views are created in multi-threaded sections, but they are referenced and I haven't determined
 	// yet whether that is safe in EnTT so creating views here to ensure everything is initialized
@@ -725,7 +742,7 @@ void QTPFS::PathManager::Update() {
 		for (auto& layerDirtyPaths : pathCache.dirtyPaths) {
 			// LOG("%s: start: %d", __func__, (int)layerDirtyPaths.size());
 			for (auto dirtyPathDetail : layerDirtyPaths) {
-				entt::entity pathEntity = dirtyPathDetail.pathEntity;
+				QTPFS::entity pathEntity = dirtyPathDetail.pathEntity;
 
 				// May have already been deleted.
 				if (!registry.valid(pathEntity)) { continue; }
@@ -756,6 +773,8 @@ void QTPFS::PathManager::Update() {
 
 					// The path may still be fine for owner, even if it can't be shared any more.
 					auto& path = registry.get<IPath>(pathEntity);
+					assert(path.GetOwner() != nullptr);
+					assert(path.IsSynced());
 
 					if (dirtyPathDetail.autoRepathTrigger > 0) {
 						// Rather than repath immediately we can defer the repath until the unit
@@ -792,7 +811,7 @@ void QTPFS::PathManager::ThreadUpdate() {
 }
 
 
-bool QTPFS::PathManager::InitializeSearch(entt::entity searchEntity) {
+bool QTPFS::PathManager::InitializeSearch(QTPFS::entity searchEntity) {
 	ZoneScoped;
 	assert(registry.all_of<PathSearch>(searchEntity));
 	PathSearch* search = &registry.get<PathSearch>(searchEntity);
@@ -808,10 +827,10 @@ bool QTPFS::PathManager::InitializeSearch(entt::entity searchEntity) {
 	assert(pathType < nodeLayers.size());
 	NodeLayer& nodeLayer = nodeLayers[pathType];
 
-	entt::entity pathEntity = (entt::entity)search->GetID();
+	QTPFS::entity pathEntity = (QTPFS::entity)search->GetID();
 	if (registry.valid(pathEntity)) {
-		assert(registry.all_of<IPath>(pathEntity));
-		IPath* path = &registry.get<IPath>(pathEntity);
+		assert((registry.any_of<IPath, UnsyncedIPath>(pathEntity)));
+		IPath* path = GetPath(pathEntity);
 		assert(path->GetPathType() == pathType);
 		search->Initialize(&nodeLayer, path->GetSourcePoint(), path->GetGoalPosition(), path->GetOwner());
 		path->SetHash(search->GetHash());
@@ -858,7 +877,7 @@ void QTPFS::PathManager::ReadyQueuedSearches() {
 		auto pathView = registry.view<PathSearch>();
 
 		// Go through in reverse order to minimize reshuffling EnTT will do with the grouping.
-		std::for_each(pathView.rbegin(), pathView.rend(), [this](entt::entity entity){
+		std::for_each(pathView.rbegin(), pathView.rend(), [this](QTPFS::entity entity){
 			if (InitializeSearch(entity))
 				registry.emplace_or_replace<ProcessPath>(entity);
 		});
@@ -868,7 +887,7 @@ void QTPFS::PathManager::ReadyQueuedSearches() {
 
 		// Any requests that cannot be processed should be removed. We can't do that with the r*
 		// iterators because that will break them.
-		std::for_each(pathView.begin(), pathView.end(), [this](entt::entity entity){
+		std::for_each(pathView.begin(), pathView.end(), [this](QTPFS::entity entity){
 			if (!registry.all_of<ProcessPath>(entity))
 				registry.destroy(entity);
 		});
@@ -885,8 +904,8 @@ void QTPFS::PathManager::ExecuteQueuedSearches() {
 	// execute pending searches collected via
 	// RequestPath and QueueDeadPathSearches
 	for_mt(0, pathView.size(), [this, &pathView](int i){
-		entt::entity pathSearchEntity = pathView.begin()[i];
-        // entt::entity pathSearchEntity = pathView.storage<PathSearch>()[i];
+		QTPFS::entity pathSearchEntity = pathView.begin()[i];
+        // QTPFS::entity pathSearchEntity = pathView.storage<PathSearch>()[i];
 
 		assert(registry.valid(pathSearchEntity));
 		assert(registry.all_of<PathSearch>(pathSearchEntity));
@@ -897,7 +916,7 @@ void QTPFS::PathManager::ExecuteQueuedSearches() {
 		ExecuteSearch(search, nodeLayer, pathType);
 	});
 
-	auto completePath = [this](entt::entity pathEntity, IPath* path){
+	auto completePath = [this](QTPFS::entity pathEntity, IPath* path){
 		// inform the movement system that the path has been changed.
 		if (registry.all_of<PathUpdatedCounterIncrease>(pathEntity)) {
 			path->SetNumPathUpdates(path->GetNumPathUpdates() + 1);
@@ -921,8 +940,9 @@ void QTPFS::PathManager::ExecuteQueuedSearches() {
 		assert(registry.all_of<PathSearch>(pathSearchEntity));
 
 		PathSearch* search = &pathView.get<PathSearch>(pathSearchEntity);
-		entt::entity pathEntity = (entt::entity)search->GetID();
+		QTPFS::entity pathEntity = (QTPFS::entity)search->GetID();
 		if (registry.valid(pathEntity)) {
+			// Only synced paths should be actioned in this function.
 			IPath* path = registry.try_get<IPath>(pathEntity);
 			if (path != nullptr) {
 				if (search->PathWasFound()) {
@@ -977,11 +997,11 @@ bool QTPFS::PathManager::ExecuteSearch(
 
 	BasicTimer searchTimer(0);
 
-	entt::entity pathEntity = (entt::entity)search->GetID();
+	QTPFS::entity pathEntity = (QTPFS::entity)search->GetID();
 	if (!registry.valid(pathEntity))
 		return false;
 
-	IPath* path = registry.try_get<IPath>(pathEntity);
+	IPath* path = GetPath(pathEntity);
 
 	int currentThread = ThreadPool::GetThreadNum();
 
@@ -1005,8 +1025,8 @@ bool QTPFS::PathManager::ExecuteSearch(
 	bool synced = path->IsSynced();
 	bool forceFullPath = false;
 
-	entt::entity chainHeadEntity = entt::null;
-	entt::entity partialChainHeadEntity = entt::null;
+	QTPFS::entity chainHeadEntity = entt::null;
+	QTPFS::entity partialChainHeadEntity = entt::null;
 
 	// TODO: make a function?
 	if (synced)
@@ -1127,6 +1147,9 @@ bool QTPFS::PathManager::ExecuteSearch(
 
 void QTPFS::PathManager::QueueDeadPathSearches() {
 	ZoneScoped;
+
+	// Only synced can be marked as dead.
+
 	auto pathUpdatesView = registry.view<IPath, PathIsToBeUpdated>();
 	if (pathUpdatesView.size_hint() == 0 && gs->frameNum >= refreshDirtyPathRateFrame) {
 		// LOG("%s: pathUpdatesView=%d,frame=%d>%d", __func__
@@ -1193,14 +1216,22 @@ unsigned int QTPFS::PathManager::QueueSearch(
 	//     calls DeletePath, which ensures any path is removed
 	//     from its cache before we get to ExecuteSearch
 
-	entt::entity pathEntity = registry.create();
-	assert(!registry.all_of<IPath>(pathEntity));
-	IPath* newPath = &(registry.emplace<IPath>(pathEntity));
+	QTPFS::entity pathEntity = registry.create();
+	assert((!registry.any_of<IPath, UnsyncedIPath>(pathEntity)));
+
+	auto createNewPath = [](QTPFS::entity entityId, bool synced) -> IPath* {
+		if (synced)
+			return &(registry.emplace<IPath>(entityId));
+		else
+			return &(registry.emplace<UnsyncedIPath>(entityId));
+	};
+
+	IPath* newPath = createNewPath(pathEntity, synced);
 
 	// Every path gets one. It gets changed in a multi-threaded section, so we can't add them on demand.
 	registry.emplace<PathRequeueSearch>(pathEntity, false);
 
-	entt::entity searchEntity = registry.create();
+	QTPFS::entity searchEntity = registry.create();
 	PathSearch* newSearch = &registry.emplace<PathSearch>(searchEntity, PATH_SEARCH_ASTAR);
 
 	if (synced) {
@@ -1216,7 +1247,7 @@ unsigned int QTPFS::PathManager::QueueSearch(
 	assert(newSearch != nullptr);
 
 	// 0 is considered a null path. Entity id 0 should have been taken by the pathing system itself.
-	assert(pathEntity != (entt::entity)0);
+	assert(pathEntity != (QTPFS::entity)0);
 
 	// NOTE:
 	//     the unclamped end-points are temporary
@@ -1264,7 +1295,7 @@ unsigned int QTPFS::PathManager::RequeueSearch(
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(!ThreadPool::inMultiThreadedSection);
-	entt::entity pathEntity = entt::entity(oldPath->GetID());
+	QTPFS::entity pathEntity = QTPFS::entity(oldPath->GetID());
 
 	// assert(!registry.all_of<PathDelayedDelete>(pathEntity));
 
@@ -1279,7 +1310,7 @@ unsigned int QTPFS::PathManager::RequeueSearch(
 
 	// Always create the search object first to ensure pathEntity can never be 0 (which is
 	// considered a non-path)
-	entt::entity searchEntity = registry.create();
+	QTPFS::entity searchEntity = registry.create();
 	PathSearch* newSearch = &registry.emplace<PathSearch>(searchEntity, PATH_SEARCH_ASTAR);
 	assert(oldPath != nullptr);
 	assert(newSearch != nullptr);
@@ -1334,7 +1365,7 @@ void QTPFS::PathManager::DeletePath(unsigned int pathID, bool force) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(!ThreadPool::inMultiThreadedSection);
 
-	entt::entity pathEntity = entt::entity(pathID);
+	QTPFS::entity pathEntity = QTPFS::entity(pathID);
 
 	if (!registry.valid(pathEntity)) return;
 
@@ -1351,7 +1382,7 @@ void QTPFS::PathManager::DeletePath(unsigned int pathID, bool force) {
 	}
 }
 
-void QTPFS::PathManager::DeletePathEntity(entt::entity pathEntity) {
+void QTPFS::PathManager::DeletePathEntity(QTPFS::entity pathEntity) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const PathTraceMapIt pathTraceIt = pathTraces.find(entt::to_integral(pathEntity));
 
@@ -1369,7 +1400,7 @@ void QTPFS::PathManager::DeletePathEntity(entt::entity pathEntity) {
 	}
 }
 
-void QTPFS::PathManager::RemovePathFromShared(entt::entity entity) {
+void QTPFS::PathManager::RemovePathFromShared(QTPFS::entity entity) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// if (!registry.valid(entity)) return;
 	if (!registry.all_of<SharedPathChain>(entity)) return;
@@ -1390,7 +1421,7 @@ void QTPFS::PathManager::RemovePathFromShared(entt::entity entity) {
 	linkedListHelper.RemoveChain<SharedPathChain>(entity);
 }
 
-void QTPFS::PathManager::RemovePathFromPartialShared(entt::entity entity) {
+void QTPFS::PathManager::RemovePathFromPartialShared(QTPFS::entity entity) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// if (!registry.valid(entity)) return;
 	if (!registry.all_of<PartialSharedPathChain>(entity)) return;
@@ -1412,17 +1443,17 @@ void QTPFS::PathManager::RemovePathFromPartialShared(entt::entity entity) {
 	linkedListHelper.RemoveChain<PartialSharedPathChain>(entity);
 }
 
-void QTPFS::PathManager::RemovePathSearch(entt::entity pathEntity) {
+void QTPFS::PathManager::RemovePathSearch(QTPFS::entity pathEntity) {
 	RECOIL_DETAILED_TRACY_ZONE;
 
 	auto search = registry.try_get<PathSearchRef>(pathEntity);
 
-	// if (pathEntity == entt::entity(257949903))
+	// if (pathEntity == QTPFS::entity(257949903))
 	// 		LOG("%s: id: %d search %p", __func__
 	// 			, entt::to_integral(pathEntity), search);
 
 	if (search != nullptr) {
-		entt::entity searchId = search->value;
+		QTPFS::entity searchId = search->value;
 		if (registry.valid(searchId))
 			registry.destroy(searchId);
 	}
@@ -1451,16 +1482,16 @@ unsigned int QTPFS::PathManager::RequestPath(
 	// 	LOG("%s: RequestPath (%d).", __func__, returnPathId);
 
 	if (immediateResult && returnPathId != 0)
-		returnPathId = ExecuteUnsyncedSearch(returnPathId);
+		returnPathId = ExecuteImmediateSearch(returnPathId);
 
 	return returnPathId;
 }
 
-unsigned int QTPFS::PathManager::ExecuteUnsyncedSearch(unsigned int pathId){
+unsigned int QTPFS::PathManager::ExecuteImmediateSearch(unsigned int pathId){
 	RECOIL_DETAILED_TRACY_ZONE;
-	entt::entity pathEntity = entt::entity(pathId);
+	QTPFS::entity pathEntity = QTPFS::entity(pathId);
 	assert(registry.valid(pathEntity));
-	entt::entity pathSearchEntity = registry.get<PathSearchRef>(pathEntity).value;
+	QTPFS::entity pathSearchEntity = registry.get<PathSearchRef>(pathEntity).value;
 	assert(registry.valid(pathSearchEntity));
 	InitializeSearch(pathSearchEntity);
 
@@ -1470,7 +1501,7 @@ unsigned int QTPFS::PathManager::ExecuteUnsyncedSearch(unsigned int pathId){
 	ExecuteSearch(&pathSearch, nodeLayer, pathType);
 
 	if (registry.valid(pathEntity)) {
-		IPath* path = registry.try_get<IPath>(pathEntity);
+		IPath* path = GetPath(pathEntity);
 		if (path != nullptr) {
 			if (pathSearch.PathWasFound()) {
 				registry.remove<PathIsTemp>(pathEntity);
@@ -1491,7 +1522,7 @@ unsigned int QTPFS::PathManager::ExecuteUnsyncedSearch(unsigned int pathId){
 
 bool QTPFS::PathManager::PathUpdated(unsigned int pathID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	entt::entity pathEntity = (entt::entity)pathID;
+	QTPFS::entity pathEntity = (QTPFS::entity)pathID;
 	if (!registry.valid(pathEntity)) { return false; }
 	IPath* livePath = registry.try_get<IPath>(pathEntity);
 
@@ -1503,7 +1534,7 @@ bool QTPFS::PathManager::PathUpdated(unsigned int pathID) {
 
 void QTPFS::PathManager::ClearPathUpdated(unsigned int pathID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	entt::entity pathEntity = (entt::entity)pathID;
+	QTPFS::entity pathEntity = (QTPFS::entity)pathID;
 	if (!registry.valid(pathEntity)) { return; }
 	IPath* livePath = registry.try_get<IPath>(pathEntity);
 
@@ -1528,11 +1559,11 @@ float3 QTPFS::PathManager::NextWayPoint(
 	if (!IsFinalized())
 		return noPathPoint;
 
-	entt::entity pathEntity = entt::entity(pathID);
+	QTPFS::entity pathEntity = QTPFS::entity(pathID);
 	if (!registry.valid(pathEntity))
 		return noPathPoint;
 
-	IPath* livePath = registry.try_get<IPath>(pathEntity);
+	IPath* livePath = GetPath(pathEntity);
 	if (livePath == nullptr)
 		return noPathPoint;
 
@@ -1611,7 +1642,7 @@ float3 QTPFS::PathManager::NextWayPoint(
 
 bool QTPFS::PathManager::CurrentWaypointIsUnreachable(unsigned int pathID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	entt::entity pathEntity = entt::entity(pathID);
+	QTPFS::entity pathEntity = QTPFS::entity(pathID);
 	if (!registry.valid(pathEntity))
 		return true;
 
@@ -1629,7 +1660,7 @@ bool QTPFS::PathManager::CurrentWaypointIsUnreachable(unsigned int pathID) {
 
 bool QTPFS::PathManager::NextWayPointIsUnreachable(unsigned int pathID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	entt::entity pathEntity = entt::entity(pathID);
+	QTPFS::entity pathEntity = QTPFS::entity(pathID);
 	if (!registry.valid(pathEntity))
 		return true;
 
@@ -1653,11 +1684,11 @@ void QTPFS::PathManager::GetPathWayPoints(
 	if (!IsFinalized())
 		return;
 
-	entt::entity pathEntity = (entt::entity)pathID;
+	QTPFS::entity pathEntity = (QTPFS::entity)pathID;
 	if (!registry.valid(pathEntity))
 		return;
 
-	const IPath* path = registry.try_get<IPath>(pathEntity);
+	const IPath* path = GetPath(pathEntity);
 	if (path == nullptr)
 		return;
 

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -1450,10 +1450,8 @@ unsigned int QTPFS::PathManager::RequestPath(
 	// if (object != nullptr && 30809 == object->id)
 	// 	LOG("%s: RequestPath (%d).", __func__, returnPathId);
 
-	if (immediateResult && returnPathId != 0) {
-		// immediateResult calls are expected to resolve immediately.
+	if (immediateResult && returnPathId != 0)
 		returnPathId = ExecuteUnsyncedSearch(returnPathId);
-	}
 
 	return returnPathId;
 }

--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -54,7 +54,7 @@ namespace QTPFS {
 		void Update() override;
 		void UpdatePath(const CSolidObject* owner, unsigned int pathID) override;
 		void DeletePath(unsigned int pathID, bool force = false) override;
-		void DeletePathEntity(entt::entity pathEntity);
+		void DeletePathEntity(QTPFS::entity pathEntity);
 
 		unsigned int RequestPath(
 			CSolidObject* object,
@@ -109,10 +109,10 @@ namespace QTPFS {
 		typedef spring::unordered_map<unsigned int, unsigned int>::iterator PathTypeMapIt;
 		typedef spring::unordered_map<unsigned int, PathSearchTrace::Execution*> PathTraceMap;
 		typedef spring::unordered_map<unsigned int, PathSearchTrace::Execution*>::iterator PathTraceMapIt;
-		typedef spring::unordered_map<PathHashType, entt::entity> SharedPathMap;
-		typedef spring::unordered_map<PathHashType, entt::entity>::iterator SharedPathMapIt;
-		typedef spring::unordered_map<PathHashType, entt::entity> PartialSharedPathMap;
-		typedef spring::unordered_map<PathHashType, entt::entity>::iterator PartialSharedPathMapIt;
+		typedef spring::unordered_map<PathHashType, QTPFS::entity> SharedPathMap;
+		typedef spring::unordered_map<PathHashType, QTPFS::entity>::iterator SharedPathMapIt;
+		typedef spring::unordered_map<PathHashType, QTPFS::entity> PartialSharedPathMap;
+		typedef spring::unordered_map<PathHashType, QTPFS::entity>::iterator PartialSharedPathMapIt;
 
 		typedef std::vector<PathSearch*> PathSearchVect;
 		typedef std::vector<PathSearch*>::iterator PathSearchVectIt;
@@ -122,10 +122,10 @@ namespace QTPFS {
 		void InitRootSize(const SRectangle& r);
 		void UpdateNodeLayer(unsigned int layerNum, const SRectangle& r, int currentThread);
 
-		bool InitializeSearch(entt::entity searchEntity);
-		void RemovePathFromShared(entt::entity entity);
-		void RemovePathFromPartialShared(entt::entity entity);
-		void RemovePathSearch(entt::entity pathEntity);
+		bool InitializeSearch(QTPFS::entity searchEntity);
+		void RemovePathFromShared(QTPFS::entity entity);
+		void RemovePathFromPartialShared(QTPFS::entity entity);
+		void RemovePathSearch(QTPFS::entity pathEntity);
 
 		void ReadyQueuedSearches();
 		void ExecuteQueuedSearches();
@@ -156,7 +156,7 @@ namespace QTPFS {
 			unsigned int pathType
 		);
 
-		unsigned int ExecuteUnsyncedSearch(unsigned int pathId);
+		unsigned int ExecuteImmediateSearch(unsigned int pathId);
 
 		bool IsFinalized() const { return isFinalized; }
 
@@ -196,7 +196,7 @@ namespace QTPFS {
 
 		std::uint32_t pfsCheckSum;
 
-		entt::entity systemEntity = entt::null;
+		QTPFS::entity systemEntity = entt::null;
 
 		bool isFinalized = false;
 

--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -62,7 +62,8 @@ namespace QTPFS {
 			float3 sourcePos,
 			float3 targetPos,
 			float radius,
-			bool synced
+			bool synced,
+			bool immediateResult = false
 		) override;
 
 		float3 NextWayPoint(

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -173,8 +173,8 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData) {
 		return false;
 	};
 
-	auto *pathToRepair = ( tryPathRepair && registry.valid(entt::entity(searchID)) )
-			? registry.try_get<IPath>(entt::entity(searchID)) : nullptr;
+	auto *pathToRepair = ( tryPathRepair && registry.valid(QTPFS::entity(searchID)) )
+			? registry.try_get<IPath>(QTPFS::entity(searchID)) : nullptr;
 
 	// Path repairs need only search to the point of finding the beginning of the renaming clean part of the old path.
 	// Such searches are also restricted in the area they can search to avoid creating poor paths that would be better
@@ -432,7 +432,7 @@ void QTPFS::PathSearch::LoadPartialPath(IPath* path) {
 }
 
 void QTPFS::PathSearch::LoadRepairPath() {
-	const auto *pathToRepair = registry.try_get<IPath>(entt::entity(searchID));
+	const auto *pathToRepair = registry.try_get<IPath>(QTPFS::entity(searchID));
 
 	const uint32_t firstCleanNodeId = pathToRepair->GetFirstNodeIdOfCleanPath();
 	const uint32_t nodeCount = pathToRepair->GetGoodNodeCount();

--- a/rts/Sim/Path/QTPFS/Registry.cpp
+++ b/rts/Sim/Path/QTPFS/Registry.cpp
@@ -1,6 +1,6 @@
 #include "Registry.h"
 
-entt::registry QTPFS::registry;
-SystemGlobals::SystemGlobal QTPFS::systemGlobals(QTPFS::registry);
+entt::basic_registry<QTPFS::entity> QTPFS::registry;
+SystemGlobals::SystemGlobal<decltype(QTPFS::registry)> QTPFS::systemGlobals(QTPFS::registry);
 SystemUtils::SystemUtils QTPFS::systemUtils;
-ecs_dll::DoubleLinkList QTPFS::linkedListHelper(QTPFS::registry);
+ecs_dll::DoubleLinkList<decltype(QTPFS::registry)> QTPFS::linkedListHelper(QTPFS::registry);

--- a/rts/Sim/Path/QTPFS/Registry.h
+++ b/rts/Sim/Path/QTPFS/Registry.h
@@ -17,10 +17,28 @@
 #include "System/Ecs/Utils/SystemUtils.h"
 
 namespace QTPFS {
-    extern entt::registry registry;
-    extern SystemGlobals::SystemGlobal systemGlobals;
+    using entity = std::int32_t;
+}
+
+// Create a special entity type which allows for all paths to be used from Lua.
+// Lua is using floats, which allows for 23 bits mantissa. So we can shave excess bits off of the entity version number.
+template<>
+struct entt::internal::entt_traits<QTPFS::entity> {
+    using entity_type = QTPFS::entity;
+    using version_type = std::uint8_t;
+
+    using difference_type = std::int32_t;
+
+    static constexpr entity_type entity_mask = 0xFFFFF;
+    static constexpr entity_type version_mask = 0x7;
+    static constexpr std::size_t entity_shift = 20u;
+};
+
+namespace QTPFS {
+    extern entt::basic_registry<QTPFS::entity> registry;
+    extern SystemGlobals::SystemGlobal<decltype(registry)> systemGlobals;
     extern SystemUtils::SystemUtils systemUtils;
-    extern ecs_dll::DoubleLinkList linkedListHelper;
+    extern ecs_dll::DoubleLinkList<decltype(registry)> linkedListHelper;
 }
 
 #endif

--- a/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
@@ -46,7 +46,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
 
     // Initialization
     if (frameModulus <= 0) {
-        layersView.each([&layersView, pm](entt::entity entity){
+        layersView.each([&layersView, pm](QTPFS::entity entity){
                 auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
                 auto& nodeLayer = pm->GetNodeLayer(layer.layerNum);
                 layer.updateCurMaxSpeed = (-std::numeric_limits<float>::infinity());
@@ -60,7 +60,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
     
     // One thread per layer: get maximum speed mod from the nodes walked thus far.
     for_mt(0, layersView.size(), [&layersView, &comp, dataChunk, pm](int idx){
-        entt::entity entity = layersView.storage<NodeLayerSpeedInfoSweep>()[idx];
+        QTPFS::entity entity = layersView.storage<NodeLayerSpeedInfoSweep>()[idx];
         auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
 
         const int idxBeg = ((dataChunk + 0) * layer.updateMaxNodes) / comp.refreshTimeInFrames;
@@ -89,7 +89,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
 
     // Finished search
     if (dataChunk == comp.refreshTimeInFrames + (-1))
-        layersView.each([&comp, &layersView](entt::entity entity){
+        layersView.each([&comp, &layersView](QTPFS::entity entity){
             auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
             comp.relSpeedModinfos[layer.layerNum].max = layer.updateCurMaxSpeed;
             comp.relSpeedModinfos[layer.layerNum].mean = layer.updateCurSumSpeed / layer.updateNumLeafNodes;
@@ -107,11 +107,11 @@ void ScanForPathSpeedModInfo(int frameModulus) {
 
 void InitLayers() {
     RECOIL_DETAILED_TRACY_ZONE;
-    std::vector<entt::entity> layers((size_t)moveDefHandler.GetNumMoveDefs());
+    std::vector<QTPFS::entity> layers((size_t)moveDefHandler.GetNumMoveDefs());
     QTPFS::registry.create<decltype(layers)::iterator>(layers.begin(), layers.end());
 
     int counter = 0;
-    std::for_each(layers.begin(), layers.end(), [&counter](entt::entity entity){
+    std::for_each(layers.begin(), layers.end(), [&counter](QTPFS::entity entity){
         auto& layer = QTPFS::registry.emplace<NodeLayerSpeedInfoSweep>(entity);
         layer.layerNum = counter++;
         layer.updateCurMaxSpeed = 0.f;
@@ -169,5 +169,5 @@ void PathSpeedModInfoSystem::Shutdown() {
     systemUtils.OnUpdate().disconnect<&PathSpeedModInfoSystem::Update>();
 
     registry.view<NodeLayerSpeedInfoSweep>()
-            .each([](entt::entity entity){ registry.destroy(entity); });
+            .each([](QTPFS::entity entity){ registry.destroy(entity); });
 }

--- a/rts/System/Ecs/Utils/DoubleLinkedList.h
+++ b/rts/System/Ecs/Utils/DoubleLinkedList.h
@@ -7,35 +7,36 @@
 
 namespace ecs_dll {
 
+template<class RegType = entt::registry>
 class DoubleLinkList {
 
 public:
 
-    DoubleLinkList(entt::registry& reg)
+    DoubleLinkList(RegType& reg)
         : registry(reg)
     {}
 
-template<class T>
-void InsertChain(entt::entity head, entt::entity newLink) {
-    auto& nextChain = registry.get<T>(head);
-    auto& prevChain = registry.get<T>(nextChain.prev);
+template<class T, typename EntityType>
+void InsertChain(EntityType head, EntityType newLink) {
+    auto& nextChain = registry.template get<T>(head);
+    auto& prevChain = registry.template get<T>(nextChain.prev);
 
     // LOG("%s: added chain link with %x <-> [%x] <-> %x.", __func__
     //         , entt::to_integral(nextChain.prev)
     //         , entt::to_integral(newLink)
     //         , entt::to_integral(prevChain.next));
 
-    registry.emplace_or_replace<T>(newLink, nextChain.prev, prevChain.next);
+    registry.template emplace_or_replace<T>(newLink, nextChain.prev, prevChain.next);
     prevChain.next = newLink;
     nextChain.prev = newLink;
 }
 
-template<class T>
-void RemoveChain(entt::entity removeLink) {
-    auto& curChain = registry.get<T>(removeLink);
+template<class T, typename EntityType>
+void RemoveChain(EntityType removeLink) {
+    auto& curChain = registry.template get<T>(removeLink);
 
-    auto& nextChain = registry.get<T>(curChain.next);
-    auto& prevChain = registry.get<T>(curChain.prev);
+    auto& nextChain = registry.template get<T>(curChain.next);
+    auto& prevChain = registry.template get<T>(curChain.prev);
 
     // LOG("%s: removed chain link from %x. Linking %x <-> %x.", __func__
     //         , entt::to_integral(removeLink)
@@ -45,12 +46,12 @@ void RemoveChain(entt::entity removeLink) {
     prevChain.next = curChain.next;
     nextChain.prev = curChain.prev;
 
-    registry.remove<T>(removeLink);
+    registry.template remove<T>(removeLink);
 }
 
 // walk the chain list
-template<class T, typename F>
-void ForEachInChain(entt::entity head, F&& func) {
+template<class T, typename F, typename EntityType>
+void ForEachInChain(EntityType head, F&& func) {
     // for (auto* chainLink = &registry.get<T>(head);
     //     chainLink->next != head;
     //     chainLink = &registry.get<T>(chainLink->next)
@@ -68,13 +69,13 @@ void ForEachInChain(entt::entity head, F&& func) {
         //         , entt::to_integral(head));
         func(curEntity);
 
-        auto* chainLink = &registry.get<T>(curEntity);
+        auto* chainLink = &registry.template get<T>(curEntity);
         curEntity = chainLink->next;
     } while (curEntity != head);
 }
 
-template<class T, typename F>
-void BackWalkWithEarlyExit(entt::entity head, F&& func) {
+template<class T, typename F, typename EntityType>
+void BackWalkWithEarlyExit(EntityType head, F&& func) {
     auto curEntity = head;
     do {
         // LOG("%s: walking chain link %x [head %x]", __func__
@@ -82,13 +83,13 @@ void BackWalkWithEarlyExit(entt::entity head, F&& func) {
         //         , entt::to_integral(head));
         if (!func(curEntity)) { break; }
 
-        auto* chainLink = &registry.get<T>(curEntity);
+        auto* chainLink = &registry.template get<T>(curEntity);
         curEntity = chainLink->prev;
     } while (curEntity != head);
 }
 
 private:
-    entt::registry& registry;
+    RegType& registry;
 
 };
 

--- a/rts/System/Ecs/Utils/SystemGlobalUtils.h
+++ b/rts/System/Ecs/Utils/SystemGlobalUtils.h
@@ -9,10 +9,10 @@
 
 namespace SystemGlobals {
 
-
+template<class RegType = entt::registry>
 class SystemGlobal {
 public:
-    SystemGlobal(entt::registry& registryReference)
+    SystemGlobal(RegType& registryReference)
         : registry(registryReference)
     {}
 
@@ -21,14 +21,14 @@ public:
         if (! registry.valid(systemGlobalsEntity))
             systemGlobalsEntity = registry.create();
 
-        return registry.emplace_or_replace<T>(systemGlobalsEntity);
+        return registry.template emplace_or_replace<T>(systemGlobalsEntity);
     };
 
     template<class T>
-    T& GetSystemComponent() { return registry.get<T>(systemGlobalsEntity); }
+    T& GetSystemComponent() { return registry.template get<T>(systemGlobalsEntity); }
 
     template<class T>
-    bool IsSystemActive() { return (nullptr != registry.try_get<T>(systemGlobalsEntity)); }
+    bool IsSystemActive() { return (nullptr != registry.template try_get<T>(systemGlobalsEntity)); }
 
     void ClearComponents() {
         if (registry.valid(systemGlobalsEntity))
@@ -41,8 +41,8 @@ public:
     void serialize(Archive &ar) { ar(systemGlobalsEntity); }
 
 private:
-    entt::entity systemGlobalsEntity = entt::null;
-    entt::registry& registry;
+    RegType::entity_type systemGlobalsEntity = entt::null;
+    RegType& registry;
 };
 
 }


### PR DESCRIPTION
This addresses the issues seen in Zero-K pertaining to desync rate increases. HAPFS and QTPFS are both fixed.

A mistake on my part, I falsely believed that widgets were not permitted to request paths, only gadgets. The HAPFS desync happened because the unsynced path requests would populate the sync path results cache, which would cause a desync after a while. HAPFS is fixed by making sure unsynced paths are correctly labelled as such so they can use the correct separate cache.

The QTPFS desync was because the unsynced paths would be added and removed, which could cause the order of the synced paths to be changed. This wouldn't normally be an issue, but we have an optimization on dirty paths where we repath a part of the list of dirty paths per frame (to balance per frame loading) and a change in path order can change which paths get updated on a given frame, which results in a desync. If we had always processed the full list then we wouldn't have a desync. QTPFS is addressed by have an identical, but independent, path component in the ECS.

I've also made sure that QTPFS will only generate LUA compatible Path Ids by creating a custom entity type.

The calls from LUA and AI now all specify that they require an immediate response to a pathing request (this was originally determined by reading the unsynced boolean parameter, which is not appropriate and the reason for the desync.) A stupid mistake on my part.

I have tested the QTPFS desync. Sautron's testing scenario was able to surface the issue quickly. After the fix, I haven't been able to reproduce the desync.
