### PR TITLE
Allow tables inside SendToUnsynced.

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1983,6 +1983,7 @@ int CSyncedLuaHandle::SendToUnsynced(lua_State* L)
 		| (1 << LUA_TBOOLEAN)
 		| (1 << LUA_TNUMBER)
 		| (1 << LUA_TSTRING)
+		| (1 << LUA_TTABLE)
 	;
 
 	for (int i = 1; i <= args; i++) {

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1967,7 +1967,7 @@ int CSyncedLuaHandle::SyncedPairs(lua_State* L)
  * Invoke `UnsyncedCallins:RecvFromSynced` callin with the given arguments.
  * 
  * @function SendToUnsynced
- * @param ... nil|boolean|number|string Arguments. Typically the first argument is the name of a function to call.
+ * @param ... nil|boolean|number|string|table Arguments. Typically the first argument is the name of a function to call.
  * @see UnsyncedCallins:RecvFromSynced
  */
 int CSyncedLuaHandle::SendToUnsynced(lua_State* L)

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1967,7 +1967,11 @@ int CSyncedLuaHandle::SyncedPairs(lua_State* L)
  * Invoke `UnsyncedCallins:RecvFromSynced` callin with the given arguments.
  * 
  * @function SendToUnsynced
+ *
  * @param ... nil|boolean|number|string|table Arguments. Typically the first argument is the name of a function to call.
+ *
+ * Argument tables will be recursively copied and stripped of unsupported types and metatables.
+ *
  * @see UnsyncedCallins:RecvFromSynced
  */
 int CSyncedLuaHandle::SendToUnsynced(lua_State* L)


### PR DESCRIPTION
### Work done

- Allow sending tables inside SendToUnsynced.

### Remarks

- Apparently this is all that's needed, but I might be overlooking something, I did test it and just works.

Receiving of a recursive table:

```lua
[t=00:00:23.623310][f=0000089] testCommand, <table>
[t=00:00:23.623383][f=0000089] {
  a=1,
  b=2,
  c={
    a2=2,
    a3=<recursive_reference>,
  },
}
```