### PR TITLE
Fix `CMake Error: The following variables are used in this project, but they are set to NOTFOUND.`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,11 @@ if    (UNIX AND (NOT APPLE) AND (NOT MINGW))
 	if    (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")
 		message(FATAL_ERROR "librt.[so|a] not found! Needed by std::chrono when statically linked!")
 	endif (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")
+	# Prevent `CMake Error: The following variables are used in this project, but they are set to NOTFOUND.`
+	# for `test_SpringTime` and `test_UDPListener`:
+	if (NOT REALTIME_LIBRARY)
+		set(REALTIME_LIBRARY "")
+	endif ()
 else  (UNIX AND (NOT APPLE) AND (NOT MINGW))
 	set(REALTIME_LIBRARY "")
 endif (UNIX AND (NOT APPLE) AND (NOT MINGW))


### PR DESCRIPTION
Fixes:
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
REALTIME_LIBRARY
    linked by target "test_SpringTime" in directory $PROJECT$/RecoilEngine/test
    linked by target "test_UDPListener" in directory $PROJECT$/RecoilEngine/test
```
when loading project into CLion 2025.1.1 bundled with CMake 3.31.6 on NixOS unstable.
