### PR TITLE
Eliminate complier warning in 3DModel

### DIFF
--- a/rts/Rendering/Models/3DModel.cpp
+++ b/rts/Rendering/Models/3DModel.cpp
@@ -18,7 +18,7 @@
 
 #include "System/Misc/TracyDefs.h"
 
-CR_BIND(LocalModelPiece, (nullptr))
+CR_BIND(LocalModelPiece, )
 CR_REG_METADATA(LocalModelPiece, (
 	CR_MEMBER(pos),
 	CR_MEMBER(rot),
@@ -449,7 +449,7 @@ LocalModelPiece::LocalModelPiece(const S3DModelPiece* piece)
 	assert(piece != nullptr);
 
 	pos = piece->offset;
-	dir = piece->GetEmitDir(); // warning investigated, seems fake
+	dir = piece->GetEmitDir();
 
 	pieceSpaceMat = CalcPieceSpaceMatrix(pos, rot, original->scales);
 


### PR DESCRIPTION
### Eliminates compiler warning:
```
In constructor 'LocalModelPiece::LocalModelPiece(const S3DModelPiece*)',
    inlined from 'static void LocalModelPiece::_ConstructInstance(void*)' at /spring/rts/Rendering/Models/3DModel.cpp:21:1:
/spring/rts/Rendering/Models/3DModel.cpp:452:32: warning: 'this' pointer is null [-Wnonnull]
  452 |         dir = piece->GetEmitDir(); // warning investigated, seems fake
```


### Issue cause:

`CR_BIND(LocalModelPiece, (nullptr))`

expands out to

`void LocalModelPiece::_ConstructInstance(void* d) { new(d) LocalModelPiece (nullptr); }`

Attempting to call this constructor with a nullptr would cause an attempt to dereference a null pointer. Fortunatly CREG does not currently seem to attempt to use it, instead using the default constructor LocalModelPiece() via vector initialization.


### Resolution:

Remove the unnecessary nullptr argument and redirect to the default constructor as that is what it was using anyway.


### Testing:

Save game before change.
Load game after change.

No issues found.