### PR TITLE
Add missing creg to variable for consistency

### DIFF
--- a/rts/Sim/Misc/Resource.cpp
+++ b/rts/Sim/Misc/Resource.cpp
@@ -25,7 +25,8 @@ CR_REG_METADATA(SResourceOrder,(
 	CR_MEMBER(use),
 	CR_MEMBER(add),
 	CR_MEMBER(quantum),
-	CR_MEMBER(overflow)
+	CR_MEMBER(overflow),
+	CR_MEMBER(separate)
 ))
 
 


### PR DESCRIPTION
The 'separate' variable was not CREG'd like the other variables in the struct. This adds it to CREG for consistency.
https://github.com/beyond-all-reason/RecoilEngine/blob/b272b93d5a4704d35642f360356385d28da033b7/rts/Sim/Misc/Resource.h#L122-L123

Note: This will conflict with PR #2271 if it gets merged.