### PR TITLE
Lua base64 methods

### DIFF
--- a/cont/LuaUI/system.lua
+++ b/cont/LuaUI/system.lua
@@ -27,6 +27,7 @@ if (System == nil) then
     VFS = VFS,
     Script = Script,
     Spring = Spring,
+    Encoding = Encoding,
     Engine = Engine,
     Platform = Platform,
     Game = Game,

--- a/cont/base/maphelper/maphelper/system.lua
+++ b/cont/base/maphelper/maphelper/system.lua
@@ -75,6 +75,7 @@ end
 local system = {
 
   --  Custom packages
+  Encoding = Encoding,
   VFS = VFS,
   Spring = Spring,
 

--- a/cont/base/springcontent/LuaGadgets/system.lua
+++ b/cont/base/springcontent/LuaGadgets/system.lua
@@ -19,6 +19,7 @@ if (System == nil) then
     --
     Script = Script,
     Spring = Spring,
+    Encoding = Encoding,
     Engine = Engine,
     Platform = Platform,
     Game = Game,

--- a/cont/base/springcontent/gamedata/system.lua
+++ b/cont/base/springcontent/gamedata/system.lua
@@ -75,6 +75,7 @@ end
 local system = {
 
   --  Custom packages
+  Encoding = Encoding,
   VFS = VFS,
   Spring = Spring,
 

--- a/rts/Lua/CMakeLists.txt
+++ b/rts/Lua/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources_engine_Lua
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaConstGame.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaConstPlatform.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaVFSDownload.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/LuaEncoding.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaFBOs.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaFeatureDefs.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaFonts.cpp"

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -1,0 +1,50 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+
+#include "LuaEncoding.h"
+
+#include "base64.h"
+#include "Lua/LuaUtils.h"
+
+
+bool LuaEncoding::PushEntries(lua_State* L)
+{
+	REGISTER_LUA_CFUNC(EncodeBase64);
+	REGISTER_LUA_CFUNC(DecodeBase64);
+
+	return true;
+}
+
+
+/*** Decodes a base64 string
+ *
+ * @function Spring.DecodeBase64
+ *
+ * @param string Text to decode
+ * @return string Decoded text
+ */
+int LuaEncoding::DecodeBase64(lua_State* L)
+{
+	const char* text = luaL_checkstring(L, 1);
+	const std::string res = base64_decode(text);
+
+	lua_pushsstring(L, res);
+	return 1;
+}
+
+
+/*** Encodes a base64 string
+ *
+ * @function Spring.EncodeBase64
+ *
+ * @param string Text to encode
+ * @return string Encoded text
+ */
+int LuaEncoding::EncodeBase64(lua_State* L)
+{
+	const std::string text = luaL_checkstring(L, 1);
+	const std::string res = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
+	lua_pushsstring(L, res);
+	return 1;
+}
+

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -66,7 +66,7 @@ int LuaEncoding::DecodeBase64(lua_State* L)
 int LuaEncoding::EncodeBase64(lua_State* L)
 {
 	size_t textLen;
-	// querying with checklstring this since there could be embedded '\0' characters.
+	// querying with checklstring since there could be embedded '\0' characters.
 	const char* text = luaL_checklstring(L, 1, &textLen);
 	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text), textLen);
 

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -6,6 +6,10 @@
 #include "base64.h"
 #include "Lua/LuaUtils.h"
 
+/***
+ * Lua Encoding API
+ * @table Encoding
+ */
 
 bool LuaEncoding::PushEntries(lua_State* L)
 {

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -20,8 +20,8 @@ bool LuaEncoding::PushEntries(lua_State* L)
  *
  * @function Spring.DecodeBase64
  *
- * @param string Text to decode
- * @return string Decoded text
+ * @param text string Text to decode
+ * @return string decoded Decoded text
  */
 int LuaEncoding::DecodeBase64(lua_State* L)
 {
@@ -37,8 +37,8 @@ int LuaEncoding::DecodeBase64(lua_State* L)
  *
  * @function Spring.EncodeBase64
  *
- * @param string Text to encode
- * @return string Encoded text
+ * @param text string Text to encode
+ * @return string encoded Encoded text
  */
 int LuaEncoding::EncodeBase64(lua_State* L)
 {

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -9,14 +9,14 @@
 
 // For validation
 static const std::string base64Chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "abcdefghijklmnopqrstuvwxyz"
-    "0123456789+/=";
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	"abcdefghijklmnopqrstuvwxyz"
+	"0123456789+/=";
 
 static const std::string base64UrlChars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "abcdefghijklmnopqrstuvwxyz"
-    "0123456789-_";
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	"abcdefghijklmnopqrstuvwxyz"
+	"0123456789-_";
 
 
 /***

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -66,6 +66,7 @@ int LuaEncoding::DecodeBase64(lua_State* L)
 int LuaEncoding::EncodeBase64(lua_State* L)
 {
 	size_t textLen;
+	// querying with checklstring this since there could be embedded '\0' characters.
 	const char* text = luaL_checklstring(L, 1, &textLen);
 	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text), textLen);
 

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -42,6 +42,9 @@ bool LuaEncoding::PushEntries(lua_State* L)
  *
  * @function Encoding.DecodeBase64
  *
+ * Decodes a base64 encoded string. If it encounters
+ * invalid data, it stops and returns whatever it parsed so far.
+ *
  * @param text string Text to decode
  * @return string decoded Decoded text
  */

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -65,8 +65,9 @@ int LuaEncoding::DecodeBase64(lua_State* L)
  */
 int LuaEncoding::EncodeBase64(lua_State* L)
 {
-	const std::string text = luaL_checkstring(L, 1);
-	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
+	size_t textLen;
+	const char* text = luaL_checklstring(L, 1, &textLen);
+	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text), textLen);
 
 	if (luaL_optboolean(L, 2, true)) {
 		encoded.erase(encoded.find_last_not_of("=") + 1);
@@ -134,8 +135,9 @@ int LuaEncoding::DecodeBase64Url(lua_State* L)
  */
 int LuaEncoding::EncodeBase64Url(lua_State* L)
 {
-	const std::string text = luaL_checkstring(L, 1);
-	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
+	size_t textLen;
+	const char* text = luaL_checklstring(L, 1, &textLen);
+	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text), textLen);
 
 	encoded.erase(encoded.find_last_not_of("=") + 1);
 

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -110,6 +110,9 @@ int LuaEncoding::IsValidBase64(lua_State* L)
  *
  * @function Encoding.DecodeBase64Url
  *
+ * Decodes a base64url encoded string. If it encounters
+ * invalid data, it stops and returns whatever it parsed so far.
+ *
  * @param text string Text to decode
  * @return string decoded Decoded text
  */

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -21,7 +21,7 @@ bool LuaEncoding::PushEntries(lua_State* L)
 
 /*** Decodes a base64 string
  *
- * @function Spring.DecodeBase64
+ * @function Encoding.DecodeBase64
  *
  * @param text string Text to decode
  * @return string decoded Decoded text
@@ -38,7 +38,7 @@ int LuaEncoding::DecodeBase64(lua_State* L)
 
 /*** Encodes a base64 string
  *
- * @function Spring.EncodeBase64
+ * @function Encoding.EncodeBase64
  *
  * @param text string Text to encode
  * @param stripPadding? boolean Remove padding (`=` characters) at the end when 'true'. Defaults to `false`.
@@ -60,7 +60,7 @@ int LuaEncoding::EncodeBase64(lua_State* L)
 
 /*** Decodes a base64url string
  *
- * @function Spring.DecodeBase64Url
+ * @function Encoding.DecodeBase64Url
  *
  * @param text string Text to decode
  * @return string decoded Decoded text
@@ -84,7 +84,7 @@ int LuaEncoding::DecodeBase64Url(lua_State* L)
 
 /*** Encodes a base64url string
  *
- * @function Spring.EncodeBase64Url
+ * @function Encoding.EncodeBase64Url
  *
  * @param text string Text to encode
  * @return string encoded Encoded text

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -6,6 +6,19 @@
 #include "base64.h"
 #include "Lua/LuaUtils.h"
 
+
+// For validation
+static const std::string base64Chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/=";
+
+static const std::string base64UrlChars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789-_";
+
+
 /***
  * Lua Encoding API
  * @table Encoding
@@ -15,9 +28,11 @@ bool LuaEncoding::PushEntries(lua_State* L)
 {
 	REGISTER_LUA_CFUNC(EncodeBase64);
 	REGISTER_LUA_CFUNC(DecodeBase64);
+	REGISTER_LUA_CFUNC(IsValidBase64);
 
 	REGISTER_LUA_CFUNC(EncodeBase64Url);
 	REGISTER_LUA_CFUNC(DecodeBase64Url);
+	REGISTER_LUA_CFUNC(IsValidBase64Url);
 
 	return true;
 }
@@ -58,6 +73,30 @@ int LuaEncoding::EncodeBase64(lua_State* L)
 	}
 
 	lua_pushsstring(L, encoded);
+	return 1;
+}
+
+
+/*** Validates a base64 string
+ *
+ * @function Encoding.IsValidBase64
+ *
+ * @param text string Text to validate
+ * @return boolean valid Whether the text is valid base64
+ */
+int LuaEncoding::IsValidBase64(lua_State* L)
+{
+	const std::string text = luaL_checkstring(L, 1);
+
+	bool valid = text.find_first_not_of(base64Chars) == std::string::npos;
+
+	if (valid) {
+		size_t firstPadding = text.find_first_of("=");
+		if (firstPadding != std::string::npos)
+			valid = firstPadding == (text.find_last_not_of("=") + 1);
+	}
+
+	lua_pushboolean(L, valid);
 	return 1;
 }
 
@@ -109,6 +148,24 @@ int LuaEncoding::EncodeBase64Url(lua_State* L)
 	}
 
 	lua_pushsstring(L, encoded);
+	return 1;
+}
+
+
+/*** Validates a base64url string
+ *
+ * @function Encoding.IsValidBase64Url
+ *
+ * @param text string Text to validate
+ * @return boolean valid Whether the text is valid base64url
+ */
+int LuaEncoding::IsValidBase64Url(lua_State* L)
+{
+	const std::string text = luaL_checkstring(L, 1);
+
+	bool valid = text.find_first_not_of(base64UrlChars) == std::string::npos;
+
+	lua_pushboolean(L, valid);
 	return 1;
 }
 

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -29,9 +29,9 @@ bool LuaEncoding::PushEntries(lua_State* L)
 int LuaEncoding::DecodeBase64(lua_State* L)
 {
 	const char* text = luaL_checkstring(L, 1);
-	const std::string res = base64_decode(text);
+	const std::string decoded = base64_decode(text);
 
-	lua_pushsstring(L, res);
+	lua_pushsstring(L, decoded);
 	return 1;
 }
 
@@ -47,13 +47,13 @@ int LuaEncoding::DecodeBase64(lua_State* L)
 int LuaEncoding::EncodeBase64(lua_State* L)
 {
 	const std::string text = luaL_checkstring(L, 1);
-	std::string res = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
+	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
 
 	if (luaL_optboolean(L, 2, false)) {
-		res.erase(res.find_last_not_of("=") + 1);
+		encoded.erase(encoded.find_last_not_of("=") + 1);
 	}
 
-	lua_pushsstring(L, res);
+	lua_pushsstring(L, encoded);
 	return 1;
 }
 
@@ -75,9 +75,9 @@ int LuaEncoding::DecodeBase64Url(lua_State* L)
 			case '_': c = '/'; break;
 		}
 	}
-	const std::string res = base64_decode(text);
+	const std::string decoded = base64_decode(text);
 
-	lua_pushsstring(L, res);
+	lua_pushsstring(L, decoded);
 	return 1;
 }
 
@@ -92,11 +92,11 @@ int LuaEncoding::DecodeBase64Url(lua_State* L)
 int LuaEncoding::EncodeBase64Url(lua_State* L)
 {
 	const std::string text = luaL_checkstring(L, 1);
-	std::string res = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
+	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
 
-	res.erase(res.find_last_not_of("=") + 1);
+	encoded.erase(encoded.find_last_not_of("=") + 1);
 
-	for (char& c: res) {
+	for (char& c: encoded) {
 		switch (c)
 		{
 			case '+': c = '-'; break;
@@ -104,7 +104,7 @@ int LuaEncoding::EncodeBase64Url(lua_State* L)
 		}
 	}
 
-	lua_pushsstring(L, res);
+	lua_pushsstring(L, encoded);
 	return 1;
 }
 

--- a/rts/Lua/LuaEncoding.cpp
+++ b/rts/Lua/LuaEncoding.cpp
@@ -60,7 +60,7 @@ int LuaEncoding::DecodeBase64(lua_State* L)
  * @function Encoding.EncodeBase64
  *
  * @param text string Text to encode
- * @param stripPadding? boolean Remove padding (`=` characters) at the end when 'true'. Defaults to `false`.
+ * @param stripPadding? boolean Remove padding (`=` characters) at the end when 'true'. Defaults to `true`.
  * @return string encoded Encoded text
  */
 int LuaEncoding::EncodeBase64(lua_State* L)
@@ -68,7 +68,7 @@ int LuaEncoding::EncodeBase64(lua_State* L)
 	const std::string text = luaL_checkstring(L, 1);
 	std::string encoded = base64_encode(reinterpret_cast<const uint8_t*>(text.c_str()), text.size());
 
-	if (luaL_optboolean(L, 2, false)) {
+	if (luaL_optboolean(L, 2, true)) {
 		encoded.erase(encoded.find_last_not_of("=") + 1);
 	}
 

--- a/rts/Lua/LuaEncoding.h
+++ b/rts/Lua/LuaEncoding.h
@@ -1,0 +1,17 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef LUA_ENCODING_H
+#define LUA_ENCODING_H
+
+struct lua_State;
+
+class LuaEncoding {
+	public:
+		static bool PushEntries(lua_State* L);
+	private:
+		static int EncodeBase64(lua_State* L);
+		static int DecodeBase64(lua_State* L);
+};
+
+
+#endif /* LUA_ENCODING_H */

--- a/rts/Lua/LuaEncoding.h
+++ b/rts/Lua/LuaEncoding.h
@@ -11,6 +11,8 @@ class LuaEncoding {
 	private:
 		static int EncodeBase64(lua_State* L);
 		static int DecodeBase64(lua_State* L);
+		static int EncodeBase64Url(lua_State* L);
+		static int DecodeBase64Url(lua_State* L);
 };
 
 

--- a/rts/Lua/LuaEncoding.h
+++ b/rts/Lua/LuaEncoding.h
@@ -11,8 +11,11 @@ class LuaEncoding {
 	private:
 		static int EncodeBase64(lua_State* L);
 		static int DecodeBase64(lua_State* L);
+		static int IsValidBase64(lua_State* L);
+
 		static int EncodeBase64Url(lua_State* L);
 		static int DecodeBase64Url(lua_State* L);
+		static int IsValidBase64Url(lua_State* L);
 };
 
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -10,6 +10,7 @@
 #include "LuaConfig.h"
 #include "LuaHashString.h"
 #include "LuaOpenGL.h"
+#include "LuaEncoding.h"
 #include "LuaMathExtra.h"
 #include "LuaTableExtra.h"
 #include "LuaTracyExtra.h"
@@ -3994,6 +3995,12 @@ bool CLuaHandle::AddBasicCalls(lua_State* L)
 	return true;
 }
 
+bool CLuaHandle::AddCommonModules(lua_State* L)
+{
+	if (!AddEntriesToTable(L, "Spring",           LuaEncoding::PushEntries        ))
+		return false;
+	return true;
+}
 
 /***
  * @function Script.GetName

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3997,7 +3997,7 @@ bool CLuaHandle::AddBasicCalls(lua_State* L)
 
 bool CLuaHandle::AddCommonModules(lua_State* L)
 {
-	if (!AddEntriesToTable(L, "Spring",           LuaEncoding::PushEntries        ))
+	if (!AddEntriesToTable(L, "Encoding",           LuaEncoding::PushEntries        ))
 		return false;
 	return true;
 }

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -307,6 +307,7 @@ class CLuaHandle : public CEventClient
 		static void PushTracebackFuncToRegistry(lua_State* L);
 
 		bool AddBasicCalls(lua_State* L);
+		bool AddCommonModules(lua_State* L);
 		bool LoadCode(lua_State* L, std::string code, const std::string& debug);
 		static bool AddEntriesToTable(lua_State* L, const char* name, bool (*entriesFunc)(lua_State*));
 

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -120,6 +120,7 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 		#define KILL { KillLua(); return false; }
 		if (!LuaSyncedTable::PushEntries(L)) KILL
 
+		if (!AddCommonModules(L)						       ) KILL
 		if (!AddEntriesToTable(L, "VFS",                   LuaVFS::PushUnsynced       )) KILL
 		if (!AddEntriesToTable(L, "VFS",         LuaZipFileReader::PushUnsynced       )) KILL
 		if (!AddEntriesToTable(L, "VFS",         LuaZipFileWriter::PushUnsynced       )) KILL
@@ -503,6 +504,7 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 	// load our libraries  (LuaSyncedCtrl overrides some LuaUnsyncedCtrl entries)
 	{
 		#define KILL { KillLua(); return false; }
+		if (!AddCommonModules(L)						     ) KILL
 		if (!AddEntriesToTable(L, "VFS",                   LuaVFS::PushSynced       )) KILL
 		if (!AddEntriesToTable(L, "VFS",         LuaZipFileReader::PushSynced       )) KILL
 		if (!AddEntriesToTable(L, "VFS",         LuaZipFileWriter::PushSynced       )) KILL

--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -103,6 +103,7 @@ CLuaIntro::CLuaIntro()
 
 	// load the spring libraries
 	if (
+	    !AddCommonModules(L)						    ||
 	    !AddEntriesToTable(L, "Spring",    LoadUnsyncedCtrlFunctions)           ||
 	    !AddEntriesToTable(L, "Spring",    LoadUnsyncedReadFunctions)           ||
 	    !AddEntriesToTable(L, "Spring",    LoadSyncedReadFunctions  )           ||

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -109,6 +109,7 @@ CLuaMenu::CLuaMenu()
 
 	// load the spring libraries
 	if (
+		!AddCommonModules(L)						   ||
 		!AddEntriesToTable(L, "Spring",    LoadUnsyncedCtrlFunctions)      ||
 		!AddEntriesToTable(L, "Spring",    LoadUnsyncedReadFunctions)      ||
 		!AddEntriesToTable(L, "Spring",    LoadLuaMenuFunctions)           ||

--- a/rts/Lua/LuaParser.cpp
+++ b/rts/Lua/LuaParser.cpp
@@ -158,6 +158,9 @@ void LuaParser::SetupEnv(bool isSyncedCtxt, bool isDefsParser)
 	AddFunc("Echo", LuaUtils::Echo);
 	AddFunc("Log", LuaUtils::Log);
 	AddFunc("TimeCheck", TimeCheck);
+	EndTable();
+
+	GetTable("Encoding");
 	LuaEncoding::PushEntries(L);
 	EndTable();
 

--- a/rts/Lua/LuaParser.cpp
+++ b/rts/Lua/LuaParser.cpp
@@ -14,6 +14,7 @@
 
 #include "LuaConstGame.h"
 #include "LuaConstEngine.h"
+#include "LuaEncoding.h"
 #include "LuaIO.h"
 #include "LuaVFS.h"
 #include "LuaUtils.h"
@@ -157,6 +158,7 @@ void LuaParser::SetupEnv(bool isSyncedCtxt, bool isDefsParser)
 	AddFunc("Echo", LuaUtils::Echo);
 	AddFunc("Log", LuaUtils::Log);
 	AddFunc("TimeCheck", TimeCheck);
+	LuaEncoding::PushEntries(L);
 	EndTable();
 
 	GetTable("Script");

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -142,6 +142,7 @@ CLuaUI::CLuaUI()
 
 	// load the spring libraries
 	if (!LoadCFunctions(L)                                                   ||
+	    !AddCommonModules(L)						 ||
 	    !AddEntriesToTable(L, "VFS",         LuaVFS::PushUnsynced)           ||
 	    !AddEntriesToTable(L, "VFS",         LuaZipFileReader::PushUnsynced) ||
 	    !AddEntriesToTable(L, "VFS",         LuaZipFileWriter::PushUnsynced) ||

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -148,6 +148,7 @@ set(engineDedicatedSources
 	${ENGINE_SRC_ROOT_DIR}/Sim/Misc/AllyTeam.cpp
 	${ENGINE_SRC_ROOT_DIR}/Sim/Units/CommandAI/Command.cpp ## LuaUtils::ParseCommand*
 	${ENGINE_SRC_ROOT_DIR}/Lua/LuaConstEngine.cpp
+	${ENGINE_SRC_ROOT_DIR}/Lua/LuaEncoding.cpp
 	${ENGINE_SRC_ROOT_DIR}/Lua/LuaIO.cpp
 	${ENGINE_SRC_ROOT_DIR}/Lua/LuaMemPool.cpp
 	${ENGINE_SRC_ROOT_DIR}/Lua/LuaParser.cpp

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -57,6 +57,7 @@ set(main_files
 	"${ENGINE_SRC_ROOT}/ExternalAI/LuaAIImplHandler.cpp"
 	"${ENGINE_SRC_ROOT}/Game/GameVersion.cpp"
 	"${ENGINE_SRC_ROOT}/Lua/LuaConstEngine.cpp"
+	"${ENGINE_SRC_ROOT}/Lua/LuaEncoding.cpp"
 	"${ENGINE_SRC_ROOT}/Lua/LuaMemPool.cpp"
 	"${ENGINE_SRC_ROOT}/Lua/LuaParser.cpp"
 	"${ENGINE_SRC_ROOT}/Lua/LuaUtils.cpp"

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -14,6 +14,9 @@ list(APPEND unitsync_libs 7zip prd::jsoncpp lua headlessStubs archives_nothreadp
 list(APPEND unitsync_libs ZLIB::ZLIB)
 list(APPEND unitsync_libs ${SPRING_MINIZIP_LIBRARY})
 
+### base64 from pr-downloader
+list(APPEND unitsync_libs "prd::base64")
+
 ### smmalloc
 list(APPEND unitsync_libs "smmalloc")
 


### PR DESCRIPTION
### Work done

- Add `Encoding.EncodeBase64`, `Encoding.DecodeBase64` and  `Encoding.IsValidBase64`
- Add `Encoding.EncodeBase64url`, `Encoding.DecodeBase64url` and `Encoding.IsValidBase64url`

#### Related issues

- https://github.com/beyond-all-reason/RecoilEngine/issues/877

### Testing

- use https://github.com/saurtron/Beyond-All-Reason/tree/test-base64

### Remarks

- Also introduce a mechanism to include modules common to all lua environments.
  - Didn't see anything for this, and later the common ones can be refactored into that, like `LuaConstEngine`.
  - Maybe base64/encoding isn't wanted everywhere, but I don't see why not.
- Could add to `string` instead of `Encoding`, or some other namespace, but then I think the names would need to conform to the string module casing.
