### PR TITLE
Lua debug module for synced when DevMode=1

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2323,7 +2323,6 @@ void CLuaHandle::SwapEnableModule(lua_State* L, bool enabled, const char* module
 	lua_pop(L, 1);
 
 	// create an empty module table
-	lua_pushvalue(L, LUA_GLOBALSINDEX);
 	if (missing) {
 		lua_createtable(L, 0, 0);
 		lua_setglobal(L, moduleName);
@@ -2331,7 +2330,9 @@ void CLuaHandle::SwapEnableModule(lua_State* L, bool enabled, const char* module
 
 	if (enabled) {
 		// relink methods
+		lua_pushvalue(L, LUA_GLOBALSINDEX);
 		LUA_OPEN_LIB(L, func);
+		lua_pop(L, 1);
 	}
 	else {
 		// unlink all methods
@@ -2346,7 +2347,6 @@ void CLuaHandle::SwapEnableModule(lua_State* L, bool enabled, const char* module
 		}
 		lua_pop(L, 1);
 	}
-	lua_pop(L, 1);
 }
 
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2295,6 +2295,23 @@ bool CLuaHandle::RecvLuaMsg(const string& msg, int playerID)
 
 /******************************************************************************/
 
+void CLuaHandle::SetDevMode(bool value)
+{
+	if (value == devMode)
+		return;
+
+	devMode = value;
+
+	for (const auto* lcd : LUAHANDLE_CONTEXTS) {
+		for (const auto* lc : *lcd) {
+			if (!lc || !lc->owner)
+				continue;
+
+			lc->owner->EnactDevMode();
+		}
+	}
+}
+
 void CLuaHandle::HandleLuaMsg(int playerID, int script, int mode, const std::vector<std::uint8_t>& data)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -342,6 +342,8 @@ class CLuaHandle : public CEventClient
 		std::map <int, std::vector <std::pair <int, std::vector <int>>>> delayedCallsByFrame;
 		void RunDelayedFunctions(int frameNum);
 
+		virtual void EnactDevMode() const {};
+
 		std::vector<bool> watchUnitDefs;        // callin masks for Unit*Collision, UnitMoveFailed
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision
 		std::vector<bool> watchProjectileDefs;  // callin masks for Projectile*
@@ -376,8 +378,7 @@ class CLuaHandle : public CEventClient
 		static inline LuaVAOs& GetActiveVAOs(lua_State* L) { return GetLuaContextData(L)->vaos; }
 		static inline CLuaDisplayLists& GetActiveDisplayLists(lua_State* L) { return GetLuaContextData(L)->displayLists; }
 #endif
-
-		static void SetDevMode(bool value) { devMode = value; }
+		static void SetDevMode(bool value);
 		static bool GetDevMode() { return devMode; }
 
 		static void HandleLuaMsg(int playerID, int script, int mode, const std::vector<std::uint8_t>& msg);

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -10,6 +10,7 @@
 #include "LuaHashString.h"
 #include "lib/lua/include/LuaInclude.h" //FIXME needed for GetLuaContextData
 
+
 #include <map>
 #include <string>
 #include <tuple>
@@ -343,6 +344,7 @@ class CLuaHandle : public CEventClient
 		void RunDelayedFunctions(int frameNum);
 
 		virtual void EnactDevMode() const {};
+		void SwapEnableModule(lua_State* L, bool enabled, const char* moduleName, lua_CFunction func) const;
 
 		std::vector<bool> watchUnitDefs;        // callin masks for Unit*Collision, UnitMoveFailed
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -93,6 +93,7 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	//LUA_OPEN_LIB(L, luaopen_os);
 	//LUA_OPEN_LIB(L, luaopen_package);
 	//LUA_OPEN_LIB(L, luaopen_debug);
+	EnactDevMode();
 
 	// delete some dangerous functions
 	lua_pushnil(L); lua_setglobal(L, "dofile");
@@ -162,6 +163,22 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	eventHandler.AddClient(this);
 	return true;
 }
+
+
+void CUnsyncedLuaHandle::EnactDevMode() const
+{
+	if (devMode) {
+		LUA_OPEN_LIB(L, luaopen_debug);
+		lua_getglobal(L, LUA_DBLIBNAME); {
+			//LuaPushNamedNil(L, "setupvalue"); //example
+		}
+		lua_pop(L, 1); // debug
+	}
+	else {
+		LUA_UNLOAD_LIB(L, LUA_DBLIBNAME);
+	}
+}
+
 
 /***
  * @class UnsyncedCallins
@@ -444,6 +461,7 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 	//SPRING_LUA_OPEN_LIB(L, luaopen_os);
 	//SPRING_LUA_OPEN_LIB(L, luaopen_package);
 	//SPRING_LUA_OPEN_LIB(L, luaopen_debug);
+	EnactDevMode();
 
 	lua_getglobal(L, "next");
 	origNextRef = luaL_ref(L, LUA_REGISTRYINDEX);
@@ -541,6 +559,21 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 	lua_settop(L, 0);
 	eventHandler.AddClient(this);
 	return true;
+}
+
+
+void CSyncedLuaHandle::EnactDevMode() const
+{
+	if (devMode) {
+		SPRING_LUA_OPEN_LIB(L, luaopen_debug);
+		lua_getglobal(L, LUA_DBLIBNAME); {
+			//LuaPushNamedNil(L, "setupvalue"); //example
+		}
+		lua_pop(L, 1); // debug
+	}
+	else {
+		LUA_UNLOAD_LIB(L, LUA_DBLIBNAME);
+	}
 }
 
 

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -167,16 +167,7 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 
 void CUnsyncedLuaHandle::EnactDevMode() const
 {
-	if (devMode) {
-		LUA_OPEN_LIB(L, luaopen_debug);
-		lua_getglobal(L, LUA_DBLIBNAME); {
-			//LuaPushNamedNil(L, "setupvalue"); //example
-		}
-		lua_pop(L, 1); // debug
-	}
-	else {
-		LUA_UNLOAD_LIB(L, LUA_DBLIBNAME);
-	}
+	SwapEnableModule(L, devMode, LUA_DBLIBNAME, luaopen_debug);
 }
 
 
@@ -564,16 +555,7 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 
 void CSyncedLuaHandle::EnactDevMode() const
 {
-	if (devMode) {
-		SPRING_LUA_OPEN_LIB(L, luaopen_debug);
-		lua_getglobal(L, LUA_DBLIBNAME); {
-			//LuaPushNamedNil(L, "setupvalue"); //example
-		}
-		lua_pop(L, 1); // debug
-	}
-	else {
-		LUA_UNLOAD_LIB(L, LUA_DBLIBNAME);
-	}
+	SwapEnableModule(L, devMode, LUA_DBLIBNAME, luaopen_debug);
 }
 
 

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -35,6 +35,8 @@ class CUnsyncedLuaHandle : public CLuaHandle
 
 		bool Init(std::string code, const std::string& file);
 
+		void EnactDevMode() const override;
+
 		static CUnsyncedLuaHandle* GetUnsyncedHandle(lua_State* L) {
 			assert(dynamic_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L)) != nullptr);
 			return static_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L));
@@ -124,6 +126,8 @@ class CSyncedLuaHandle : public CLuaHandle
 		virtual ~CSyncedLuaHandle();
 
 		bool Init(std::string code, const std::string& file);
+
+		void EnactDevMode() const override;
 
 		static CSyncedLuaHandle* GetSyncedHandle(lua_State* L) {
 			assert(dynamic_cast<CSyncedLuaHandle*>(CLuaHandle::GetHandle(L)));


### PR DESCRIPTION
### Work done

- Allow the lua `debug` module for `/DevMode 1`

#### Related issues

- https://github.com/beyond-all-reason/RecoilEngine/issues/867

### Remarks

- Loosely based on previous effort by @lhog
- Difference is I implemented a method so we export an empty `debug` table, and fill or remove the methods as DevMode is enabled and disabled.
  - This is needed, since otherwise the wupgets don't get the "new" debug module linked into gadget/widget environment, probably because of how games (probably basecontent, but at least BAR) link environment into widgets/gadgets... it doesn't appear after DevMode is enabled and needs a reload.
  - This solution doesn't help much with security, other than ensuring debug module itself is empty/filled, obviously ppl can link the methods when enabled and the references will still work. Still should make it more difficult to shoot yourself in the foot once DevMode is disabled.
- Not really completely happy about linking this to DevMode, since that one has other implications, for example BAR rn crashing with it on `/luarules reload` (or other reloads), at least for me, due to it setting `VFSMODE = VFS.RAW_ONLY` when that's enabled, I had to change it to set `VFSMODE = VFS.RAW_FIRST` instead.
  - Might be better to just allow relinking modules with some new command like `/LuaDebug 1` (requiring cheat mode), that way DevMode and LuaDebug can be used interchangeably.


### Testing

Try the following in some gadget GameFrame or similar:

```lua
if debug.traceback then
    debug.traceback()
end
```

As soon as you run `/cheat 1` and then `/DevMode 1` it will start showing the traceback, when you `/DevMode 0` it stops.