### PR TITLE
Don't force-deduplicate log lines

### DIFF
--- a/rts/Game/UI/InfoConsole.cpp
+++ b/rts/Game/UI/InfoConsole.cpp
@@ -214,9 +214,6 @@ void CInfoConsole::RecordLogMessage(int level, const std::string& section, const
 	RECOIL_DETAILED_TRACY_ZONE;
 	std::lock_guard<decltype(infoConsoleMutex)> scoped_lock(infoConsoleMutex);
 
-	if (section == prvSection && message == prvMessage)
-		return;
-
 	newLines += (newLines < maxRawLines);
 
 	if (rawLines.size() > maxRawLines)

--- a/rts/System/Log/Backend.cpp
+++ b/rts/System/Log/Backend.cpp
@@ -113,7 +113,7 @@ void log_backend_record(int level, const char* section, const char* fmt, va_list
 	cur_record.cnt += cmp;
 	cur_record.cnt *= cmp;
 
-	if (cur_record.cnt >= log_filter_getRepeatLimit())
+	if (const auto limit = log_filter_getRepeatLimit(); limit && cur_record.cnt >= limit)
 		return;
 
 	// sink the record into each registered sink

--- a/rts/System/LogOutput.cpp
+++ b/rts/System/LogOutput.cpp
@@ -41,8 +41,8 @@ CONFIG(int, LogFlushLevel)
 	.description("Flush the logfile when a message's level exceeds this value. ERROR is flushed by default, WARNING is not.");
 
 CONFIG(int, LogRepeatLimit)
-	.defaultValue(10)
-	.description("Allow at most this many consecutive identical messages to be logged.");
+	.defaultValue(0)
+	.description("Allow at most this many consecutive identical messages to be logged. Set to 0 to disable the limit.");
 
 /******************************************************************************/
 /******************************************************************************/


### PR DESCRIPTION
 * default ingame console max duplicates: 1 -> ∞
 * default infolog.txt max duplicates: 10 -> ∞

Logs are easily the most useful debugging tool. Forced deduplication cripples debugging attempts and leaves newer gamedevs confused. Veteran gamedevs know to circumvent it by adding garbage to each log.

Games can still easily add console deduplication via `widget:AddConsoleLine` in case they hate having useful, accurate logs or something (idk).