### PR TITLE
Document registering AllowWeapon and Projectile callins.

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2131,8 +2131,8 @@ void CLuaHandle::ProjectileCreated(const CProjectile* p)
  * @param ownerID integer
  * @param proWeaponDefID integer
  *
- * @see Spring.SetWatchProjectile
- * @see Spring.SetWatchWeapon
+ * @see Script.SetWatchProjectile
+ * @see Script.SetWatchWeapon
  */
 void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
 {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2082,8 +2082,8 @@ void CLuaHandle::FeatureDamaged(
  * @param proOwnerID integer
  * @param weaponDefID integer
  *
- * @see Spring.SetWatchProjectile
- * @see Spring.SetWatchWeapon
+ * @see Script.SetWatchProjectile
+ * @see Script.SetWatchWeapon
  */
 void CLuaHandle::ProjectileCreated(const CProjectile* p)
 {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2068,7 +2068,8 @@ void CLuaHandle::FeatureDamaged(
  * Projectiles
  * @section projectiles
  *
- * The following Callins are only called for weaponDefIDs registered via Script.SetWatchWeapon.
+ * The following Callins are only called for weaponDefIDs registered
+ * via Script.SetWatchWeapon or Script.SetWatchProjectile.
 ******************************************************************************/
 
 /*** Called when the projectile is created.
@@ -2184,6 +2185,9 @@ void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
  * @param pz number
  * @param attackerID integer
  * @param projectileID integer
+ *
+ * Only called for weaponDefIDs registered via Script.SetWatchExplosion or Script.SetWatchWeapon.
+ *
  * @return boolean noGfx if then no graphical effects are drawn by the engine for this explosion.
  */
 bool CLuaHandle::Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner)

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2082,6 +2082,8 @@ void CLuaHandle::FeatureDamaged(
  * @param proOwnerID integer
  * @param weaponDefID integer
  *
+ * @see Spring.SetWatchProjectile
+ * @see Spring.SetWatchWeapon
  */
 void CLuaHandle::ProjectileCreated(const CProjectile* p)
 {
@@ -2128,6 +2130,9 @@ void CLuaHandle::ProjectileCreated(const CProjectile* p)
  * @param proID integer
  * @param ownerID integer
  * @param proWeaponDefID integer
+ *
+ * @see Spring.SetWatchProjectile
+ * @see Spring.SetWatchWeapon
  */
 void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
 {
@@ -2189,6 +2194,9 @@ void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
  * Only called for weaponDefIDs registered via Script.SetWatchExplosion or Script.SetWatchWeapon.
  *
  * @return boolean noGfx if then no graphical effects are drawn by the engine for this explosion.
+ *
+ * @see Script.SetWatchExplosion
+ * @see Script.SetWatchWeapon
  */
 bool CLuaHandle::Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner)
 {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2184,15 +2184,15 @@ void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
  *
  * @function Callins:Explosion
  *
+ * Only called for weaponDefIDs registered via Script.SetWatchExplosion or Script.SetWatchWeapon.
+ *
  * @param weaponDefID integer
  * @param px number
  * @param py number
  * @param pz number
  * @param attackerID integer
  * @param projectileID integer
- *
- * Only called for weaponDefIDs registered via Script.SetWatchExplosion or Script.SetWatchWeapon.
- *
+  *
  * @return boolean noGfx if then no graphical effects are drawn by the engine for this explosion.
  *
  * @see Script.SetWatchExplosion

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1699,6 +1699,9 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
  * @param attackerID integer
  * @param attackerWeaponNum integer
  * @param attackerWeaponDefID integer
+ *
+ * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ *
  * @return boolean allowCheck
  * @return boolean ignoreCheck
  */
@@ -1741,6 +1744,9 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  * @param attackerWeaponNum integer
  * @param attackerWeaponDefID integer
  * @param defPriority number
+ *
+ * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ *
  * @return boolean allowed
  * @return number the new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.
  */
@@ -1800,7 +1806,7 @@ bool CSyncedLuaHandle::AllowWeaponTarget(
  *
  * @function SyncedCallins:AllowWeaponInterceptTarget
  *
- * Only called for weaponDefIDs registered via Script.SetWatchWeapon.
+ * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
  *
  * @param interceptorUnitID integer
  * @param interceptorWeaponID integer

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1697,7 +1697,7 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
  *
  * @function SyncedCallins:AllowWeaponTargetCheck
  *
- * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
  * @param attackerID integer
  * @param attackerWeaponNum integer
@@ -1744,7 +1744,7 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  *
  * @function SyncedCallins:AllowWeaponTarget
  *
- * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
  * @param attackerID integer
  * @param targetID integer
@@ -1814,7 +1814,7 @@ bool CSyncedLuaHandle::AllowWeaponTarget(
  *
  * @function SyncedCallins:AllowWeaponInterceptTarget
  *
- * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
  * @param interceptorUnitID integer
  * @param interceptorWeaponID integer

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1704,6 +1704,9 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
  *
  * @return boolean allowCheck
  * @return boolean ignoreCheck
+ *
+ * @see Spring.SetWatchAllowTarget
+ * @see Spring.SetWatchWeapon
  */
 int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned int attackerWeaponNum, unsigned int attackerWeaponDefID)
 {
@@ -1749,6 +1752,9 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  *
  * @return boolean allowed
  * @return number the new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.
+ *
+ * @see Spring.SetWatchAllowTarget
+ * @see Spring.SetWatchWeapon
  */
 bool CSyncedLuaHandle::AllowWeaponTarget(
 	unsigned int attackerID,
@@ -1813,6 +1819,9 @@ bool CSyncedLuaHandle::AllowWeaponTarget(
  * @param targetProjectileID integer
  *
  * @return boolean allowed
+ *
+ * @see Spring.SetWatchAllowTarget
+ * @see Spring.SetWatchWeapon
  */
 bool CSyncedLuaHandle::AllowWeaponInterceptTarget(
 	const CUnit* interceptorUnit,

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1706,8 +1706,8 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
  * @return boolean allowCheck
  * @return boolean ignoreCheck
  *
- * @see Spring.SetWatchAllowTarget
- * @see Spring.SetWatchWeapon
+ * @see Script.SetWatchAllowTarget
+ * @see Script.SetWatchWeapon
  */
 int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned int attackerWeaponNum, unsigned int attackerWeaponDefID)
 {
@@ -1755,8 +1755,8 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  * @return boolean allowed
  * @return number the new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.
  *
- * @see Spring.SetWatchAllowTarget
- * @see Spring.SetWatchWeapon
+ * @see Script.SetWatchAllowTarget
+ * @see Script.SetWatchWeapon
  */
 bool CSyncedLuaHandle::AllowWeaponTarget(
 	unsigned int attackerID,
@@ -1822,8 +1822,8 @@ bool CSyncedLuaHandle::AllowWeaponTarget(
  *
  * @return boolean allowed
  *
- * @see Spring.SetWatchAllowTarget
- * @see Spring.SetWatchWeapon
+ * @see Script.SetWatchAllowTarget
+ * @see Script.SetWatchWeapon
  */
 bool CSyncedLuaHandle::AllowWeaponInterceptTarget(
 	const CUnit* interceptorUnit,

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1696,11 +1696,12 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
 /*** Determines if this weapon can automatically generate targets itself. See also commandFire weaponDef tag.
  *
  * @function SyncedCallins:AllowWeaponTargetCheck
+ *
+ * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ *
  * @param attackerID integer
  * @param attackerWeaponNum integer
  * @param attackerWeaponDefID integer
- *
- * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
  *
  * @return boolean allowCheck
  * @return boolean ignoreCheck
@@ -1742,13 +1743,14 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
 /*** Controls blocking of a specific target from being considered during a weapon's periodic auto-targeting sweep.
  *
  * @function SyncedCallins:AllowWeaponTarget
+ *
+ * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
+ *
  * @param attackerID integer
  * @param targetID integer
  * @param attackerWeaponNum integer
  * @param attackerWeaponDefID integer
  * @param defPriority number
- *
- * Only called for weaponDefIDs registered via Script.SetWatchAllowTarget or Script.SetWatchWeapon.
  *
  * @return boolean allowed
  * @return number the new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.


### PR DESCRIPTION
### Work done

- Document registering the different callins requiring use of SetWatchAllowWeapon, SetWatchProjectile or SetWatchWeapon.


### Remarks

- The Spring.SetWatchAllowWeapon, etc methods need to be documented as well but I'll add as part of a different PR.