### PR TITLE
Add new color indicator codes with no conflicts with visible characters.

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -78,10 +78,11 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 	lua_rawset(L, -3);
 
 	lua_pushliteral(L, "textColorCodes");
+	bool newIndicators = FtLibraryHandlerProxy::UseNewColorIndicators();
 	lua_createtable(L, 0, 3);
-		LuaPushNamedChar(L, "Color"          , static_cast<char>(CglFont::ColorCodeIndicator  ));
-		LuaPushNamedChar(L, "ColorAndOutline", static_cast<char>(CglFont::ColorCodeIndicatorEx));
-		LuaPushNamedChar(L, "Reset"          , static_cast<char>(CglFont::ColorResetIndicator ));
+		LuaPushNamedChar(L, "Color"          , static_cast<char>(newIndicators ? CglFont::ColorCodeIndicator : CglFont::OldColorCodeIndicator)  );
+		LuaPushNamedChar(L, "ColorAndOutline", static_cast<char>(newIndicators ? CglFont::ColorCodeIndicatorEx : CglFont::OldColorCodeIndicatorEx));
+		LuaPushNamedChar(L, "Reset"          , static_cast<char>(CglFont::ColorResetIndicator) );
 	lua_rawset(L, -3);
 
 	return true;

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -325,11 +325,13 @@ bool LuaConstGame::PushEntries(lua_State* L)
 	}
 	{
 		// inline color-codes for text fonts
+		bool newIndicators = FtLibraryHandlerProxy::UseNewColorIndicators();
+
 		lua_pushliteral(L, "textColorCodes");
 		lua_createtable(L, 0, 3);
-			LuaPushNamedChar(L, "Color"          , static_cast<char>(CglFont::ColorCodeIndicator)  );
-			LuaPushNamedChar(L, "ColorAndOutline", static_cast<char>(CglFont::ColorCodeIndicatorEx));
-			LuaPushNamedChar(L, "Reset"          , static_cast<char>(CglFont::ColorResetIndicator) );
+				LuaPushNamedChar(L, "Color"          , static_cast<char>(newIndicators ? CglFont::ColorCodeIndicator : CglFont::OldColorCodeIndicator)  );
+				LuaPushNamedChar(L, "ColorAndOutline", static_cast<char>(newIndicators ? CglFont::ColorCodeIndicatorEx : CglFont::OldColorCodeIndicatorEx));
+				LuaPushNamedChar(L, "Reset"          , static_cast<char>(CglFont::ColorResetIndicator) );
 		lua_rawset(L, -3);
 	}
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -161,6 +161,7 @@ public:
 			searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
 			searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
 			searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
+			useNewColorIndicators = configHandler->GetBool("TextUseNewColorIndicators");
 
 			FcBool res;
 			std::string errprefix = fmt::sprintf("[%s] Fontconfig(version %d.%d.%d) failed to initialize", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
@@ -307,6 +308,9 @@ public:
 	static bool GetSearchApplySubstitutions() {
 		return singleton->searchApplySubstitutions;
 	}
+	static bool GetUseNewColorIndicators() {
+		return singleton ? singleton->useNewColorIndicators : false;
+	}
 	#endif
 private:
 	FcConfig* config;
@@ -318,6 +322,7 @@ private:
 	bool searchSystemFonts;
 	bool searchFontAttributes;
 	bool searchApplySubstitutions;
+	bool useNewColorIndicators;
 
 	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
 };
@@ -343,6 +348,16 @@ bool FtLibraryHandlerProxy::InitFontconfig(bool console)
 #endif
 }
 
+
+bool FtLibraryHandlerProxy::UseNewColorIndicators()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+#ifndef HEADLESS
+	return FtLibraryHandler::GetUseNewColorIndicators();
+#else
+	return false;
+#endif
+}
 
 
 /*******************************************************************************/

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -23,6 +23,7 @@ class FtLibraryHandlerProxy {
 public:
 	static void InitFtLibrary();
 	static bool InitFontconfig(bool console);
+	static bool UseNewColorIndicators();
 };
 
 

--- a/rts/Rendering/Fonts/TextWrap.cpp
+++ b/rts/Rendering/Fonts/TextWrap.cpp
@@ -39,7 +39,8 @@ static inline int SkipColorCodes(const spring::u8string& text, T* pos, SColor* c
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	int colorFound = 0;
-	while (text[(*pos)] == CTextWrap::ColorCodeIndicator) {
+	const char8_t colorIndicator = FtLibraryHandlerProxy::UseNewColorIndicators() ? CTextWrap::ColorCodeIndicator : CTextWrap::OldColorCodeIndicator;
+	while (text[(*pos)] == colorIndicator) {
 		(*pos) += 4;
 		if ((*pos) >= text.size()) {
 			return -(1 + colorFound);

--- a/rts/Rendering/Fonts/TextWrap.h
+++ b/rts/Rendering/Fonts/TextWrap.h
@@ -10,7 +10,6 @@
 #include "ustring.h"
 #include "System/Color.h"
 
-
 class CTextWrap : public CFontTexture
 {
 public:
@@ -20,8 +19,12 @@ public:
 
 	static constexpr float MAX_HEIGHT_DEFAULT = 1e3;
 
-	static constexpr const char8_t ColorCodeIndicator = 0xFF;
-	static constexpr const char8_t ColorResetIndicator = 0x08; //! =: '\\b'
+	static constexpr char8_t OldColorCodeIndicator   = 0xFF; // ÿ
+	static constexpr char8_t OldColorCodeIndicatorEx = 0xFE; // þ
+	static constexpr char8_t ColorCodeIndicator   = 0x11; // dc1
+	static constexpr char8_t ColorCodeIndicatorEx = 0x12; // dc2
+	static constexpr char8_t ColorResetIndicator  = 0x08; // =: '\\b'
+
 protected:
 	CTextWrap(const std::string& fontfile, int size, int outlinesize, float  outlineweight);
 	virtual ~CTextWrap() {}
@@ -41,7 +44,7 @@ private:
 			if (resetColor) {
 				out = ColorResetIndicator;
 			} else {
-				out = ColorCodeIndicator;
+				out = FtLibraryHandlerProxy::UseNewColorIndicators() ? ColorCodeIndicator : OldColorCodeIndicator;
 				out += color.r;
 				out += color.g;
 				out += color.b;

--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -30,6 +30,7 @@ CONFIG(int,      FontOutlineWidth).defaultValue(2).description("Sets the width o
 CONFIG(int, SmallFontOutlineWidth).defaultValue(2).description("see FontOutlineWidth");
 CONFIG(float,      FontOutlineWeight).defaultValue(25.0f).description("Sets the opacity of Spring engine text, such as the title screen version number, clock, and basic UI. Does not affect LuaUI elements.");
 CONFIG(float, SmallFontOutlineWeight).defaultValue(10.0f).description("see FontOutlineWeight");
+CONFIG(bool, TextUseNewColorIndicators).defaultValue(false).description("Old color indicators don't allow writing some characters.");
 
 std::shared_ptr<CglFont> font = nullptr;
 std::shared_ptr<CglFont> smallFont = nullptr;
@@ -233,9 +234,17 @@ static inline int SkipColorCodes(const spring::u8string& text, int idx)
 	while (idx < text.size()) {
 		switch (text[idx])
 		{
+		case CglFont::OldColorCodeIndicator:
+			if (FtLibraryHandlerProxy::UseNewColorIndicators())
+				break;
+			[[fallthrough]];
 		case CglFont::ColorCodeIndicator: {
 			idx += 3 + 1; // RGB
 		} continue;
+		case CglFont::OldColorCodeIndicatorEx:
+			if (FtLibraryHandlerProxy::UseNewColorIndicators())
+				break;
+			[[fallthrough]];
 		case CglFont::ColorCodeIndicatorEx: {
 			idx += 2 * 4 + 1; // RGBA,RGBA
 		} continue;
@@ -258,6 +267,14 @@ bool CglFont::SkipColorCodesAndNewLines(const spring::u8string& text, int& curIn
 	char32_t nextChar = 0;
 	for (int end = static_cast<int>(text.length()); idx < end; ) {
 		switch (nextChar = utf8::GetNextChar(text, idx, false/*do not advance*/)) {
+			case CglFont::OldColorCodeIndicator:
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as default case
+					curIndex = idx;
+					numLines = nls;
+					return false;
+				}
+				[[fallthrough]];
 			case CglFont::ColorCodeIndicator: {
 				if ((idx += 3 + 1) < end) {
 					const float4 newTextColor = { text[idx - 3] / 255.0f, text[idx - 2] / 255.0f, text[idx - 1] / 255.0f, 1.0f };
@@ -267,6 +284,14 @@ bool CglFont::SkipColorCodesAndNewLines(const spring::u8string& text, int& curIn
 						SetTextColor(&newTextColor);
 				}
 			} break;
+			case CglFont::OldColorCodeIndicatorEx:
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as default case
+					curIndex = idx;
+					numLines = nls;
+					return false;
+				}
+				[[fallthrough]];
 			case CglFont::ColorCodeIndicatorEx: {
 				if ((idx += 4 * 2 + 1) < end) {
 					const float4 newTextColor = { text[idx - 8] / 255.0f, text[idx - 7] / 255.0f, text[idx - 6] / 255.0f, text[idx - 5] / 255.0f };
@@ -364,6 +389,15 @@ float CglFont::GetTextWidth_(const spring::u8string& text)
 				prvGlyphPtr = nullptr;
 			} break;
 
+			case OldColorCodeIndicatorEx: [[fallthrough]];
+			case OldColorCodeIndicator: {
+				if (!FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					idx = SkipColorCodes(text, idx - 1);
+					break;
+				}
+				[[fallthrough]];
+			}
+
 			// printable char
 			default: {
 				curGlyphPtr = &GetGlyph(curGlyphIdx);
@@ -430,6 +464,15 @@ float CglFont::GetTextHeight_(const spring::u8string& text, float* descender, in
 				d = GetLineHeight() + GetDescender();
 			} break;
 
+			case OldColorCodeIndicatorEx: [[fallthrough]];
+			case OldColorCodeIndicator: {
+				if (!FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					idx = SkipColorCodes(text, idx - 1);
+					break;
+				}
+				[[fallthrough]];
+			}
+
 			// printable char
 			default: {
 				const GlyphInfo& g = GetGlyph(u);
@@ -477,6 +520,15 @@ void CglFont::ScanForWantedGlyphs(const spring::u8string& ustr)
 			// LF
 		} break;
 
+		case OldColorCodeIndicatorEx: [[fallthrough]];
+		case OldColorCodeIndicator: {
+			if (!FtLibraryHandlerProxy::UseNewColorIndicators()) {
+				idx = SkipColorCodes(ustr, idx - 1);
+				break;
+			}
+			[[fallthrough]];
+		}
+
 			// printable char
 		default: {
 			const GlyphInfo& curGlyph = GetGlyph(nextChar);
@@ -506,6 +558,14 @@ std::deque<std::string> CglFont::SplitIntoLines(const spring::u8string& text)
 
 		switch (c) {
 			// inlined colorcode; push to stack if [I,R,G,B] is followed by more text
+			case OldColorCodeIndicator: {
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as 'default' case
+					lines.back() += c;
+					break;
+				}
+				[[fallthrough]];
+			}
 			case ColorCodeIndicator: {
 				if ((idx + 3 + 1) < end) {
 					colorCodeStack.emplace_back(text.substr(idx, 4));
@@ -516,6 +576,14 @@ std::deque<std::string> CglFont::SplitIntoLines(const spring::u8string& text)
 					idx += 4;
 				}
 			} break;
+			case OldColorCodeIndicatorEx: {
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as 'default' case
+					lines.back() += c;
+					break;
+				}
+				[[fallthrough]];
+			}
 			// inlined colorcodeEx; push to stack if [I,R,G,B,A,R,G,B,A] is followed by more text
 			case ColorCodeIndicatorEx: {
 				if ((idx + 4 * 2 + 1) < end) {
@@ -921,6 +989,14 @@ void CglFont::glPrintTable(float x, float y, float s, const int options, const s
 		const unsigned char& c = text[pos];
 
 		switch (c) {
+			case OldColorCodeIndicator: {
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as 'default' case
+					colLines[col] += c;
+					break;
+				}
+				[[fallthrough]];
+			}
 			// inline colorcodes
 			case ColorCodeIndicator: {
 				for (int i = 0; i < 4 && pos < text.length(); ++i, ++pos) {
@@ -930,6 +1006,14 @@ void CglFont::glPrintTable(float x, float y, float s, const int options, const s
 				colColor[col] = curColor;
 				pos -= 1;
 			} break;
+			case OldColorCodeIndicatorEx: {
+				if (FtLibraryHandlerProxy::UseNewColorIndicators()) {
+					// same as 'default' case
+					colLines[col] += c;
+					break;
+				}
+				[[fallthrough]];
+			}
 			case ColorCodeIndicatorEx: {
 				assert(false); //not implemented
 			} break;

--- a/rts/Rendering/Fonts/glFont.h
+++ b/rts/Rendering/Fonts/glFont.h
@@ -106,10 +106,6 @@ public:
 	const std::string& GetFilePath() const { return fontPath; }
 
 	void GetStats(std::array<size_t, 8>& stats) const;
-
-	static constexpr char8_t ColorCodeIndicator   = 0xFF;
-	static constexpr char8_t ColorCodeIndicatorEx = 0xFE;
-	static constexpr char8_t ColorResetIndicator  = 0x08; // =: '\\b'
 private:
 	static const float4* ChooseOutlineColor(const float4& textColor);
 


### PR DESCRIPTION
### Work done

- Add new color indicator codes
- They can be enabled with the new config option: TextUseNewColorIndicators

### Remarks

- The old ones are actually visible: þ and ÿ.
- Checked the [ascii table](https://www.ascii-code.com/) and chose some non visible characters that look safe, the "Device control" characters.
  - This may need to be reviewed in case they're not safe, and maybe choose other ones.
  - The ResetColorIndicator is using the BELL non renderable one, and it works well (didn't have to change it).
  - Not sure why they chose ascii 254 and 255 originally, maybe they didn't think much about it. Find it strange none of the non visible ones are fit for us since many look like historic artifacts.
  - There could be some even better ones, but not sure, we can find out.
- Need a config option since the old indicators will stop working if these are enabled and will be a mess since ppl have so much codes.
  - For now not deprecating I think we should let 1 or 2 courtesy release at least before deprecating the old ones.

### Screenshots

The color indicator characters (previously invisible and would cause color artifacts):

![forbidden-characters](https://github.com/user-attachments/assets/2a96d7e2-0f42-47bf-be76-e2aaebe28712)


### Migration scripts for games

Even tho games have it hardcoded everywhere it's not that difficult to fix most appearances in one go, search for `\255` and `\254`, and replace those with `\017` and `\018`. As most of the times they appear with either a `"`, a `'`, a `\n` or a ` `, they can be replaced in masse. Then one has to search in case there's some color codes interleaved with text.

I'm sure a sed one liner can be created to do all that and more, or a python script or something, but for now using these to test:

<details>
<summary>rplcolorcodes.sh for BYAR-Chobby</summary>

```bash
rpl  -F "\"\\255" "\"\\017" ./libs/chiliui/gui_chiliguidemo.lua
rpl  -F "\"\\255" "\"\\017" LuaMenu/widgets/chobby/components/*
rpl  -F "\"\\255" "\"\\017" libs/chiliui/chili/controls/*
rpl  -F "\"\\255" "\"\\017" LuaMenu/widgets/*


rpl  -F "'\\255" "'\\017" libs/chiliui/chili/headers/util.lua
rpl  -F "'\\255" "'\\017" libs/chiliui/chili/controls/editbox.lua


rpl  -F "\n\\255" "\n\\017" LuaMenu/widgets/sl_upload_log.lua

rpl  -F " \\255" " \\017" libs/chiliui/gui_chiliguidemo.lua
rpl  -F " \\255" " \\017" ./LuaMenu/widgets/chobby/components/console.lua
rpl  -F " \\255" " \\017" ./LuaMenu/widgets/gui_modoptions_panel.lua
```

</details>

<details>
<summary>rplcolorcodes.sh for BAR</summary>

```bash
rpl  -F "\"\\255" "\"\\017" luaui/Widgets/*
rpl  -F "\"\\255" "\"\\017" luarules/colors.h.lua
rpl  -F "\"\\255" "\"\\017" luaui/Headers/colors.h.lua
rpl  -F "\"\\255" "\"\\017" luarules/gadgets/*
rpl  -F "\"\\255" "\"\\017" modoptions.lua
rpl  -F "\"\\255" "\"\\017" common/testing/results.lua

rpl  -F " \\255" " \\017" luaui/Widgets/*

rpl  -F "'\\255" "'\\017" luaui/Widgets/*
rpl  -F "'\\255" "'\\017" luarules/gadgets/*
rpl  -F "'\\255" "'\\017" luaintro/Addons/main.lua

rpl  -F "\n\\255" "\n\\017" luaui/Widgets/*
rpl  -F "\n\\255" "\n\\017" luarules/gadgets/*
```

</details>