### PR TITLE
Allow registering and sending Explosion callins to unsynced.

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -267,7 +267,7 @@ void CGameHelper::Explosion(const CExplosionParams& params) {
 	const float altitude = (params.pos).y - realHeight;
 
 	// NOTE: event triggers before damage is applied to objects
-	const bool noGfx = eventHandler.Explosion(weaponDefID, params.projectileID, params.pos, params.owner);
+	const bool noGfx = eventHandler.Explosion(weaponDefID, weaponDef, params.projectileID, params.pos, params.owner);
 
 	if (luaUI != nullptr && weaponDef != nullptr)
 		luaUI->ShockFront(params.pos, weaponDef->cameraShake, damageAOE);

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -267,7 +267,7 @@ void CGameHelper::Explosion(const CExplosionParams& params) {
 	const float altitude = (params.pos).y - realHeight;
 
 	// NOTE: event triggers before damage is applied to objects
-	const bool noGfx = eventHandler.Explosion(weaponDefID, weaponDef, params.projectileID, params.pos, params.owner);
+	const bool noGfx = eventHandler.Explosion(weaponDefID, weaponDef, params);
 
 	if (luaUI != nullptr && weaponDef != nullptr)
 		luaUI->ShockFront(params.pos, weaponDef->cameraShake, damageAOE);

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -20,6 +20,7 @@
 #include "Game/GlobalUnsynced.h"
 #include "Game/Players/Player.h"
 #include "Game/Players/PlayerHandler.h"
+#include "Sim/Misc/LosHandler.h"
 #include "Net/Protocol/NetProtocol.h"
 #include "Game/UI/KeySet.h"
 #include "Game/UI/MiniMap.h"
@@ -2210,6 +2211,17 @@ bool CLuaHandle::Explosion(int weaponDefID, int projectileID, const float3& pos,
 		return false;
 	if (!watchExplosionDefs[weaponDefID])
 		return false;
+
+	bool synced = GetHandleSynced(L);
+
+	if (!synced) {
+		const int allyTeamID = CLuaHandle::GetHandleReadAllyTeam(L);
+
+		if (allyTeamID < 0 && allyTeamID != CEventClient::AllAccessTeam)
+			return false;
+		if (allyTeamID >= 0 && !losHandler->InLos(pos, allyTeamID))
+			return false;
+	}
 
 	LUA_CALL_IN_CHECK(L, false);
 	luaL_checkstack(L, 7, __func__);

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -16,6 +16,7 @@
 #include "LuaUtils.h"
 #include "LuaZip.h"
 #include "Game/Game.h"
+#include "Game/GameHelper.h"
 #include "Game/Action.h"
 #include "Game/GlobalUnsynced.h"
 #include "Game/Players/Player.h"
@@ -2185,10 +2186,10 @@ void CLuaHandle::ProjectileDestroyed(const CProjectile* p)
  * Helper to get Explosion visibility.
  */
 
-bool CLuaHandle::IsExplosionVisible(const WeaponDef* weaponDef, const float3& pos)
+bool CLuaHandle::IsExplosionVisible(const WeaponDef* weaponDef, const CExplosionParams& params)
 {
 	const int allyTeamID = CLuaHandle::GetHandleReadAllyTeam(L);
-	return explGenHandler.PredictExplosionVisible(weaponDef, pos, allyTeamID);
+	return explGenHandler.PredictExplosionVisible(weaponDef, params, allyTeamID);
 }
 
 /*** Called when an explosion occurs.
@@ -2209,7 +2210,7 @@ bool CLuaHandle::IsExplosionVisible(const WeaponDef* weaponDef, const float3& po
  * @see Script.SetWatchExplosion
  * @see Script.SetWatchWeapon
  */
-bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner)
+bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, const CExplosionParams& params)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// piece-projectile collision (*ALL* other
@@ -2225,7 +2226,7 @@ bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, int proj
 
 	bool synced = GetHandleSynced(L);
 
-	if (!synced && !IsExplosionVisible(weaponDef, pos))
+	if (!synced && !IsExplosionVisible(weaponDef, params))
 		return false;
 
 	LUA_CALL_IN_CHECK(L, false);
@@ -2236,15 +2237,15 @@ bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, int proj
 		return false;
 
 	lua_pushnumber(L, weaponDefID);
-	lua_pushnumber(L, pos.x);
-	lua_pushnumber(L, pos.y);
-	lua_pushnumber(L, pos.z);
-	if (owner != nullptr) {
-		lua_pushnumber(L, owner->id);
+	lua_pushnumber(L, params.pos.x);
+	lua_pushnumber(L, params.pos.y);
+	lua_pushnumber(L, params.pos.z);
+	if (params.owner != nullptr) {
+		lua_pushnumber(L, params.owner->id);
 	} else {
 		lua_pushnil(L); // for backward compatibility
 	}
-	lua_pushnumber(L, projectileID);
+	lua_pushnumber(L, params.projectileID);
 
 	// call the routine
 	if (!RunCallIn(L, cmdStr, 6, 1))

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2218,7 +2218,7 @@ bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, const CE
 	if (weaponDefID < 0)
 		return false;
 
-	// if empty, we are not a LuaHandleSynced
+	// if empty, we are a handle with no explosion watch support.
 	if (watchExplosionDefs.empty())
 		return false;
 	if (!watchExplosionDefs[weaponDefID])

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2254,7 +2254,7 @@ bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, const CE
 	// get the results
 	const bool retval = luaL_optboolean(L, -1, false);
 	lua_pop(L, 1);
-	return retval;
+	return synced && retval;
 }
 
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -43,6 +43,7 @@ class LuaTextures;
 class LuaShaders;
 class CLuaDisplayLists;
 class CLuaRules;
+class CLuaUI;
 
 
 class CLuaHandle : public CEventClient
@@ -393,6 +394,7 @@ class CLuaHandle : public CEventClient
 
 		// FIXME needs access to L & RunCallIn
 		friend class CLuaRules;
+		friend class CLuaUI;
 
 		friend class CLuaStateCollector;
 };

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -44,6 +44,7 @@ class LuaShaders;
 class CLuaDisplayLists;
 class CLuaRules;
 class CLuaUI;
+class WeaponDef;
 
 
 class CLuaHandle : public CEventClient
@@ -188,7 +189,8 @@ class CLuaHandle : public CEventClient
 		void ProjectileCreated(const CProjectile* p) override;
 		void ProjectileDestroyed(const CProjectile* p) override;
 
-		bool Explosion(int weaponID, int projectileID, const float3& pos, const CUnit* owner) override;
+		bool IsExplosionVisible(const WeaponDef* weaponDef, const float3& pos);
+		bool Explosion(int weaponID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner) override;
 
 		void StockpileChanged(const CUnit* owner,
 		                      const CWeapon* weapon, int oldCount) override;

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -189,8 +189,8 @@ class CLuaHandle : public CEventClient
 		void ProjectileCreated(const CProjectile* p) override;
 		void ProjectileDestroyed(const CProjectile* p) override;
 
-		bool IsExplosionVisible(const WeaponDef* weaponDef, const float3& pos);
-		bool Explosion(int weaponID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner) override;
+		bool IsExplosionVisible(const WeaponDef* weaponDef, const CExplosionParams& params);
+		bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) override;
 
 		void StockpileChanged(const CUnit* owner,
 		                      const CWeapon* weapon, int oldCount) override;

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -84,6 +84,9 @@ bool CUnsyncedLuaHandle::Init(std::string code, const std::string& file)
 	if (!IsValid())
 		return false;
 
+	// other watch defs not initialized here since unsupported on unsynced
+	watchExplosionDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
+
 	// load the standard libraries
 	LUA_OPEN_LIB(L, luaopen_base);
 	LUA_OPEN_LIB(L, luaopen_math);
@@ -2094,9 +2097,9 @@ int CSyncedLuaHandle::RemoveSyncedActionFallback(lua_State* L)
 
 
 
-#define GetWatchDef(DefType)                                                \
-	int CSyncedLuaHandle::GetWatch ## DefType ## Def(lua_State* L) {        \
-		const CSyncedLuaHandle* lhs = GetSyncedHandle(L);                   \
+#define GetWatchDef(HandleType, DefType)                                                \
+	int C ## HandleType ## LuaHandle::GetWatch ## DefType ## Def(lua_State* L) {        \
+		const C ## HandleType ## LuaHandle* lhs = Get ## HandleType ## Handle(L);                   \
 		const auto& vec = lhs->watch ## DefType ## Defs;                    \
                                                                             \
 		const uint32_t defIdx = luaL_checkint(L, 1);                        \
@@ -2113,9 +2116,9 @@ int CSyncedLuaHandle::RemoveSyncedActionFallback(lua_State* L)
 		return 1;                                                           \
 	}
 
-#define SetWatchDef(DefType)                                                \
-	int CSyncedLuaHandle::SetWatch ## DefType ## Def(lua_State* L) {        \
-		CSyncedLuaHandle* lhs = GetSyncedHandle(L);                         \
+#define SetWatchDef(HandleType, DefType)                                                \
+	int C ## HandleType ## LuaHandle::SetWatch ## DefType ## Def(lua_State* L) {        \
+		C ## HandleType ## LuaHandle* lhs = Get ## HandleType ## Handle(L);                         \
 		auto& vec = lhs->watch ## DefType ## Defs;                          \
                                                                             \
 		const uint32_t defIdx = luaL_checkint(L, 1);                        \
@@ -2177,7 +2180,7 @@ int CSyncedLuaHandle::GetWatchWeaponDef(lua_State* L) {
  * @see Script.SetWatchUnit
  */
 
-GetWatchDef(Unit)
+GetWatchDef(Synced, Unit)
 
 
 /*** Query whether any callins are registered for a featureDefID.
@@ -2190,7 +2193,7 @@ GetWatchDef(Unit)
  * @see Script.SetWatchFeature
  */
 
-GetWatchDef(Feature)
+GetWatchDef(Synced, Feature)
 
 
 /*** Query whether any callins are registered for a weaponDefID.
@@ -2218,7 +2221,8 @@ GetWatchDef(Feature)
  * @see Script.SetWatchExplosion
  */
 
-GetWatchDef(Explosion)
+GetWatchDef(Synced, Explosion)
+GetWatchDef(Unsynced, Explosion)
 
 
 /*** Query whether projectile callins are registered for a weaponDefID.
@@ -2231,7 +2235,7 @@ GetWatchDef(Explosion)
  * @see Script.SetWatchProjectile
  */
 
-GetWatchDef(Projectile)
+GetWatchDef(Synced, Projectile)
 
 
 /*** Query whether weapon targeting callins are registered for a weaponDefID.
@@ -2244,7 +2248,7 @@ GetWatchDef(Projectile)
  * @see Script.SetWatchAllowTarget
  */
 
-GetWatchDef(AllowTarget)
+GetWatchDef(Synced, AllowTarget)
 
 
 /*** Register or deregister unitDefID for expensive callins.
@@ -2260,7 +2264,7 @@ GetWatchDef(AllowTarget)
  * @see Callins:UnitMoveFailed
  */
 
-SetWatchDef(Unit)
+SetWatchDef(Synced, Unit)
 
 
 /*** Register or deregister featureDefID for expensive callins.
@@ -2274,7 +2278,7 @@ SetWatchDef(Unit)
  * @see Callins:UnitFeatureCollision
  */
 
-SetWatchDef(Feature)
+SetWatchDef(Synced, Feature)
 
 
 /*** Register or deregister weaponDefID for all expensive callins.
@@ -2311,7 +2315,8 @@ SetWatchDef(Feature)
  * @see Callins:Explosion
  */
 
-SetWatchDef(Explosion)
+SetWatchDef(Synced, Explosion)
+SetWatchDef(Unsynced, Explosion)
 
 
 /*** Register or deregister weaponDefID for expensive projectile callins.
@@ -2326,7 +2331,7 @@ SetWatchDef(Explosion)
  * @see Callins:ProjectileDestroyed
  */
 
-SetWatchDef(Projectile)
+SetWatchDef(Synced, Projectile)
 
 
 /*** Register or deregister weaponDefID for weapon targeting callins.
@@ -2342,7 +2347,7 @@ SetWatchDef(Projectile)
  * @see SyncedCallins:AllowWeaponInterceptTarget
  */
 
-SetWatchDef(AllowTarget)
+SetWatchDef(Synced, AllowTarget)
 
 #undef GetWatchDef
 #undef SetWatchDef

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -42,6 +42,9 @@ class CUnsyncedLuaHandle : public CLuaHandle
 			return static_cast<CUnsyncedLuaHandle*>(CLuaHandle::GetHandle(L));
 		}
 
+		static int GetWatchExplosionDef(lua_State* L);
+		static int SetWatchExplosionDef(lua_State* L);
+
 	protected:
 		CSplitLuaHandle& base;
 };

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -207,7 +207,6 @@ CLuaUI::~CLuaUI()
 		const auto& vec = lhs->watch ## DefType ## Defs;                    \
                                                                             \
 		const uint32_t defIdx = luaL_checkint(L, 1);                        \
-                                                                            \
                                                                            \
 		if (defIdx >= vec.size())                                           \
 			return 0;                                                       \

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -173,7 +173,7 @@ CLuaUI::CLuaUI()
 	lua_getglobal(L, "Script");
 		LuaPushNamedCFunc(L, "GetWatchExplosion",    GetWatchExplosionDef);
 		LuaPushNamedCFunc(L, "SetWatchExplosion",    SetWatchExplosionDef);
-	lua_pop(L, 1); // os
+	lua_pop(L, 1); // Script
 
 	InitializeRmlUi();
 

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -232,10 +232,6 @@ CLuaUI::~CLuaUI()
 GetWatchDef(Explosion)
 SetWatchDef(Explosion)
 
-bool CLuaUI::Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner)
-{
-	return CLuaHandle::Explosion(weaponDefID, projectileID, pos, owner);
-}
 
 void CLuaUI::InitLuaSocket(lua_State* L) {
 	std::string code;

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -267,7 +267,6 @@ string CLuaUI::LoadFile(const string& name, const std::string& mode) const
 static bool IsDisallowedCallIn(const string& name)
 {
 	switch (hashString(name.c_str())) {
-		//case hashString("Explosion"     ): { return true; } break; // so dangerous??
 		case hashString("DrawUnit"      ): { return true; } break;
 		case hashString("DrawFeature"   ): { return true; } break;
 		case hashString("DrawShield"    ): { return true; } break;

--- a/rts/Lua/LuaUI.h
+++ b/rts/Lua/LuaUI.h
@@ -74,6 +74,9 @@ public: // call-ins
 
 	void ShockFront(const float3& pos, float power, float areaOfEffect, const float* distMod = NULL);
 
+	static int GetWatchExplosionDef(lua_State* L);
+	static int SetWatchExplosionDef(lua_State* L);
+	bool Explosion(int weaponID, int projectileID, const float3& pos, const CUnit* owner) override;
 protected:
 	CLuaUI();
 	virtual ~CLuaUI();

--- a/rts/Lua/LuaUI.h
+++ b/rts/Lua/LuaUI.h
@@ -76,7 +76,6 @@ public: // call-ins
 
 	static int GetWatchExplosionDef(lua_State* L);
 	static int SetWatchExplosionDef(lua_State* L);
-	bool Explosion(int weaponID, int projectileID, const float3& pos, const CUnit* owner) override;
 protected:
 	CLuaUI();
 	virtual ~CLuaUI();

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -398,17 +398,22 @@ bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weapon
 		CCustomExplosionGenerator* cGen;
 		if (gen && (cGen = dynamic_cast<CCustomExplosionGenerator*>(gen)) != nullptr) {
 			const float realHeight = CGround::GetHeightReal(pos);
-			const unsigned int heightFlags = CCustomExplosionGenerator::GetFlagsFromHeight(pos.y, realHeight);
-			const unsigned int commonFlags = cGen->CommonVisibleFlags(heightFlags); // TODO: should also pass bit about hitting unit or not unit to filter.
+			unsigned int visFlags = CCustomExplosionGenerator::GetFlagsFromHeight(pos.y, realHeight);
+
+			const bool unitCollision = (params.hitUnit != nullptr);
+			visFlags |= (CCustomExplosionGenerator::CEG_SPWF_UNIT    * (    unitCollision));
+			visFlags |= (CCustomExplosionGenerator::CEG_SPWF_NO_UNIT * (1 - unitCollision));
+
+			const unsigned int commonFlags = cGen->CommonVisibleFlags(visFlags); // TODO: should also pass bit about hitting unit or not unit to filter.
 
 			if (commonFlags & CCustomExplosionGenerator::CEG_SPWF_ALWAYS_VISIBLE) {
 				return true;
 			}
 
-			const bool    airExplosion = ((heightFlags & CCustomExplosionGenerator::CEG_SPWF_AIR       ) != 0);
-			const bool groundExplosion = ((heightFlags & CCustomExplosionGenerator::CEG_SPWF_GROUND    ) != 0);
-			const bool  waterExplosion = ((heightFlags & CCustomExplosionGenerator::CEG_SPWF_WATER     ) != 0);
-			const bool     uwExplosion = ((heightFlags & CCustomExplosionGenerator::CEG_SPWF_UNDERWATER) != 0);
+			const bool    airExplosion = ((visFlags & CCustomExplosionGenerator::CEG_SPWF_AIR       ) != 0);
+			const bool groundExplosion = ((visFlags & CCustomExplosionGenerator::CEG_SPWF_GROUND    ) != 0);
+			const bool  waterExplosion = ((visFlags & CCustomExplosionGenerator::CEG_SPWF_WATER     ) != 0);
+			const bool     uwExplosion = ((visFlags & CCustomExplosionGenerator::CEG_SPWF_UNDERWATER) != 0);
 			losAir = airExplosion;
 			losGround = groundExplosion || waterExplosion || uwExplosion;
 		}

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -915,7 +915,6 @@ void CCustomExplosionGenerator::ParseExplosionCode(
 unsigned int CCustomExplosionGenerator::CommonVisibleFlags(unsigned int visibilityFlags) const
 {
 	int resFlags = 0;
-	visibilityFlags |= CEG_SPWF_ALWAYS_VISIBLE;
 	for (auto& psi: expGenParams.projectiles) {
 		if (psi.flags & visibilityFlags)
 			resFlags |= psi.flags;

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -394,9 +394,8 @@ bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weapon
 
 		const int explosionID = (weaponDef != nullptr)? weaponDef->impactExplosionGeneratorID: CExplosionGeneratorHandler::EXPGEN_ID_STANDARD;
 
-		IExplosionGenerator* gen = explGenHandler.GetGenerator(explosionID);
-		CCustomExplosionGenerator* cGen;
-		if (gen && (cGen = dynamic_cast<CCustomExplosionGenerator*>(gen)) != nullptr) {
+		const auto* cGen = dynamic_cast<CCustomExplosionGenerator*>(explGenHandler.GetGenerator(explosionID));
+		if (cGen != nullptr) {
 			const float realHeight = CGround::GetHeightReal(pos);
 			unsigned int visFlags = CCustomExplosionGenerator::GetFlagsFromHeight(pos.y, realHeight);
 

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -404,7 +404,7 @@ bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weapon
 			visFlags |= (CCustomExplosionGenerator::CEG_SPWF_UNIT    * (    unitCollision));
 			visFlags |= (CCustomExplosionGenerator::CEG_SPWF_NO_UNIT * (1 - unitCollision));
 
-			const unsigned int commonFlags = cGen->CommonVisibleFlags(visFlags); // TODO: should also pass bit about hitting unit or not unit to filter.
+			const unsigned int commonFlags = cGen->CommonVisibleFlags(visFlags);
 
 			if (commonFlags & CCustomExplosionGenerator::CEG_SPWF_ALWAYS_VISIBLE) {
 				return true;

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -10,6 +10,7 @@
 #include "ExpGenSpawnable.h"
 #include "ExpGenSpawnableMemberInfo.h"
 #include "Game/Camera.h"
+#include "Game/GameHelper.h"
 #include "Game/GlobalUnsynced.h" // guRNG
 #include "Lua/LuaParser.h"
 #include "Map/Ground.h"
@@ -376,7 +377,7 @@ bool CExplosionGeneratorHandler::GenExplosion(
 }
 
 
-bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weaponDef, const float3& pos, int allyTeamID)
+bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weaponDef, const CExplosionParams& params, int allyTeamID)
 {
 	if (gu->spectatingFullView)
 		return true;
@@ -386,6 +387,7 @@ bool CExplosionGeneratorHandler::PredictExplosionVisible(const WeaponDef* weapon
 
 	bool losAir = true;
 	bool losGround = true;
+	const auto& pos = params.pos;
 	if (weaponDef != nullptr) {
 		if (weaponDef != nullptr && weaponDef->visuals.alwaysVisible)
 			return true;

--- a/rts/Sim/Projectiles/ExplosionGenerator.h
+++ b/rts/Sim/Projectiles/ExplosionGenerator.h
@@ -17,6 +17,7 @@ class LuaTable;
 class float3;
 class CUnit;
 class IExplosionGenerator;
+struct WeaponDef;
 
 struct SExpGenSpawnableMemberInfo;
 
@@ -57,6 +58,8 @@ public:
 
 	IExplosionGenerator* LoadGenerator(const char* tag, const char* pre = "");
 	IExplosionGenerator* GetGenerator(unsigned int expGenID);
+
+	bool PredictExplosionVisible(const WeaponDef* weaponDef, const float3& pos, int allyTeamID);
 
 	bool GenExplosion(
 		unsigned int expGenID,
@@ -169,6 +172,8 @@ public:
 	static unsigned int GetFlagsFromTable(const LuaTable& table);
 	static unsigned int GetFlagsFromHeight(float height, float groundHeight);
 
+	unsigned int CommonVisibleFlags(unsigned int visibilityFlags) const;
+
 	/// @throws content_error/runtime_error on errors
 	bool Load(CExplosionGeneratorHandler* handler, const char* tag) override;
 	bool Reload(CExplosionGeneratorHandler* handler, const char* tag) override;
@@ -193,6 +198,7 @@ public:
 		CEG_SPWF_UNDERWATER = 1 << 5,  // TODO: UNDERVOIDWATER?
 		CEG_SPWF_UNIT       = 1 << 6,  // only execute when the explosion hits a unit
 		CEG_SPWF_NO_UNIT    = 1 << 7,  // only execute when the explosion doesn't hit a unit (environment)
+		CEG_SPWF_ALWAYS_VISIBLE = 1 << 8,
 	};
 
 	enum {

--- a/rts/Sim/Projectiles/ExplosionGenerator.h
+++ b/rts/Sim/Projectiles/ExplosionGenerator.h
@@ -18,6 +18,7 @@ class float3;
 class CUnit;
 class IExplosionGenerator;
 struct WeaponDef;
+struct CExplosionParams;
 
 struct SExpGenSpawnableMemberInfo;
 
@@ -59,7 +60,7 @@ public:
 	IExplosionGenerator* LoadGenerator(const char* tag, const char* pre = "");
 	IExplosionGenerator* GetGenerator(unsigned int expGenID);
 
-	bool PredictExplosionVisible(const WeaponDef* weaponDef, const float3& pos, int allyTeamID);
+	bool PredictExplosionVisible(const WeaponDef* weaponDef, const CExplosionParams& params, int allyTeamID);
 
 	bool GenExplosion(
 		unsigned int expGenID,

--- a/rts/Sim/Projectiles/ExplosionGenerator.h
+++ b/rts/Sim/Projectiles/ExplosionGenerator.h
@@ -199,7 +199,7 @@ public:
 		CEG_SPWF_UNDERWATER = 1 << 5,  // TODO: UNDERVOIDWATER?
 		CEG_SPWF_UNIT       = 1 << 6,  // only execute when the explosion hits a unit
 		CEG_SPWF_NO_UNIT    = 1 << 7,  // only execute when the explosion doesn't hit a unit (environment)
-		CEG_SPWF_ALWAYS_VISIBLE = 1 << 8,
+		CEG_SPWF_ALWAYS_VISIBLE = 1 << 31,
 	};
 
 	enum {

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -33,6 +33,7 @@ struct UnitDef;
 struct BuildInfo;
 struct FeatureDef;
 class LuaMaterial;
+struct WeaponDef;
 
 #ifndef zipFile
 	// might be defined through zip.h already
@@ -200,7 +201,7 @@ class CEventClient
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}
 
-		virtual bool Explosion(int weaponID, int projectileID, const float3& pos, const CUnit* owner) { return false; }
+		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner) { return false; }
 
 
 		virtual bool CommandFallback(const CUnit* unit, const Command& cmd) { return false; }

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -20,6 +20,7 @@
 using std::string;
 using std::vector;
 
+struct CExplosionParams;
 class CSolidObject;
 class CUnit;
 class CWeapon;
@@ -201,7 +202,7 @@ class CEventClient
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}
 
-		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner) { return false; }
+		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) { return false; }
 
 
 		virtual bool CommandFallback(const CUnit* unit, const Command& cmd) { return false; }

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -15,6 +15,7 @@ class CWeapon;
 struct Command;
 struct BuildInfo;
 class LuaMaterial;
+struct WeaponDef;
 
 class CEventHandler
 {
@@ -135,7 +136,7 @@ class CEventHandler
 		void ProjectileCreated(const CProjectile* proj, int allyTeam);
 		void ProjectileDestroyed(const CProjectile* proj, int allyTeam);
 
-		bool Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner);
+		bool Explosion(int weaponDefID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner);
 
 		void StockpileChanged(const CUnit* unit,
 		                      const CWeapon* weapon, int oldCount);
@@ -702,7 +703,7 @@ inline void CEventHandler::UnsyncedHeightMapUpdate(const SRectangle& rect)
 
 
 
-inline bool CEventHandler::Explosion(int weaponDefID, int projectileID, const float3& pos, const CUnit* owner)
+inline bool CEventHandler::Explosion(int weaponDefID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner)
 {
 	auto& clients = listExplosion;
 
@@ -712,7 +713,7 @@ inline bool CEventHandler::Explosion(int weaponDefID, int projectileID, const fl
 		// discard return-value from clients lacking full-read access
 		// (redundant for synced gadgets; watchWeaponDefs is checked)
 		// NOTE: the call-in may remove itself from the client list
-		if (!ec->Explosion(weaponDefID, projectileID, pos, owner) || !ec->GetFullRead()) {
+		if (!ec->Explosion(weaponDefID, weaponDef, projectileID, pos, owner) || !ec->GetFullRead()) {
 			i += (i < clients.size() && ec == clients[i]);
 			continue;
 		}

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -11,6 +11,7 @@
 #include "Sim/Features/Feature.h"
 #include "Sim/Projectiles/Projectile.h"
 
+struct CExplosionParams;
 class CWeapon;
 struct Command;
 struct BuildInfo;
@@ -136,7 +137,7 @@ class CEventHandler
 		void ProjectileCreated(const CProjectile* proj, int allyTeam);
 		void ProjectileDestroyed(const CProjectile* proj, int allyTeam);
 
-		bool Explosion(int weaponDefID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner);
+		bool Explosion(int weaponDefID, const WeaponDef* weaponDef, const CExplosionParams& params);
 
 		void StockpileChanged(const CUnit* unit,
 		                      const CWeapon* weapon, int oldCount);
@@ -703,7 +704,7 @@ inline void CEventHandler::UnsyncedHeightMapUpdate(const SRectangle& rect)
 
 
 
-inline bool CEventHandler::Explosion(int weaponDefID, const WeaponDef* weaponDef, int projectileID, const float3& pos, const CUnit* owner)
+inline bool CEventHandler::Explosion(int weaponDefID, const WeaponDef* weaponDef, const CExplosionParams& params)
 {
 	auto& clients = listExplosion;
 
@@ -713,7 +714,7 @@ inline bool CEventHandler::Explosion(int weaponDefID, const WeaponDef* weaponDef
 		// discard return-value from clients lacking full-read access
 		// (redundant for synced gadgets; watchWeaponDefs is checked)
 		// NOTE: the call-in may remove itself from the client list
-		if (!ec->Explosion(weaponDefID, weaponDef, projectileID, pos, owner) || !ec->GetFullRead()) {
+		if (!ec->Explosion(weaponDefID, weaponDef, params) || !ec->GetFullRead()) {
 			i += (i < clients.size() && ec == clients[i]);
 			continue;
 		}


### PR DESCRIPTION
### Work done

- Allow registering and sending Explosion callins to unsynced

### Testing

- Use the following bar branch: https://github.com/saurtron/Beyond-All-Reason/tree/test-new-unsynced-callins

### Remarks

- It works, but probably still needs some refactor or even rethinking it a bit.
- Also thinking about maybe approach the unsynced callins in a different way
  - at least make them asynchronous to the synced code
  - maybe also make them batched? that way clients could get one callin with a table of explosions happened in current frame maybe
- Draft for now to gather feedback while I finish testing and reorganizing.
- Framework is there to allow registering other Get/SetWatch* methods for unsynced, but not sure any are needed/useful/possible.
  - also note Get/SetWatch* registrations are independent for syncedGadgets, unsyncedGadgets and luaUI.

