### PR TITLE
Finish deprecation notices for DrawUnit and similar callins

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -223,6 +223,8 @@ bool CUnsyncedLuaHandle::DrawUnit(const CUnit* unit)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
+	LOG_DEPRECATED("DrawUnit is deprecated.");
+
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
 
@@ -259,6 +261,8 @@ bool CUnsyncedLuaHandle::DrawFeature(const CFeature* feature)
 	static const LuaHashString cmdStr(__func__);
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
+
+	LOG_DEPRECATED("DrawFeature is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -297,6 +301,8 @@ bool CUnsyncedLuaHandle::DrawShield(const CUnit* unit, const CWeapon* weapon)
 
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
+
+	LOG_DEPRECATED("DrawShield is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -337,6 +343,8 @@ bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
+	LOG_DEPRECATED("DrawProjectile is deprecated.");
+
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
 
@@ -372,6 +380,8 @@ bool CUnsyncedLuaHandle::DrawMaterial(const LuaMaterial* material)
 	static const LuaHashString cmdStr(__func__);
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
+
+	LOG_DEPRECATED("DrawMaterial is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -223,7 +223,7 @@ bool CUnsyncedLuaHandle::DrawUnit(const CUnit* unit)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	LOG_DEPRECATED("DrawUnit is deprecated.");
+	LOG_DEPRECATED("Usage of the DrawUnit callin is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -262,7 +262,7 @@ bool CUnsyncedLuaHandle::DrawFeature(const CFeature* feature)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	LOG_DEPRECATED("DrawFeature is deprecated.");
+	LOG_DEPRECATED("Usage of the DrawFeature callin is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -302,7 +302,7 @@ bool CUnsyncedLuaHandle::DrawShield(const CUnit* unit, const CWeapon* weapon)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	LOG_DEPRECATED("DrawShield is deprecated.");
+	LOG_DEPRECATED("Usage of the DrawShield callin is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -343,7 +343,7 @@ bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	LOG_DEPRECATED("DrawProjectile is deprecated.");
+	LOG_DEPRECATED("Usage of the DrawProjectile callin is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);
@@ -381,7 +381,7 @@ bool CUnsyncedLuaHandle::DrawMaterial(const LuaMaterial* material)
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	LOG_DEPRECATED("DrawMaterial is deprecated.");
+	LOG_DEPRECATED("Usage of the DrawMaterial callin is deprecated.");
 
 	const bool oldDrawState = LuaOpenGL::IsDrawingEnabled(L);
 	LuaOpenGL::SetDrawingEnabled(L, true);


### PR DESCRIPTION
### Work done

- Add LOG_DEPRECATED to Draw* callins.
  - affected callins: DrawUnit, DrawFeature, DrawShield, DrawProjectile, DrawMaterial

#### Related issues

- Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2114

### Remarks

- Don't know what the alternative to recommend is here, so probably shouldn't merge until we decide something, on the other hand the callins are already `@deprecated`.
- This goes tied to the `LuaOpenGL::UnitCommon` callDrawUnit parameter, the 4th parameter of gl.Unit, gl.UnitRaw, regrettably that's the 4th out of 5 parameters so can't deprecate that one easily... also not sure if gl.Unit and gl.UnitRaw are supposed to be deprecated too. The parameter is also true by default for gl.Unit so smth should be done about that.