### PR TITLE
Document DrawScreenPost gotcha

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2777,6 +2777,9 @@ void CLuaHandle::DrawScreenEffects()
 /*** Similar to DrawScreenEffects, this can be used to alter the contents of a frame after it has been completely rendered (i.e. World, MiniMap, Menu, UI).
  *
  * @function Callins:DrawScreenPost
+ *
+ * Note: This callin is invoked after the software rendered cursor (configuration variable HardwareCursor=0) is drawn.
+ *
  * @param viewSizeX number
  * @param viewSizeY number
  */


### PR DESCRIPTION
Software rendered cursors are overdrawn, hardware cursors are not

Related to https://github.com/beyond-all-reason/RecoilEngine/issues/2291