### PR TITLE
DWMFlush 

### DIFF
--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -71,6 +71,7 @@ CONFIG(int, MinimizeOnFocusLoss).defaultValue(0).minimumValue(0).maximumValue(1)
 CONFIG(bool, Fullscreen).defaultValue(true).headlessValue(false).description("Sets whether the game will run in fullscreen, as opposed to a window. For Windowed Fullscreen of Borderless Window, set this to 0, WindowBorderless to 1, and WindowPosX and WindowPosY to 0.");
 CONFIG(bool, WindowBorderless).defaultValue(false).description("When set and Fullscreen is 0, will put the game in Borderless Window mode, also known as Windowed Fullscreen. When using this, it is generally best to also set WindowPosX and WindowPosY to 0");
 CONFIG(bool, BlockCompositing).defaultValue(false).safemodeValue(true).description("Disables kwin compositing to fix tearing, possible fixes low FPS in windowed mode, too.");
+CONFIG(int, DWMFlush).defaultValue(0).description("Force Windows Desktop Compositors DWMFlush before each SDL_GL_SwapWindow, preventing dropped frames (use nVidias FrameView to validate dropped frames, or BARs Jitter Timer widget). Value of 1 does DWMFlush before SwapBuffers, value of 2 does DWMFlush after swapbuffers.");
 
 CONFIG(int, XResolution).defaultValue(0).headlessValue(8).minimumValue(0).description("Sets the width of the game screen. If set to 0 Spring will autodetect the current resolution of your desktop.");
 CONFIG(int, YResolution).defaultValue(0).headlessValue(8).minimumValue(0).description("Sets the height of the game screen. If set to 0 Spring will autodetect the current resolution of your desktop.");
@@ -207,6 +208,7 @@ CR_REG_METADATA(CGlobalRendering, (
 	CR_IGNORED(borderless),
 
 	CR_IGNORED(underExternalDebug),
+	CR_IGNORED(forceDWMFlush),
 
 	CR_IGNORED(sdlWindow),
 	CR_IGNORED(glContext),
@@ -336,6 +338,7 @@ CGlobalRendering::CGlobalRendering()
 	, fullScreen(configHandler->GetBool("Fullscreen"))
 	, borderless(configHandler->GetBool("WindowBorderless"))
 	, underExternalDebug(false)
+	, forceDWMFlush(configHandler->GetInt("DWMFlush"))
 	, sdlWindow{nullptr}
 	, glContext{nullptr}
 	, glExtensions{}
@@ -347,6 +350,7 @@ CGlobalRendering::CGlobalRendering()
 		"DualScreenMiniMapOnLeft",
 		"Fullscreen",
 		"WindowBorderless",
+		"DWMFlush",
 		"XResolution",
 		"YResolution",
 		"XResolutionWindowed",
@@ -676,8 +680,23 @@ void CGlobalRendering::SwapBuffers(bool allowSwapBuffers, bool clearErrors)
 
 		//https://stackoverflow.com/questions/68480028/supporting-opengl-screen-capture-by-third-party-applications
 		glBindFramebuffer(GL_READ_FRAMEBUFFER_EXT, 0);
-
+		
+		#ifdef _WIN32
+			if (forceDWMFlush == 1){ 
+				ZoneScopedN("CGlobalRendering::SwapBuffers::DWMFlushPre");
+				HRESULT result = dwmLoader.DwmFlush();
+			}
+		#endif
+		
 		SDL_GL_SwapWindow(sdlWindow);
+
+		#ifdef _WIN32
+			if (forceDWMFlush == 2){ 
+				ZoneScopedN("CGlobalRendering::SwapBuffers::DWMFlushPost");
+				HRESULT result = dwmLoader.DwmFlush();
+			}
+		#endif
+
 		FrameMark;
 	}
 	// exclude debug from SCOPED_TIMER("Misc::SwapBuffers");
@@ -1247,6 +1266,7 @@ void CGlobalRendering::ConfigNotify(const std::string& key, const std::string& v
 		return;
 	}
 	winChgFrame = drawFrame + 1; //need to do on next frame since config mutex is locked inside ConfigNotify
+	forceDWMFlush = configHandler->GetInt("DWMFlush");
 }
 
 void CGlobalRendering::UpdateWindow()

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -13,6 +13,55 @@
 #include "System/UnorderedSet.hpp"
 #include "System/type2.h"
 
+#ifdef _WIN32
+	#include <windows.h>
+	class DwmApiLoader {
+		public:
+			static DwmApiLoader& getInstance() {
+				static DwmApiLoader instance;
+				return instance;
+			}
+
+			HRESULT DwmFlush() {
+				if (!isLoaded) {
+					dwmapiDll = LoadLibrary("dwmapi.dll");
+					if (dwmapiDll == NULL) {
+						//std::cerr << "Failed to load dwmapi.dll" << std::endl;
+						return E_FAIL;
+					}
+
+					DwmFlushFunc = reinterpret_cast<DwmFlushFuncType>(GetProcAddress(dwmapiDll, "DwmFlush"));
+					if (DwmFlushFunc == NULL) {
+						//std::cerr << "Failed to get address of DwmFlush function" << std::endl;
+						FreeLibrary(dwmapiDll);
+						return E_FAIL;
+					}
+
+					isLoaded = true;
+				}
+
+				return DwmFlushFunc();
+			}
+
+			~DwmApiLoader() {
+				if (isLoaded) {
+					FreeLibrary(dwmapiDll);
+				}
+			}
+
+		private:
+			typedef HRESULT(WINAPI* DwmFlushFuncType)();
+			HMODULE dwmapiDll = NULL;
+			DwmFlushFuncType DwmFlushFunc = NULL;
+			bool isLoaded = false;
+
+			DwmApiLoader() {} // Private constructor to enforce singleton pattern
+			DwmApiLoader(const DwmApiLoader&) = delete; // Disable copy constructor
+			DwmApiLoader& operator=(const DwmApiLoader&) = delete; // Disable assignment operator
+	};
+#endif
+
+
 struct SDL_version;
 struct SDL_Rect;
 struct SDL_Window;
@@ -368,6 +417,15 @@ public:
 	bool borderless;
 
 	bool underExternalDebug;
+	
+	/** 
+	 * @brief Forces Window's desktop compositing before(1)/after(2) each glSwapWindow
+	*/
+	int forceDWMFlush;
+
+	#ifdef _WIN32
+		DwmApiLoader& dwmLoader  = DwmApiLoader::getInstance();
+	#endif
 public:
 	SDL_Window* sdlWindow;
 	SDL_GLContext glContext;


### PR DESCRIPTION
DWMFlush support

Support for telling windows (before or after swapbuffers) to perform desktop window compositing. This is intended for the very sad case were plenty of frames get drawn, but they never make it to the monitor. This can be confirmed when sim load is high, and the BAR widget Jitter Timer. Especially useful when running in windowed mode.

Force Windows Desktop Compositors DWMFlush before or after each SDL_GL_SwapWindow, preventing dropped frames (use nVidias FrameView to validate dropped frames, or BARs Jitter Timer widget). Value of 1 does DWMFlush before SwapBuffers, value of 2 does DWMFlush after swapbuffers. **Default is 0 which is DWMFlush is off**
