### PR TITLE
LuaOpenGL: Add POINT_SMOOTH const and query.

### DIFF
--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -3903,6 +3903,23 @@ int LuaOpenGL::PointSize(lua_State* L)
 
 
 /***
+ * @function gl.PointSmooth
+ * @param flag boolean
+ */
+int LuaOpenGL::PointSmooth(lua_State* L)
+{
+	CheckDrawingEnabled(L, __func__);
+	CondWarnDeprecatedGL(L, __func__);
+
+	if (luaL_checkboolean(L, 1))
+		glEnable(GL_POINT_SMOOTH);
+	else
+		glDisable(GL_POINT_SMOOTH);
+	return 0;
+}
+
+
+/***
  * @function gl.PointSprite
  * @param enable boolean
  * @param enableCoordReplace boolean?

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -134,6 +134,8 @@ std::unordered_map<GLenum, std::string> LuaOpenGL::fixedStateEnumToString = {
 		FillFixedStateEnumToString(GL_FLAT),
 		FillFixedStateEnumToString(GL_SMOOTH),
 
+		FillFixedStateEnumToString(GL_POINT_SMOOTH),
+
 		FillFixedStateEnumToString(GL_FRONT),
 		FillFixedStateEnumToString(GL_BACK),
 		FillFixedStateEnumToString(GL_FRONT_AND_BACK),
@@ -6047,6 +6049,15 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			lua_pushnumber(L, pointSize);
 
 			return 2;
+		} break;
+		case hashString("pointSmooth"):
+		case hashString("pointsmooth"): {
+			GLboolean pointSmoothFlag;
+
+			glGetBooleanv(GL_POINT_SMOOTH, &pointSmoothFlag);
+			lua_pushnumber(L, pointSmoothFlag);
+
+			return 1;
 		} break;
 		default: {
 			luaL_error(L, "Incorrect first argument (%s) to gl.GetFixedState", param);

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -3903,23 +3903,6 @@ int LuaOpenGL::PointSize(lua_State* L)
 
 
 /***
- * @function gl.PointSmooth
- * @param flag boolean
- */
-int LuaOpenGL::PointSmooth(lua_State* L)
-{
-	CheckDrawingEnabled(L, __func__);
-	CondWarnDeprecatedGL(L, __func__);
-
-	if (luaL_checkboolean(L, 1))
-		glEnable(GL_POINT_SMOOTH);
-	else
-		glDisable(GL_POINT_SMOOTH);
-	return 0;
-}
-
-
-/***
  * @function gl.PointSprite
  * @param enable boolean
  * @param enableCoordReplace boolean?

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -6052,6 +6052,8 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 		} break;
 		case hashString("pointSmooth"):
 		case hashString("pointsmooth"): {
+			CondWarnDeprecatedGL(L, __func__);
+
 			GLboolean pointSmoothFlag;
 
 			glGetBooleanv(GL_POINT_SMOOTH, &pointSmoothFlag);

--- a/rts/Lua/LuaOpenGL.h
+++ b/rts/Lua/LuaOpenGL.h
@@ -221,6 +221,7 @@ class LuaOpenGL {
 
 		static int LineWidth(lua_State* L);
 		static int PointSize(lua_State* L);
+		static int PointSmooth(lua_State* L);
 		static int PointSprite(lua_State* L);
 		static int PointParameter(lua_State* L);
 

--- a/rts/Lua/LuaOpenGL.h
+++ b/rts/Lua/LuaOpenGL.h
@@ -221,7 +221,6 @@ class LuaOpenGL {
 
 		static int LineWidth(lua_State* L);
 		static int PointSize(lua_State* L);
-		static int PointSmooth(lua_State* L);
 		static int PointSprite(lua_State* L);
 		static int PointParameter(lua_State* L);
 


### PR DESCRIPTION
### Work done

- Add POINT_SMOOTH const and query capability.

### Remarks

- In some situations users might need to set/query/restore the POINT_SMOOTH to avoid points rendering as squares.
- Unsure if this is wanted since I guess modern opengl doesn't recommend drawing points like that, or maybe it's even deprecated, but couldn't find where it says to be deprecated so proposing this since it can be needed to easy fix widgets rendering points as squares on some gfx cards (like ping wheel).
  - This isn't strictly needed, but specially the query capability is important so state can be restored and not break anything for others. I'm guessing it must be disabled generally, but can't know for sure without being able to query.
- Didn't add a setter since it can be awkwardly done through `gl.UnsafeState`, but could add it too if preferred.