### PR TITLE
Make aircraft die on first contact with ground when crashing.

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -793,7 +793,7 @@ void CHoverAirMoveType::UpdateVerticalSpeed(const float4& spd, float curRelHeigh
 }
 
 
-void CHoverAirMoveType::UpdateAirPhysics()
+bool CHoverAirMoveType::UpdateAirPhysics()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float3& pos = owner->pos;
@@ -827,18 +827,17 @@ void CHoverAirMoveType::UpdateAirPhysics()
 	// between model and ground)
 	// note: unlike StrafeAirMoveType, UpdateTakeoff and UpdateLanding call
 	// UpdateAirPhysics() so we ignore terrain while we are in those states
+	bool crashed = false;
 	if (modInfo.allowAircraftToHitGround) {
 		const bool cpGroundContact = (cpGroundHeight > ownerMinHeight);
 		const bool bpGroundContact = (bpGroundHeight > ownerMinHeight);
 		const bool   handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 
-		if (cpGroundContact && aircraftState == AIRCRAFT_CRASHING) {
-			owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
-			return;
-		}
-
-		// hard avoidance in case soft constraint fails
-		if (cpGroundContact && handleContact)
+		if (cpGroundContact && aircraftState == AIRCRAFT_CRASHING)
+			// avoid moving up since explosion would look a bit off
+			crashed = true;
+		else if (cpGroundContact && handleContact)
+			// hard avoidance in case soft constraint fails
 			owner->Move(UpVector * (cpGroundHeight - ownerMinHeight + 0.01f), true);
 
 		// soft avoidance
@@ -877,6 +876,8 @@ void CHoverAirMoveType::UpdateAirPhysics()
 
 	if (modInfo.allowAircraftToLeaveMap || (pos + spd).IsInBounds())
 		owner->Move(spd, true);
+
+	return crashed;
 }
 
 
@@ -963,9 +964,7 @@ bool CHoverAirMoveType::Update()
 			UpdateHovering();
 			break;
 		case AIRCRAFT_CRASHING: {
-			UpdateAirPhysics();
-
-			if ((CGround::GetHeightAboveWater(owner->pos.x, owner->pos.z) + 5.0f + owner->radius) > owner->pos.y) {
+			if (UpdateAirPhysics()) {
 				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 			} else {
 				#define SPIN_DIR(o) ((o->id & 1) * 2 - 1)

--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -832,6 +832,11 @@ void CHoverAirMoveType::UpdateAirPhysics()
 		const bool bpGroundContact = (bpGroundHeight > ownerMinHeight);
 		const bool   handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 
+		if (cpGroundContact && aircraftState == AIRCRAFT_CRASHING) {
+			owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
+			return;
+		}
+
 		// hard avoidance in case soft constraint fails
 		if (cpGroundContact && handleContact)
 			owner->Move(UpVector * (cpGroundHeight - ownerMinHeight + 0.01f), true);

--- a/rts/Sim/MoveTypes/HoverAirMoveType.h
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.h
@@ -52,7 +52,7 @@ private:
 	// Helpers for (multiple) state handlers
 	void UpdateHeading();
 	void UpdateBanking(bool noBanking);
-	void UpdateAirPhysics();
+	bool UpdateAirPhysics();
 	void UpdateMoveRate();
 
 	void UpdateVerticalSpeed(const float4& spd, float curRelHeight, float curVertSpeed) const;

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -1170,6 +1170,8 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 				rightdir = frontdir.cross(updir.Normalize());
 				frontdir = updir.cross(rightdir.Normalize());
 			}
+			if (aircraftState == AIRCRAFT_CRASHING)
+				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 		}
 	}
 

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -1144,7 +1144,7 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 		const bool groundContact = (groundHeight > (owner->midPos.y - owner->radius));
 		const bool handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 
-		if (aircraftState == AIRCRAFT_CRASHING) {
+		if (groundContact && aircraftState == AIRCRAFT_CRASHING) {
 			owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 			return;
 		}

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -1144,6 +1144,11 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 		const bool groundContact = (groundHeight > (owner->midPos.y - owner->radius));
 		const bool handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 
+		if (aircraftState == AIRCRAFT_CRASHING) {
+			owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
+			return;
+		}
+
 		if (groundContact && handleContact) {
 			const float3  groundOffset = UpVector * (groundHeight - (owner->midPos.y - owner->radius) + 0.01f);
 			const float3& groundNormal = CGround::GetNormal(pos.x, pos.z);
@@ -1170,8 +1175,6 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 				rightdir = frontdir.cross(updir.Normalize());
 				frontdir = updir.cross(rightdir.Normalize());
 			}
-			if (aircraftState == AIRCRAFT_CRASHING)
-				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 		}
 	}
 

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -1150,7 +1150,9 @@ bool CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 
 			const float impactSpeed = -spd.dot(groundNormal) * int(1 - owner->IsStunned());
 
-			owner->Move(groundOffset, true);
+			if (aircraftState != AIRCRAFT_CRASHING)
+				// skip when crashing to explode a bit into the ground
+				owner->Move(groundOffset, true);
 
 			if (impactSpeed > 0.0f) {
 				// fix for mantis #1355

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -520,9 +520,7 @@ bool CStrafeAirMoveType::Update()
 			break;
 		case AIRCRAFT_CRASHING: {
 			// NOTE: the crashing-state can only be set (and unset) by scripts
-			UpdateAirPhysics({crashRudder, crashElevator, crashAileron, 0.0f}, owner->frontdir);
-
-			if ((CGround::GetHeightAboveWater(owner->pos.x, owner->pos.z) + 5.0f + owner->radius) > owner->pos.y)
+			if (UpdateAirPhysics({crashRudder, crashElevator, crashAileron, 0.0f}, owner->frontdir))
 				owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
 
 			amtEmitCrashTrailFuncs[crashExpGenID != -1u](owner, crashExpGenID);
@@ -1043,7 +1041,7 @@ void CStrafeAirMoveType::UpdateLanding()
 
 
 
-void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const float3& thrustVector)
+bool CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const float3& thrustVector)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float3& pos = owner->pos;
@@ -1140,14 +1138,11 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 	//   impulse from weapon impacts can add speed and cause us
 	//   to start bouncing with ever-increasing amplitude while
 	//   stunned, so the same applies there
+	bool crashed = false;
 	if (modInfo.allowAircraftToHitGround) {
 		const bool groundContact = (groundHeight > (owner->midPos.y - owner->radius));
 		const bool handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 
-		if (groundContact && aircraftState == AIRCRAFT_CRASHING) {
-			owner->ForcedKillUnit(nullptr, true, false, -CSolidObject::DAMAGE_AIRCRAFT_CRASHED);
-			return;
-		}
 
 		if (groundContact && handleContact) {
 			const float3  groundOffset = UpVector * (groundHeight - (owner->midPos.y - owner->radius) + 0.01f);
@@ -1175,6 +1170,7 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 				rightdir = frontdir.cross(updir.Normalize());
 				frontdir = updir.cross(rightdir.Normalize());
 			}
+			crashed = true;
 		}
 	}
 
@@ -1187,6 +1183,7 @@ void CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 	owner->SetSpeed(spd);
 	owner->UpdateMidAndAimPos();
 	owner->SetHeadingFromDirection();
+	return crashed;
 }
 
 

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.h
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.h
@@ -35,7 +35,7 @@ public:
 	void UpdateAttack();
 	bool UpdateFlying(float wantedHeight, float wantedThrottle);
 	void UpdateLanding();
-	void UpdateAirPhysics(const float4& controlInputs, const float3& thrustVector);
+	bool UpdateAirPhysics(const float4& controlInputs, const float3& thrustVector);
 	void SetState(AircraftState state) override;
 	void UpdateTakeOff();
 


### PR DESCRIPTION
### Work done

- Make StrafeAirMoveType and HoverAirMoveType die on first contact with ground when crashing.

### Remarks

- I think this is the intended behaviour.
- Not very clear why there was [another test](https://github.com/beyond-all-reason/RecoilEngine/blob/e288853833d48b3b1bd9f4f599782b65f9f5f434/rts/Sim/MoveTypes/StrafeAirMoveType.cpp#L525) for close to ground to be killed, instead of just using the previous ground test by UpdatePhysics, but it's not very deterministic... I suppose the bounce can take the aircraft further than the threshold.
- I did a quick test and out of 4000 crashing aircraft there were 2 with 3 bounces and another with 5.

### Screenshots

- https://www.reddit.com/r/beyondallreason/comments/1kuz2of/let_me_just_take_out_this_mex/

with pr:

hover:

<image src="https://github.com/user-attachments/assets/7f290dee-4ef2-4145-b828-f7c1bee77966" width="480"></image>

strafe:

<image src="https://github.com/user-attachments/assets/94a9d7cb-d897-4bf2-87ed-aebfde49b96b" width="480"></image>

