### PR TITLE
Address the need to have separate (up to 4) animation parameters per CEG effect

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
@@ -78,8 +78,10 @@ void CBitmapMuzzleFlame::Serialize(creg::ISerializer* s)
 void CBitmapMuzzleFlame::Draw()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (!UpdateAnimParams())
+		return;
+
 	UpdateRotation();
-	UpdateAnimParams();
 
 	const float3 drawPos = pos + speed * globalRendering->timeOffset;
 	const float life = (gs->frameNum - createFrame + globalRendering->timeOffset) * invttl;
@@ -121,13 +123,13 @@ void CBitmapMuzzleFlame::Draw()
 	}
 
 	if (IsValidTexture(sideTexture)) {
-		AddEffectsQuad(
+		AddEffectsQuad<2>(
 			{ drawPos + bounds[0], sideTexture->xstart, sideTexture->ystart, col },
 			{ drawPos + bounds[1], sideTexture->xend  , sideTexture->ystart, col },
 			{ drawPos + bounds[2], sideTexture->xend  , sideTexture->yend  , col },
 			{ drawPos + bounds[3], sideTexture->xstart, sideTexture->yend  , col }
 		);
-		AddEffectsQuad(
+		AddEffectsQuad<2>(
 			{ drawPos + bounds[4], sideTexture->xstart, sideTexture->ystart, col },
 			{ drawPos + bounds[5], sideTexture->xend  , sideTexture->ystart, col },
 			{ drawPos + bounds[6], sideTexture->xend  , sideTexture->yend  , col },
@@ -136,7 +138,7 @@ void CBitmapMuzzleFlame::Draw()
 	}
 
 	if (IsValidTexture(frontTexture)) {
-		AddEffectsQuad(
+		AddEffectsQuad<1>(
 			{ fpos + bounds[8 ], frontTexture->xstart, frontTexture->ystart, col },
 			{ fpos + bounds[9 ], frontTexture->xend  , frontTexture->ystart, col },
 			{ fpos + bounds[10], frontTexture->xend  , frontTexture->yend , col },
@@ -164,6 +166,10 @@ void CBitmapMuzzleFlame::Init(const CUnit* owner, const float3& offset)
 	invttl = 1.0f / ttl;
 
 	SetDrawRadius(std::max(size, length));
+
+	validTextures[1] = IsValidTexture(frontTexture);
+	validTextures[2] = IsValidTexture(sideTexture);
+	validTextures[0] = validTextures[1] || validTextures[2];
 }
 
 int CBitmapMuzzleFlame::GetProjectilesCount() const
@@ -179,18 +185,18 @@ bool CBitmapMuzzleFlame::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr)
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr)
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString)
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, size       )
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, length     )
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, sizeGrowth )
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, frontOffset)
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeed      )
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeedSpread)
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, airdrag    )
-	CHECK_MEMBER_INFO_FLOAT3(CBitmapMuzzleFlame, gravity    )
-	CHECK_MEMBER_INFO_INT   (CBitmapMuzzleFlame, ttl        )
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString                     );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, size               );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, length             );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, sizeGrowth         );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, frontOffset        );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeed      );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeedSpread);
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, airdrag            );
+	CHECK_MEMBER_INFO_FLOAT3(CBitmapMuzzleFlame, gravity            );
+	CHECK_MEMBER_INFO_INT   (CBitmapMuzzleFlame, ttl                );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
@@ -24,8 +24,6 @@ CR_REG_METADATA(CBitmapMuzzleFlame,
 	CR_MEMBER_BEGINFLAG(CM_Config),
 		CR_IGNORED(sideTexture),
 		CR_IGNORED(frontTexture),
-		CR_FAKE(frontTextureAnimParams, float3),
-		CR_FAKE(sideTextureAnimParams , float3),
 		CR_MEMBER(colorMap),
 		CR_MEMBER(size),
 		CR_MEMBER(length),
@@ -187,20 +185,18 @@ bool CBitmapMuzzleFlame::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr);
-	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr);
-	CHECK_MEMBER_INFO_FLOAT3_NAME(CBitmapMuzzleFlame, animParams1, frontTextureAnimParams                        );
-	CHECK_MEMBER_INFO_FLOAT3_NAME(CBitmapMuzzleFlame, animParams2,  sideTextureAnimParams                        );
-	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString                     );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, size               );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, length             );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, sizeGrowth         );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, frontOffset        );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, particleSpeed      );
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, particleSpeedSpread);
-	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, airdrag            );
-	CHECK_MEMBER_INFO_FLOAT3     (CBitmapMuzzleFlame, gravity            );
-	CHECK_MEMBER_INFO_INT        (CBitmapMuzzleFlame, ttl                );
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString                     );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, size               );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, length             );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, sizeGrowth         );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, frontOffset        );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeed      );
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeedSpread);
+	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, airdrag            );
+	CHECK_MEMBER_INFO_FLOAT3(CBitmapMuzzleFlame, gravity            );
+	CHECK_MEMBER_INFO_INT   (CBitmapMuzzleFlame, ttl                );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
@@ -24,6 +24,8 @@ CR_REG_METADATA(CBitmapMuzzleFlame,
 	CR_MEMBER_BEGINFLAG(CM_Config),
 		CR_IGNORED(sideTexture),
 		CR_IGNORED(frontTexture),
+		CR_FAKE(frontTextureAnimParams, float3),
+		CR_FAKE(sideTextureAnimParams , float3),
 		CR_MEMBER(colorMap),
 		CR_MEMBER(size),
 		CR_MEMBER(length),
@@ -185,18 +187,20 @@ bool CBitmapMuzzleFlame::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr);
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr);
-	CHECK_MEMBER_INFO_PTR   (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString                     );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, size               );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, length             );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, sizeGrowth         );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, frontOffset        );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeed      );
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, particleSpeedSpread);
-	CHECK_MEMBER_INFO_FLOAT (CBitmapMuzzleFlame, airdrag            );
-	CHECK_MEMBER_INFO_FLOAT3(CBitmapMuzzleFlame, gravity            );
-	CHECK_MEMBER_INFO_INT   (CBitmapMuzzleFlame, ttl                );
+	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, sideTexture,  projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, frontTexture, projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_FLOAT3_NAME(CBitmapMuzzleFlame, animParams1, frontTextureAnimParams                        );
+	CHECK_MEMBER_INFO_FLOAT3_NAME(CBitmapMuzzleFlame, animParams2,  sideTextureAnimParams                        );
+	CHECK_MEMBER_INFO_PTR        (CBitmapMuzzleFlame, colorMap, CColorMap::LoadFromDefString                     );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, size               );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, length             );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, sizeGrowth         );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, frontOffset        );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, particleSpeed      );
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, particleSpeedSpread);
+	CHECK_MEMBER_INFO_FLOAT      (CBitmapMuzzleFlame, airdrag            );
+	CHECK_MEMBER_INFO_FLOAT3     (CBitmapMuzzleFlame, gravity            );
+	CHECK_MEMBER_INFO_INT        (CBitmapMuzzleFlame, ttl                );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/BubbleProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BubbleProjectile.cpp
@@ -89,14 +89,13 @@ void CBubbleProjectile::Draw()
 
 	const float interSize = size + sizeExpansion * globalRendering->timeOffset;
 
-	#define bt projectileDrawer->bubbletex
-	AddEffectsQuad(
+	const auto* bt = projectileDrawer->bubbletex;
+	AddEffectsQuad<0>(
 		{ drawPos - camera->GetRight() * interSize - camera->GetUp() * interSize, bt->xstart, bt->ystart, col },
 		{ drawPos + camera->GetRight() * interSize - camera->GetUp() * interSize, bt->xend,   bt->ystart, col },
 		{ drawPos + camera->GetRight() * interSize + camera->GetUp() * interSize, bt->xend,   bt->yend,   col },
 		{ drawPos - camera->GetRight() * interSize + camera->GetUp() * interSize, bt->xstart, bt->yend,   col }
 	);
-	#undef bt
 }
 
 int CBubbleProjectile::GetProjectilesCount() const
@@ -112,10 +111,10 @@ bool CBubbleProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, alpha        )
-	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, startSize    )
-	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, sizeExpansion)
-	CHECK_MEMBER_INFO_INT  (CBubbleProjectile, ttl          )
+	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, alpha        );
+	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, startSize    );
+	CHECK_MEMBER_INFO_FLOAT(CBubbleProjectile, sizeExpansion);
+	CHECK_MEMBER_INFO_INT  (CBubbleProjectile, ttl          );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
@@ -112,7 +112,7 @@ void CDirtProjectile::Draw()
 	const float interSize = size + globalRendering->timeOffset * sizeExpansion;
 	const float texx = texture->xstart + (texture->xend - texture->xstart) * ((1.0f - partAbove) * 0.5f);
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ drawPos - camera->GetRight() * interSize - camera->GetUp() * interSize * partAbove, texx,          texture->ystart, col },
 		{ drawPos - camera->GetRight() * interSize + camera->GetUp() * interSize,             texture->xend, texture->ystart, col },
 		{ drawPos + camera->GetRight() * interSize + camera->GetUp() * interSize,             texture->xend, texture->yend,   col },
@@ -133,13 +133,13 @@ bool CDirtProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, alpha        )
-	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, alphaFalloff )
-	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, size         )
-	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, sizeExpansion)
-	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, slowdown     )
-	CHECK_MEMBER_INFO_FLOAT3(CDirtProjectile, color        )
-	CHECK_MEMBER_INFO_PTR   (CDirtProjectile, texture, projectileDrawer->textureAtlas->GetTexturePtr)
+	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, alpha        );
+	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, alphaFalloff );
+	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, size         );
+	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, sizeExpansion);
+	CHECK_MEMBER_INFO_FLOAT (CDirtProjectile, slowdown     );
+	CHECK_MEMBER_INFO_FLOAT3(CDirtProjectile, color        );
+	CHECK_MEMBER_INFO_PTR   (CDirtProjectile, texture, projectileDrawer->textureAtlas->GetTexturePtr);
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/ExploSpikeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ExploSpikeProjectile.cpp
@@ -98,14 +98,13 @@ void CExploSpikeProjectile::Draw()
 	const float3 l = (dir * length) + (lengthGrowth * globalRendering->timeOffset);
 	const float3 w = dir2 * width;
 
-	#define let projectileDrawer->laserendtex
-	AddEffectsQuad(
+	const auto* let = projectileDrawer->laserendtex;
+	AddEffectsQuad<0>(
 		{ drawPos - l - w, let->xstart, let->ystart, col },
 		{ drawPos + l - w, let->xend,   let->ystart, col },
 		{ drawPos + l + w, let->xend,   let->yend,   col },
 		{ drawPos - l + w, let->xstart, let->yend,   col }
 	);
-	#undef let
 }
 
 
@@ -122,12 +121,12 @@ bool CExploSpikeProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, length      )
-	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, width       )
-	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, alpha       )
-	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, alphaDecay  )
-	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, lengthGrowth)
-	CHECK_MEMBER_INFO_FLOAT3(CExploSpikeProjectile, color       )
+	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, length      );
+	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, width       );
+	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, alpha       );
+	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, alphaDecay  );
+	CHECK_MEMBER_INFO_FLOAT (CExploSpikeProjectile, lengthGrowth);
+	CHECK_MEMBER_INFO_FLOAT3(CExploSpikeProjectile, color       );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/GeoSquareProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/GeoSquareProjectile.cpp
@@ -67,14 +67,14 @@ void CGeoSquareProjectile::Draw()
 	const float v1 = projectileDrawer->geosquaretex->yend;
 
 	if (w2 != 0) {
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ p1 - dir1 * w1, u, v1, col },
 			{ p1 + dir1 * w1, u, v0, col },
 			{ p2 + dir2 * w2, u, v0, col },
 			{ p2 - dir2 * w2, u, v1, col }
 		);
 	} else {
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ p1 - dir1 * w1, u, v1,                    col },
 			{ p1 + dir1 * w1, u, v0,                    col },
 			{ p2,             u, v0 + (v1 - v0) * 0.5f, col },

--- a/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
@@ -128,7 +128,7 @@ void CHeatCloudProjectile::Draw()
 	if (math::fabs(rotVal) > 0.01f) {
 		float3::rotate<false>(rotVal, camera->GetForward(), bounds);
 	}
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ drawPos + bounds[0], texture->xstart, texture->ystart, col },
 		{ drawPos + bounds[1], texture->xend,   texture->ystart, col },
 		{ drawPos + bounds[2], texture->xend,   texture->yend,   col },
@@ -148,14 +148,14 @@ bool CHeatCloudProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, heat       )
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, maxheat    )
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, heatFalloff)
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, size       )
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizeGrowth )
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizemod    )
-	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizemodmod )
-	CHECK_MEMBER_INFO_PTR   (CHeatCloudProjectile, texture, projectileDrawer->textureAtlas->GetTexturePtr)
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, heat       );
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, maxheat    );
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, heatFalloff);
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, size       );
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizeGrowth );
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizemod    );
+	CHECK_MEMBER_INFO_FLOAT (CHeatCloudProjectile, sizemodmod );
+	CHECK_MEMBER_INFO_PTR   (CHeatCloudProjectile, texture, projectileDrawer->textureAtlas->GetTexturePtr);
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/MuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/MuzzleFlame.cpp
@@ -73,14 +73,13 @@ void CMuzzleFlame::Draw()
 		col[2] = (unsigned char) (180 * alpha * fade);
 		col[3] = (unsigned char) (255 * alpha * fade);
 
-		#define st projectileDrawer->GetSmokeTexture(tex)
-		AddEffectsQuad(
+		const auto* st = projectileDrawer->GetSmokeTexture(tex);
+		AddEffectsQuad<0>(
 			{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, st->xstart, st->ystart, col },
 			{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, st->xend,   st->ystart, col },
 			{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, st->xend,   st->yend,   col },
 			{ interPos - camera->GetRight() * drawsize + camera->GetUp() * drawsize, st->xstart, st->yend,   col }
 		);
-		#undef st
 
 		if (fade < 1.0f) {
 			float ifade = 1.0f - fade;
@@ -89,14 +88,13 @@ void CMuzzleFlame::Draw()
 			col[2] = (unsigned char) (ifade * 255);
 			col[3] = (unsigned char) (1);
 
-			#define mft projectileDrawer->muzzleflametex
-			AddEffectsQuad(
+			const auto* mft = projectileDrawer->muzzleflametex;
+			AddEffectsQuad<0>(
 				{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, mft->xstart, mft->ystart, col },
 				{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, mft->xend,   mft->ystart, col },
 				{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, mft->xend,   mft->yend,   col },
 				{ interPos - camera->GetRight() * drawsize + camera->GetUp() * drawsize, mft->xstart, mft->yend,   col }
 			);
-			#undef mft
 		}
 	}
 }

--- a/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
@@ -100,7 +100,7 @@ void CNanoProjectile::Draw()
 	}
 
 	const auto* gfxt = projectileDrawer->gfxtex;
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ drawPos + bounds[0], gfxt->xstart, gfxt->ystart, color },
 		{ drawPos + bounds[1], gfxt->xend  , gfxt->ystart, color },
 		{ drawPos + bounds[2], gfxt->xend  , gfxt->yend  , color },
@@ -126,8 +126,8 @@ bool CNanoProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_INT   (CNanoProjectile, deathFrame)
-	CHECK_MEMBER_INFO_SCOLOR(CNanoProjectile, color     )
+	CHECK_MEMBER_INFO_INT   (CNanoProjectile, deathFrame);
+	CHECK_MEMBER_INFO_SCOLOR(CNanoProjectile, color     );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
+++ b/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
@@ -110,7 +110,7 @@ void CRepulseGfx::Draw()
 		for (int x = 0; x < loopCountX; ++x) {
 			const float dx = x - 2.00f;
 			const float rx = x * 0.25f;
-			AddEffectsQuad(
+			AddEffectsQuad<0>(
 				{ pos + xdirDS * (dx + 0) + ydirDS * (dy + 0) + zdir * vertexDists[(y    ) * 5 + x    ],  txo + (ry        ) * txs, tyo + (rx        ) * tys,  col },
 				{ pos + xdirDS * (dx + 0) + ydirDS * (dy + 1) + zdir * vertexDists[(y + 1) * 5 + x    ],  txo + (ry + 0.25f) * txs, tyo + (rx        ) * tys,  col },
 				{ pos + xdirDS * (dx + 1) + ydirDS * (dy + 1) + zdir * vertexDists[(y + 1) * 5 + x + 1],  txo + (ry + 0.25f) * txs, tyo + (rx + 0.25f) * tys,  col },
@@ -134,28 +134,28 @@ void CRepulseGfx::Draw()
 	xdirDS = xdir * drawsize;
 	ydirDS = ydir * drawsize;
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ owner->pos + (-xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + ( xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos + xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },
 		{ pos - xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col }
 	);
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ owner->pos + (-xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + ( xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos + xdirDS - ydirDS + zdir * vertexDists[6],  tx, ty, col },
 		{ pos - xdirDS - ydirDS + zdir * vertexDists[6],  tx, ty, col }
 	);
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ owner->pos + ( xdir - ydir) * drawsize * 0.2f,   tx, ty, col2 },
 		{ owner->pos + ( xdir + ydir) * drawsize * 0.2f,   tx, ty, col2 },
 		{ pos + xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },
 		{ pos + xdirDS - ydirDS + zdir * vertexDists[6],  tx, ty, col }
 	);
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ owner->pos + (-xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + (-xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos - xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },

--- a/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
@@ -353,7 +353,7 @@ void ShieldSegmentProjectile::Draw()
 		for (int x = 0; x < (NUM_VERTICES_X - 1); ++x) {
 			const int idxTL = (y    ) * NUM_VERTICES_X + x, idxTR = (y    ) * NUM_VERTICES_X + x + 1;
 			const int idxBL = (y + 1) * NUM_VERTICES_X + x, idxBR = (y + 1) * NUM_VERTICES_X + x + 1;
-			AddEffectsQuad(
+			AddEffectsQuad<0>(
 				{ shieldPos + vertices[idxTL] * size, texCoors[idxTL].x, texCoors[idxTL].y, color },
 				{ shieldPos + vertices[idxTR] * size, texCoors[idxTR].x, texCoors[idxTR].y, color },
 				{ shieldPos + vertices[idxBR] * size, texCoors[idxBR].x, texCoors[idxBR].y, color },

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -260,7 +260,7 @@ bool CSimpleParticleSystem::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo
 	CHECK_MEMBER_INFO_INT   (CSimpleParticleSystem, numParticles       );
 	CHECK_MEMBER_INFO_BOOL  (CSimpleParticleSystem, directional        );
 	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, texture, projectileDrawer->textureAtlas->GetTexturePtr);
-	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, colorMap, CColorMap::LoadFromDefString                 );
+	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, colorMap, CColorMap::LoadFromDefString                );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -99,7 +99,8 @@ void CSimpleParticleSystem::Serialize(creg::ISerializer* s)
 void CSimpleParticleSystem::Draw()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	UpdateAnimParams();
+	if (!UpdateAnimParams())
+		return;
 
 	float3 zdir;
 	float3 ydir;
@@ -122,7 +123,7 @@ void CSimpleParticleSystem::Draw()
 		if (math::fabs(p->rotVal) > 0.01f) {
 			float3::rotate<false>(p->rotVal, zdir, bounds);
 		}
-		AddEffectsQuad(
+		AddEffectsQuad<1>(
 			{ pDrawPos + bounds[0], texture->xstart, texture->ystart, color },
 			{ pDrawPos + bounds[1], texture->xend,   texture->ystart, color },
 			{ pDrawPos + bounds[2], texture->xend,   texture->yend,   color },
@@ -220,10 +221,13 @@ void CSimpleParticleSystem::Init(const CUnit* owner, const float3& offset)
 		p.rotVel = rotParams.x; //initial rotation velocity
 		p.life = 0.0f;
 		p.decayrate = 1.0f / (particleLife + (guRNG.NextFloat() * particleLifeSpread));
-		p.size = particleSize + guRNG.NextFloat()*particleSizeSpread;
+		p.size = particleSize + guRNG.NextFloat() * particleSizeSpread;
 	}
 
 	drawRadius = (particleSpeed + particleSpeedSpread) * (particleLife + particleLifeSpread);
+
+	validTextures[1] = IsValidTexture(texture);
+	validTextures[0] = validTextures[1];
 }
 
 int CSimpleParticleSystem::GetProjectilesCount() const
@@ -239,24 +243,24 @@ bool CSimpleParticleSystem::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, emitVector         )
-	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, emitMul            )
-	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, gravity            )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSpeed      )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSpeedSpread)
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, emitRot            )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, emitRotSpread      )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleLife       )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleLifeSpread )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSize       )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSizeSpread )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, airdrag            )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, sizeGrowth         )
-	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, sizeMod            )
-	CHECK_MEMBER_INFO_INT   (CSimpleParticleSystem, numParticles       )
-	CHECK_MEMBER_INFO_BOOL  (CSimpleParticleSystem, directional        )
-	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, texture , projectileDrawer->textureAtlas->GetTexturePtr)
-	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, colorMap, CColorMap::LoadFromDefString                 )
+	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, emitVector         );
+	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, emitMul            );
+	CHECK_MEMBER_INFO_FLOAT3(CSimpleParticleSystem, gravity            );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSpeed      );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSpeedSpread);
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, emitRot            );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, emitRotSpread      );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleLife       );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleLifeSpread );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSize       );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, particleSizeSpread );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, airdrag            );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, sizeGrowth         );
+	CHECK_MEMBER_INFO_FLOAT (CSimpleParticleSystem, sizeMod            );
+	CHECK_MEMBER_INFO_INT   (CSimpleParticleSystem, numParticles       );
+	CHECK_MEMBER_INFO_BOOL  (CSimpleParticleSystem, directional        );
+	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, texture, projectileDrawer->textureAtlas->GetTexturePtr);
+	CHECK_MEMBER_INFO_PTR   (CSimpleParticleSystem, colorMap, CColorMap::LoadFromDefString                 );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/SmokeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeProjectile.cpp
@@ -114,14 +114,13 @@ void CSmokeProjectile::Draw()
 	const float3 pos1 ((camera->GetRight() - camera->GetUp()) * interSize);
 	const float3 pos2 ((camera->GetRight() + camera->GetUp()) * interSize);
 
-	#define st projectileDrawer->GetSmokeTexture(textureNum)
-	AddEffectsQuad(
+	const auto* st = projectileDrawer->GetSmokeTexture(textureNum);
+	AddEffectsQuad<0>(
 		{ drawPos - pos2, st->xstart, st->ystart, col },
 		{ drawPos + pos1, st->xend,   st->ystart, col },
 		{ drawPos + pos2, st->xend,   st->yend,   col },
 		{ drawPos - pos1, st->xstart, st->yend,   col }
 	);
-	#undef st
 }
 
 int CSmokeProjectile::GetProjectilesCount() const
@@ -136,11 +135,11 @@ bool CSmokeProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, color        )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, size         )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, startSize    )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, sizeExpansion)
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, ageSpeed     )
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, color        );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, size         );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, startSize    );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, sizeExpansion);
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile, ageSpeed     );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/SmokeProjectile2.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeProjectile2.cpp
@@ -129,14 +129,13 @@ void CSmokeProjectile2::Draw()
 	const float3 pos1 ((camera->GetRight() - camera->GetUp()) * interSize);
 	const float3 pos2 ((camera->GetRight() + camera->GetUp()) * interSize);
 
-	#define st projectileDrawer->GetSmokeTexture(textureNum)
-	AddEffectsQuad(
+	const auto* st = projectileDrawer->GetSmokeTexture(textureNum);
+	AddEffectsQuad<0>(
 		{ interPos - pos2, st->xstart, st->ystart, col },
 		{ interPos + pos1, st->xend,   st->ystart, col },
 		{ interPos + pos2, st->xend,   st->yend,   col },
 		{ interPos - pos1, st->xstart, st->yend,   col }
 	);
-	#undef st
 }
 
 int CSmokeProjectile2::GetProjectilesCount() const
@@ -151,13 +150,13 @@ bool CSmokeProjectile2::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, color        )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, size         )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, startSize    )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, sizeExpansion)
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, ageSpeed     )
-	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, glowFalloff  )
-	CHECK_MEMBER_INFO_FLOAT3(CSmokeProjectile2, wantedPos    )
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, color        );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, size         );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, startSize    );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, sizeExpansion);
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, ageSpeed     );
+	CHECK_MEMBER_INFO_FLOAT (CSmokeProjectile2, glowFalloff  );
+	CHECK_MEMBER_INFO_FLOAT3(CSmokeProjectile2, wantedPos    );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
@@ -148,21 +148,21 @@ void CSmokeTrailProjectile::Draw()
 
 		const SColor colm = colBase * std::clamp(lerpm, 0.0f, 1.0f);
 
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ pos1   - (odir1 * size1), texture->xstart, texture->ystart, col1  },
 			{ midpos - (odirm * sizem), midtexx        , texture->ystart, colm },
 			{ midpos + (odirm * sizem), midtexx        , texture->yend  , colm },
 			{ pos1   + (odir1 * size1), texture->xstart, texture->yend  , col1  }
 		);
 
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ midpos - (odirm * sizem), midtexx      ,   texture->ystart, colm },
 			{ pos2   - (odir2 * size2), texture->xend,   texture->ystart, col2 },
 			{ pos2   + (odir2 * size2), texture->xend,   texture->yend  , col2 },
 			{ midpos + (odirm * sizem), midtexx      ,   texture->yend  , colm }
 		);
 	} else {
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ pos1 - (odir1 * size1), texture->xstart, texture->ystart, col1 },
 			{ pos2 - (odir2 * size2), texture->xend  , texture->ystart, col2 },
 			{ pos2 + (odir2 * size2), texture->xend  , texture->yend  , col2 },

--- a/rts/Rendering/Env/Particles/Classes/SpherePartProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SpherePartProjectile.cpp
@@ -105,7 +105,7 @@ void CSpherePartProjectile::Draw()
 			col1[2] = (unsigned char)(color.z * 255.0f * alpha);
 			col1[3] = ((unsigned char)(40 * alpha)) + 1;
 
-			AddEffectsQuad(
+			AddEffectsQuad<0>(
 				{ centerPos + vectors[y*5 + x    ]     * interSize, texx, texy, col0 },
 				{ centerPos + vectors[y*5 + x + 1]     * interSize, texx, texy, col0 },
 				{ centerPos+vectors[(y + 1)*5 + x + 1] * interSize, texx, texy, col1 },
@@ -175,10 +175,10 @@ bool CSpherePartSpawner::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CSpherePartSpawner, alpha         )
-	CHECK_MEMBER_INFO_FLOAT (CSpherePartSpawner, expansionSpeed)
-	CHECK_MEMBER_INFO_INT   (CSpherePartSpawner, ttl           )
-	CHECK_MEMBER_INFO_FLOAT3(CSpherePartSpawner, color         )
+	CHECK_MEMBER_INFO_FLOAT (CSpherePartSpawner, alpha         );
+	CHECK_MEMBER_INFO_FLOAT (CSpherePartSpawner, expansionSpeed);
+	CHECK_MEMBER_INFO_INT   (CSpherePartSpawner, ttl           );
+	CHECK_MEMBER_INFO_FLOAT3(CSpherePartSpawner, color         );
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
@@ -93,7 +93,7 @@ bool CTracerProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT (CTracerProjectile, length)
+	CHECK_MEMBER_INFO_FLOAT(CTracerProjectile, length);
 
 	return false;
 }

--- a/rts/Rendering/Env/Particles/Classes/WakeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/WakeProjectile.cpp
@@ -98,14 +98,13 @@ void CWakeProjectile::Draw()
 	const float3 dir1 = float3(std::cos(interRot), 0, std::sin(interRot)) * interSize;
 	const float3 dir2 = dir1.cross(UpVector);
 
-	#define wt projectileDrawer->waketex
-	AddEffectsQuad(
+	const auto* wt = projectileDrawer->waketex;
+	AddEffectsQuad<0>(
 		{ drawPos + dir1 + dir2, wt->xstart, wt->ystart, col },
 		{ drawPos - dir1 + dir2, wt->xend,   wt->ystart, col },
 		{ drawPos - dir1 - dir2, wt->xend,   wt->yend,   col },
 		{ drawPos + dir1 - dir2, wt->xstart, wt->yend,   col }
 	);
-	#undef wt
 }
 
 int CWakeProjectile::GetProjectilesCount() const

--- a/rts/Rendering/Env/Particles/Classes/WreckProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/WreckProjectile.cpp
@@ -57,14 +57,13 @@ void CWreckProjectile::Draw()
 	col[2] = (unsigned char) (0.05f * 200);
 	col[3] = 200;
 
-	#define wt projectileDrawer->wrecktex
-	AddEffectsQuad(
+	const auto* wt = projectileDrawer->wrecktex;
+	AddEffectsQuad<0>(
 		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, wt->xstart, wt->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, wt->xend,   wt->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, wt->xend,   wt->yend,   col },
 		{ drawPos - camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, wt->xstart, wt->yend,   col }
 	);
-	#undef wt
 }
 
 void CWreckProjectile::DrawOnMinimap() const

--- a/rts/Rendering/GroundFlash.cpp
+++ b/rts/Rendering/GroundFlash.cpp
@@ -88,6 +88,11 @@ CGroundFlash::CGroundFlash(const float3& _pos) : CGroundFlash()
 	pos = _pos;
 }
 
+bool CGroundFlash::UpdateAnimParams() {
+	UpdateAnimParamsImpl(animParams1, animProgress1);
+	return true;
+}
+
 float3 CGroundFlash::CalcNormal(const float3 midPos, const float3 camDir, float quadSize) const
 {
 	// no degenerate quads, otherwise ANormalize() fails
@@ -116,9 +121,9 @@ bool CGroundFlash::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CExpGenSpawnable::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT(CGroundFlash, size)
-	CHECK_MEMBER_INFO_BOOL (CGroundFlash, depthTest)
-	CHECK_MEMBER_INFO_BOOL (CGroundFlash, depthMask)
+	CHECK_MEMBER_INFO_FLOAT(CGroundFlash, size     );
+	CHECK_MEMBER_INFO_BOOL (CGroundFlash, depthTest);
+	CHECK_MEMBER_INFO_BOOL (CGroundFlash, depthMask);
 
 	return false;
 }
@@ -225,7 +230,7 @@ void CStandardGroundFlash::Draw()
 		const float3 p4 = pos + (-side1 + side2) * iSize;
 
 		color.a = (unsigned char)(iAlpha * 255);
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ p1, projectileDrawer->groundringtex->xstart, projectileDrawer->groundringtex->ystart, color },
 			{ p2, projectileDrawer->groundringtex->xend,   projectileDrawer->groundringtex->ystart, color },
 			{ p3, projectileDrawer->groundringtex->xend,   projectileDrawer->groundringtex->yend,   color },
@@ -247,7 +252,7 @@ void CStandardGroundFlash::Draw()
 		const float3 p3 = pos + ( side1 - side2) * size;
 		const float3 p4 = pos + (-side1 - side2) * size;
 
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ p1, projectileDrawer->groundflashtex->xstart, projectileDrawer->groundflashtex->ystart, color },
 			{ p2, projectileDrawer->groundflashtex->xend  , projectileDrawer->groundflashtex->ystart, color },
 			{ p3, projectileDrawer->groundflashtex->xend  , projectileDrawer->groundflashtex->yend  , color },
@@ -262,11 +267,11 @@ bool CStandardGroundFlash::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CGroundFlash::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, flashSize   )
-	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, flashAlpha  )
-	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, circleGrowth)
-	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, circleAlpha )
-	CHECK_MEMBER_INFO_SCOLOR(CStandardGroundFlash, color      )
+	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, flashSize   );
+	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, flashAlpha  );
+	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, circleGrowth);
+	CHECK_MEMBER_INFO_FLOAT(CStandardGroundFlash, circleAlpha );
+	CHECK_MEMBER_INFO_SCOLOR(CStandardGroundFlash, color      );
 
 	return false;
 }
@@ -329,7 +334,7 @@ void CSimpleGroundFlash::Draw()
 		float3::rotate<false>(rotVal, normal, bounds);
 	}
 
-	AddEffectsQuad(
+	AddEffectsQuad<1>(
 		{ pos + bounds[0], texture->xstart, texture->ystart, color },
 		{ pos + bounds[1], texture->xend  , texture->ystart, color },
 		{ pos + bounds[2], texture->xend  , texture->yend  , color },
@@ -351,10 +356,10 @@ bool CSimpleGroundFlash::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CGroundFlash::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_FLOAT(CSimpleGroundFlash, sizeGrowth)
-	CHECK_MEMBER_INFO_INT  (CSimpleGroundFlash, ttl       )
-	CHECK_MEMBER_INFO_PTR  (CSimpleGroundFlash, colorMap, CColorMap::LoadFromDefString)
-	CHECK_MEMBER_INFO_PTR  (CSimpleGroundFlash, texture , projectileDrawer->groundFXAtlas->GetTexturePtr)
+	CHECK_MEMBER_INFO_FLOAT(CSimpleGroundFlash, sizeGrowth);
+	CHECK_MEMBER_INFO_INT  (CSimpleGroundFlash, ttl       );
+	CHECK_MEMBER_INFO_PTR  (CSimpleGroundFlash, colorMap, CColorMap::LoadFromDefString                  );
+	CHECK_MEMBER_INFO_PTR  (CSimpleGroundFlash, texture , projectileDrawer->groundFXAtlas->GetTexturePtr);
 
 	return false;
 }
@@ -409,7 +414,7 @@ void CSeismicGroundFlash::Draw()
 	const float3 p3 = pos + ( side1 + side2) * size;
 	const float3 p4 = pos + (-side1 + side2) * size;
 
-	AddEffectsQuad(
+	AddEffectsQuad<0>(
 		{ p1, texture->xstart, texture->ystart, color },
 		{ p2, texture->xend,   texture->ystart, color },
 		{ p3, texture->xend,   texture->yend,   color },

--- a/rts/Rendering/GroundFlash.h
+++ b/rts/Rendering/GroundFlash.h
@@ -20,6 +20,8 @@ public:
 	CGroundFlash(const float3& _pos);
 	CGroundFlash();
 
+	bool UpdateAnimParams() override;
+
 	virtual ~CGroundFlash() {}
 	virtual void Draw() {}
 	/// @return false when it should be deleted

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -29,14 +29,21 @@ CR_REG_METADATA(CExpGenSpawnable, (
 	CR_MEMBER(rotVal),
 	CR_MEMBER(rotVel),
 	CR_MEMBER(createFrame),
+	CR_MEMBER(animProgress1),
+	CR_MEMBER(animProgress2),
+	CR_MEMBER(animProgress3),
+	CR_MEMBER(animProgress4),
 	CR_MEMBER_BEGINFLAG(CM_Config),
 		CR_MEMBER(rotParams),
-		CR_MEMBER(animParams),
-	CR_MEMBER_ENDFLAG(CM_Config),
-	CR_IGNORED(animProgress)
+		CR_FAKE(animParams, float3),
+		CR_MEMBER(animParams1),
+		CR_MEMBER(animParams2),
+		CR_MEMBER(animParams3),
+		CR_MEMBER(animParams4),
+	CR_MEMBER_ENDFLAG(CM_Config)
 ))
 
-std::array<CExpGenSpawnable::SpawnableTuple, 14> CExpGenSpawnable::spawnables = {};
+decltype(CExpGenSpawnable::spawnables) CExpGenSpawnable::spawnables = {};
 
 CExpGenSpawnable::CExpGenSpawnable(const float3& pos, const float3& spd)
 	: CWorldObject(pos, spd)
@@ -82,12 +89,7 @@ void CExpGenSpawnable::UpdateRotation()
 	rotVal = rotParams.z + rotVel      * t;
 }
 
-void CExpGenSpawnable::UpdateAnimParams()
-{
-	UpdateAnimParamsImpl(animParams, animProgress);
-}
-
-void CExpGenSpawnable::UpdateAnimParamsImpl(const float3& ap, float& p)
+void CExpGenSpawnable::UpdateAnimParamsImpl(const float3& ap, float& p) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (static_cast<int>(ap.x) <= 1 && static_cast<int>(ap.y) <= 1) {
@@ -121,13 +123,17 @@ bool CExpGenSpawnable::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 		spring::LiteHash("alwaysvisible",  sizeof("alwaysvisible") - 1, 0),
 	};
 
-	CHECK_MEMBER_INFO_FLOAT3_HASH(CExpGenSpawnable, pos          , memberHashes[0])
-	CHECK_MEMBER_INFO_FLOAT4_HASH(CExpGenSpawnable, speed        , memberHashes[1])
-	CHECK_MEMBER_INFO_BOOL_HASH  (CExpGenSpawnable, useAirLos    , memberHashes[2])
-	CHECK_MEMBER_INFO_BOOL_HASH  (CExpGenSpawnable, alwaysVisible, memberHashes[3])
+	CHECK_MEMBER_INFO_FLOAT3_HASH(CExpGenSpawnable, pos          , memberHashes[0]);
+	CHECK_MEMBER_INFO_FLOAT4_HASH(CExpGenSpawnable, speed        , memberHashes[1]);
+	CHECK_MEMBER_INFO_BOOL_HASH  (CExpGenSpawnable, useAirLos    , memberHashes[2]);
+	CHECK_MEMBER_INFO_BOOL_HASH  (CExpGenSpawnable, alwaysVisible, memberHashes[3]);
 
-	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, rotParams)
-	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, animParams)
+	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, rotParams);
+
+	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, animParams1);
+	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, animParams2);
+	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, animParams3);
+	CHECK_MEMBER_INFO_FLOAT3(CExpGenSpawnable, animParams4);
 
 	return false;
 }
@@ -218,11 +224,6 @@ CExpGenSpawnable* CExpGenSpawnable::CreateSpawnable(int spawnableID)
 		return nullptr;
 
 	return std::get<2>(spawnables[spawnableID])();
-}
-
-void CExpGenSpawnable::AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const
-{
-	AddEffectsQuadImpl(tl, tr, br, bl, animParams, animProgress);
 }
 
 void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p)

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -40,10 +40,11 @@ protected:
 
 	//update in Draw() of CGroundFlash or CProjectile
 	void UpdateRotation();
-	void UpdateAnimParams();
+	virtual bool UpdateAnimParams() = 0;
 
-	void UpdateAnimParamsImpl(const float3& ap, float& p);
+	void UpdateAnimParamsImpl(const float3& ap, float& p) const;
 
+	template <uint32_t texIdx>
 	void AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
 
 	static void AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p);
@@ -51,8 +52,15 @@ protected:
 
 	static bool GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo);
 
-	float3 animParams = { 1.0f, 1.0f, 30.0f }; // numX, numY, animLength, 
-	float animProgress = 0.0f; // animProgress = (gf_dt % animLength) / animLength
+	// anim params for 4 textures (max) in an effect
+	float3 animParams1 = { 1.0f, 1.0f, 30.0f }; // numX, numY, animLength, 
+	float animProgress1 = 0.0f; // animProgress = (gf_dt % animLength) / animLength
+	float3 animParams2 = { 1.0f, 1.0f, 30.0f }; // numX, numY, animLength, 
+	float animProgress2 = 0.0f; // animProgress = (gf_dt % animLength) / animLength
+	float3 animParams3 = { 1.0f, 1.0f, 30.0f }; // numX, numY, animLength, 
+	float animProgress3 = 0.0f; // animProgress = (gf_dt % animLength) / animLength
+	float3 animParams4 = { 1.0f, 1.0f, 30.0f }; // numX, numY, animLength, 
+	float animProgress4 = 0.0f; // animProgress = (gf_dt % animLength) / animLength
 
 	float3 rotParams = { 0.0f, 0.0f, 0.0f }; // speed, accel, startRot |deg/s, deg/s2, deg|
 
@@ -63,5 +71,31 @@ protected:
 
 	static std::array<SpawnableTuple, 14> spawnables;
 };
+
+template <>
+inline void CExpGenSpawnable::AddEffectsQuad<0>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	// no animation
+	AddEffectsQuadImpl(tl, tr, br, bl);
+}
+
+template <>
+inline void CExpGenSpawnable::AddEffectsQuad<1>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(tl, tr, br, bl, animParams1, animProgress1);
+}
+
+template <>
+inline void CExpGenSpawnable::AddEffectsQuad<2>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(tl, tr, br, bl, animParams2, animProgress2);
+}
+
+template <>
+inline void CExpGenSpawnable::AddEffectsQuad<3>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(tl, tr, br, bl, animParams3, animProgress3);
+}
+
+template <>
+inline void CExpGenSpawnable::AddEffectsQuad<4>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(tl, tr, br, bl, animParams4, animProgress4);
+}
 
 #endif //EXP_GEN_SPAWNABLE_H

--- a/rts/Sim/Projectiles/ExpGenSpawnableMemberInfo.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnableMemberInfo.h
@@ -37,34 +37,45 @@ struct SExpGenSpawnableMemberInfo
 
 
 #define SET_MEMBER_INFO(memberInfo, memberHash, Offset, Size, Length, Type, Ptr)  \
-	if (memberInfo.phash == memberHash) {                                         \
-		memberInfo.offset      = (Offset);                                        \
-		memberInfo.size        = (Size);                                          \
-		memberInfo.length      = (Length);                                        \
-		memberInfo.type        = (Type);                                          \
-		memberInfo.ptrCallback = (Ptr);                                           \
-		return true;                                                              \
-	}
+	do {                                                                          \
+		if (memberInfo.phash == memberHash) {                                     \
+			memberInfo.offset      = (Offset);                                    \
+			memberInfo.size        = (Size);                                      \
+			memberInfo.length      = (Length);                                    \
+			memberInfo.type        = (Type);                                      \
+			memberInfo.ptrCallback = (Ptr);                                       \
+			return true;                                                          \
+		}                                                                         \
+	} while(0)
 
 #define CHECK_MEMBER_INFO_INT(type, member) \
 	static_assert(std::is_integral<decltype(member)>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_INT  , nullptr );
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_INT  , nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT(type, member) \
 	static_assert(std::is_same<decltype(member), float>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT3(type, member) \
 	static_assert(std::is_same<decltype(member), float3>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member.x), 3, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member.x), 3, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
+
+#define CHECK_MEMBER_INFO_FLOAT3_NAME(type, member, memberName) \
+	static_assert(std::is_same<decltype(member), float3>::value, "Member type mismatch"); \
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(memberName), offsetof_expgen(type, member), sizeof_expgen(type, member.x), 3, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT4(type, member) \
 	static_assert(std::is_same<decltype(member), float4>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member.x), 4, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(type, member), sizeof_expgen(type, member.x), 4, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_PTR(t, member, callback) \
 	static_assert(std::is_same<decltype(callback("")), decltype(member)>::value, "Member and callback type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(t, member), sizeof_expgen(t, member), 1, SExpGenSpawnableMemberInfo::TYPE_PTR, [](const std::string& s) { return (void *) callback(s.c_str()); } );
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(member), offsetof_expgen(t, member), sizeof_expgen(t, member), 1, SExpGenSpawnableMemberInfo::TYPE_PTR, [](const std::string& s) { return (void *) callback(s.c_str()); } )
+
+#define CHECK_MEMBER_INFO_PTR_NAME(t, member, memberName, callback) \
+	static_assert(std::is_same<decltype(callback("")), decltype(member)>::value, "Member and callback type mismatch"); \
+	SET_MEMBER_INFO(memberInfo, MEMBER_HASH(memberName), offsetof_expgen(t, member), sizeof_expgen(t, member), 1, SExpGenSpawnableMemberInfo::TYPE_PTR, [](const std::string& s) { return (void *) callback(s.c_str()); } )
+
 
 #define CHECK_MEMBER_INFO_BOOL(type, member) CHECK_MEMBER_INFO_INT(type, member)
 #define CHECK_MEMBER_INFO_SCOLOR(type, member) CHECK_MEMBER_INFO_INT(type, member.i)
@@ -73,23 +84,23 @@ struct SExpGenSpawnableMemberInfo
 
 #define CHECK_MEMBER_INFO_INT_HASH(type, member, memberHash) \
 	static_assert(std::is_integral<decltype(member)>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_INT  , nullptr );
+	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_INT  , nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT_HASH(type, member, memberHash) \
 	static_assert(std::is_same<decltype(member), float>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member)  , 1, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT3_HASH(type, member, memberHash) \
 	static_assert(std::is_same<decltype(member), float3>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member.x), 3, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member.x), 3, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_FLOAT4_HASH(type, member, memberHash) \
 	static_assert(std::is_same<decltype(member), float4>::value, "Member type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member.x), 4, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr );
+	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(type, member), sizeof_expgen(type, member.x), 4, SExpGenSpawnableMemberInfo::TYPE_FLOAT, nullptr )
 
 #define CHECK_MEMBER_INFO_PTR_HASH(t, member, callback, memberHash) \
 	static_assert(std::is_same<decltype(callback("")), decltype(member)>::value, "Member and callback type mismatch"); \
-	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(t, member), sizeof_expgen(t, member), 1, SExpGenSpawnableMemberInfo::TYPE_PTR, [](const std::string& s) { return (void *) callback(s); } );
+	SET_MEMBER_INFO(memberInfo, memberHash, offsetof_expgen(t, member), sizeof_expgen(t, member), 1, SExpGenSpawnableMemberInfo::TYPE_PTR, [](const std::string& s) { return (void *) callback(s); } )
 
 #define CHECK_MEMBER_INFO_BOOL_HASH(type, member, memberHash) CHECK_MEMBER_INFO_INT_HASH(type, member, memberHash)
 #define CHECK_MEMBER_INFO_SCOLOR_HASH(type, member, memberHash) CHECK_MEMBER_INFO_INT_HASH(type, member.i, memberHash)

--- a/rts/Sim/Projectiles/ExpGenSpawner.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawner.cpp
@@ -59,10 +59,10 @@ bool CExpGenSpawner::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_INT  (CExpGenSpawner, delay )
-	CHECK_MEMBER_INFO_FLOAT(CExpGenSpawner, damage)
+	CHECK_MEMBER_INFO_INT(CExpGenSpawner, delay);
+	CHECK_MEMBER_INFO_FLOAT(CExpGenSpawner, damage);
 	// TODO: much nicer to load cegID directly via LoadGeneratorID callback
-	CHECK_MEMBER_INFO_PTR  (CExpGenSpawner, explosionGenerator, explGenHandler.LoadGenerator)
+	CHECK_MEMBER_INFO_PTR(CExpGenSpawner, explosionGenerator, explGenHandler.LoadGenerator);
 
 	return false;
 }

--- a/rts/Sim/Projectiles/ExpGenSpawner.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawner.cpp
@@ -59,10 +59,10 @@ bool CExpGenSpawner::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CProjectile::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_INT(CExpGenSpawner, delay);
+	CHECK_MEMBER_INFO_INT  (CExpGenSpawner, delay );
 	CHECK_MEMBER_INFO_FLOAT(CExpGenSpawner, damage);
 	// TODO: much nicer to load cegID directly via LoadGeneratorID callback
-	CHECK_MEMBER_INFO_PTR(CExpGenSpawner, explosionGenerator, explGenHandler.LoadGenerator);
+	CHECK_MEMBER_INFO_PTR  (CExpGenSpawner, explosionGenerator, explGenHandler.LoadGenerator);
 
 	return false;
 }

--- a/rts/Sim/Projectiles/FireProjectile.cpp
+++ b/rts/Sim/Projectiles/FireProjectile.cpp
@@ -149,6 +149,8 @@ void CFireProjectile::Draw()
 	col[3] = 1;
 	uint8_t col2[4];
 
+	const auto* et = projectileDrawer->explotex;
+
 	for (const SubParticle& pi: subParticles2) {
 		const float  age = pi.age + ageSpeed * globalRendering->timeOffset;
 		const float size = pi.maxSize * age;
@@ -166,15 +168,16 @@ void CFireProjectile::Draw()
 		col[1] = (uint8_t) ((1 - age) * 255);
 		col[2] = (uint8_t) ((1 - age) * 255);
 
-		AddEffectsQuad(
-			{ interPos - dir1 - dir2, projectileDrawer->explotex->xstart, projectileDrawer->explotex->ystart, col },
-			{ interPos + dir1 - dir2, projectileDrawer->explotex->xend,   projectileDrawer->explotex->ystart, col },
-			{ interPos + dir1 + dir2, projectileDrawer->explotex->xend,   projectileDrawer->explotex->yend,   col },
-			{ interPos - dir1 + dir2, projectileDrawer->explotex->xstart, projectileDrawer->explotex->yend,   col }
+		AddEffectsQuad<0>(
+			{ interPos - dir1 - dir2, et->xstart, et->ystart, col },
+			{ interPos + dir1 - dir2, et->xend,   et->ystart, col },
+			{ interPos + dir1 + dir2, et->xend,   et->yend,   col },
+			{ interPos - dir1 + dir2, et->xstart, et->yend,   col }
 		);
 	}
+
 	for (const SubParticle& pi: subParticles) {
-		const AtlasedTexture* at = projectileDrawer->GetSmokeTexture(pi.smokeType);
+		const auto* at = projectileDrawer->GetSmokeTexture(pi.smokeType);
 
 		const float  age = pi.age + ageSpeed * globalRendering->timeOffset;
 		const float size = pi.maxSize * fastmath::apxsqrt(age);
@@ -194,11 +197,11 @@ void CFireProjectile::Draw()
 			col[2] = (uint8_t) ((1 - age * 1.3f) * 255);
 			col[3] = 1;
 
-			AddEffectsQuad(
-				{ interPos - dir1 - dir2, projectileDrawer->explotex->xstart, projectileDrawer->explotex->ystart, col },
-				{ interPos + dir1 - dir2, projectileDrawer->explotex->xend,   projectileDrawer->explotex->ystart, col },
-				{ interPos + dir1 + dir2, projectileDrawer->explotex->xend,   projectileDrawer->explotex->yend,   col },
-				{ interPos - dir1 + dir2, projectileDrawer->explotex->xstart, projectileDrawer->explotex->yend,   col }
+			AddEffectsQuad<0>(
+				{ interPos - dir1 - dir2, et->xstart, et->ystart, col },
+				{ interPos + dir1 - dir2, et->xend,   et->ystart, col },
+				{ interPos + dir1 + dir2, et->xend,   et->yend,   col },
+				{ interPos - dir1 + dir2, et->xstart, et->yend,   col }
 			);
 		}
 
@@ -213,7 +216,7 @@ void CFireProjectile::Draw()
 		col2[2] = (uint8_t) (c * 0.6f);
 		col2[3] = c;
 
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ interPos - dir1 - dir2, at->xstart, at->ystart, col2 },
 			{ interPos + dir1 - dir2, at->xend,   at->ystart, col2 },
 			{ interPos + dir1 + dir2, at->xend,   at->yend,   col2 },

--- a/rts/Sim/Projectiles/FlareProjectile.cpp
+++ b/rts/Sim/Projectiles/FlareProjectile.cpp
@@ -129,7 +129,7 @@ void CFlareProjectile::Draw()
 		const float3 interPos = subProjPos[a] + subProjVel[a] * globalRendering->timeOffset;
 
 		#define fpt projectileDrawer->flareprojectiletex
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ interPos - camera->GetRight() * rad - camera->GetUp() * rad, fpt->xstart, fpt->ystart, col },
 			{ interPos + camera->GetRight() * rad - camera->GetUp() * rad, fpt->xend,   fpt->ystart, col },
 			{ interPos + camera->GetRight() * rad + camera->GetUp() * rad, fpt->xend,   fpt->yend,   col },

--- a/rts/Sim/Projectiles/PieceProjectile.cpp
+++ b/rts/Sim/Projectiles/PieceProjectile.cpp
@@ -277,7 +277,7 @@ void CPieceProjectile::Draw()
 	if ((explFlags & PF_Fire) == 0)
 		return;
 
-	static const SColor lightOrange(1.f, 0.78f, 0.59f, 0.2f);
+	static constexpr SColor lightOrange(1.f, 0.78f, 0.59f, 0.2f);
 
 	for (unsigned int age = 0; age < NUM_TRAIL_PARTS; ++age) {
 		const float3 interPos = fireTrailPoints[age].pos;
@@ -288,7 +288,7 @@ void CPieceProjectile::Draw()
 		const SColor col = lightOrange * alpha;
 
 		const auto eft = projectileDrawer->explofadetex;
-		AddEffectsQuad(
+		AddEffectsQuad<0>(
 			{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, eft->xstart, eft->ystart, col },
 			{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, eft->xend,   eft->ystart, col },
 			{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, eft->xend,   eft->yend,   col },

--- a/rts/Sim/Projectiles/Projectile.cpp
+++ b/rts/Sim/Projectiles/Projectile.cpp
@@ -208,9 +208,9 @@ bool CProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CExpGenSpawnable::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_BOOL(CProjectile, castShadow);
-	CHECK_MEMBER_INFO_FLOAT3(CProjectile, dir);
-	CHECK_MEMBER_INFO_INT(CProjectile, drawOrder);
+	CHECK_MEMBER_INFO_BOOL  (CProjectile, castShadow);
+	CHECK_MEMBER_INFO_FLOAT3(CProjectile, dir       );
+	CHECK_MEMBER_INFO_INT   (CProjectile, drawOrder );
 
 	return false;
 }

--- a/rts/Sim/Projectiles/Projectile.cpp
+++ b/rts/Sim/Projectiles/Projectile.cpp
@@ -156,6 +156,25 @@ void CProjectile::DrawOnMinimap() const
 	AddMiniMapVertices({ pos        , color4::whiteA }, { pos + speed, color4::whiteA });
 }
 
+bool CProjectile::UpdateAnimParams()
+{
+	if (!validTextures[0])
+		return false;
+
+	if (validTextures[1])
+		UpdateAnimParamsImpl(animParams1, animProgress1);
+
+	if (validTextures[2])
+		UpdateAnimParamsImpl(animParams2, animProgress2);
+
+	if (validTextures[3])
+		UpdateAnimParamsImpl(animParams3, animProgress3);
+
+	if (validTextures[4])
+		UpdateAnimParamsImpl(animParams4, animProgress4);
+
+	return true;
+}
 
 CUnit* CProjectile::owner() const {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -189,9 +208,9 @@ bool CProjectile::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	if (CExpGenSpawnable::GetMemberInfo(memberInfo))
 		return true;
 
-	CHECK_MEMBER_INFO_BOOL(CProjectile, castShadow)
-	CHECK_MEMBER_INFO_FLOAT3(CProjectile, dir)
-	CHECK_MEMBER_INFO_INT(CProjectile, drawOrder)
+	CHECK_MEMBER_INFO_BOOL(CProjectile, castShadow);
+	CHECK_MEMBER_INFO_FLOAT3(CProjectile, dir);
+	CHECK_MEMBER_INFO_INT(CProjectile, drawOrder);
 
 	return false;
 }

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -51,6 +51,8 @@ public:
 	virtual void Draw() {}
 	virtual void DrawOnMinimap() const;
 
+	bool UpdateAnimParams() override;
+
 	virtual int GetProjectilesCount() const = 0;
 
 	// override WorldObject::SetVelocityAndSpeed so

--- a/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
@@ -102,7 +102,7 @@ void CBeamLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	const float3 midPos = (targetPos + startPos) * 0.5f;
 	const float3 cameraDir = (midPos - camera->GetPos()).SafeANormalize();
@@ -129,13 +129,13 @@ void CBeamLaserProjectile::Draw()
 
 	if (playerCamDistSq < Square(1000.0f)) {
 		if (validTextures[2]) {
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos1 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos1 - xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos1 + xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
 				{ pos1 + xdir * beamEdgeSize,                       midtexx  , WT2->yend  , edgeColStart }
 			);
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos1 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos1 - xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos1 + xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -144,14 +144,14 @@ void CBeamLaserProjectile::Draw()
 
 		}
 		if (validTextures[1]) {
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
 				{ pos1 + xdir * beamEdgeSize,                       WT1->xstart, WT1->yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -159,14 +159,14 @@ void CBeamLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[2]) {
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos2 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos2 + xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
 				{ pos2 + xdir * beamEdgeSize,                       midtexx  , WT2->yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos2 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos2 + xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -175,14 +175,14 @@ void CBeamLaserProjectile::Draw()
 		}
 	} else {
 		if (validTextures[1]) {
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
 				{ pos1 + xdir * beamEdgeSize,                       WT1->xstart, WT1->yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -193,14 +193,14 @@ void CBeamLaserProjectile::Draw()
 
 	// draw flare
 	if (validTextures[3]) {
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 - camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xstart, WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize + camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->yend,   edgeColStart },
 			{ pos1 - camera->GetRight() * flareEdgeSize + camera->GetUp() * flareEdgeSize, WT3->xstart, WT3->yend,   edgeColStart }
 		);
 
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 - camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xstart, WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xend,   WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize + camera->GetUp() * flareCoreSize, WT3->xend,   WT3->yend,   coreColStart },

--- a/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
@@ -70,7 +70,7 @@ void CEmgProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	const uint8_t col[4] {
 		(uint8_t)(color.x * intensity * 255),
@@ -81,7 +81,7 @@ void CEmgProjectile::Draw()
 
 	const auto* tex = weaponDef->visuals.texture1;
 
-	AddWeaponEffectsQuad<1>(
+	AddEffectsQuad<1>(
 		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xstart, tex->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xend,   tex->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, tex->xend,   tex->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
@@ -79,7 +79,7 @@ void CExplosiveProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	uint8_t col[4] = {0};
 
@@ -118,7 +118,7 @@ void CExplosiveProjectile::Draw()
 		col[2] = stageDecay * col[2];
 		col[3] = stageDecay * col[3];
 
-		AddWeaponEffectsQuad<1>(
+		AddEffectsQuad<1>(
 			{ stagePos - xdirCam - ydirCam, tex->xstart, tex->ystart, col },
 			{ stagePos + xdirCam - ydirCam, tex->xend,   tex->ystart, col },
 			{ stagePos + xdirCam + ydirCam, tex->xend,   tex->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
@@ -54,7 +54,7 @@ void CFireBallProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	unsigned char col[4] = {255, 150, 100, 1};
 
@@ -71,7 +71,7 @@ void CFireBallProjectile::Draw()
 		col[2] = (numSparks - i) *  4;
 
 		const auto* ept = projectileDrawer->explotex;
-		AddWeaponEffectsQuad<1>(
+		AddEffectsQuad<1>(
 			{ sparks[i].pos - camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xstart, ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xend  , ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size + camera->GetUp() * sparks[i].size, ept->xend  , ept->yend  , col },
@@ -85,7 +85,7 @@ void CFireBallProjectile::Draw()
 		col[1] = (maxCol - i) * 15;
 		col[2] = (maxCol - i) * 10;
 		const auto* dgt = projectileDrawer->dguntex;
-		AddWeaponEffectsQuad<2>(
+		AddEffectsQuad<2>(
 			{ interPos - (speed * 0.5f * i) - camera->GetRight() * size - camera->GetUp() * size, dgt->xstart, dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size - camera->GetUp() * size, dgt->xend ,  dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size + camera->GetUp() * size, dgt->xend ,  dgt->yend  , col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -80,12 +80,12 @@ void CFlameProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	unsigned char col[4];
 	weaponDef->visuals.colorMap->GetColor(col, curTime);
 
-	AddWeaponEffectsQuad<1>(
+	AddEffectsQuad<1>(
 		{ drawPos - camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->ystart, col },
 		{ drawPos + camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->ystart, col },
 		{ drawPos + camera->GetRight() * radius + camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
@@ -91,7 +91,7 @@ void CLargeBeamLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	const float3 midPos = (targetPos + startPos) * 0.5f;
 	const float3 cameraDir = (midPos - camera->GetPos()).SafeANormalize();
@@ -130,14 +130,14 @@ void CLargeBeamLaserProjectile::Draw()
 			// draw laser start
 			tex.xstart = WT1->xstart + startTex * texSizeX;
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -150,14 +150,14 @@ void CLargeBeamLaserProjectile::Draw()
 			// draw laser start
 			tex.xstart = WT1->xstart + startTex * texSizeX;
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -171,14 +171,14 @@ void CLargeBeamLaserProjectile::Draw()
 				pos1 = startPos + zdir * i;
 				pos2 = startPos + zdir * (i + tilelength);
 
-				AddWeaponEffectsQuad<1>(
+				AddEffectsQuad<1>(
 					{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 					{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 					{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 					{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 				);
 
-				AddWeaponEffectsQuad<1>(
+				AddEffectsQuad<1>(
 					{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 					{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 					{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -191,14 +191,14 @@ void CLargeBeamLaserProjectile::Draw()
 			pos2 = targetPos;
 			tex.xend = tex.xstart + (pos1.distance(pos2) / tilelength) * texSizeX;
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend,   tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
 				{ pos1 + (xdir * beamEdgeSize), tex.xstart, tex.yend  , edgeColStart }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -208,14 +208,14 @@ void CLargeBeamLaserProjectile::Draw()
 	}
 
 	if (validTextures[2]) {
-		AddWeaponEffectsQuad<2>(
+		AddEffectsQuad<2>(
 			{ pos2 - (xdir * beamEdgeSize),                         WT2->xstart, WT2->ystart, edgeColStart },
 			{ pos2 - (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->ystart, edgeColStart },
 			{ pos2 + (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->yend,   edgeColStart },
 			{ pos2 + (xdir * beamEdgeSize),                         WT2->xstart, WT2->yend,   edgeColStart }
 		);
 
-		AddWeaponEffectsQuad<2>(
+		AddEffectsQuad<2>(
 			{ pos2 - (xdir * beamCoreSize),                         WT2->xstart, WT2->ystart, coreColStart },
 			{ pos2 - (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->ystart, coreColStart },
 			{ pos2 + (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->yend,   coreColStart },
@@ -239,14 +239,14 @@ void CLargeBeamLaserProjectile::Draw()
 		// draw muzzleflare
 		pos1 = startPos - zdir * (thickness * flaresize) * 0.02f;
 
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
 			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
 			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
 			{ pos1 - (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->yend,   edgeColor }
 		);
 
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
 			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
 			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
@@ -264,7 +264,7 @@ void CLargeBeamLaserProjectile::Draw()
 
 		muzzleEdgeSize = thickness * flaresize * pulseStartTime;
 
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
 			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
 			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
@@ -273,7 +273,7 @@ void CLargeBeamLaserProjectile::Draw()
 
 		muzzleCoreSize = muzzleEdgeSize * 0.6f;
 
-		AddWeaponEffectsQuad<3>(
+		AddEffectsQuad<3>(
 			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
 			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
 			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
@@ -285,14 +285,14 @@ void CLargeBeamLaserProjectile::Draw()
 		// draw flare (moved slightly along the camera direction)
 		pos1 = startPos - (camera->GetDir() * 3.0f);
 
-		AddWeaponEffectsQuad<4>(
+		AddEffectsQuad<4>(
 			{ pos1 - (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xstart, WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) + (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->yend  , edgeColStart },
 			{ pos1 - (camera->GetRight() * flareEdgeSize) + (camera->GetUp() * flareEdgeSize), WT4->xstart, WT4->yend  , edgeColStart }
 		);
 
-		AddWeaponEffectsQuad<4>(
+		AddEffectsQuad<4>(
 			{ pos1 - (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xstart, WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) + (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->yend  , coreColStart },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
@@ -185,7 +185,7 @@ void CLaserProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	float3 dif(pos - camera->GetPos());
 	const float camDist = dif.LengthNormalize();
@@ -224,14 +224,14 @@ void CLaserProjectile::Draw()
 		}
 
 		if (validTextures[2]) {
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ drawPos - (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col },
 				{ drawPos - (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->ystart, col },
 				{ drawPos + (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->yend  , col },
 				{ drawPos + (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->yend  , col }
 			);
 
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ drawPos - (dir1 * coresize) - (dir2 * coresize), weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col2 },
 				{ drawPos - (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->ystart, col2 },
 				{ drawPos + (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->yend  , col2 },
@@ -239,14 +239,14 @@ void CLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[1]) {
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ drawPos - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2    - (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col },
 				{ pos2    + (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col },
 				{ drawPos + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ drawPos - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2    - (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2    + (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col2 },
@@ -254,14 +254,14 @@ void CLaserProjectile::Draw()
 			);
 		}
 		if (validTextures[2]) {
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos2 - (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->ystart, col },
 				{ pos2 - (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col },
 				{ pos2 + (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col },
 				{ pos2 + (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->yend  , col }
 			);
 
-			AddWeaponEffectsQuad<2>(
+			AddEffectsQuad<2>(
 				{ pos2 - (dir1 * coresize),                     midtexx,                           weaponDef->visuals.texture2->ystart, col2 },
 				{ pos2 - (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col2 },
 				{ pos2 + (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col2 },
@@ -282,14 +282,14 @@ void CLaserProjectile::Draw()
 			texEndOffset   = ((float)stayTime * (speedf / maxLength)) * (weaponDef->visuals.texture1->xstart - weaponDef->visuals.texture1->xend);
 		}
 		if (validTextures[1]) {
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2 - (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col },
 				{ pos2 + (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col },
 				{ pos1 + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
 			);
 
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ pos1 - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2 - (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col2 },
 				{ pos2 + (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col2 },

--- a/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
@@ -64,7 +64,7 @@ void CLightningProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	uint8_t col[4] {
 		(uint8_t)(color.x * 255),
@@ -87,7 +87,7 @@ void CLightningProjectile::Draw()
 			tempPos  = (startPos * (1.0f - f)) + (targetPos * f);
 
 			const auto& WDV = weaponDef->visuals;
-			AddWeaponEffectsQuad<1>(
+			AddEffectsQuad<1>(
 				{ tempPosO + (dir1 * (displacement[d    ] + WDV.thickness)), WDV.texture1->xstart, WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] + WDV.thickness)), WDV.texture1->xend,   WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] - WDV.thickness)), WDV.texture1->xend,   WDV.texture1->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
@@ -381,7 +381,7 @@ void CMissileProjectile::Draw()
 	if (!validTextures[1])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	// rocket flare
 	const SColor lightYellow(255, 210, 180, 1);
@@ -389,7 +389,7 @@ void CMissileProjectile::Draw()
 
 	const auto* WT1 = weaponDef->visuals.texture1;
 
-	AddWeaponEffectsQuad<1>(
+	AddEffectsQuad<1>(
 		{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xstart, WT1->ystart, lightYellow },
 		{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xend,   WT1->ystart, lightYellow },
 		{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, WT1->xend,   WT1->yend,   lightYellow },

--- a/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
@@ -349,7 +349,7 @@ void CStarburstProjectile::Draw()
 	if (!validTextures[0])
 		return;
 
-	UpdateWeaponAnimParams();
+	UpdateAnimParams();
 
 	const auto wt3 = weaponDef->visuals.texture3;
 	const auto wt1 = weaponDef->visuals.texture1;
@@ -379,7 +379,7 @@ void CStarburstProjectile::Draw()
 			SColor col = lightYellow * std::clamp(alpha, 0.0f, 1.0f);
 			col.a = 1;
 
-			AddWeaponEffectsQuad<3>(
+			AddEffectsQuad<3>(
 				{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xstart, wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xend,   wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, wt3->xend,   wt3->yend,   col },
@@ -395,7 +395,7 @@ void CStarburstProjectile::Draw()
 	constexpr float fsize = 25.0f;
 
 	if (validTextures[1]) {
-		AddWeaponEffectsQuad<1>(
+		AddEffectsQuad<1>(
 			{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xstart, wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xend,   wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, wt1->xend,   wt1->yend,   lightRed },

--- a/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
@@ -172,7 +172,7 @@ void CTorpedoProjectile::Draw()
 	if (model != nullptr)
 		return;
 
-	//UpdateWeaponAnimParams();
+	//UpdateAnimParams();
 
 	float3 r = dir.cross(UpVector);
 
@@ -185,56 +185,56 @@ void CTorpedoProjectile::Draw()
 	const float w = 2;
 	const SColor col(60, 60, 100, 255);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col }
 	);
 
-	AddWeaponEffectsQuad<0>(
+	AddEffectsQuad<0>(
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
@@ -66,6 +66,11 @@ CWeaponProjectile::CWeaponProjectile(const ProjectileParams& params)
 
 	assert(weaponDef != nullptr);
 
+	animParams1 = weaponDef->visuals.animParams[0];
+	animParams2 = weaponDef->visuals.animParams[1];
+	animParams3 = weaponDef->visuals.animParams[2];
+	animParams4 = weaponDef->visuals.animParams[3];
+
 	if (weaponDef->IsHitScanWeapon()) {
 		hitscan = true;
 		// the else-case (default) is handled in CProjectile::Init
@@ -275,26 +280,6 @@ void CWeaponProjectile::Update()
 	UpdateGroundBounce();
 	UpdateInterception();
 }
-
-void CWeaponProjectile::UpdateWeaponAnimParams()
-{
-	assert(weaponDef);
-	if (!validTextures[0])
-		return;
-
-	if (validTextures[1])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[0],      animProgress   );
-
-	if (validTextures[2])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[1], extraAnimProgress[0]);
-
-	if (validTextures[3])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[2], extraAnimProgress[1]);
-
-	if (validTextures[4])
-		UpdateAnimParamsImpl(weaponDef->visuals.animParams[3], extraAnimProgress[2]);
-}
-
 
 void CWeaponProjectile::UpdateInterception()
 {

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
@@ -31,11 +31,6 @@ public:
 	void Collision(CUnit* unit) override;
 	void Update() override;
 
-	void UpdateWeaponAnimParams();
-
-	template <uint32_t texIdx>
-	void AddWeaponEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
-
 	/// @return 0=unaffected, 1=instant repulse, 2=gradual repulse
 	virtual int ShieldRepulse(const float3& shieldPos, float shieldForce, float shieldMaxSpeed) { return 0; }
 
@@ -106,39 +101,6 @@ protected:
 
 	float3 bounceHitPos;
 	float3 bounceParams;
-
-	std::array<float, 3> extraAnimProgress;
 };
-
-template <>
-inline void CWeaponProjectile::AddWeaponEffectsQuad<0>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	assert(weaponDef);
-	AddEffectsQuadImpl(tl, tr, br, bl);
-}
-
-template <>
-inline void CWeaponProjectile::AddWeaponEffectsQuad<1>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	assert(weaponDef);
-	//reuse animProgress
-	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[0], animProgress);
-}
-
-template <>
-inline void CWeaponProjectile::AddWeaponEffectsQuad<2>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	assert(weaponDef);
-	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[1], extraAnimProgress[0]);
-}
-
-template <>
-inline void CWeaponProjectile::AddWeaponEffectsQuad<3>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	assert(weaponDef);
-	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[2], extraAnimProgress[1]);
-}
-
-template <>
-inline void CWeaponProjectile::AddWeaponEffectsQuad<4>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	assert(weaponDef);
-	AddEffectsQuadImpl(tl, tr, br, bl, weaponDef->visuals.animParams[3], extraAnimProgress[2]);
-}
 
 #endif /* WEAPON_PROJECTILE_H */

--- a/rts/System/creg/BasicTypes.h
+++ b/rts/System/creg/BasicTypes.h
@@ -59,6 +59,26 @@ namespace creg {
 		}
 	};
 
+	class FakeType : public IType
+	{
+	public:
+		FakeType(const IType* orig)
+			: IType(0)
+		{
+			origName = orig->GetName();
+		}
+		~FakeType() {}
+
+		void Serialize(ISerializer* s, void* instance)
+		{}
+		std::string GetName() const
+		{
+			return origName;
+		}
+	protected:
+		std::string origName;
+	};
+
 	class BasicType : public IType
 	{
 	public:

--- a/rts/System/creg/BasicTypes.h
+++ b/rts/System/creg/BasicTypes.h
@@ -62,21 +62,20 @@ namespace creg {
 	class FakeType : public IType
 	{
 	public:
-		FakeType(const IType* orig)
+		FakeType(const IType* orig_)
 			: IType(0)
-		{
-			origName = orig->GetName();
-		}
+			, orig(orig_)
+		{}
 		~FakeType() {}
 
 		void Serialize(ISerializer* s, void* instance)
 		{}
 		std::string GetName() const
 		{
-			return origName;
+			return orig->GetName();
 		}
 	protected:
-		std::string origName;
+		const IType* orig = nullptr;
 	};
 
 	class BasicType : public IType

--- a/rts/System/creg/VarTypes.cpp
+++ b/rts/System/creg/VarTypes.cpp
@@ -84,3 +84,8 @@ std::unique_ptr<IType> IType::CreateIgnoredType(size_t size)
 {
 	return std::unique_ptr<IType>(new IgnoredType(size));
 }
+
+std::unique_ptr<IType> creg::IType::CreateFakeType(const IType* orig)
+{
+	return std::unique_ptr<IType>(new FakeType(orig));
+}

--- a/rts/System/creg/creg.h
+++ b/rts/System/creg/creg.h
@@ -62,9 +62,8 @@ namespace creg {
 		static std::unique_ptr<IType> CreateStringType();
 		static std::unique_ptr<IType> CreateObjInstanceType(Class* objectType, size_t size);
 		static std::unique_ptr<IType> CreateIgnoredType(size_t size);
+		static std::unique_ptr<IType> CreateFakeType(const IType* orig);
 	};
-
-
 
 	/**
 	 * Represents a C++ class or struct, declared with
@@ -478,6 +477,12 @@ public: \
 #define CR_IGNORED(Member) \
 	class_->AddMember( #Member, creg::IType::CreateIgnoredType(sizeof(Type::Member)), offsetof_creg(Type, Member), alignof(decltype(Type::Member)), (creg::ClassMemberFlag) currentMemberFlags) // NOLINT{misc-sizeof-container}
 
+ /** @def CR_FAKE
+  * Registers a fake member variable, that actually doesn't exist in the class
+  * Useful only for CM_Config scenarios
+  */
+#define CR_FAKE(Member, MemberType) \
+	class_->AddMember( #Member, creg::IType::CreateFakeType(creg::DeduceType<MemberType>::Get().get()), 0, 0, (creg::ClassMemberFlag) currentMemberFlags) // NOLINT{misc-sizeof-container}
 
 /** @def CR_MEMBER_UN
  * Registers a member variable that is unsynced.


### PR DESCRIPTION
This is already done for model-less weapon projectiles, so we're essentially bringing CEG effects to the same level of capabilities. With that:
* `animParams` is now used as a fallback to `animParams1`, `animParams2`, `animParams3`, `animParams4`.