### PR TITLE
VFS.CalculateHash: Sha512 actually gets hex encoded.

### DIFF
--- a/rts/Lua/LuaVFS.cpp
+++ b/rts/Lua/LuaVFS.cpp
@@ -906,7 +906,10 @@ int LuaVFS::ZlibDecompress(lua_State* L)
  */
 
 /***
- * Calculates hash (in base64 form) of a given string.
+ * Calculates hash of a given string.
+ *
+ * - MD5 gets base64 encoded.
+ * - SHA512 gets hex encoded.
  * 
  * @function VFS.CalculateHash
  * @param input string


### PR DESCRIPTION
### Work done

- Fix incorrect mention of base64 hashes for sha512, they're actually hex


### Remarks

- Tested it to make sure, since specially didn't find the CalcHash function in use by md5 xd.
- We might want to fix the return instead to base64, hex is quite unwieldy here, could break smth tho.

```lua
Spring.Echo(VFS.CalculateHash("teststring", 0), VFS.CalculateHash("teststring", 1))
=> 1nxcv1sByfkZMuO43vXl+A==, 6253b39071e5df8b5098f59202d414c37a17d6a38a875ef5f8c7d89b0212b028692d3d2090ce03ae1de66c862fa8a561e57ed9eb7935ce627344f742c0931d72
```