### PR TITLE
Multipage texture atlases, works with projectile and ground flash textures only for now

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
@@ -1,23 +1,24 @@
 #version 130
 
-uniform sampler2D atlasTex;
-#ifdef SMOOTH_PARTICLES
-	uniform sampler2D depthTex;
-	uniform float softenThreshold;
-	uniform vec2 softenExponent;
+#ifdef USE_TEXTURE_ARRAY
+	uniform sampler2DArray atlasTex;
+#else
+	uniform sampler2D      atlasTex;
 #endif
+
+uniform sampler2D depthTex;
+uniform float softenThreshold;
+uniform vec2 softenExponent;
 uniform vec4 alphaCtrl = vec4(0.0, 0.0, 0.0, 1.0); //always pass
 uniform vec3 fogColor;
 
 in vec4 vCol;
 centroid in vec4 vUV;
-in float vLayer; //for sampler2Darray (future)
+in float vLayer;
 in float vBF;
 in float fogFactor;
-#ifdef SMOOTH_PARTICLES
-	in vec4 vsPos;
-	noperspective in vec2 screenUV;
-#endif
+in vec4 vsPos;
+noperspective in vec2 screenUV;
 
 out vec4 fragColor;
 
@@ -26,14 +27,12 @@ out vec4 fragColor;
 #define NORM2SNORM(value) (value * 2.0 - 1.0)
 #define SNORM2NORM(value) (value * 0.5 + 0.5)
 
-#ifdef SMOOTH_PARTICLES
 float GetViewSpaceDepth(float d) {
 	#ifndef DEPTH_CLIP01
 		d = NORM2SNORM(d);
 	#endif
 	return -projMatrix[3][2] / (projMatrix[2][2] + d);
 }
-#endif
 
 bool AlphaDiscard(float a) {
 	float alphaTestGT = float(a > alphaCtrl.x) * alphaCtrl.y;
@@ -43,8 +42,13 @@ bool AlphaDiscard(float a) {
 }
 
 void main() {
-	vec4 c0 = texture(atlasTex, vUV.xy);
-	vec4 c1 = texture(atlasTex, vUV.zw);
+	#ifdef USE_TEXTURE_ARRAY
+		vec4 c0 = texture(atlasTex, vec3(vUV.xy, vLayer));
+		vec4 c1 = texture(atlasTex, vec3(vUV.zw, vLayer));
+	#else
+		vec4 c0 = texture(atlasTex, vUV.xy);
+		vec4 c1 = texture(atlasTex, vUV.zw);
+	#endif
 
 	vec4 color = vec4(mix(c0, c1, vBF));
 	fragColor = color * vCol;

--- a/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
@@ -52,7 +52,6 @@ void main() {
 
 	vec4 color = vec4(mix(c0, c1, vBF));
 	fragColor = color * vCol;
-
 	fragColor.rgb = mix(fragColor.rgb, fogColor * fragColor.a, (1.0 - fogFactor));
 
 	#ifdef SMOOTH_PARTICLES

--- a/cont/base/springcontent/shaders/GLSL/ProjFXFragShadowProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXFragShadowProg.glsl
@@ -1,6 +1,11 @@
 #version 130
 
-uniform sampler2D atlasTex;
+#ifdef USE_TEXTURE_ARRAY
+	uniform sampler2DArray atlasTex;
+#else
+	uniform sampler2D      atlasTex;
+#endif
+
 uniform vec4 alphaCtrl = vec4(0.0, 1.0, 0.0, 0.0);  //always pass
 uniform float shadowColorMode = 1.0;
 
@@ -21,8 +26,13 @@ bool AlphaDiscard(float a) {
 const vec3 LUMA = vec3(0.299, 0.587, 0.114);
 
 void main() {
-	vec4 c0 = texture(atlasTex, vUV.xy);
-	vec4 c1 = texture(atlasTex, vUV.zw);
+	#ifdef USE_TEXTURE_ARRAY
+		vec4 c0 = texture(atlasTex, vec3(vUV.xy, vLayer));
+		vec4 c1 = texture(atlasTex, vec3(vUV.zw, vLayer));
+	#else
+		vec4 c0 = texture(atlasTex, vUV.xy);
+		vec4 c1 = texture(atlasTex, vUV.zw);
+	#endif
 
 	vec4 color = vec4(mix(c0, c1, vBF));
 	color *= vCol;

--- a/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
@@ -12,10 +12,8 @@ centroid out vec4 vUV;
 out float vLayer;
 out float vBF;
 out float fogFactor;
-#ifdef SMOOTH_PARTICLES
-	out vec4 vsPos;
-	noperspective out vec2 screenUV;
-#endif
+out vec4 vsPos;
+noperspective out vec2 screenUV;
 
 out float gl_ClipDistance[1];
 
@@ -60,12 +58,8 @@ void main() {
 
 	gl_ClipDistance[0] = dot(vec4(pos, 1.0), clipPlane); //water clip plane
 
-	#ifdef SMOOTH_PARTICLES
-		// viewport relative UV [0.0, 1.0]
-		vsPos = gl_ModelViewMatrix * vec4(pos, 1.0);
-		gl_Position = gl_ProjectionMatrix * vsPos;
-		screenUV = SNORM2NORM(gl_Position.xy / gl_Position.w);
-	#else
-		gl_Position = gl_ModelViewProjectionMatrix * vec4(pos, 1.0);
-	#endif
+	// viewport relative UV [0.0, 1.0]
+	vsPos = gl_ModelViewMatrix * vec4(pos, 1.0);
+	gl_Position = gl_ProjectionMatrix * vsPos;
+	screenUV = SNORM2NORM(gl_Position.xy / gl_Position.w);
 }

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -4981,7 +4981,7 @@ int LuaOpenGL::GetAtlasTexture(lua_State* L)
 
 	const std::string subAtlasTexName = luaL_checksstring(L, 2);
 
-	AtlasedTexture atlTex = atlas->GetTexture(subAtlasTexName);
+	auto atlTex = atlas->GetTexture(subAtlasTexName);
 	if (atlTex == AtlasedTexture::DefaultAtlasTexture)
 		luaL_error(L, "gl.%s() Invalid atlas named texture specified %s", __func__, subAtlasTexName.c_str());
 
@@ -4989,7 +4989,8 @@ int LuaOpenGL::GetAtlasTexture(lua_State* L)
 	lua_pushnumber(L, atlTex.x2);
 	lua_pushnumber(L, atlTex.y1);
 	lua_pushnumber(L, atlTex.y2);
-	return 4;
+	lua_pushnumber(L, atlTex.pageNum);
+	return 5;
 }
 
 /***

--- a/rts/Rendering/CMakeLists.txt
+++ b/rts/Rendering/CMakeLists.txt
@@ -105,6 +105,7 @@ set(sources_engine_Rendering
 		"${CMAKE_CURRENT_SOURCE_DIR}/Shaders/ShaderStates.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/ShadowHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/TeamHighlight.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Textures/AtlasedTexture.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Textures/3DOTextureHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Textures/Bitmap.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Textures/ColorMap.cpp"

--- a/rts/Rendering/Env/BumpWater.cpp
+++ b/rts/Rendering/Env/BumpWater.cpp
@@ -635,7 +635,6 @@ void CBumpWater::UploadCoastline(const bool forceFull)
 
 	// create a texture atlas for the to-be-updated areas
 	CTextureAtlas atlas;
-	atlas.SetFreeTexture(false);
 
 	const float* heightMap = (!gs->PreSimFrame()) ? readMap->GetCornerHeightMapUnsynced() : readMap->GetCornerHeightMapSynced();
 
@@ -670,6 +669,9 @@ void CBumpWater::UploadCoastline(const bool forceFull)
 		coastmapAtlasRects.clear();
 		return;
 	}
+
+	// must happen after atlas.Finalize()
+	atlas.DisOwnTexture();
 
 	coastUpdateTexture = atlas.GetTexID();
 	atlasX = (atlas.GetSize()).x;

--- a/rts/Rendering/Env/BumpWater.cpp
+++ b/rts/Rendering/Env/BumpWater.cpp
@@ -680,7 +680,7 @@ void CBumpWater::UploadCoastline(const bool forceFull)
 	// save the area positions in the texture atlas
 	for (size_t i = 0; i < coastmapAtlasRects.size(); i++) {
 		CoastAtlasRect& r = coastmapAtlasRects[i];
-		const AtlasedTexture& tex = atlas.GetTexture(IntToString(i));
+		const auto& tex = atlas.GetTexture(IntToString(i));
 		r.tx1 = tex.xstart;
 		r.tx2 = tex.xend;
 		r.ty1 = tex.ystart;

--- a/rts/Rendering/Env/Decals/GroundDecal.h
+++ b/rts/Rendering/Env/Decals/GroundDecal.h
@@ -38,8 +38,8 @@ public:
 	float2 posBR;
 	float2 posBL;
 
-	AtlasedTexture texMainOffsets;
-	AtlasedTexture texNormOffsets;
+	float4 texMainOffsets;
+	float4 texNormOffsets;
 
 	float alpha;
 	float alphaFalloff;

--- a/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
@@ -660,8 +660,8 @@ void CGroundDecalHandler::AddExplosion(AddExplosionInfo&& ei)
 		.posTR = posTR,
 		.posBR = posBR,
 		.posBL = posBL,
-		.texMainOffsets = atlasMain->GetTexture(mainName, "%FB_MAIN%"),
-		.texNormOffsets = atlasNorm->GetTexture(normName, "%FB_NORM%"),
+		.texMainOffsets = static_cast<float4>(atlasMain->GetTexture(mainName, "%FB_MAIN%")),
+		.texNormOffsets = static_cast<float4>(atlasNorm->GetTexture(normName, "%FB_NORM%")),
 		.alpha = alpha,
 		.alphaFalloff = alphaDecay,
 		.glow = glow,
@@ -694,14 +694,14 @@ void CGroundDecalHandler::ReloadTextures()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 
-	spring::unordered_map<AtlasedTexture, std::string, AtlasedTextureHash> subTexToNameMain;
-	spring::unordered_map<AtlasedTexture, std::string, AtlasedTextureHash> subTexToNameNorm;
+	spring::unordered_map<float4, std::string, float4Hash> subTexToNameMain;
+	spring::unordered_map<float4, std::string, float4Hash> subTexToNameNorm;
 
 	for (const auto& [name, ae] : atlasMain->GetAllocator()->GetEntries()) {
-		subTexToNameMain.emplace(atlasMain->GetTexture(name), name);
+		subTexToNameMain.emplace(static_cast<float4>(atlasMain->GetTexture(name)), name);
 	}
 	for (const auto& [name, ae] : atlasNorm->GetAllocator()->GetEntries()) {
-		subTexToNameNorm.emplace(atlasNorm->GetTexture(name), name);
+		subTexToNameNorm.emplace(static_cast<float4>(atlasNorm->GetTexture(name)), name);
 	}
 
 	// can't use {atlas}->ReloadTextures() here as all textures come from memory
@@ -731,10 +731,10 @@ void CGroundDecalHandler::ReloadTextures()
 
 	for (auto& decal : decals) {
 		if (auto it = subTexToNameMain.find(decal.texMainOffsets); it != subTexToNameMain.end()) {
-			decal.texMainOffsets = atlasMain->GetTexture(it->second, "%FB_MAIN%");
+			decal.texMainOffsets = static_cast<float4>(atlasMain->GetTexture(it->second, "%FB_MAIN%"));
 		}
 		if (auto it = subTexToNameNorm.find(decal.texNormOffsets); it != subTexToNameNorm.end()) {
-			decal.texNormOffsets = atlasNorm->GetTexture(it->second, "%FB_NORM%");
+			decal.texNormOffsets = static_cast<float4>(atlasNorm->GetTexture(it->second, "%FB_NORM%"));
 		}
 	}
 	decalsUpdateList.SetNeedUpdateAll();
@@ -887,8 +887,8 @@ void CGroundDecalHandler::MoveSolidObject(const CSolidObject* object, const floa
 		.posTR = posTR,
 		.posBR = posBR,
 		.posBL = posBL,
-		.texMainOffsets = atlasMain->GetTexture(                   (decalDef.groundDecalTypeName), "%FB_MAIN%"),
-		.texNormOffsets = atlasNorm->GetTexture(GetExtraTextureName(decalDef.groundDecalTypeName), "%FB_NORM%"),
+		.texMainOffsets = static_cast<float4>(atlasMain->GetTexture(                   (decalDef.groundDecalTypeName), "%FB_MAIN%")),
+		.texNormOffsets = static_cast<float4>(atlasNorm->GetTexture(GetExtraTextureName(decalDef.groundDecalTypeName), "%FB_NORM%")),
 		.alpha = 1.0f,
 		.alphaFalloff = 0.0f,
 		.glow = 0.0f,
@@ -988,8 +988,8 @@ uint32_t CGroundDecalHandler::CreateLuaDecal()
 		.posTR = float2{},
 		.posBR = float2{},
 		.posBL = float2{},
-		.texMainOffsets = atlasMain->GetTexture("%FB_MAIN%"),
-		.texNormOffsets = atlasNorm->GetTexture("%FB_NORM%"),
+		.texMainOffsets = static_cast<float4>(atlasMain->GetTexture("%FB_MAIN%")),
+		.texNormOffsets = static_cast<float4>(atlasNorm->GetTexture("%FB_NORM%")),
 		.alpha = 1.0f,
 		.alphaFalloff = 0.0f,
 		.glow = 0.0f,
@@ -1081,7 +1081,7 @@ bool CGroundDecalHandler::SetDecalTexture(uint32_t id, const std::string& texNam
 	if (newOffset == AtlasedTexture::DefaultAtlasTexture)
 		return false;
 
-	offset = newOffset;
+	offset = static_cast<float4>(newOffset);
 	decalsUpdateList.SetUpdate(it->second);
 	return true;
 }
@@ -1101,7 +1101,7 @@ std::string CGroundDecalHandler::GetDecalTexture(uint32_t id, bool mainTex) cons
 	const auto& atlas = mainTex ? atlasMain : atlasNorm;
 
 	for (auto& [name, _] : atlas->GetAllocator()->GetEntries()) {
-		const auto at = atlas->GetTexture(name);
+		const auto at = static_cast<float4>(atlas->GetTexture(name));
 		if (at == offset)
 			return name;
 	}
@@ -1233,8 +1233,8 @@ void CGroundDecalHandler::AddTrack(const CUnit* unit, const float3& newPos, bool
 			.posTR = decalPos2 - wc,
 			.posBR = decalPos2 + wc,
 			.posBL = decalPos2 + wc,
-			.texMainOffsets = atlasMain->GetTexture(mainName, "%FB_MAIN%"),
-			.texNormOffsets = atlasNorm->GetTexture(normName, "%FB_NORM%"),
+			.texMainOffsets = static_cast<float4>(atlasMain->GetTexture(mainName, "%FB_MAIN%")),
+			.texNormOffsets = static_cast<float4>(atlasNorm->GetTexture(normName, "%FB_NORM%")),
 			.alpha = 1.0f,
 			.alphaFalloff = alphaDecay,
 			.glow = 0.0f,

--- a/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
+++ b/rts/Rendering/Env/Decals/GroundDecalHandler.cpp
@@ -693,11 +693,6 @@ void CGroundDecalHandler::AddExplosion(AddExplosionInfo&& ei)
 void CGroundDecalHandler::ReloadTextures()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	struct AtlasedTextureHash {
-		uint32_t operator()(const AtlasedTexture& at) const {
-			return spring::LiteHash(&at, sizeof(at));
-		}
-	};
 
 	spring::unordered_map<AtlasedTexture, std::string, AtlasedTextureHash> subTexToNameMain;
 	spring::unordered_map<AtlasedTexture, std::string, AtlasedTextureHash> subTexToNameNorm;

--- a/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BitmapMuzzleFlame.cpp
@@ -129,6 +129,7 @@ void CBitmapMuzzleFlame::Draw()
 	if (IsValidTexture(sideTexture)) {
 		if (drawSideY)
 			AddEffectsQuad<2>(
+				sideTexture->pageNum,
 				{ drawPos + bounds[0], sideTexture->xstart, sideTexture->ystart, col },
 				{ drawPos + bounds[1], sideTexture->xend  , sideTexture->ystart, col },
 				{ drawPos + bounds[2], sideTexture->xend  , sideTexture->yend  , col },
@@ -137,6 +138,7 @@ void CBitmapMuzzleFlame::Draw()
 
 		if (drawSideX)
 			AddEffectsQuad<2>(
+				sideTexture->pageNum,
 				{ drawPos + bounds[4], sideTexture->xstart, sideTexture->ystart, col },
 				{ drawPos + bounds[5], sideTexture->xend  , sideTexture->ystart, col },
 				{ drawPos + bounds[6], sideTexture->xend  , sideTexture->yend  , col },
@@ -146,6 +148,7 @@ void CBitmapMuzzleFlame::Draw()
 
 	if (IsValidTexture(frontTexture)) {
 		AddEffectsQuad<1>(
+			frontTexture->pageNum,
 			{ fpos + bounds[8 ], frontTexture->xstart, frontTexture->ystart, col },
 			{ fpos + bounds[9 ], frontTexture->xend  , frontTexture->ystart, col },
 			{ fpos + bounds[10], frontTexture->xend  , frontTexture->yend , col },

--- a/rts/Rendering/Env/Particles/Classes/BubbleProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/BubbleProjectile.cpp
@@ -91,6 +91,7 @@ void CBubbleProjectile::Draw()
 
 	const auto* bt = projectileDrawer->bubbletex;
 	AddEffectsQuad<0>(
+		bt->pageNum,
 		{ drawPos - camera->GetRight() * interSize - camera->GetUp() * interSize, bt->xstart, bt->ystart, col },
 		{ drawPos + camera->GetRight() * interSize - camera->GetUp() * interSize, bt->xend,   bt->ystart, col },
 		{ drawPos + camera->GetRight() * interSize + camera->GetUp() * interSize, bt->xend,   bt->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/DirtProjectile.cpp
@@ -113,6 +113,7 @@ void CDirtProjectile::Draw()
 	const float texx = texture->xstart + (texture->xend - texture->xstart) * ((1.0f - partAbove) * 0.5f);
 
 	AddEffectsQuad<0>(
+		texture->pageNum,
 		{ drawPos - camera->GetRight() * interSize - camera->GetUp() * interSize * partAbove, texx,          texture->ystart, col },
 		{ drawPos - camera->GetRight() * interSize + camera->GetUp() * interSize,             texture->xend, texture->ystart, col },
 		{ drawPos + camera->GetRight() * interSize + camera->GetUp() * interSize,             texture->xend, texture->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/ExploSpikeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ExploSpikeProjectile.cpp
@@ -100,6 +100,7 @@ void CExploSpikeProjectile::Draw()
 
 	const auto* let = projectileDrawer->laserendtex;
 	AddEffectsQuad<0>(
+		let->pageNum,
 		{ drawPos - l - w, let->xstart, let->ystart, col },
 		{ drawPos + l - w, let->xend,   let->ystart, col },
 		{ drawPos + l + w, let->xend,   let->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/GeoSquareProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/GeoSquareProjectile.cpp
@@ -65,9 +65,11 @@ void CGeoSquareProjectile::Draw()
 	const float u = (projectileDrawer->geosquaretex->xstart + projectileDrawer->geosquaretex->xend) / 2;
 	const float v0 = projectileDrawer->geosquaretex->ystart;
 	const float v1 = projectileDrawer->geosquaretex->yend;
+	const auto& pageNum = projectileDrawer->geosquaretex->pageNum;
 
 	if (w2 != 0) {
 		AddEffectsQuad<0>(
+			pageNum,
 			{ p1 - dir1 * w1, u, v1, col },
 			{ p1 + dir1 * w1, u, v0, col },
 			{ p2 + dir2 * w2, u, v0, col },
@@ -75,6 +77,7 @@ void CGeoSquareProjectile::Draw()
 		);
 	} else {
 		AddEffectsQuad<0>(
+			pageNum,
 			{ p1 - dir1 * w1, u, v1,                    col },
 			{ p1 + dir1 * w1, u, v0,                    col },
 			{ p2,             u, v0 + (v1 - v0) * 0.5f, col },

--- a/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/HeatCloudProjectile.cpp
@@ -128,7 +128,9 @@ void CHeatCloudProjectile::Draw()
 	if (math::fabs(rotVal) > 0.01f) {
 		float3::rotate<false>(rotVal, camera->GetForward(), bounds);
 	}
+
 	AddEffectsQuad<0>(
+		texture->pageNum,
 		{ drawPos + bounds[0], texture->xstart, texture->ystart, col },
 		{ drawPos + bounds[1], texture->xend,   texture->ystart, col },
 		{ drawPos + bounds[2], texture->xend,   texture->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/MuzzleFlame.cpp
+++ b/rts/Rendering/Env/Particles/Classes/MuzzleFlame.cpp
@@ -75,6 +75,7 @@ void CMuzzleFlame::Draw()
 
 		const auto* st = projectileDrawer->GetSmokeTexture(tex);
 		AddEffectsQuad<0>(
+			st->pageNum,
 			{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, st->xstart, st->ystart, col },
 			{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, st->xend,   st->ystart, col },
 			{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, st->xend,   st->yend,   col },
@@ -90,6 +91,7 @@ void CMuzzleFlame::Draw()
 
 			const auto* mft = projectileDrawer->muzzleflametex;
 			AddEffectsQuad<0>(
+				mft->pageNum,
 				{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, mft->xstart, mft->ystart, col },
 				{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, mft->xend,   mft->ystart, col },
 				{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, mft->xend,   mft->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
@@ -101,6 +101,7 @@ void CNanoProjectile::Draw()
 
 	const auto* gfxt = projectileDrawer->gfxtex;
 	AddEffectsQuad<0>(
+		gfxt->pageNum,
 		{ drawPos + bounds[0], gfxt->xstart, gfxt->ystart, color },
 		{ drawPos + bounds[1], gfxt->xend  , gfxt->ystart, color },
 		{ drawPos + bounds[2], gfxt->xend  , gfxt->yend  , color },

--- a/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
+++ b/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
@@ -94,7 +94,7 @@ void CRepulseGfx::Draw()
 	xdirDS = xdir * drawsize;
 	ydirDS = ydir * drawsize;
 
-	const AtlasedTexture* et = projectileDrawer->repulsetex;
+	const auto* et = projectileDrawer->repulsetex;
 	const float txo = et->xstart;
 	const float tyo = et->ystart;
 	const float txs = et->xend - et->xstart;
@@ -127,7 +127,7 @@ void CRepulseGfx::Draw()
 	col[2] = (unsigned char) (color.z * alpha       );
 	col[3] = (unsigned char) (color.w * alpha * 0.4f);
 
-	const AtlasedTexture* ct = projectileDrawer->repulsegfxtex;
+	const auto* ct = projectileDrawer->repulsegfxtex;
 	const float tx = (ct->xend + ct->xstart) * 0.5f;
 	const float ty = (ct->yend + ct->ystart) * 0.5f;
 

--- a/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
+++ b/rts/Rendering/Env/Particles/Classes/RepulseGfx.cpp
@@ -111,6 +111,7 @@ void CRepulseGfx::Draw()
 			const float dx = x - 2.00f;
 			const float rx = x * 0.25f;
 			AddEffectsQuad<0>(
+				et->pageNum,
 				{ pos + xdirDS * (dx + 0) + ydirDS * (dy + 0) + zdir * vertexDists[(y    ) * 5 + x    ],  txo + (ry        ) * txs, tyo + (rx        ) * tys,  col },
 				{ pos + xdirDS * (dx + 0) + ydirDS * (dy + 1) + zdir * vertexDists[(y + 1) * 5 + x    ],  txo + (ry + 0.25f) * txs, tyo + (rx        ) * tys,  col },
 				{ pos + xdirDS * (dx + 1) + ydirDS * (dy + 1) + zdir * vertexDists[(y + 1) * 5 + x + 1],  txo + (ry + 0.25f) * txs, tyo + (rx + 0.25f) * tys,  col },
@@ -135,6 +136,7 @@ void CRepulseGfx::Draw()
 	ydirDS = ydir * drawsize;
 
 	AddEffectsQuad<0>(
+		ct->pageNum,
 		{ owner->pos + (-xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + ( xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos + xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },
@@ -142,6 +144,7 @@ void CRepulseGfx::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		ct->pageNum,
 		{ owner->pos + (-xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + ( xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos + xdirDS - ydirDS + zdir * vertexDists[6],  tx, ty, col },
@@ -149,6 +152,7 @@ void CRepulseGfx::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		ct->pageNum,
 		{ owner->pos + ( xdir - ydir) * drawsize * 0.2f,   tx, ty, col2 },
 		{ owner->pos + ( xdir + ydir) * drawsize * 0.2f,   tx, ty, col2 },
 		{ pos + xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },
@@ -156,6 +160,7 @@ void CRepulseGfx::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		ct->pageNum,
 		{ owner->pos + (-xdir - ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ owner->pos + (-xdir + ydir) * drawsize * 0.2f,  tx, ty, col2 },
 		{ pos - xdirDS + ydirDS + zdir * vertexDists[6],  tx, ty, col },

--- a/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
@@ -347,6 +347,7 @@ void ShieldSegmentProjectile::Draw()
 
 	const float3 shieldPos = collection->GetShieldDrawPos();
 	const float size = collection->GetSize();
+	const auto& pageNum = collection->GetShieldTexture()->pageNum;
 
 	// draw all quads
 	for (int y = 0; y < (NUM_VERTICES_Y - 1); ++y) {
@@ -354,6 +355,7 @@ void ShieldSegmentProjectile::Draw()
 			const int idxTL = (y    ) * NUM_VERTICES_X + x, idxTR = (y    ) * NUM_VERTICES_X + x + 1;
 			const int idxBL = (y + 1) * NUM_VERTICES_X + x, idxBR = (y + 1) * NUM_VERTICES_X + x + 1;
 			AddEffectsQuad<0>(
+				pageNum,
 				{ shieldPos + vertices[idxTL] * size, texCoors[idxTL].x, texCoors[idxTL].y, color },
 				{ shieldPos + vertices[idxTR] * size, texCoors[idxTR].x, texCoors[idxTR].y, color },
 				{ shieldPos + vertices[idxBR] * size, texCoors[idxBR].x, texCoors[idxBR].y, color },

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -123,7 +123,9 @@ void CSimpleParticleSystem::Draw()
 		if (math::fabs(p->rotVal) > 0.01f) {
 			float3::rotate<false>(p->rotVal, zdir, bounds);
 		}
+
 		AddEffectsQuad<1>(
+			texture->pageNum,
 			{ pDrawPos + bounds[0], texture->xstart, texture->ystart, color },
 			{ pDrawPos + bounds[1], texture->xend,   texture->ystart, color },
 			{ pDrawPos + bounds[2], texture->xend,   texture->yend,   color },

--- a/rts/Rendering/Env/Particles/Classes/SmokeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeProjectile.cpp
@@ -116,6 +116,7 @@ void CSmokeProjectile::Draw()
 
 	const auto* st = projectileDrawer->GetSmokeTexture(textureNum);
 	AddEffectsQuad<0>(
+		st->pageNum,
 		{ drawPos - pos2, st->xstart, st->ystart, col },
 		{ drawPos + pos1, st->xend,   st->ystart, col },
 		{ drawPos + pos2, st->xend,   st->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/SmokeProjectile2.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeProjectile2.cpp
@@ -131,6 +131,7 @@ void CSmokeProjectile2::Draw()
 
 	const auto* st = projectileDrawer->GetSmokeTexture(textureNum);
 	AddEffectsQuad<0>(
+		st->pageNum,
 		{ interPos - pos2, st->xstart, st->ystart, col },
 		{ interPos + pos1, st->xend,   st->ystart, col },
 		{ interPos + pos2, st->xend,   st->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SmokeTrailProjectile.cpp
@@ -149,6 +149,7 @@ void CSmokeTrailProjectile::Draw()
 		const SColor colm = colBase * std::clamp(lerpm, 0.0f, 1.0f);
 
 		AddEffectsQuad<0>(
+			texture->pageNum,
 			{ pos1   - (odir1 * size1), texture->xstart, texture->ystart, col1  },
 			{ midpos - (odirm * sizem), midtexx        , texture->ystart, colm },
 			{ midpos + (odirm * sizem), midtexx        , texture->yend  , colm },
@@ -156,6 +157,7 @@ void CSmokeTrailProjectile::Draw()
 		);
 
 		AddEffectsQuad<0>(
+			texture->pageNum,
 			{ midpos - (odirm * sizem), midtexx      ,   texture->ystart, colm },
 			{ pos2   - (odir2 * size2), texture->xend,   texture->ystart, col2 },
 			{ pos2   + (odir2 * size2), texture->xend,   texture->yend  , col2 },
@@ -163,6 +165,7 @@ void CSmokeTrailProjectile::Draw()
 		);
 	} else {
 		AddEffectsQuad<0>(
+			texture->pageNum,
 			{ pos1 - (odir1 * size1), texture->xstart, texture->ystart, col1 },
 			{ pos2 - (odir2 * size2), texture->xend  , texture->ystart, col2 },
 			{ pos2 + (odir2 * size2), texture->xend  , texture->yend  , col2 },

--- a/rts/Rendering/Env/Particles/Classes/SpherePartProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SpherePartProjectile.cpp
@@ -86,6 +86,8 @@ void CSpherePartProjectile::Draw()
 
 	const float interSize = sphereSize + expansionSpeed * globalRendering->timeOffset;
 
+	const auto& pageNum = projectileDrawer->sphereparttex->pageNum;
+
 	for (int y = 0; y < 4; ++y) {
 		for (int x = 0; x < 4; ++x) {
 			float alpha =
@@ -106,6 +108,7 @@ void CSpherePartProjectile::Draw()
 			col1[3] = ((unsigned char)(40 * alpha)) + 1;
 
 			AddEffectsQuad<0>(
+				pageNum,
 				{ centerPos + vectors[y*5 + x    ]     * interSize, texx, texy, col0 },
 				{ centerPos + vectors[y*5 + x + 1]     * interSize, texx, texy, col0 },
 				{ centerPos+vectors[(y + 1)*5 + x + 1] * interSize, texx, texy, col1 },

--- a/rts/Rendering/Env/Particles/Classes/WakeProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/WakeProjectile.cpp
@@ -100,6 +100,7 @@ void CWakeProjectile::Draw()
 
 	const auto* wt = projectileDrawer->waketex;
 	AddEffectsQuad<0>(
+		wt->pageNum,
 		{ drawPos + dir1 + dir2, wt->xstart, wt->ystart, col },
 		{ drawPos - dir1 + dir2, wt->xend,   wt->ystart, col },
 		{ drawPos - dir1 - dir2, wt->xend,   wt->yend,   col },

--- a/rts/Rendering/Env/Particles/Classes/WreckProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/WreckProjectile.cpp
@@ -59,6 +59,7 @@ void CWreckProjectile::Draw()
 
 	const auto* wt = projectileDrawer->wrecktex;
 	AddEffectsQuad<0>(
+		wt->pageNum,
 		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, wt->xstart, wt->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, wt->xend,   wt->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, wt->xend,   wt->yend,   col },

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -86,7 +86,7 @@ void CProjectileDrawer::Init() {
 
 	loadscreen->SetLoadMessage("Creating Projectile Textures");
 
-	textureAtlas  = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "ExplosFXAtlas", true);
+	textureAtlas  = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 512, 512, "ExplosFXAtlas", true);
 	groundFXAtlas = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "GroundFXAtlas", true);
 
 	LuaParser resourcesParser("gamedata/resources.lua", SPRING_VFS_MOD_BASE, SPRING_VFS_ZIP);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -86,8 +86,8 @@ void CProjectileDrawer::Init() {
 
 	loadscreen->SetLoadMessage("Creating Projectile Textures");
 
-	textureAtlas = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_LEGACY, 0, 0, "ProjectileTextureAtlas", true);
-	groundFXAtlas = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_LEGACY, 0, 0, "ProjectileEffectsAtlas", true);
+	textureAtlas  = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "ExplosFXAtlas", true);
+	groundFXAtlas = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "GroundFXAtlas", true);
 
 	LuaParser resourcesParser("gamedata/resources.lua", SPRING_VFS_MOD_BASE, SPRING_VFS_ZIP);
 	LuaParser mapResParser("gamedata/resources_map.lua", SPRING_VFS_MAP_BASE, SPRING_VFS_ZIP);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -855,7 +855,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 			glBindTexture(GL_TEXTURE_2D, 0); //15th slot
 			glActiveTexture(GL_TEXTURE0);
 		}
-		glBindTexture(GL_TEXTURE_2D, 0);
+		textureAtlas->UnbindTexture();
 	}
 }
 
@@ -1083,7 +1083,8 @@ void CProjectileDrawer::DrawGroundFlashes()
 		glBindTexture(GL_TEXTURE_2D, 0); //15th slot
 		glActiveTexture(GL_TEXTURE0);
 	}
-	glBindTexture(GL_TEXTURE_2D, 0);
+
+	groundFXAtlas->UnbindTexture();
 
 //	glFogfv(GL_FOG_COLOR, sky->fogColor);
 	glDisable(GL_POLYGON_OFFSET_FILL);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -86,7 +86,7 @@ void CProjectileDrawer::Init() {
 
 	loadscreen->SetLoadMessage("Creating Projectile Textures");
 
-	textureAtlas  = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 512, 512, "ExplosFXAtlas", true);
+	textureAtlas  = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "ExplosFXAtlas", true);
 	groundFXAtlas = new CTextureAtlas(CTextureAtlas::ATLAS_ALLOC_MP_LEGACY, 0, 0, "GroundFXAtlas", true);
 
 	LuaParser resourcesParser("gamedata/resources.lua", SPRING_VFS_MOD_BASE, SPRING_VFS_ZIP);
@@ -1008,7 +1008,7 @@ void CProjectileDrawer::DrawGroundFlashes()
 	const auto camPlayer = CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER);
 	const auto& sky = ISky::GetSky();
 
-	auto* fxShader = fxShaders[textureAtlas->GetNumPages() > 1];
+	auto* fxShader = fxShaders[groundFXAtlas->GetNumPages() > 1];
 	fxShader->Enable();
 	fxShader->SetUniform("alphaCtrl", 0.01f, 1.0f, 0.0f, 0.0f);
 	fxShader->SetUniform("softenThreshold", -CProjectileDrawer::softenThreshold[1]);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -73,7 +73,7 @@ public:
 	bool CanDrawSoften() {
 		return
 			CheckSoftenExt() &&
-			fxShaders[1] && fxShaders[1]->IsValid() &&
+			fxShader && fxShader->IsValid() &&
 			depthBufferCopy->IsValid(false);
 	};
 
@@ -169,8 +169,8 @@ private:
 
 	bool drawSorted = true;
 
-	std::array<Shader::IProgramObject*, 2> fxShaders = { nullptr };
-	std::array<Shader::IProgramObject*, 2> fsShadowShaders = { nullptr };
+	Shader::IProgramObject* fxShader = nullptr;
+	Shader::IProgramObject* fxShadowShader = nullptr;
 
 	constexpr static int WANT_SOFTEN_COUNT = 2;
 	int wantSoften = 0;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -170,7 +170,7 @@ private:
 	bool drawSorted = true;
 
 	std::array<Shader::IProgramObject*, 2> fxShaders = { nullptr };
-	Shader::IProgramObject* fsShadowShader = nullptr;
+	std::array<Shader::IProgramObject*, 2> fsShadowShaders = { nullptr };
 
 	constexpr static int WANT_SOFTEN_COUNT = 2;
 	int wantSoften = 0;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -1111,22 +1111,22 @@ void CFontTexture::LoadWantedGlyphs(const std::vector<char32_t>& wanted)
 			if (!atlasAlloc.contains(glyphName))
 				continue;
 
-			const auto texpos  = atlasAlloc.GetEntry(glyphName);
+			const auto texpos1 = atlasAlloc.GetEntry(glyphName );
 			const auto texpos2 = atlasAlloc.GetEntry(glyphName2);
 
 			//glyphs is a map
 			auto& thisGlyph = glyphs[i];
 
-			thisGlyph.texCord       = IGlyphRect(texpos [0], texpos [1], texpos [2] - texpos [0], texpos [3] - texpos [1]);
-			thisGlyph.shadowTexCord = IGlyphRect(texpos2[0], texpos2[1], texpos2[2] - texpos2[0], texpos2[3] - texpos2[1]);
+			thisGlyph.texCord       = IGlyphRect(texpos1.x1, texpos1.y1, texpos1.x2 - texpos1.x1, texpos1.y2 - texpos1.y1);
+			thisGlyph.shadowTexCord = IGlyphRect(texpos2.x1, texpos2.y1, texpos2.x2 - texpos2.x1, texpos2.y2 - texpos2.y1);
 
 			const size_t glyphIdx = reinterpret_cast<size_t>(atlasAlloc.GetEntryData(glyphName));
 
 			assert(glyphIdx < atlasGlyphs.size());
 
-			if (texpos[2] != 0)
-				atlasUpdate.CopySubImage(atlasGlyphs[glyphIdx], texpos.x, texpos.y);
-			if (texpos2[2] != 0) {
+			if (texpos1.x2 != 0)
+				atlasUpdate.CopySubImage(atlasGlyphs[glyphIdx], texpos1.x, texpos1.y);
+			if (texpos2.x2 != 0) {
 				const int x = texpos2.x;
 				const int y = texpos2.y;
 				blurRectangles.emplace_back(

--- a/rts/Rendering/GroundFlash.cpp
+++ b/rts/Rendering/GroundFlash.cpp
@@ -231,6 +231,7 @@ void CStandardGroundFlash::Draw()
 
 		color.a = (unsigned char)(iAlpha * 255);
 		AddEffectsQuad<0>(
+			projectileDrawer->groundringtex->pageNum,
 			{ p1, projectileDrawer->groundringtex->xstart, projectileDrawer->groundringtex->ystart, color },
 			{ p2, projectileDrawer->groundringtex->xend,   projectileDrawer->groundringtex->ystart, color },
 			{ p3, projectileDrawer->groundringtex->xend,   projectileDrawer->groundringtex->yend,   color },
@@ -253,6 +254,7 @@ void CStandardGroundFlash::Draw()
 		const float3 p4 = pos + (-side1 - side2) * size;
 
 		AddEffectsQuad<0>(
+			projectileDrawer->groundflashtex->pageNum,
 			{ p1, projectileDrawer->groundflashtex->xstart, projectileDrawer->groundflashtex->ystart, color },
 			{ p2, projectileDrawer->groundflashtex->xend  , projectileDrawer->groundflashtex->ystart, color },
 			{ p3, projectileDrawer->groundflashtex->xend  , projectileDrawer->groundflashtex->yend  , color },
@@ -335,6 +337,7 @@ void CSimpleGroundFlash::Draw()
 	}
 
 	AddEffectsQuad<1>(
+		texture->pageNum,
 		{ pos + bounds[0], texture->xstart, texture->ystart, color },
 		{ pos + bounds[1], texture->xend  , texture->ystart, color },
 		{ pos + bounds[2], texture->xend  , texture->yend  , color },
@@ -415,6 +418,7 @@ void CSeismicGroundFlash::Draw()
 	const float3 p4 = pos + (-side1 + side2) * size;
 
 	AddEffectsQuad<0>(
+		texture->pageNum,
 		{ p1, texture->xstart, texture->ystart, color },
 		{ p2, texture->xend,   texture->ystart, color },
 		{ p3, texture->xend,   texture->yend,   color },

--- a/rts/Rendering/Textures/3DOTextureHandler.cpp
+++ b/rts/Rendering/Textures/3DOTextureHandler.cpp
@@ -101,7 +101,7 @@ void C3DOTextureHandler::Init()
 
 		const size_t foundx = atlasAlloc->GetEntry(texFile.name).x;
 		const size_t foundy = atlasAlloc->GetEntry(texFile.name).y;
-		const float4 texCoords = atlasAlloc->GetTexCoords(texFile.name);
+		const auto texCoords = atlasAlloc->GetTexCoords(texFile.name);
 
 		const uint8_t* rmem1 = curtex1.GetRawMem();
 		const uint8_t* rmem2 = curtex2.GetRawMem();

--- a/rts/Rendering/Textures/3DOTextureHandler.h
+++ b/rts/Rendering/Textures/3DOTextureHandler.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "Rendering/GL/myGL.h"
+#include "Rendering/Textures/AtlasedTexture.hpp"
 #include "Rendering/Textures/TAPalette.h"
 #include "System/float4.h"
 #include "System/UnorderedMap.hpp"
@@ -16,7 +17,7 @@ struct TexFile;
 class C3DOTextureHandler
 {
 public:
-	typedef float4 UnitTexture;
+	using UnitTexture = AtlasedTexture;
 
 	void Init();
 	void Kill();

--- a/rts/Rendering/Textures/3DOTextureHandler.h
+++ b/rts/Rendering/Textures/3DOTextureHandler.h
@@ -17,7 +17,7 @@ struct TexFile;
 class C3DOTextureHandler
 {
 public:
-	using UnitTexture = AtlasedTexture;
+	using UnitTexture = float4;
 
 	void Init();
 	void Kill();

--- a/rts/Rendering/Textures/AtlasedTexture.cpp
+++ b/rts/Rendering/Textures/AtlasedTexture.cpp
@@ -1,0 +1,11 @@
+#include "AtlasedTexture.hpp"
+
+CR_BIND(AtlasedTexture, )
+CR_REG_METADATA(AtlasedTexture, (
+	CR_MEMBER(x),
+	CR_MEMBER(y),
+	CR_MEMBER(z),
+	CR_MEMBER(w)
+))
+
+const AtlasedTexture& AtlasedTexture::DefaultAtlasTexture = AtlasedTexture{};

--- a/rts/Rendering/Textures/AtlasedTexture.cpp
+++ b/rts/Rendering/Textures/AtlasedTexture.cpp
@@ -7,5 +7,10 @@ CR_REG_METADATA(AtlasedTexture, (
 	CR_MEMBER(z),
 	CR_MEMBER(w)
 ))
-
 const AtlasedTexture& AtlasedTexture::DefaultAtlasTexture = AtlasedTexture{};
+
+CR_BIND(AtlasedTextureLayered, )
+CR_REG_METADATA(AtlasedTextureLayered, (
+	CR_MEMBER(pageNum)
+))
+const AtlasedTextureLayered& AtlasedTextureLayered::DefaultAtlasTextureLayered = AtlasedTextureLayered{};

--- a/rts/Rendering/Textures/AtlasedTexture.cpp
+++ b/rts/Rendering/Textures/AtlasedTexture.cpp
@@ -7,10 +7,5 @@ CR_REG_METADATA(AtlasedTexture, (
 	CR_MEMBER(z),
 	CR_MEMBER(w)
 ))
-const AtlasedTexture& AtlasedTexture::DefaultAtlasTexture = AtlasedTexture{};
 
-CR_BIND(AtlasedTextureLayered, )
-CR_REG_METADATA(AtlasedTextureLayered, (
-	CR_MEMBER(pageNum)
-))
-const AtlasedTextureLayered& AtlasedTextureLayered::DefaultAtlasTextureLayered = AtlasedTextureLayered{};
+const AtlasedTexture& AtlasedTexture::DefaultAtlasTexture = AtlasedTexture{};

--- a/rts/Rendering/Textures/AtlasedTexture.hpp
+++ b/rts/Rendering/Textures/AtlasedTexture.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+
+#include "System/float4.h"
+#include "System/creg/creg_cond.h"
+
+/** @brief texture coordinates of an atlas subimage. */
+struct AtlasedTexture
+{
+	CR_DECLARE_STRUCT(AtlasedTexture)
+
+	explicit AtlasedTexture()
+		: x(0.0f)
+		, y(0.0f)
+		, z(0.0f)
+		, w(0.0f)
+	{}
+	explicit AtlasedTexture(float x_, float y_, float z_, float w_, uint32_t page_ = 0)
+		: x(x_)
+		, y(y_)
+		, z(z_)
+		, w(w_)
+	{}
+	explicit AtlasedTexture(const float4& f, uint32_t page_ = 0)
+		: x(f.x)
+		, y(f.y)
+		, z(f.z)
+		, w(f.w)
+	{}
+/*
+	AtlasedTexture(AtlasedTexture&& f) noexcept { *this = std::move(f); }
+	AtlasedTexture& operator= (AtlasedTexture&& f) = default;
+
+	AtlasedTexture(const AtlasedTexture& f) { *this = f; }
+	AtlasedTexture& operator= (const AtlasedTexture& f) = default;
+*/
+	bool operator==(const AtlasedTexture& rhs) const {
+		if (this == &rhs)
+			return true;
+
+		float4 f0(x    , y    , z    , w    );
+		float4 f1(rhs.x, rhs.y, rhs.z, rhs.w);
+		return f0 == f1;
+	}
+	bool operator!=(const AtlasedTexture& rhs) const { return !(*this == rhs); }
+
+	union {
+		struct { float x, y, z, w; };
+		struct { float x1, y1, x2, y2; };
+		struct { float s, t, p, q; };
+		struct { float xstart, ystart, xend, yend; };
+	};
+
+	static const AtlasedTexture& DefaultAtlasTexture;
+};

--- a/rts/Rendering/Textures/AtlasedTexture.hpp
+++ b/rts/Rendering/Textures/AtlasedTexture.hpp
@@ -17,14 +17,14 @@ struct AtlasedTexture
 		, w(0.0f)
 		, pageNum(0)
 	{}
-	explicit AtlasedTexture(float x_, float y_, float z_, float w_, uint32_t pageNum_ = 0)
+	AtlasedTexture(float x_, float y_, float z_, float w_, uint32_t pageNum_)
 		: x(x_)
 		, y(y_)
 		, z(z_)
 		, w(w_)
 		, pageNum(pageNum_)
 	{}
-	explicit AtlasedTexture(const float4& f, uint32_t pageNum_ = 0)
+	AtlasedTexture(const float4& f, uint32_t pageNum_)
 		: x(f.x)
 		, y(f.y)
 		, z(f.z)

--- a/rts/Rendering/Textures/AtlasedTexture.hpp
+++ b/rts/Rendering/Textures/AtlasedTexture.hpp
@@ -28,13 +28,7 @@ struct AtlasedTexture
 		, z(f.z)
 		, w(f.w)
 	{}
-/*
-	AtlasedTexture(AtlasedTexture&& f) noexcept { *this = std::move(f); }
-	AtlasedTexture& operator= (AtlasedTexture&& f) = default;
 
-	AtlasedTexture(const AtlasedTexture& f) { *this = f; }
-	AtlasedTexture& operator= (const AtlasedTexture& f) = default;
-*/
 	bool operator==(const AtlasedTexture& rhs) const {
 		if (this == &rhs)
 			return true;
@@ -53,4 +47,42 @@ struct AtlasedTexture
 	};
 
 	static const AtlasedTexture& DefaultAtlasTexture;
+};
+
+struct AtlasedTextureLayered : public AtlasedTexture {
+	CR_DECLARE_STRUCT(AtlasedTextureLayered)
+	explicit AtlasedTextureLayered()
+		: AtlasedTexture()
+		, pageNum(0)
+	{}
+	AtlasedTextureLayered(const AtlasedTexture& other)
+		: AtlasedTexture(other.x1, other.y1, other.x2, other.y2)
+		, pageNum(0)
+	{}
+
+	bool operator==(const AtlasedTextureLayered& rhs) const {
+		if (this == &rhs)
+			return true;
+
+		if (!AtlasedTexture::operator==(rhs))
+			return false;
+
+		return pageNum == rhs.pageNum;
+	}
+	bool operator!=(const AtlasedTextureLayered& rhs) const { return !(*this == rhs); }
+
+	uint32_t pageNum;
+	static const AtlasedTextureLayered& DefaultAtlasTextureLayered;
+};
+
+struct AtlasedTextureHash {
+	uint32_t operator()(const AtlasedTexture& at) const {
+		return spring::LiteHash(&at, sizeof(at));
+	}
+};
+
+struct AtlasedTextureLayeredHash {
+	uint32_t operator()(const AtlasedTextureLayered& at) const {
+		return spring::LiteHash(&at, sizeof(at));
+	}
 };

--- a/rts/Rendering/Textures/AtlasedTexture.hpp
+++ b/rts/Rendering/Textures/AtlasedTexture.hpp
@@ -15,27 +15,35 @@ struct AtlasedTexture
 		, y(0.0f)
 		, z(0.0f)
 		, w(0.0f)
+		, pageNum(0)
 	{}
-	explicit AtlasedTexture(float x_, float y_, float z_, float w_, uint32_t page_ = 0)
+	explicit AtlasedTexture(float x_, float y_, float z_, float w_, uint32_t pageNum_ = 0)
 		: x(x_)
 		, y(y_)
 		, z(z_)
 		, w(w_)
+		, pageNum(pageNum_)
 	{}
-	explicit AtlasedTexture(const float4& f, uint32_t page_ = 0)
+	explicit AtlasedTexture(const float4& f, uint32_t pageNum_ = 0)
 		: x(f.x)
 		, y(f.y)
 		, z(f.z)
 		, w(f.w)
+		, pageNum(pageNum_)
 	{}
+
+	explicit operator float4() const {
+		return float4(x, y, z, w);
+	}
 
 	bool operator==(const AtlasedTexture& rhs) const {
 		if (this == &rhs)
 			return true;
 
-		float4 f0(x    , y    , z    , w    );
-		float4 f1(rhs.x, rhs.y, rhs.z, rhs.w);
-		return f0 == f1;
+		if (pageNum != rhs.pageNum)
+			return false;
+
+		return static_cast<float4>(*this) == static_cast<float4>(rhs);
 	}
 	bool operator!=(const AtlasedTexture& rhs) const { return !(*this == rhs); }
 
@@ -45,44 +53,13 @@ struct AtlasedTexture
 		struct { float s, t, p, q; };
 		struct { float xstart, ystart, xend, yend; };
 	};
+	uint32_t pageNum;
 
 	static const AtlasedTexture& DefaultAtlasTexture;
 };
 
-struct AtlasedTextureLayered : public AtlasedTexture {
-	CR_DECLARE_STRUCT(AtlasedTextureLayered)
-	explicit AtlasedTextureLayered()
-		: AtlasedTexture()
-		, pageNum(0)
-	{}
-	AtlasedTextureLayered(const AtlasedTexture& other)
-		: AtlasedTexture(other.x1, other.y1, other.x2, other.y2)
-		, pageNum(0)
-	{}
-
-	bool operator==(const AtlasedTextureLayered& rhs) const {
-		if (this == &rhs)
-			return true;
-
-		if (!AtlasedTexture::operator==(rhs))
-			return false;
-
-		return pageNum == rhs.pageNum;
-	}
-	bool operator!=(const AtlasedTextureLayered& rhs) const { return !(*this == rhs); }
-
-	uint32_t pageNum;
-	static const AtlasedTextureLayered& DefaultAtlasTextureLayered;
-};
-
 struct AtlasedTextureHash {
 	uint32_t operator()(const AtlasedTexture& at) const {
-		return spring::LiteHash(&at, sizeof(at));
-	}
-};
-
-struct AtlasedTextureLayeredHash {
-	uint32_t operator()(const AtlasedTextureLayered& at) const {
 		return spring::LiteHash(&at, sizeof(at));
 	}
 };

--- a/rts/Rendering/Textures/IAtlasAllocator.h
+++ b/rts/Rendering/Textures/IAtlasAllocator.h
@@ -78,12 +78,12 @@ public:
 
 	const auto& GetEntries() const { return entries; }
 
-	AtlasedTextureLayered GetTexCoords(const spring::unordered_map<std::string, SAtlasEntry>::const_iterator& it)
+	AtlasedTexture GetTexCoords(const spring::unordered_map<std::string, SAtlasEntry>::const_iterator& it)
 	{
 		if (it == entries.end())
-			return AtlasedTextureLayered::DefaultAtlasTextureLayered;
+			return AtlasedTexture::DefaultAtlasTexture;
 
-		AtlasedTextureLayered uv(it->second.texCoords);
+		AtlasedTexture uv(it->second.texCoords);
 		uv.x1 /= atlasSize.x;
 		uv.y1 /= atlasSize.y;
 		uv.x2 /= atlasSize.x;

--- a/rts/Rendering/Textures/IAtlasAllocator.h
+++ b/rts/Rendering/Textures/IAtlasAllocator.h
@@ -83,7 +83,7 @@ public:
 		if (it == entries.end())
 			return AtlasedTexture::DefaultAtlasTexture;
 
-		AtlasedTexture uv(it->second.texCoords);
+		AtlasedTexture uv(static_cast<float4>(it->second.texCoords), it->second.pageIdx);
 		uv.x1 /= atlasSize.x;
 		uv.y1 /= atlasSize.y;
 		uv.x2 /= atlasSize.x;

--- a/rts/Rendering/Textures/IAtlasAllocator.h
+++ b/rts/Rendering/Textures/IAtlasAllocator.h
@@ -50,10 +50,26 @@ public:
 		entries[name] = SAtlasEntry(size, name, data);
 	}
 
-	const auto& GetEntry(const std::string& name)
+	auto FindEntry(const std::string& name) const
 	{
-		return entries[name].texCoords;
+		return entries.find(name);
 	}
+
+	const auto& GetEntry(const spring::unordered_map<std::string, SAtlasEntry>::const_iterator& it) const {
+		if (it == entries.end())
+			return AtlasedTexture::DefaultAtlasTexture;
+
+		return it->second.texCoords;
+	}
+	const auto& GetEntry(const std::string& name) const { return GetEntry(FindEntry(name));	}
+
+	auto GetEntryPage(const spring::unordered_map<std::string, SAtlasEntry>::const_iterator& it) const {
+		if (it == entries.end())
+			return uint32_t(-1);
+
+		return it->second.pageIdx;
+	}
+	auto GetEntryPage(const std::string& name) const { return GetEntryPage(FindEntry(name)); }
 
 	void*& GetEntryData(const std::string& name)
 	{
@@ -62,9 +78,12 @@ public:
 
 	const auto& GetEntries() const { return entries; }
 
-	AtlasedTexture GetTexCoords(const std::string& name)
+	AtlasedTextureLayered GetTexCoords(const spring::unordered_map<std::string, SAtlasEntry>::const_iterator& it)
 	{
-		AtlasedTexture uv(entries[name].texCoords);
+		if (it == entries.end())
+			return AtlasedTextureLayered::DefaultAtlasTextureLayered;
+
+		AtlasedTextureLayered uv(it->second.texCoords);
 		uv.x1 /= atlasSize.x;
 		uv.y1 /= atlasSize.y;
 		uv.x2 /= atlasSize.x;
@@ -77,6 +96,10 @@ public:
 		uv.y2 += 0.5f / atlasSize.y;
 
 		return uv;
+	}
+	AtlasedTexture GetTexCoords(const std::string& name)
+	{
+		return GetTexCoords(FindEntry(name));
 	}
 
 	bool contains(const std::string& name) const

--- a/rts/Rendering/Textures/LegacyAtlasAlloc.cpp
+++ b/rts/Rendering/Textures/LegacyAtlasAlloc.cpp
@@ -150,7 +150,7 @@ bool CLegacyAtlasAlloc::Allocate()
 		if (recalc) {
 			// reset all existing texcoords
 			for (auto it = memtextures.begin(); it != memtextures.end(); ++it) {
-				(*it)->texCoords = float4();
+				(*it)->texCoords = AtlasedTexture();
 			}
 			recalc = false;
 			a = -1;

--- a/rts/Rendering/Textures/LegacyAtlasAlloc.h
+++ b/rts/Rendering/Textures/LegacyAtlasAlloc.h
@@ -16,7 +16,7 @@ public:
 
 	bool Allocate() override;
 	int GetNumTexLevels() const override;
-
+	uint32_t GetNumPages() const override { return 1; }
 private:
 	bool IncreaseSize();
 	static bool CompareTex(const SAtlasEntry* tex1, const SAtlasEntry* tex2);

--- a/rts/Rendering/Textures/MultiPageAtlasAlloc.hpp
+++ b/rts/Rendering/Textures/MultiPageAtlasAlloc.hpp
@@ -44,7 +44,11 @@ public:
 		}
 
 		std::stable_sort(memtextures.begin(), memtextures.end(), [](const auto* lhs, const auto* rhs) {
+		#if 0
 			return std::forward_as_tuple(lhs->size.y, lhs->size.x, lhs->name) > std::forward_as_tuple(rhs->size.y, rhs->size.x, rhs->name);
+		#else
+			return std::forward_as_tuple(lhs->size.y * lhs->size.x, lhs->name) > std::forward_as_tuple(rhs->size.y * rhs->size.x, rhs->name);
+		#endif
 		});
 
 		// guestimate the initial number of pages
@@ -73,6 +77,7 @@ public:
 			for (const auto* memtexture : memtextures) {
 				auto minAreaIdx = std::distance(areaSums.begin(), std::min_element(areaSums.begin(), areaSums.end()));
 				allocators[minAreaIdx]->AddEntry(*memtexture);
+				areaSums[minAreaIdx] += (memtexture->size.x * memtexture->size.y);
 			}
 
 			done = true;

--- a/rts/Rendering/Textures/MultiPageAtlasAlloc.hpp
+++ b/rts/Rendering/Textures/MultiPageAtlasAlloc.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <type_traits>
+#include <memory>
+#include <tuple>
+#include <vector>
+#include <algorithm>
+#include <set>
+#include <limits>
+#include <cmath>
+
+#include "IAtlasAllocator.h"
+
+// Concept requiring T to inherit from Base
+template <typename T>
+concept DerivedFromIAtlasAllocator = std::is_base_of_v<IAtlasAllocator, T>;
+
+template<DerivedFromIAtlasAllocator AtlasAlloc>
+class MultiPageAtlasAlloc : public IAtlasAllocator {
+public:
+	MultiPageAtlasAlloc(uint32_t maxPages_)
+		: maxPages(maxPages_)
+	{}
+public:
+	// Inherited via IAtlasAllocator
+	bool Allocate() override
+	{
+		if (maxsize.x * maxsize.y <= 0)
+			return false;
+
+		std::vector<const SAtlasEntry*> memtextures;
+		memtextures.reserve(entries.size());
+
+		std::set<std::string> sortedNames;
+		for (auto& entry : entries) {
+			sortedNames.insert(entry.first);
+		}
+
+		size_t totalAreaSum = 0;
+		for (auto& name : sortedNames) {
+			const auto& entry = entries[name];
+			memtextures.push_back(&entry);
+			totalAreaSum += (entry.size.x * entry.size.y);
+		}
+
+		std::stable_sort(memtextures.begin(), memtextures.end(), [](const auto* lhs, const auto* rhs) {
+			return std::forward_as_tuple(lhs->size.y, lhs->size.x, lhs->name) > std::forward_as_tuple(rhs->size.y, rhs->size.x, rhs->name);
+		});
+
+		// guestimate the initial number of pages
+		auto numPages = static_cast<uint32_t>(::ceilf(
+			totalAreaSum / static_cast<float>(maxsize.x * maxsize.y)
+		));
+
+		std::vector<size_t> areaSums;
+
+		bool done = false;
+		while (!done) {
+			if (numPages > maxPages)
+				break;
+
+			allocators.clear();
+			allocators.resize(numPages);
+			areaSums.clear();
+			areaSums.resize(numPages, 0);
+
+			for (auto& allocator : allocators) {
+				allocator = std::move(std::make_unique<AtlasAlloc>());
+				allocator->SetMaxSize(maxsize.x, maxsize.y);
+				allocator->SetMaxTexLevel(numLevels);
+			}
+
+			for (const auto* memtexture : memtextures) {
+				auto minAreaIdx = std::distance(areaSums.begin(), std::min_element(areaSums.begin(), areaSums.end()));
+				allocators[minAreaIdx]->AddEntry(*memtexture);
+			}
+
+			done = true;
+			for (auto& allocator : allocators) {
+				done &= allocator->Allocate();
+			}
+
+			++numPages;
+		}
+
+		if (!done)
+			return false;
+
+		// figure out tex coords and atlasSize
+		for (size_t i = 0; i < allocators.size(); ++i) {
+			const auto& allocator = allocators[i];
+
+			const auto& allocEntries = allocator->GetEntries();
+			for (const auto& [name, ae] : allocEntries) {
+				assert(entries.contains(name));
+				auto& myEntry = entries[name];
+				myEntry.texCoords = ae.texCoords;
+				myEntry.pageIdx = static_cast<uint32_t>(i);
+			}
+
+			const auto& as = allocator->GetAtlasSize();
+			atlasSize.x = std::max(atlasSize.x, as.x);
+			atlasSize.y = std::max(atlasSize.y, as.y);
+		}
+
+		return true;
+	}
+
+	int GetNumTexLevels() const override
+	{
+		int minLevels = std::numeric_limits<int>::max();
+		for (auto& allocator : allocators) {
+			minLevels = std::min(minLevels, allocator->GetNumTexLevels());
+		}
+
+		return (minLevels == std::numeric_limits<int>::max()) ? 0 : minLevels;
+	}
+	uint32_t GetNumPages() const override { return allocators.size(); }
+private:
+	uint32_t maxPages;
+	std::vector<std::unique_ptr<AtlasAlloc>> allocators;
+};

--- a/rts/Rendering/Textures/QuadtreeAtlasAlloc.h
+++ b/rts/Rendering/Textures/QuadtreeAtlasAlloc.h
@@ -17,7 +17,7 @@ public:
 
 	bool Allocate() override;
 	int GetNumTexLevels() const override;
-
+	uint32_t GetNumPages() const override { return 1; }
 private:
 	static bool CompareTex(const SAtlasEntry* tex1, const SAtlasEntry* tex2);
 	QuadTreeNode* FindPosInQuadTree(int xsize, int ysize);

--- a/rts/Rendering/Textures/RowAtlasAlloc.h
+++ b/rts/Rendering/Textures/RowAtlasAlloc.h
@@ -18,7 +18,7 @@ public:
 
 	bool Allocate() override;
 	int GetNumTexLevels() const override;
-
+	uint32_t GetNumPages() const override { return 1; }
 private:
 	struct Row {
 		Row(int _ypos,int _height):

--- a/rts/Rendering/Textures/Texture.cpp
+++ b/rts/Rendering/Textures/Texture.cpp
@@ -56,17 +56,61 @@ namespace GL {
 		}
 	}
 
-	Texture2D::~Texture2D() {
+	// not great as the texture is created in a derived class, but passable
+	TextureBase::~TextureBase()
+	{
 		if (!ownTexID || !texID)
 			return;
 
 		glDeleteTextures(1, &texID);
 	}
 
-	Texture2D& Texture2D::operator=(Texture2D&& other) noexcept
+	GL::TexBind TextureBase::ScopedBind()
 	{
+		auto scopedBinding = GL::TexBind(texTarget, texID);
+		lastBoundSlot = scopedBinding.GetLastActiveTextureSlot();
+		return scopedBinding; // NRTO should optimize it
+	}
+	GL::TexBind TextureBase::ScopedBind(uint32_t relSlot)
+	{
+		lastBoundSlot = GL_TEXTURE0 + relSlot;
+		return GL::TexBind(relSlot, texTarget, texID);
+	}
+
+	void TextureBase::ScopedBind(const GL::TexBind& existingScopedBinding)
+	{
+		glActiveTexture(existingScopedBinding.GetLastActiveTextureSlot());
+		glBindTexture(texTarget, texID);
+	}
+
+	void TextureBase::Bind()
+	{
+		lastBoundSlot = GL::FetchActiveTextureSlot();
+		glBindTexture(texTarget, texID);
+	}
+
+	void TextureBase::Bind(uint32_t relSlot)
+	{
+		lastBoundSlot = GL_TEXTURE0 + relSlot;
+		glActiveTexture(GL_TEXTURE0 + relSlot);
+		glBindTexture(texTarget, texID);
+	}
+
+	void TextureBase::Unbind()
+	{
+		glBindTexture(texTarget, 0);
+		lastBoundSlot = 0;
+	}
+
+	void TextureBase::Unbind(uint32_t relSlot)
+	{
+		glActiveTexture(GL_TEXTURE0 + relSlot);
+		glBindTexture(texTarget, 0);
+		lastBoundSlot = 0;
+	}
+
+	TextureBase& TextureBase::operator=(TextureBase&& other) noexcept {
 		std::swap(texID, other.texID);
-		std::swap(size, other.size);
 		std::swap(intFormat, other.intFormat);
 		std::swap(numLevels, other.numLevels);
 		std::swap(lastBoundSlot, other.lastBoundSlot);
@@ -75,51 +119,8 @@ namespace GL {
 		return *this;
 	}
 
-	GL::TexBind Texture2D::ScopedBind()
-	{
-		auto scopedBinding = GL::TexBind(texTarget, texID);
-		lastBoundSlot = scopedBinding.GetLastActiveTextureSlot();
-		return scopedBinding; // NRTO should optimize it
-	}
-	GL::TexBind Texture2D::ScopedBind(uint32_t relSlot)
-	{
-		lastBoundSlot = GL_TEXTURE0 + relSlot;
-		return GL::TexBind(relSlot, texTarget, texID);
-	}
-
-	void Texture2D::ScopedBind(const GL::TexBind& existingScopedBinding)
-	{
-		glActiveTexture(existingScopedBinding.GetLastActiveTextureSlot());
-		glBindTexture(texTarget, texID);
-	}
-
-	void Texture2D::Bind()
-	{
-		lastBoundSlot = GL::FetchActiveTextureSlot();
-		glBindTexture(texTarget, texID);
-	}
-
-	void Texture2D::Bind(uint32_t relSlot)
-	{
-		lastBoundSlot = GL_TEXTURE0 + relSlot;
-		glActiveTexture(GL_TEXTURE0 + relSlot);
-		glBindTexture(texTarget, texID);
-	}
-
-	void Texture2D::Unbind()
-	{
-		glBindTexture(texTarget, 0);
-		lastBoundSlot = 0;
-	}
-
-	void Texture2D::Unbind(uint32_t relSlot)
-	{
-		glActiveTexture(GL_TEXTURE0 + relSlot);
-		glBindTexture(texTarget, 0);
-		lastBoundSlot = 0;
-	}
-
 	Texture2D::Texture2D(int xsize_, int ysize_, uint32_t intFormat_, const TextureCreationParams& tcp, bool wantCompress)
+		: Texture2D()
 	{
 		size = int2(xsize_, ysize_);
 		intFormat = intFormat_;
@@ -147,6 +148,14 @@ namespace GL {
 		glTexParameteri(texTarget, GL_TEXTURE_MAX_LEVEL , numLevels - 1);
 	}
 
+	Texture2D& Texture2D::operator=(Texture2D&& other) noexcept
+	{
+		TextureBase::operator=(static_cast<TextureBase&&>(other));
+		std::swap(size, other.size);
+
+		return *this;
+	}
+
 	void Texture2D::UploadSubImage(const void* data, int xOffset, int yOffset, int width, int height, int level) const
 	{
 		assert(lastBoundSlot >= GL_TEXTURE0);
@@ -162,6 +171,73 @@ namespace GL {
 	}
 
 	void Texture2D::ProduceMipmaps() const
+	{
+		assert(lastBoundSlot >= GL_TEXTURE0);
+		if (globalRendering->amdHacks) {
+			glEnable(texTarget);
+			glGenerateMipmap(texTarget);
+			glDisable(texTarget);
+		}
+		else {
+			glGenerateMipmap(texTarget);
+		}
+	}
+
+
+	Texture2DArray::Texture2DArray(int xsize_, int ysize_, int numPages_, uint32_t intFormat_, const TextureCreationParams& tcp, bool wantCompress)
+		: Texture2DArray()
+	{
+		size = int2(xsize_, ysize_);
+		numPages = numPages;
+		intFormat = intFormat_;
+
+		numLevels = tcp.reqNumLevels <= 0
+			? std::bit_width(static_cast<uint32_t>(std::max({ size.x , size.y })))
+			: tcp.reqNumLevels;
+
+		lastBoundSlot = GL::FetchActiveTextureSlot();
+		auto&& [genTexID, binding] = Impl::InitTexture(tcp, texTarget, numLevels);
+		texID = genTexID;
+
+		if (GLAD_GL_ARB_texture_storage && !wantCompress) {
+			glTexStorage3D(texTarget, numLevels, intFormat, size.x, size.y, numPages);
+		}
+		else {
+			const auto compressedIntFormat = GetCompressedInternalFormat(intFormat);
+			const auto extFormat = GetExternalFormatFromInternalFormat(intFormat);
+			const auto dataType = GetDataTypeFromInternalFormat(intFormat);
+
+			for (int level = 0; level < numLevels; ++level)
+				glTexImage3D(texTarget, level, compressedIntFormat, std::max(size.x >> level, 1), std::max(size.y >> level, 1), numPages, 0, extFormat, dataType, nullptr);
+		}
+		glTexParameteri(texTarget, GL_TEXTURE_BASE_LEVEL, 0);
+		glTexParameteri(texTarget, GL_TEXTURE_MAX_LEVEL, numLevels - 1);
+	}
+
+	Texture2DArray& Texture2DArray::operator=(Texture2DArray&& other) noexcept
+	{
+		TextureBase::operator=(static_cast<TextureBase&&>(other));
+		std::swap(size, other.size);
+		std::swap(numLevels, other.numLevels);
+
+		return *this;
+	}
+
+	void Texture2DArray::UploadSubImage(const void* data, int layer, int xOffset, int yOffset, int width, int height, int level) const
+	{
+		assert(lastBoundSlot >= GL_TEXTURE0);
+		const auto extFormat = GetExternalFormatFromInternalFormat(intFormat);
+		const auto dataType = GetDataTypeFromInternalFormat(intFormat);
+		const auto dataSize = GetDataTypeSize(dataType);
+		using namespace GL::State;
+		auto state = GL::SubState(
+			PixelStoreUnpackAlignment(dataSize)
+		);
+		auto binding = GL::TexBind(texTarget, texID);
+		glTexSubImage3D(texTarget, level, xOffset, yOffset, layer, width, height, 1, extFormat, dataType, data);
+	}
+
+	void Texture2DArray::ProduceMipmaps() const
 	{
 		assert(lastBoundSlot >= GL_TEXTURE0);
 		if (globalRendering->amdHacks) {

--- a/rts/Rendering/Textures/Texture.cpp
+++ b/rts/Rendering/Textures/Texture.cpp
@@ -166,7 +166,6 @@ namespace GL {
 		auto state = GL::SubState(
 			PixelStoreUnpackAlignment(dataSize)
 		);
-		auto binding = GL::TexBind(texTarget, texID);
 		glTexSubImage2D(texTarget, level, xOffset, yOffset, width, height, extFormat, dataType, data);
 	}
 
@@ -188,7 +187,7 @@ namespace GL {
 		: Texture2DArray()
 	{
 		size = int2(xsize_, ysize_);
-		numPages = numPages;
+		numPages = numPages_;
 		intFormat = intFormat_;
 
 		numLevels = tcp.reqNumLevels <= 0
@@ -233,7 +232,6 @@ namespace GL {
 		auto state = GL::SubState(
 			PixelStoreUnpackAlignment(dataSize)
 		);
-		auto binding = GL::TexBind(texTarget, texID);
 		glTexSubImage3D(texTarget, level, xOffset, yOffset, layer, width, height, 1, extFormat, dataType, data);
 	}
 

--- a/rts/Rendering/Textures/Texture.hpp
+++ b/rts/Rendering/Textures/Texture.hpp
@@ -130,7 +130,7 @@ namespace GL {
 			const auto dataType = GetDataTypeFromInternalFormat(intFormat);
 			const auto dataSize = GetDataTypeSize(dataType);
 			const auto numChannels = GetNumChannelsFromInternalFormat(intFormat);
-			assert(c.size() * sizeof(C::value_type) >= size.x * size.y * numChannels * dataSize);
+			assert(c.size() * sizeof(typename C::value_type) >= size.x * size.y * numChannels * dataSize);
 		#endif // DEBUG
 			UploadImage(c.data());
 		}
@@ -142,7 +142,7 @@ namespace GL {
 			const auto dataType = GetDataTypeFromInternalFormat(intFormat);
 			const auto dataSize = GetDataTypeSize(dataType);
 			const auto numChannels = GetNumChannelsFromInternalFormat(intFormat);
-			assert(c.size() * sizeof(C::value_type) >= width * height * numChannels * dataSize);
+			assert(c.size() * sizeof(typename C::value_type) >= width * height * numChannels * dataSize);
 		#endif // DEBUG
 			UploadSubImage(c.data(), layer, xOffset, yOffset, width, height, 0);
 		}

--- a/rts/Rendering/Textures/Texture.hpp
+++ b/rts/Rendering/Textures/Texture.hpp
@@ -15,20 +15,12 @@ namespace GL {
 		{ t.data() } -> std::convertible_to<const typename T::value_type*>;
 	};
 
-	class Texture2D {
+	class TextureBase {
 	public:
-		Texture2D() {}
-		Texture2D(int xsize_, int ysize_, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true);
-		Texture2D(const int2& size, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true)
-			: Texture2D(size.x, size.y, intFormat_, tcp_, wantCompress)
+		TextureBase(uint32_t texTarget_)
+			: texTarget(texTarget_)
 		{}
-		~Texture2D();
-
-		Texture2D(Texture2D&& other) noexcept { *this = std::move(other); }
-		Texture2D(const Texture2D&) = delete;
-
-		Texture2D& operator=(Texture2D&& other) noexcept;
-		Texture2D& operator=(const Texture2D&) = delete;
+		virtual ~TextureBase();
 
 		bool IsValid() const { return texID != 0; }
 		const auto GetId() const { return texID; }
@@ -42,6 +34,42 @@ namespace GL {
 		void Bind(uint32_t relSlot);
 		void Unbind();
 		void Unbind(uint32_t relSlot);
+	public:
+		TextureBase(TextureBase&& other) noexcept{ *this = std::move(other); }
+		TextureBase(const TextureBase&) = delete;
+
+		TextureBase& operator=(TextureBase&& other) noexcept;
+		TextureBase& operator=(const TextureBase&) = delete;
+	public:
+		virtual void ProduceMipmaps() const = 0;
+	protected:
+		uint32_t texID = 0;
+		uint32_t intFormat = 0;
+		int32_t numLevels = -1;
+		uint32_t lastBoundSlot = 0;
+		bool ownTexID = true;
+		uint32_t texTarget;
+	};
+
+	class Texture2D : public TextureBase {
+	public:
+		Texture2D()
+			: TextureBase(0x0DE1/*GL_TEXTURE_2D*/)
+		{}
+		Texture2D(int xsize_, int ysize_, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true);
+		Texture2D(const int2& size, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true)
+			: Texture2D(size.x, size.y, intFormat_, tcp_, wantCompress)
+		{}
+
+		Texture2D(Texture2D&& other) noexcept
+			: TextureBase(other.texTarget)
+		{
+			*this = std::move(other);
+		}
+		Texture2D(const Texture2D&) = delete;
+
+		Texture2D& operator=(Texture2D&& other) noexcept;
+		Texture2D& operator=(const Texture2D&) = delete;
 
 		template <HasSizeAndData C>
 		void UploadImage(const C& c) const {
@@ -70,14 +98,62 @@ namespace GL {
 			UploadSubImage(data, 0, 0, size.x, size.y, level);
 		}
 		void UploadSubImage(const void* data, int xOffset, int yOffset, int width, int height, int level = 0) const;
-		void ProduceMipmaps() const;
+		void ProduceMipmaps() const override;
 	private:
 		int2 size;
-		uint32_t texID = 0;
-		uint32_t intFormat = 0;
-		int32_t numLevels = -1;
-		uint32_t lastBoundSlot = 0;
-		bool ownTexID = true;
-		static constexpr uint32_t texTarget = 0x0DE1; /*GL_TEXTURE_2D*/
+	};
+
+	class Texture2DArray : public TextureBase {
+	public:
+		Texture2DArray()
+			: TextureBase(0x8C1A/*GL_TEXTURE_2D_ARRAY*/)
+			, numPages(0)
+		{}
+		Texture2DArray(int xsize_, int ysize_, int numPages_, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true);
+		Texture2DArray(const int2& size, int numPages_, uint32_t intFormat_, const TextureCreationParams& tcp_, bool wantCompress = true)
+			: Texture2DArray(size.x, size.y, numPages_, intFormat_, tcp_, wantCompress)
+		{}
+
+		Texture2DArray(Texture2DArray&& other) noexcept
+			: TextureBase(other.texTarget)
+		{
+			*this = std::move(other);
+		}
+		Texture2DArray(const Texture2DArray&) = delete;
+
+		Texture2DArray& operator=(Texture2DArray&& other) noexcept;
+		Texture2DArray& operator=(const Texture2DArray&) = delete;
+
+		template <HasSizeAndData C>
+		void UploadImage(const C& c, int layer) const {
+		#ifdef DEBUG
+			const auto dataType = GetDataTypeFromInternalFormat(intFormat);
+			const auto dataSize = GetDataTypeSize(dataType);
+			const auto numChannels = GetNumChannelsFromInternalFormat(intFormat);
+			assert(c.size() * sizeof(C::value_type) >= size.x * size.y * numChannels * dataSize);
+		#endif // DEBUG
+			UploadImage(c.data());
+		}
+
+		template <HasSizeAndData C>
+		void UploadSubImage(const C& c, int layer, int xOffset, int yOffset, int width, int height) const {
+		#ifdef DEBUG
+			assert(xOffset + width <= size.x && yOffset + height <= size.y);
+			const auto dataType = GetDataTypeFromInternalFormat(intFormat);
+			const auto dataSize = GetDataTypeSize(dataType);
+			const auto numChannels = GetNumChannelsFromInternalFormat(intFormat);
+			assert(c.size() * sizeof(C::value_type) >= width * height * numChannels * dataSize);
+		#endif // DEBUG
+			UploadSubImage(c.data(), layer, xOffset, yOffset, width, height, 0);
+		}
+
+		void UploadImage(const void* data, int layer, int level = 0) const {
+			UploadSubImage(data, layer, 0, 0, size.x, size.y, level);
+		}
+		void UploadSubImage(const void* data, int layer, int xOffset, int yOffset, int width, int height, int level = 0) const;
+		void ProduceMipmaps() const override;
+	private:
+		int2 size;
+		int numPages;
 	};
 }

--- a/rts/Rendering/Textures/TextureAtlas.cpp
+++ b/rts/Rendering/Textures/TextureAtlas.cpp
@@ -148,11 +148,16 @@ bool CTextureAtlas::Finalize()
 	return success;
 }
 
-const uint32_t CTextureAtlas::GetTexTarget() const
+uint32_t CTextureAtlas::GetTexTarget() const
 {
 	return (atlasAllocator->GetNumPages() > 1) ?
 		GL_TEXTURE_2D_ARRAY :
 		GL_TEXTURE_2D;
+}
+
+uint32_t CTextureAtlas::GetNumPages() const
+{
+	return atlasAllocator->GetNumPages();
 }
 
 int CTextureAtlas::GetNumTexLevels() const

--- a/rts/Rendering/Textures/TextureAtlas.h
+++ b/rts/Rendering/Textures/TextureAtlas.h
@@ -120,7 +120,8 @@ public:
 	std::string GetName() const { return name; }
 
 	uint32_t GetTexID() const { return atlasTex->GetId(); }
-	const uint32_t GetTexTarget() const;
+	uint32_t GetTexTarget() const;
+	uint32_t GetNumPages() const;
 
 	int GetNumTexLevels() const;
 	void SetMaxTexLevel(int maxLevels);

--- a/rts/Rendering/Textures/TextureAtlas.h
+++ b/rts/Rendering/Textures/TextureAtlas.h
@@ -185,7 +185,7 @@ protected:
 	std::vector<MemTex> memTextures;
 
 	spring::unordered_map<std::string, size_t> files;
-	spring::unordered_map<std::string, AtlasedTextureLayered> textures;
+	spring::unordered_map<std::string, AtlasedTexture> textures;
 	spring::unordered_map<AtlasedTexture*, std::string> texToName;  // non-creg serialization
 
 	std::unique_ptr<GL::TextureBase> atlasTex;

--- a/rts/Rendering/Textures/TextureAtlas.h
+++ b/rts/Rendering/Textures/TextureAtlas.h
@@ -1,59 +1,15 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef TEXTURE_ATLAS_H
-#define TEXTURE_ATLAS_H
+#pragma once
 
 #include <string>
 #include <vector>
 
-#include "System/creg/creg_cond.h"
+#include "IAtlasAllocator.h"
+#include "AtlasedTexture.hpp"
 #include "System/float4.h"
 #include "System/type2.h"
 #include "System/UnorderedMap.hpp"
-#include "Rendering/Textures/IAtlasAllocator.h"
-
-/** @brief texture coordinates of an atlas subimage. */
-//typedef float4 AtlasedTexture;
-
-struct AtlasedTexture
-{
-	CR_DECLARE_STRUCT(AtlasedTexture)
-
-	explicit AtlasedTexture() = default;
-	explicit AtlasedTexture(const float4& f)
-		: x(f.x)
-		, y(f.y)
-		, z(f.z)
-		, w(f.w)
-	{};
-/*
-	AtlasedTexture(AtlasedTexture&& f) noexcept { *this = std::move(f); }
-	AtlasedTexture& operator= (AtlasedTexture&& f) = default;
-
-	AtlasedTexture(const AtlasedTexture& f) { *this = f; }
-	AtlasedTexture& operator= (const AtlasedTexture& f) = default;
-*/
-	bool operator==(const AtlasedTexture& rhs) const {
-		if (this == &rhs)
-			return true;
-
-		float4 f0(x    , y    , z    , w    );
-		float4 f1(rhs.x, rhs.y, rhs.z, rhs.w);
-		return f0 == f1;
-	}
-	bool operator!=(const AtlasedTexture& rhs) const { return !(*this == rhs); }
-
-	union {
-		struct { float x, y, z, w; };
-		struct { float x1, y1, x2, y2; };
-		struct { float s, t, p, q; };
-		struct { float xstart, ystart, xend, yend; };
-	};
-
-	static const AtlasedTexture& DefaultAtlasTexture;
-};
-
-
 
 /** @brief Class for combining multiple bitmaps into one large single bitmap. */
 class CTextureAtlas
@@ -63,9 +19,12 @@ public:
 		RGBA32
 	};
 	enum AllocatorType {
-		ATLAS_ALLOC_LEGACY   = 0,
-		ATLAS_ALLOC_QUADTREE = 1,
-		ATLAS_ALLOC_ROW      = 2,
+		ATLAS_ALLOC_LEGACY      = 0,
+		ATLAS_ALLOC_QUADTREE    = 1,
+		ATLAS_ALLOC_ROW         = 2,
+		ATLAS_ALLOC_MP_LEGACY   = 3,
+		ATLAS_ALLOC_MP_QUADTREE = 4,
+		ATLAS_ALLOC_MP_ROW      = 5
 	};
 
 public:
@@ -235,5 +194,3 @@ protected:
 	// set to true to write finalized texture atlas to disk
 	static inline bool debug = false;
 };
-
-#endif // TEXTURE_ATLAS_H

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -226,7 +226,7 @@ CExpGenSpawnable* CExpGenSpawnable::CreateSpawnable(int spawnableID)
 	return std::get<2>(spawnables[spawnableID])();
 }
 
-void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p)
+void CExpGenSpawnable::AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
@@ -242,18 +242,18 @@ void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC
 
 	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
 	const auto animInfo = float3{ ap.x, ap.y, p };
-	constexpr float layer = 0.0f; //for future texture arrays
+	const auto pn = static_cast<float>(pageNum);
 
 	//pos, uvw, uvmm, col
 	rb.AddQuadTriangles(
-		{ tl.pos, float3{ tl.s, tl.t, layer }, uvInfo, animInfo, tl.c },
-		{ tr.pos, float3{ tr.s, tr.t, layer }, uvInfo, animInfo, tr.c },
-		{ br.pos, float3{ br.s, br.t, layer }, uvInfo, animInfo, br.c },
-		{ bl.pos, float3{ bl.s, bl.t, layer }, uvInfo, animInfo, bl.c }
+		{ tl.pos, float3{ tl.s, tl.t, pn }, uvInfo, animInfo, tl.c },
+		{ tr.pos, float3{ tr.s, tr.t, pn }, uvInfo, animInfo, tr.c },
+		{ br.pos, float3{ br.s, br.t, pn }, uvInfo, animInfo, br.c },
+		{ bl.pos, float3{ bl.s, bl.t, pn }, uvInfo, animInfo, bl.c }
 	);
 }
 
-void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl)
+void CExpGenSpawnable::AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	float minS = std::numeric_limits<float>::max()   ; float minT = std::numeric_limits<float>::max()   ;
@@ -269,13 +269,13 @@ void CExpGenSpawnable::AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC
 
 	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
 	static constexpr auto animInfo = float3{ 1.0f, 1.0f , 0.0f };
-	constexpr float layer = 0.0f; //for future texture arrays
+	const auto pn = static_cast<float>(pageNum);
 
 	//pos, uvw, uvmm, col
 	rb.AddQuadTriangles(
-		{ tl.pos, float3{ tl.s, tl.t, layer }, uvInfo, animInfo, tl.c },
-		{ tr.pos, float3{ tr.s, tr.t, layer }, uvInfo, animInfo, tr.c },
-		{ br.pos, float3{ br.s, br.t, layer }, uvInfo, animInfo, br.c },
-		{ bl.pos, float3{ bl.s, bl.t, layer }, uvInfo, animInfo, bl.c }
+		{ tl.pos, float3{ tl.s, tl.t, pn }, uvInfo, animInfo, tl.c },
+		{ tr.pos, float3{ tr.s, tr.t, pn }, uvInfo, animInfo, tr.c },
+		{ br.pos, float3{ br.s, br.t, pn }, uvInfo, animInfo, br.c },
+		{ bl.pos, float3{ bl.s, bl.t, pn }, uvInfo, animInfo, bl.c }
 	);
 }

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -45,10 +45,10 @@ protected:
 	void UpdateAnimParamsImpl(const float3& ap, float& p) const;
 
 	template <uint32_t texIdx>
-	void AddEffectsQuad(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
+	void AddEffectsQuad(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const;
 
-	static void AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p);
-	static void AddEffectsQuadImpl(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl);
+	static void AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl, const float3& ap, const float& p);
+	static void AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl);
 
 	static bool GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo);
 
@@ -73,29 +73,29 @@ protected:
 };
 
 template <>
-inline void CExpGenSpawnable::AddEffectsQuad<0>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+inline void CExpGenSpawnable::AddEffectsQuad<0>(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
 	// no animation
-	AddEffectsQuadImpl(tl, tr, br, bl);
+	AddEffectsQuadImpl(pageNum, tl, tr, br, bl);
 }
 
 template <>
-inline void CExpGenSpawnable::AddEffectsQuad<1>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	AddEffectsQuadImpl(tl, tr, br, bl, animParams1, animProgress1);
+inline void CExpGenSpawnable::AddEffectsQuad<1>(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(pageNum, tl, tr, br, bl, animParams1, animProgress1);
 }
 
 template <>
-inline void CExpGenSpawnable::AddEffectsQuad<2>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	AddEffectsQuadImpl(tl, tr, br, bl, animParams2, animProgress2);
+inline void CExpGenSpawnable::AddEffectsQuad<2>(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(pageNum, tl, tr, br, bl, animParams2, animProgress2);
 }
 
 template <>
-inline void CExpGenSpawnable::AddEffectsQuad<3>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	AddEffectsQuadImpl(tl, tr, br, bl, animParams3, animProgress3);
+inline void CExpGenSpawnable::AddEffectsQuad<3>(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(pageNum, tl, tr, br, bl, animParams3, animProgress3);
 }
 
 template <>
-inline void CExpGenSpawnable::AddEffectsQuad<4>(const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
-	AddEffectsQuadImpl(tl, tr, br, bl, animParams4, animProgress4);
+inline void CExpGenSpawnable::AddEffectsQuad<4>(uint32_t pageNum, const VA_TYPE_TC& tl, const VA_TYPE_TC& tr, const VA_TYPE_TC& br, const VA_TYPE_TC& bl) const {
+	AddEffectsQuadImpl(pageNum, tl, tr, br, bl, animParams4, animProgress4);
 }
 
 #endif //EXP_GEN_SPAWNABLE_H

--- a/rts/Sim/Projectiles/FireProjectile.cpp
+++ b/rts/Sim/Projectiles/FireProjectile.cpp
@@ -169,6 +169,7 @@ void CFireProjectile::Draw()
 		col[2] = (uint8_t) ((1 - age) * 255);
 
 		AddEffectsQuad<0>(
+			et->pageNum,
 			{ interPos - dir1 - dir2, et->xstart, et->ystart, col },
 			{ interPos + dir1 - dir2, et->xend,   et->ystart, col },
 			{ interPos + dir1 + dir2, et->xend,   et->yend,   col },
@@ -198,6 +199,7 @@ void CFireProjectile::Draw()
 			col[3] = 1;
 
 			AddEffectsQuad<0>(
+				et->pageNum,
 				{ interPos - dir1 - dir2, et->xstart, et->ystart, col },
 				{ interPos + dir1 - dir2, et->xend,   et->ystart, col },
 				{ interPos + dir1 + dir2, et->xend,   et->yend,   col },
@@ -217,6 +219,7 @@ void CFireProjectile::Draw()
 		col2[3] = c;
 
 		AddEffectsQuad<0>(
+			at->pageNum,
 			{ interPos - dir1 - dir2, at->xstart, at->ystart, col2 },
 			{ interPos + dir1 - dir2, at->xend,   at->ystart, col2 },
 			{ interPos + dir1 + dir2, at->xend,   at->yend,   col2 },

--- a/rts/Sim/Projectiles/FlareProjectile.cpp
+++ b/rts/Sim/Projectiles/FlareProjectile.cpp
@@ -128,14 +128,14 @@ void CFlareProjectile::Draw()
 	for (int a = 0; a < numSubProjs; ++a) {
 		const float3 interPos = subProjPos[a] + subProjVel[a] * globalRendering->timeOffset;
 
-		#define fpt projectileDrawer->flareprojectiletex
+		const auto* fpt = projectileDrawer->flareprojectiletex;
 		AddEffectsQuad<0>(
+			fpt->pageNum,
 			{ interPos - camera->GetRight() * rad - camera->GetUp() * rad, fpt->xstart, fpt->ystart, col },
 			{ interPos + camera->GetRight() * rad - camera->GetUp() * rad, fpt->xend,   fpt->ystart, col },
 			{ interPos + camera->GetRight() * rad + camera->GetUp() * rad, fpt->xend,   fpt->yend,   col },
 			{ interPos - camera->GetRight() * rad + camera->GetUp() * rad, fpt->xstart, fpt->yend,   col }
 		);
-		#undef fpt
 	}
 }
 

--- a/rts/Sim/Projectiles/PieceProjectile.cpp
+++ b/rts/Sim/Projectiles/PieceProjectile.cpp
@@ -289,6 +289,7 @@ void CPieceProjectile::Draw()
 
 		const auto eft = projectileDrawer->explofadetex;
 		AddEffectsQuad<0>(
+			eft->pageNum,
 			{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, eft->xstart, eft->ystart, col },
 			{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, eft->xend,   eft->ystart, col },
 			{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, eft->xend,   eft->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/BeamLaserProjectile.cpp
@@ -130,12 +130,14 @@ void CBeamLaserProjectile::Draw()
 	if (playerCamDistSq < Square(1000.0f)) {
 		if (validTextures[2]) {
 			AddEffectsQuad<2>(
+				WT2->pageNum,
 				{ pos1 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos1 - xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos1 + xdir * beamEdgeSize - ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
 				{ pos1 + xdir * beamEdgeSize,                       midtexx  , WT2->yend  , edgeColStart }
 			);
 			AddEffectsQuad<2>(
+				WT2->pageNum,
 				{ pos1 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos1 - xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos1 + xdir * beamCoreSize - ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -145,6 +147,7 @@ void CBeamLaserProjectile::Draw()
 		}
 		if (validTextures[1]) {
 			AddEffectsQuad<1>(
+				WT1->pageNum,
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
@@ -152,6 +155,7 @@ void CBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<1>(
+				WT1->pageNum,
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -160,6 +164,7 @@ void CBeamLaserProjectile::Draw()
 		}
 		if (validTextures[2]) {
 			AddEffectsQuad<2>(
+				WT2->pageNum,
 				{ pos2 - xdir * beamEdgeSize,                       midtexx  , WT2->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->ystart, edgeColStart },
 				{ pos2 + xdir * beamEdgeSize + ydir * beamEdgeSize, WT2->xend, WT2->yend  , edgeColStart },
@@ -167,6 +172,7 @@ void CBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<2>(
+				WT2->pageNum,
 				{ pos2 - xdir * beamCoreSize,                       midtexx  , WT2->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->ystart, coreColStart },
 				{ pos2 + xdir * beamCoreSize + ydir * beamCoreSize, WT2->xend, WT2->yend  , coreColStart },
@@ -176,6 +182,7 @@ void CBeamLaserProjectile::Draw()
 	} else {
 		if (validTextures[1]) {
 			AddEffectsQuad<1>(
+				WT1->pageNum,
 				{ pos1 - xdir * beamEdgeSize,                       WT1->xstart, WT1->ystart, edgeColStart },
 				{ pos2 - xdir * beamEdgeSize,                       WT1->xend  , WT1->ystart, edgeColEnd   },
 				{ pos2 + xdir * beamEdgeSize,                       WT1->xend  , WT1->yend  , edgeColEnd   },
@@ -183,6 +190,7 @@ void CBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<1>(
+				WT1->pageNum,
 				{ pos1 - xdir * beamCoreSize,                       WT1->xstart, WT1->ystart, coreColStart },
 				{ pos2 - xdir * beamCoreSize,                       WT1->xend  , WT1->ystart, coreColEnd   },
 				{ pos2 + xdir * beamCoreSize,                       WT1->xend  , WT1->yend  , coreColEnd   },
@@ -194,6 +202,7 @@ void CBeamLaserProjectile::Draw()
 	// draw flare
 	if (validTextures[3]) {
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 - camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xstart, WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize - camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->ystart, edgeColStart },
 			{ pos1 + camera->GetRight() * flareEdgeSize + camera->GetUp() * flareEdgeSize, WT3->xend,   WT3->yend,   edgeColStart },
@@ -201,6 +210,7 @@ void CBeamLaserProjectile::Draw()
 		);
 
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 - camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xstart, WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize - camera->GetUp() * flareCoreSize, WT3->xend,   WT3->ystart, coreColStart },
 			{ pos1 + camera->GetRight() * flareCoreSize + camera->GetUp() * flareCoreSize, WT3->xend,   WT3->yend,   coreColStart },

--- a/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/EmgProjectile.cpp
@@ -82,6 +82,7 @@ void CEmgProjectile::Draw()
 	const auto* tex = weaponDef->visuals.texture1;
 
 	AddEffectsQuad<1>(
+		tex->pageNum,
 		{ drawPos - camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xstart, tex->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius - camera->GetUp() * drawRadius, tex->xend,   tex->ystart, col },
 		{ drawPos + camera->GetRight() * drawRadius + camera->GetUp() * drawRadius, tex->xend,   tex->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/ExplosiveProjectile.cpp
@@ -119,6 +119,7 @@ void CExplosiveProjectile::Draw()
 		col[3] = stageDecay * col[3];
 
 		AddEffectsQuad<1>(
+			tex->pageNum,
 			{ stagePos - xdirCam - ydirCam, tex->xstart, tex->ystart, col },
 			{ stagePos + xdirCam - ydirCam, tex->xend,   tex->ystart, col },
 			{ stagePos + xdirCam + ydirCam, tex->xend,   tex->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FireBallProjectile.cpp
@@ -72,6 +72,7 @@ void CFireBallProjectile::Draw()
 
 		const auto* ept = projectileDrawer->explotex;
 		AddEffectsQuad<1>(
+			ept->pageNum,
 			{ sparks[i].pos - camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xstart, ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size - camera->GetUp() * sparks[i].size, ept->xend  , ept->ystart, col },
 			{ sparks[i].pos + camera->GetRight() * sparks[i].size + camera->GetUp() * sparks[i].size, ept->xend  , ept->yend  , col },
@@ -86,6 +87,7 @@ void CFireBallProjectile::Draw()
 		col[2] = (maxCol - i) * 10;
 		const auto* dgt = projectileDrawer->dguntex;
 		AddEffectsQuad<2>(
+			dgt->pageNum,
 			{ interPos - (speed * 0.5f * i) - camera->GetRight() * size - camera->GetUp() * size, dgt->xstart, dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size - camera->GetUp() * size, dgt->xend ,  dgt->ystart, col },
 			{ interPos - (speed * 0.5f * i) + camera->GetRight() * size + camera->GetUp() * size, dgt->xend ,  dgt->yend  , col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/FlameProjectile.cpp
@@ -84,12 +84,14 @@ void CFlameProjectile::Draw()
 
 	unsigned char col[4];
 	weaponDef->visuals.colorMap->GetColor(col, curTime);
+	const auto* tex = weaponDef->visuals.texture1;
 
 	AddEffectsQuad<1>(
-		{ drawPos - camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->ystart, col },
-		{ drawPos + camera->GetRight() * radius - camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->ystart, col },
-		{ drawPos + camera->GetRight() * radius + camera->GetUp() * radius, weaponDef->visuals.texture1->xend,   weaponDef->visuals.texture1->yend,   col },
-		{ drawPos - camera->GetRight() * radius + camera->GetUp() * radius, weaponDef->visuals.texture1->xstart, weaponDef->visuals.texture1->yend,   col }
+		tex->pageNum,
+		{ drawPos - camera->GetRight() * radius - camera->GetUp() * radius, tex->xstart, tex->ystart, col },
+		{ drawPos + camera->GetRight() * radius - camera->GetUp() * radius, tex->xend,   tex->ystart, col },
+		{ drawPos + camera->GetRight() * radius + camera->GetUp() * radius, tex->xend,   tex->yend,   col },
+		{ drawPos - camera->GetRight() * radius + camera->GetUp() * radius, tex->xstart, tex->yend,   col }
 	);
 }
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LargeBeamLaserProjectile.cpp
@@ -131,6 +131,7 @@ void CLargeBeamLaserProjectile::Draw()
 			tex.xstart = WT1->xstart + startTex * texSizeX;
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
@@ -138,6 +139,7 @@ void CLargeBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -151,6 +153,7 @@ void CLargeBeamLaserProjectile::Draw()
 			tex.xstart = WT1->xstart + startTex * texSizeX;
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
@@ -158,6 +161,7 @@ void CLargeBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -172,6 +176,7 @@ void CLargeBeamLaserProjectile::Draw()
 				pos2 = startPos + zdir * (i + tilelength);
 
 				AddEffectsQuad<1>(
+					tex.pageNum,
 					{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 					{ pos2 - (xdir * beamEdgeSize), tex.xend  , tex.ystart, edgeColStart },
 					{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
@@ -179,6 +184,7 @@ void CLargeBeamLaserProjectile::Draw()
 				);
 
 				AddEffectsQuad<1>(
+					tex.pageNum,
 					{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 					{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 					{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -192,6 +198,7 @@ void CLargeBeamLaserProjectile::Draw()
 			tex.xend = tex.xstart + (pos1.distance(pos2) / tilelength) * texSizeX;
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamEdgeSize), tex.xstart, tex.ystart, edgeColStart },
 				{ pos2 - (xdir * beamEdgeSize), tex.xend,   tex.ystart, edgeColStart },
 				{ pos2 + (xdir * beamEdgeSize), tex.xend  , tex.yend  , edgeColStart },
@@ -199,6 +206,7 @@ void CLargeBeamLaserProjectile::Draw()
 			);
 
 			AddEffectsQuad<1>(
+				tex.pageNum,
 				{ pos1 - (xdir * beamCoreSize), tex.xstart, tex.ystart, coreColStart },
 				{ pos2 - (xdir * beamCoreSize), tex.xend  , tex.ystart, coreColStart },
 				{ pos2 + (xdir * beamCoreSize), tex.xend  , tex.yend  , coreColStart },
@@ -209,6 +217,7 @@ void CLargeBeamLaserProjectile::Draw()
 
 	if (validTextures[2]) {
 		AddEffectsQuad<2>(
+			WT2->pageNum,
 			{ pos2 - (xdir * beamEdgeSize),                         WT2->xstart, WT2->ystart, edgeColStart },
 			{ pos2 - (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->ystart, edgeColStart },
 			{ pos2 + (xdir * beamEdgeSize) + (ydir * beamEdgeSize), WT2->xend,   WT2->yend,   edgeColStart },
@@ -216,6 +225,7 @@ void CLargeBeamLaserProjectile::Draw()
 		);
 
 		AddEffectsQuad<2>(
+			WT2->pageNum,
 			{ pos2 - (xdir * beamCoreSize),                         WT2->xstart, WT2->ystart, coreColStart },
 			{ pos2 - (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->ystart, coreColStart },
 			{ pos2 + (xdir * beamCoreSize) + (ydir * beamCoreSize), WT2->xend,   WT2->yend,   coreColStart },
@@ -240,6 +250,7 @@ void CLargeBeamLaserProjectile::Draw()
 		pos1 = startPos - zdir * (thickness * flaresize) * 0.02f;
 
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
 			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
 			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
@@ -247,6 +258,7 @@ void CLargeBeamLaserProjectile::Draw()
 		);
 
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
 			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
 			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
@@ -265,6 +277,7 @@ void CLargeBeamLaserProjectile::Draw()
 		muzzleEdgeSize = thickness * flaresize * pulseStartTime;
 
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 + (ydir * muzzleEdgeSize),                           WT3->xstart, WT3->ystart, edgeColor },
 			{ pos1 + (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->ystart, edgeColor },
 			{ pos1 - (ydir * muzzleEdgeSize) + (zdir * muzzleEdgeSize), WT3->xend,   WT3->yend,   edgeColor },
@@ -274,6 +287,7 @@ void CLargeBeamLaserProjectile::Draw()
 		muzzleCoreSize = muzzleEdgeSize * 0.6f;
 
 		AddEffectsQuad<3>(
+			WT3->pageNum,
 			{ pos1 + (ydir * muzzleCoreSize),                           WT3->xstart, WT3->ystart, coreColor },
 			{ pos1 + (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->ystart, coreColor },
 			{ pos1 - (ydir * muzzleCoreSize) + (zdir * muzzleCoreSize), WT3->xend,   WT3->yend,   coreColor },
@@ -286,6 +300,7 @@ void CLargeBeamLaserProjectile::Draw()
 		pos1 = startPos - (camera->GetDir() * 3.0f);
 
 		AddEffectsQuad<4>(
+			WT4->pageNum,
 			{ pos1 - (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xstart, WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) - (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->ystart, edgeColStart },
 			{ pos1 + (camera->GetRight() * flareEdgeSize) + (camera->GetUp() * flareEdgeSize), WT4->xend  , WT4->yend  , edgeColStart },
@@ -293,15 +308,13 @@ void CLargeBeamLaserProjectile::Draw()
 		);
 
 		AddEffectsQuad<4>(
+			WT4->pageNum,
 			{ pos1 - (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xstart, WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) - (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->ystart, coreColStart },
 			{ pos1 + (camera->GetRight() * flareCoreSize) + (camera->GetUp() * flareCoreSize), WT4->xend  , WT4->yend  , coreColStart },
 			{ pos1 - (camera->GetRight() * flareCoreSize) + (camera->GetUp() * flareCoreSize), WT4->xstart, WT4->yend  , coreColStart }
 		);
 	}
-
-#undef WT4
-#undef WT2
 }
 
 void CLargeBeamLaserProjectile::DrawOnMinimap() const

--- a/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
@@ -224,48 +224,57 @@ void CLaserProjectile::Draw()
 		}
 
 		if (validTextures[2]) {
+			const auto* tex2 = weaponDef->visuals.texture2;
 			AddEffectsQuad<2>(
-				{ drawPos - (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col },
-				{ drawPos - (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->ystart, col },
-				{ drawPos + (dir1 * size),                        midtexx,                             weaponDef->visuals.texture2->yend  , col },
-				{ drawPos + (dir1 * size) - (dir2 * size),        weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->yend  , col }
+				tex2->pageNum,
+				{ drawPos - (dir1 * size) - (dir2 * size),        tex2->xstart, tex2->ystart, col },
+				{ drawPos - (dir1 * size),                        midtexx,      tex2->ystart, col },
+				{ drawPos + (dir1 * size),                        midtexx,      tex2->yend  , col },
+				{ drawPos + (dir1 * size) - (dir2 * size),        tex2->xstart, tex2->yend  , col }
 			);
 
 			AddEffectsQuad<2>(
-				{ drawPos - (dir1 * coresize) - (dir2 * coresize), weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->ystart, col2 },
-				{ drawPos - (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->ystart, col2 },
-				{ drawPos + (dir1 * coresize),                     midtexx,                             weaponDef->visuals.texture2->yend  , col2 },
-				{ drawPos + (dir1 * coresize) - (dir2 * coresize), weaponDef->visuals.texture2->xstart, weaponDef->visuals.texture2->yend  , col2 }
+				tex2->pageNum,
+				{ drawPos - (dir1 * coresize) - (dir2 * coresize), tex2->xstart, tex2->ystart, col2 },
+				{ drawPos - (dir1 * coresize),                     midtexx,      tex2->ystart, col2 },
+				{ drawPos + (dir1 * coresize),                     midtexx,      tex2->yend  , col2 },
+				{ drawPos + (dir1 * coresize) - (dir2 * coresize), tex2->xstart, tex2->yend  , col2 }
 			);
 		}
 		if (validTextures[1]) {
+			const auto* tex1 = weaponDef->visuals.texture1;
 			AddEffectsQuad<1>(
-				{ drawPos - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
-				{ pos2    - (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col },
-				{ pos2    + (dir1 * size),     weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col },
-				{ drawPos + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
+				tex1->pageNum,
+				{ drawPos - (dir1 * size),     tex1->xstart + texStartOffset, tex1->ystart, col },
+				{ pos2    - (dir1 * size),     tex1->xend   + texEndOffset  , tex1->ystart, col },
+				{ pos2    + (dir1 * size),     tex1->xend   + texEndOffset  , tex1->yend  , col },
+				{ drawPos + (dir1 * size),     tex1->xstart + texStartOffset, tex1->yend  , col }
 			);
 
 			AddEffectsQuad<1>(
-				{ drawPos - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
-				{ pos2    - (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->ystart, col2 },
-				{ pos2    + (dir1 * coresize), weaponDef->visuals.texture1->xend   + texEndOffset  , weaponDef->visuals.texture1->yend  , col2 },
-				{ drawPos + (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col2 }
+				tex1->pageNum,
+				{ drawPos - (dir1 * coresize), tex1->xstart + texStartOffset, tex1->ystart, col2 },
+				{ pos2    - (dir1 * coresize), tex1->xend   + texEndOffset  , tex1->ystart, col2 },
+				{ pos2    + (dir1 * coresize), tex1->xend   + texEndOffset  , tex1->yend  , col2 },
+				{ drawPos + (dir1 * coresize), tex1->xstart + texStartOffset, tex1->yend  , col2 }
 			);
 		}
 		if (validTextures[2]) {
+			const auto* tex2 = weaponDef->visuals.texture2;
 			AddEffectsQuad<2>(
-				{ pos2 - (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->ystart, col },
-				{ pos2 - (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col },
-				{ pos2 + (dir1 * size) + (dir2 * size),         weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col },
-				{ pos2 + (dir1 * size),                         midtexx,                           weaponDef->visuals.texture2->yend  , col }
+				tex2->pageNum,
+				{ pos2 - (dir1 * size),                         midtexx,    tex2->ystart, col },
+				{ pos2 - (dir1 * size) + (dir2 * size),         tex2->xend, tex2->ystart, col },
+				{ pos2 + (dir1 * size) + (dir2 * size),         tex2->xend, tex2->yend  , col },
+				{ pos2 + (dir1 * size),                         midtexx,    tex2->yend  , col }
 			);
 
 			AddEffectsQuad<2>(
-				{ pos2 - (dir1 * coresize),                     midtexx,                           weaponDef->visuals.texture2->ystart, col2 },
-				{ pos2 - (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->ystart, col2 },
-				{ pos2 + (dir1 * coresize) + (dir2 * coresize), weaponDef->visuals.texture2->xend, weaponDef->visuals.texture2->yend  , col2 },
-				{ pos2 + (dir1 * coresize),                     midtexx,                           weaponDef->visuals.texture2->yend  , col2 }
+				tex2->pageNum,
+				{ pos2 - (dir1 * coresize),                     midtexx,    tex2->ystart, col2 },
+				{ pos2 - (dir1 * coresize) + (dir2 * coresize), tex2->xend, tex2->ystart, col2 },
+				{ pos2 + (dir1 * coresize) + (dir2 * coresize), tex2->xend, tex2->yend  , col2 },
+				{ pos2 + (dir1 * coresize),                     midtexx,    tex2->yend  , col2 }
 			);
 		}
 	} else {
@@ -282,18 +291,21 @@ void CLaserProjectile::Draw()
 			texEndOffset   = ((float)stayTime * (speedf / maxLength)) * (weaponDef->visuals.texture1->xstart - weaponDef->visuals.texture1->xend);
 		}
 		if (validTextures[1]) {
+			const auto* tex1 = weaponDef->visuals.texture1;
 			AddEffectsQuad<1>(
-				{ pos1 - (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col },
-				{ pos2 - (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col },
-				{ pos2 + (dir1 * size),     weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col },
-				{ pos1 + (dir1 * size),     weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col }
+				tex1->pageNum,
+				{ pos1 - (dir1 * size),     tex1->xstart + texStartOffset, tex1->ystart, col },
+				{ pos2 - (dir1 * size),     tex1->xend +     texEndOffset, tex1->ystart, col },
+				{ pos2 + (dir1 * size),     tex1->xend +     texEndOffset, tex1->yend  , col },
+				{ pos1 + (dir1 * size),     tex1->xstart + texStartOffset, tex1->yend  , col }
 			);
 
 			AddEffectsQuad<1>(
-				{ pos1 - (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->ystart, col2 },
-				{ pos2 - (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->ystart, col2 },
-				{ pos2 + (dir1 * coresize), weaponDef->visuals.texture1->xend +     texEndOffset, weaponDef->visuals.texture1->yend  , col2 },
-				{ pos1 + (dir1 * coresize), weaponDef->visuals.texture1->xstart + texStartOffset, weaponDef->visuals.texture1->yend  , col2 }
+				tex1->pageNum,
+				{ pos1 - (dir1 * coresize), tex1->xstart + texStartOffset, tex1->ystart, col2 },
+				{ pos2 - (dir1 * coresize), tex1->xend +     texEndOffset, tex1->ystart, col2 },
+				{ pos2 + (dir1 * coresize), tex1->xend +     texEndOffset, tex1->yend  , col2 },
+				{ pos1 + (dir1 * coresize), tex1->xstart + texStartOffset, tex1->yend  , col2 }
 			);
 		}
 	}

--- a/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LightningProjectile.cpp
@@ -88,6 +88,7 @@ void CLightningProjectile::Draw()
 
 			const auto& WDV = weaponDef->visuals;
 			AddEffectsQuad<1>(
+				WDV.texture1->pageNum,
 				{ tempPosO + (dir1 * (displacement[d    ] + WDV.thickness)), WDV.texture1->xstart, WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] + WDV.thickness)), WDV.texture1->xend,   WDV.texture1->ystart, col },
 				{ tempPos  + (dir1 * (displacement[d + 1] - WDV.thickness)), WDV.texture1->xend,   WDV.texture1->yend,   col },

--- a/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/MissileProjectile.cpp
@@ -390,6 +390,7 @@ void CMissileProjectile::Draw()
 	const auto* WT1 = weaponDef->visuals.texture1;
 
 	AddEffectsQuad<1>(
+		WT1->pageNum,
 		{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xstart, WT1->ystart, lightYellow },
 		{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, WT1->xend,   WT1->ystart, lightYellow },
 		{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, WT1->xend,   WT1->yend,   lightYellow },

--- a/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/StarburstProjectile.cpp
@@ -380,6 +380,7 @@ void CStarburstProjectile::Draw()
 			col.a = 1;
 
 			AddEffectsQuad<3>(
+				wt3->pageNum,
 				{ interPos - camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xstart, wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize - camera->GetUp() * drawsize, wt3->xend,   wt3->ystart, col },
 				{ interPos + camera->GetRight() * drawsize + camera->GetUp() * drawsize, wt3->xend,   wt3->yend,   col },
@@ -396,6 +397,7 @@ void CStarburstProjectile::Draw()
 
 	if (validTextures[1]) {
 		AddEffectsQuad<1>(
+			wt1->pageNum,
 			{ drawPos - camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xstart, wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize - camera->GetUp() * fsize, wt1->xend,   wt1->ystart, lightRed },
 			{ drawPos + camera->GetRight() * fsize + camera->GetUp() * fsize, wt1->xend,   wt1->yend,   lightRed },

--- a/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/TorpedoProjectile.cpp
@@ -185,7 +185,10 @@ void CTorpedoProjectile::Draw()
 	const float w = 2;
 	const SColor col(60, 60, 100, 255);
 
+	const auto& pageNum = projectileDrawer->torpedotex->pageNum;
+
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
@@ -193,6 +196,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos + (u * w),             texx, texy, col },
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
@@ -200,6 +204,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos - (r * w),             texx, texy, col },
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
@@ -207,6 +212,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos - (u * w),             texx, texy, col },
 		{ drawPos + (r * w),             texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
@@ -214,6 +220,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
@@ -221,6 +228,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos + (u * w) + (dir * h), texx, texy, col },
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
@@ -228,6 +236,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos - (r * w) + (dir * h), texx, texy, col },
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },
@@ -235,6 +244,7 @@ void CTorpedoProjectile::Draw()
 	);
 
 	AddEffectsQuad<0>(
+		pageNum,
 		{ drawPos - (u * w) + (dir * h), texx, texy, col },
 		{ drawPos + (r * w) + (dir * h), texx, texy, col },
 		{ drawPos + (dir * h * 1.2f),    texx, texy, col },

--- a/rts/System/float4.h
+++ b/rts/System/float4.h
@@ -117,4 +117,10 @@ struct float4 : public float3
 	operator       float* ()       { return reinterpret_cast<      float*>(&x); }
 };
 
+struct float4Hash {
+	uint32_t operator()(const float4& v) const {
+		return spring::LiteHash(&v, sizeof(v));
+	}
+};
+
 #endif /* FLOAT4_H */

--- a/rts/System/float4.h
+++ b/rts/System/float4.h
@@ -4,6 +4,7 @@
 #define FLOAT4_H
 
 #include "System/float3.h"
+#include "System/SpringHash.h"
 #include "System/creg/creg_cond.h"
 
 /** Float3 with a fourth data member, which is basically unused but required


### PR DESCRIPTION
Currently only enabled for projectiles and ground flashes.
If the atlas cannot be fit into the TEXTURE_2D, it's instead fit into multiple pages of TEXTURE_2D_ARRAY. This way game devs are no longer limited by the fixed maximum dimension of TEXTURE_2D.

The memory efficiency in case of TEXTURE_2D_ARRAY is lower because the multipage algorithm is greedy, but in this case it looked like a reasonable sacrifice.