### PR TITLE
fonts: Allow disabling automatic setting of glBlendFunc

### DIFF
--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -18,6 +18,15 @@
 #include "System/Misc/TracyDefs.h"
 
 
+/***
+ * Lua opengl font object.
+ *
+ * @class LuaFont
+ * @table LuaFont
+ * @see gl.LoadFont
+ */
+
+
 bool LuaFonts::PushEntries(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -358,7 +367,7 @@ int LuaFonts::PrintWorld(lua_State* L)
 
 /*** Begin a block of font commands.
  *
- * @function gl.BeginText
+ * @function LuaFont:Begin
  *
  * Fonts can be printed without using Start/End, but when doing several operations it's more optimal
  * if done inside a block.
@@ -392,7 +401,7 @@ int LuaFonts::End(lua_State* L)
 
 /*** Draws text printed with the `buffered` option.
  *
- * @function gl.SubmitBuffered
+ * @function LuaFont:SubmitBuffered
  *
  * @param noBillboarding boolean? When `false` sets 3d billboard mode. Defaults to `true`.
  * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -375,7 +375,7 @@ int LuaFonts::PrintWorld(lua_State* L)
  * Also allows disabling automatic setting of the blend mode. Otherwise the font will always print
  * with `BlendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)`.
 
- * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ * @param userDefinedBlending boolean? When `true` doesn't set the gl.BlendFunc automatically. Defaults to `false`.
  *
  * @see gl.BlendFunc
  * @see gl.BlendFuncSeparate
@@ -385,8 +385,8 @@ int LuaFonts::Begin(lua_State* L)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CheckDrawingEnabled(L, __func__);
 	auto f = tofont(L, 1);
-	auto autoBlendMode = luaL_optboolean(L, 2, true);
-	f->Begin(autoBlendMode);
+	auto userDefinedBlending = luaL_optboolean(L, 2, false);
+	f->Begin(userDefinedBlending);
 	return 0;
 }
 
@@ -404,7 +404,7 @@ int LuaFonts::End(lua_State* L)
  * @function LuaFont:SubmitBuffered
  *
  * @param noBillboarding boolean? When `false` sets 3d billboard mode. Defaults to `true`.
- * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ * @param userDefinedBlending boolean? When `true` doesn't set the gl.BlendFunc automatically. Defaults to `false`.
  *
  * @see gl.BlendFunc
  * @see gl.BlendFuncSeparate
@@ -414,12 +414,12 @@ int LuaFonts::SubmitBuffered(lua_State* L)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CheckDrawingEnabled(L, __func__);
 	auto f = tofont(L, 1);
-	auto autoBlendMode = luaL_optboolean(L, 3, true);
+	auto userDefinedBlending = luaL_optboolean(L, 3, false);
 
 	if (luaL_optboolean(L, 2, true)) // world or not
-		f->DrawBuffered(autoBlendMode);
+		f->DrawBuffered(userDefinedBlending);
 	else
-		f->DrawWorldBuffered(autoBlendMode);
+		f->DrawWorldBuffered(userDefinedBlending);
 
 	return 0;
 }

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -356,12 +356,28 @@ int LuaFonts::PrintWorld(lua_State* L)
 /******************************************************************************/
 /******************************************************************************/
 
+/*** Begin a block of font commands.
+ *
+ * @function gl.BeginText
+ *
+ * Fonts can be printed without using Start/End, but when doing several operations it's more optimal
+ * if done inside a block.
+ *
+ * Also allows disabling automatic setting of the blend mode. Otherwise the font will always print
+ * with `BlendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)`.
+
+ * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ *
+ * @see gl.BlendFunc
+ * @see gl.BlendFuncSeparate
+ */
 int LuaFonts::Begin(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	CheckDrawingEnabled(L, __func__);
 	auto f = tofont(L, 1);
-	f->Begin();
+	auto autoBlendMode = luaL_optboolean(L, 2, true);
+	f->Begin(autoBlendMode);
 	return 0;
 }
 
@@ -374,16 +390,27 @@ int LuaFonts::End(lua_State* L)
 	return 0;
 }
 
+/*** Draws text printed with the `buffered` option.
+ *
+ * @function gl.SubmitBuffered
+ *
+ * @param noBillboarding boolean? When `false` sets 3d billboard mode. Defaults to `true`.
+ * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ *
+ * @see gl.BlendFunc
+ * @see gl.BlendFuncSeparate
+ */
 int LuaFonts::SubmitBuffered(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	CheckDrawingEnabled(L, __func__);
 	auto f = tofont(L, 1);
+	auto autoBlendMode = luaL_optboolean(L, 3, true);
 
 	if (luaL_optboolean(L, 2, true)) // world or not
-		f->DrawBuffered();
+		f->DrawBuffered(autoBlendMode);
 	else
-		f->DrawWorldBuffered();
+		f->DrawWorldBuffered(autoBlendMode);
 
 	return 0;
 }

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -1324,13 +1324,26 @@ int LuaOpenGL::DrawMiniMap(lua_State* L)
 ******************************************************************************/
 
 
-/***
+/*** Begin a block of text commands.
+ *
  * @function gl.BeginText
+ *
+ * Text can be drawn without Start/End, but when doing several operations it's more optimal
+ * if done inside a block.
+ *
+ * Also allows disabling automatic setting of the blend mode. Otherwise the font will always print
+ * with `BlendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)`.
+ *
+ * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ *
+ * @see gl.BlendFunc
+ * @see gl.BlendFuncSeparate
  */
 int LuaOpenGL::BeginText(lua_State* L)
 {
 	CheckDrawingEnabled(L, __func__);
-	font->Begin();
+	auto autoBlendMode = luaL_optboolean(L, 2, true);
+	font->Begin(autoBlendMode);
 	return 0;
 }
 

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -1334,7 +1334,7 @@ int LuaOpenGL::DrawMiniMap(lua_State* L)
  * Also allows disabling automatic setting of the blend mode. Otherwise the font will always print
  * with `BlendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA)`.
  *
- * @param autoBlendMode boolean? When `false` doesn't set the gl.BlendFunc automatically. Defaults to `true`.
+ * @param userDefinedBlending boolean? When `true` doesn't set the gl.BlendFunc automatically. Defaults to `false`.
  *
  * @see gl.BlendFunc
  * @see gl.BlendFuncSeparate
@@ -1342,8 +1342,8 @@ int LuaOpenGL::DrawMiniMap(lua_State* L)
 int LuaOpenGL::BeginText(lua_State* L)
 {
 	CheckDrawingEnabled(L, __func__);
-	auto autoBlendMode = luaL_optboolean(L, 2, true);
-	font->Begin(autoBlendMode);
+	auto userDefinedBlending = luaL_optboolean(L, 2, false);
+	font->Begin(userDefinedBlending);
 	return 0;
 }
 

--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -191,10 +191,10 @@ CglFont::CglFont(const std::string& fontFile, int size, int _outlineWidth, float
 }
 
 #ifdef HEADLESS
-void CglFont::Begin() {}
+void CglFont::Begin(bool autoBlendMode) {}
 void CglFont::End() {}
-void CglFont::DrawBuffered() {}
-void CglFont::DrawWorldBuffered() {}
+void CglFont::DrawBuffered(bool autoBlendMode) {}
+void CglFont::DrawWorldBuffered(bool autoBlendMode) {}
 
 void CglFont::glWorldPrint(const float3& p, const float size, const std::string& str, int options) {}
 
@@ -619,9 +619,11 @@ const float4* CglFont::ChooseOutlineColor(const float4& textColor)
 	return &lightOutline;
 }
 
-void CglFont::Begin() {
+void CglFont::Begin(bool autoBlendMode) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	sync.Lock();
+
+	fontRenderer->SetAutoBlendMode(autoBlendMode);
 
 	if (inBeginEndBlock) {
 		sync.Unlock();
@@ -650,7 +652,7 @@ void CglFont::End() {
 }
 
 
-void CglFont::DrawBuffered()
+void CglFont::DrawBuffered(bool autoBlendMode)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	auto lock = sync.GetScopedLock();
@@ -658,18 +660,20 @@ void CglFont::DrawBuffered()
 	UpdateGlyphAtlasTexture();
 	UploadGlyphAtlasTexture();
 
+	fontRenderer->SetAutoBlendMode(autoBlendMode);
+
 	fontRenderer->PushGLState(*this);
 	fontRenderer->DrawTraingleElements();
 	fontRenderer->PopGLState();
 }
 
-void CglFont::DrawWorldBuffered()
+void CglFont::DrawWorldBuffered(bool autoBlendMode)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	glPushMatrix();
 	glMultMatrixf(camera->GetBillBoardMatrix());
 
-	DrawBuffered();
+	DrawBuffered(autoBlendMode);
 
 	glPopMatrix();
 }

--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -647,6 +647,8 @@ void CglFont::End() {
 	fontRenderer->DrawTraingleElements();
 	fontRenderer->PopGLState();
 
+	fontRenderer->SetUserDefinedBlending(false);
+
 	inBeginEndBlock = false;
 	sync.Unlock();
 }
@@ -665,6 +667,8 @@ void CglFont::DrawBuffered(bool userDefinedBlending)
 	fontRenderer->PushGLState(*this);
 	fontRenderer->DrawTraingleElements();
 	fontRenderer->PopGLState();
+
+	fontRenderer->SetUserDefinedBlending(false);
 }
 
 void CglFont::DrawWorldBuffered(bool userDefinedBlending)

--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -191,10 +191,10 @@ CglFont::CglFont(const std::string& fontFile, int size, int _outlineWidth, float
 }
 
 #ifdef HEADLESS
-void CglFont::Begin(bool autoBlendMode) {}
+void CglFont::Begin(bool userDefinedBlending) {}
 void CglFont::End() {}
-void CglFont::DrawBuffered(bool autoBlendMode) {}
-void CglFont::DrawWorldBuffered(bool autoBlendMode) {}
+void CglFont::DrawBuffered(bool userDefinedBlending) {}
+void CglFont::DrawWorldBuffered(bool userDefinedBlending) {}
 
 void CglFont::glWorldPrint(const float3& p, const float size, const std::string& str, int options) {}
 
@@ -619,11 +619,11 @@ const float4* CglFont::ChooseOutlineColor(const float4& textColor)
 	return &lightOutline;
 }
 
-void CglFont::Begin(bool autoBlendMode) {
+void CglFont::Begin(bool userDefinedBlending) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	sync.Lock();
 
-	fontRenderer->SetAutoBlendMode(autoBlendMode);
+	fontRenderer->SetUserDefinedBlending(userDefinedBlending);
 
 	if (inBeginEndBlock) {
 		sync.Unlock();
@@ -652,7 +652,7 @@ void CglFont::End() {
 }
 
 
-void CglFont::DrawBuffered(bool autoBlendMode)
+void CglFont::DrawBuffered(bool userDefinedBlending)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	auto lock = sync.GetScopedLock();
@@ -660,20 +660,20 @@ void CglFont::DrawBuffered(bool autoBlendMode)
 	UpdateGlyphAtlasTexture();
 	UploadGlyphAtlasTexture();
 
-	fontRenderer->SetAutoBlendMode(autoBlendMode);
+	fontRenderer->SetUserDefinedBlending(userDefinedBlending);
 
 	fontRenderer->PushGLState(*this);
 	fontRenderer->DrawTraingleElements();
 	fontRenderer->PopGLState();
 }
 
-void CglFont::DrawWorldBuffered(bool autoBlendMode)
+void CglFont::DrawWorldBuffered(bool userDefinedBlending)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	glPushMatrix();
 	glMultMatrixf(camera->GetBillBoardMatrix());
 
-	DrawBuffered(autoBlendMode);
+	DrawBuffered(userDefinedBlending);
 
 	glPopMatrix();
 }

--- a/rts/Rendering/Fonts/glFont.h
+++ b/rts/Rendering/Fonts/glFont.h
@@ -138,7 +138,6 @@ public:
 	static auto GetLoadedFonts() -> const decltype(allFonts)& {
 		return allFonts;
 	}
-	bool autoBlendMode = true;
 private:
 	std::string fontPath;
 

--- a/rts/Rendering/Fonts/glFont.h
+++ b/rts/Rendering/Fonts/glFont.h
@@ -55,12 +55,12 @@ public:
 
 	CglFont(const std::string& fontFile, int size, int outlinewidth, float outlineweight);
 
-	void Begin(bool autoBlendMode = true);
+	void Begin(bool userDefinedBlending = false);
 	void End();
 
-	void DrawBuffered(bool autoBlendMode = true);
+	void DrawBuffered(bool userDefinedBlending = false);
 
-	void DrawWorldBuffered(bool autoBlendMode = true);
+	void DrawWorldBuffered(bool userDefinedBlending = false);
 
 	void glWorldPrint(const float3& p, const float size, const std::string& str, int options = FONT_DESCENDER | FONT_CENTER | FONT_OUTLINE | FONT_BUFFERED);
 

--- a/rts/Rendering/Fonts/glFont.h
+++ b/rts/Rendering/Fonts/glFont.h
@@ -55,12 +55,12 @@ public:
 
 	CglFont(const std::string& fontFile, int size, int outlinewidth, float outlineweight);
 
-	void Begin();
+	void Begin(bool autoBlendMode = true);
 	void End();
 
-	void DrawBuffered();
+	void DrawBuffered(bool autoBlendMode = true);
 
-	void DrawWorldBuffered();
+	void DrawWorldBuffered(bool autoBlendMode = true);
 
 	void glWorldPrint(const float3& p, const float size, const std::string& str, int options = FONT_DESCENDER | FONT_CENTER | FONT_OUTLINE | FONT_BUFFERED);
 
@@ -138,6 +138,7 @@ public:
 	static auto GetLoadedFonts() -> const decltype(allFonts)& {
 		return allFonts;
 	}
+	bool autoBlendMode = true;
 private:
 	std::string fontPath;
 

--- a/rts/Rendering/Fonts/glFontRenderer.cpp
+++ b/rts/Rendering/Fonts/glFontRenderer.cpp
@@ -192,8 +192,6 @@ void CglShaderFontRenderer::PopGLState()
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	glPopAttrib();
-
-	userDefinedBlending = false;
 }
 
 void CglShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const
@@ -341,8 +339,6 @@ void CglNoShaderFontRenderer::PopGLState()
 
 	glDisable(GL_TEXTURE_2D);
 	glPopAttrib();
-
-	userDefinedBlending = false;
 }
 
 void CglNoShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const

--- a/rts/Rendering/Fonts/glFontRenderer.cpp
+++ b/rts/Rendering/Fonts/glFontRenderer.cpp
@@ -171,7 +171,8 @@ void CglShaderFontRenderer::PushGLState(const CglFont& fnt)
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_ALPHA_TEST); //just in case
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	if (autoBlendMode)
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glBindTexture(GL_TEXTURE_2D, fnt.GetTexture());
 
@@ -191,6 +192,8 @@ void CglShaderFontRenderer::PopGLState()
 	glBindTexture(GL_TEXTURE_2D, 0);
 
 	glPopAttrib();
+
+	autoBlendMode = true;
 }
 
 void CglShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const
@@ -309,7 +312,8 @@ void CglNoShaderFontRenderer::PushGLState(const CglFont& fnt)
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_ALPHA_TEST);
 	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	if (autoBlendMode)
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glEnable(GL_TEXTURE_2D);
 
 	glMatrixMode(GL_TEXTURE);
@@ -337,6 +341,8 @@ void CglNoShaderFontRenderer::PopGLState()
 
 	glDisable(GL_TEXTURE_2D);
 	glPopAttrib();
+
+	autoBlendMode = true;
 }
 
 void CglNoShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const

--- a/rts/Rendering/Fonts/glFontRenderer.cpp
+++ b/rts/Rendering/Fonts/glFontRenderer.cpp
@@ -171,7 +171,7 @@ void CglShaderFontRenderer::PushGLState(const CglFont& fnt)
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_ALPHA_TEST); //just in case
 	glEnable(GL_BLEND);
-	if (autoBlendMode)
+	if (!userDefinedBlending)
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glBindTexture(GL_TEXTURE_2D, fnt.GetTexture());
@@ -193,7 +193,7 @@ void CglShaderFontRenderer::PopGLState()
 
 	glPopAttrib();
 
-	autoBlendMode = true;
+	userDefinedBlending = false;
 }
 
 void CglShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const
@@ -312,7 +312,7 @@ void CglNoShaderFontRenderer::PushGLState(const CglFont& fnt)
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_ALPHA_TEST);
 	glEnable(GL_BLEND);
-	if (autoBlendMode)
+	if (!userDefinedBlending)
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glEnable(GL_TEXTURE_2D);
 
@@ -342,7 +342,7 @@ void CglNoShaderFontRenderer::PopGLState()
 	glDisable(GL_TEXTURE_2D);
 	glPopAttrib();
 
-	autoBlendMode = true;
+	userDefinedBlending = false;
 }
 
 void CglNoShaderFontRenderer::GetStats(std::array<size_t, 8>& stats) const

--- a/rts/Rendering/Fonts/glFontRenderer.h
+++ b/rts/Rendering/Fonts/glFontRenderer.h
@@ -22,7 +22,7 @@ public:
 	virtual bool IsValid() const = 0;
 	virtual void GetStats(std::array<size_t, 8>& stats) const = 0;
 
-	void SetUserDefinedBlending(bool newAutoBlendMode) { userDefinedBlending = userDefinedBlending; };
+	void SetUserDefinedBlending(bool enableUserDefinedBlending) { userDefinedBlending = enableUserDefinedBlending; };
 
 	static std::unique_ptr<CglFontRenderer> CreateInstance();
 	static void DeleteInstance(std::unique_ptr<CglFontRenderer>& instance);

--- a/rts/Rendering/Fonts/glFontRenderer.h
+++ b/rts/Rendering/Fonts/glFontRenderer.h
@@ -22,10 +22,13 @@ public:
 	virtual bool IsValid() const = 0;
 	virtual void GetStats(std::array<size_t, 8>& stats) const = 0;
 
+	void SetAutoBlendMode(bool newAutoBlendMode) { autoBlendMode = newAutoBlendMode; };
+
 	static std::unique_ptr<CglFontRenderer> CreateInstance();
 	static void DeleteInstance(std::unique_ptr<CglFontRenderer>& instance);
 protected:
 	GLint currProgID = 0;
+	bool autoBlendMode = true;
 
 	// should be enough to hold all data for a given frame
 	static constexpr size_t NUM_BUFFER_ELEMS = (1 << 14);

--- a/rts/Rendering/Fonts/glFontRenderer.h
+++ b/rts/Rendering/Fonts/glFontRenderer.h
@@ -22,13 +22,13 @@ public:
 	virtual bool IsValid() const = 0;
 	virtual void GetStats(std::array<size_t, 8>& stats) const = 0;
 
-	void SetAutoBlendMode(bool newAutoBlendMode) { autoBlendMode = newAutoBlendMode; };
+	void SetUserDefinedBlending(bool newAutoBlendMode) { userDefinedBlending = userDefinedBlending; };
 
 	static std::unique_ptr<CglFontRenderer> CreateInstance();
 	static void DeleteInstance(std::unique_ptr<CglFontRenderer>& instance);
 protected:
 	GLint currProgID = 0;
-	bool autoBlendMode = true;
+	bool userDefinedBlending = false;
 
 	// should be enough to hold all data for a given frame
 	static constexpr size_t NUM_BUFFER_ELEMS = (1 << 14);


### PR DESCRIPTION
### Work done

- Allow rendering fonts without automatic setting of the glBlendFunc to `(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)`)
  - Through new `userDefinedBlending` argument for `LuaFont:Begin`, `LuaFont:SubmitBuffered`, `gl.BeginText`.

### Remarks

- This is needed so advanced blending can be done with fonts.
  - Required when rendering to a texture with alpha that afterwards needs to be rendered into screen.
- Sometimes also premultiplied alpha can be used, but that will need further changes, so the shader can either sometimes draw with premult alpha, or always draw with premultiplied alpha.
  - I think always premult in shader can be more flexible, since it's easy to blend premultiplied image in all situations, anyways that's smth for a different PR.
- Can't make this a font property, since otherwise user would be forced to create different fonts for different blendings, and that would involve more font bitmaps for nothing.
- Could be called `customBlendMode` or `noAutoBlend` instead of `userDefinedBlending`.
  - open to ideas.
- Had to add some extra documentation so I could document the new argument.

### Screenshots

1. no render to texture:

![blend-lorem-no-r2t](https://github.com/user-attachments/assets/7da31060-ef5a-46a8-ac67-489aa2a777e9)

2. "standard" render to texture (just letting everything render with `(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)`):

![blend-lorem-r2t-autoblend](https://github.com/user-attachments/assets/a4e9217b-af7e-4e62-848a-99980e3dcda9)

3. As recommended [at first answer "option 2" here](https://stackoverflow.com/questions/24346585/opengl-render-to-texture-with-partial-transparancy-translucency-and-then-rende). Rendering to fbo (including text) using `(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE)`, then I'm rendering the fbo to screen with `(GL_ONE, GL_ONE_MINUS_SRC_ALPHA)`:

![blend-lorem-r2t-noautoblend](https://github.com/user-attachments/assets/b0bc94a4-da40-4c9a-a9b0-37986410c9b2)

Note this is still has some very small differences, at the sides of some characters like "l", "p"..., so not sure if this is the best solution (unsure if the difference here is due to blend mode), but afaics any solution for r2t will involve disabling the autoblend mode so application can set its own preferred blend mode.