### PR TITLE
NETMSG_SECRET_CHAT: Secret chat messages

### DIFF
--- a/cont/base/springcontent/EngineOptions.lua
+++ b/cont/base/springcontent/EngineOptions.lua
@@ -102,6 +102,15 @@ local options =
     type   = 'bool',
     def    = false,
   },
+
+  {
+    key    = 'InterplayerSecrets',
+    name   = 'Allow Interplayer Secrets',
+    desc   = 'Enables player sending of secret chat messages to other players',
+    type   = 'bool',
+    def    = false,
+  },
+
 --[[
 -- the following options can create problems and were never used by interface programs, thus are commented out for the moment
 

--- a/rts/Game/ChatMessage.cpp
+++ b/rts/Game/ChatMessage.cpp
@@ -8,9 +8,10 @@
 
 #include "System/Misc/TracyDefs.h"
 
-ChatMessage::ChatMessage(int from, int dest, const std::string& chat)
+ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isPrivate)
 	: fromPlayer(from)
 	, destination(dest)
+	, isPrivate(isPrivate)
 {
 	// restrict all (player and autohost) chat-messages before they get Pack()'ed
 	msg.resize(std::min(chat.size(), MAX_MSG_SIZE));
@@ -25,7 +26,7 @@ ChatMessage::ChatMessage(int from, int dest, const std::string& chat)
 ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	assert(data->data[0] == NETMSG_CHAT);
+	assert(data->data[0] == NETMSG_CHAT || data->data[0] == NETMSG_PRIVATE_CHAT);
 	assert(data->length <= (4 * sizeof(uint8_t) + MAX_MSG_SIZE + 1));
 
 	netcode::UnpackPacket packet(data, 2);
@@ -39,6 +40,8 @@ ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 
 	fromPlayer = from;
 	destination = dest;
+
+	isPrivate = (data->data[0] == NETMSG_PRIVATE_CHAT);
 }
 
 const netcode::RawPacket* ChatMessage::Pack() const
@@ -52,7 +55,7 @@ const netcode::RawPacket* ChatMessage::Pack() const
 
 	assert(packetSize <= (headerSize + MAX_MSG_SIZE + 1));
 
-	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, NETMSG_CHAT);
+	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, isPrivate ? NETMSG_PRIVATE_CHAT : NETMSG_CHAT);
 
 	*buffer << packetSize;
 	*buffer << static_cast<uint8_t>(fromPlayer);

--- a/rts/Game/ChatMessage.cpp
+++ b/rts/Game/ChatMessage.cpp
@@ -8,10 +8,10 @@
 
 #include "System/Misc/TracyDefs.h"
 
-ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isPrivate)
+ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isSecure)
 	: fromPlayer(from)
 	, destination(dest)
-	, isPrivate(isPrivate)
+	, isSecure(isSecure)
 {
 	// restrict all (player and autohost) chat-messages before they get Pack()'ed
 	msg.resize(std::min(chat.size(), MAX_MSG_SIZE));
@@ -26,7 +26,7 @@ ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isPri
 ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	assert(data->data[0] == NETMSG_CHAT || data->data[0] == NETMSG_PRIVATE_CHAT);
+	assert(data->data[0] == NETMSG_CHAT || data->data[0] == NETMSG_SECURE_CHAT);
 	assert(data->length <= (4 * sizeof(uint8_t) + MAX_MSG_SIZE + 1));
 
 	netcode::UnpackPacket packet(data, 2);
@@ -41,7 +41,7 @@ ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 	fromPlayer = from;
 	destination = dest;
 
-	isPrivate = (data->data[0] == NETMSG_PRIVATE_CHAT);
+	isSecure = (data->data[0] == NETMSG_SECURE_CHAT);
 }
 
 const netcode::RawPacket* ChatMessage::Pack() const
@@ -55,7 +55,7 @@ const netcode::RawPacket* ChatMessage::Pack() const
 
 	assert(packetSize <= (headerSize + MAX_MSG_SIZE + 1));
 
-	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, isPrivate ? NETMSG_PRIVATE_CHAT : NETMSG_CHAT);
+	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, isSecure ? NETMSG_SECURE_CHAT : NETMSG_CHAT);
 
 	*buffer << packetSize;
 	*buffer << static_cast<uint8_t>(fromPlayer);

--- a/rts/Game/ChatMessage.cpp
+++ b/rts/Game/ChatMessage.cpp
@@ -8,10 +8,10 @@
 
 #include "System/Misc/TracyDefs.h"
 
-ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isSecure)
+ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isSecret)
 	: fromPlayer(from)
 	, destination(dest)
-	, isSecure(isSecure)
+	, isSecret(isSecret)
 {
 	// restrict all (player and autohost) chat-messages before they get Pack()'ed
 	msg.resize(std::min(chat.size(), MAX_MSG_SIZE));
@@ -26,7 +26,7 @@ ChatMessage::ChatMessage(int from, int dest, const std::string& chat, bool isSec
 ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	assert(data->data[0] == NETMSG_CHAT || data->data[0] == NETMSG_SECURE_CHAT);
+	assert(data->data[0] == NETMSG_CHAT || data->data[0] == NETMSG_SECRET_CHAT);
 	assert(data->length <= (4 * sizeof(uint8_t) + MAX_MSG_SIZE + 1));
 
 	netcode::UnpackPacket packet(data, 2);
@@ -41,7 +41,7 @@ ChatMessage::ChatMessage(std::shared_ptr<const netcode::RawPacket> data)
 	fromPlayer = from;
 	destination = dest;
 
-	isSecure = (data->data[0] == NETMSG_SECURE_CHAT);
+	isSecret = (data->data[0] == NETMSG_SECRET_CHAT);
 }
 
 const netcode::RawPacket* ChatMessage::Pack() const
@@ -55,7 +55,7 @@ const netcode::RawPacket* ChatMessage::Pack() const
 
 	assert(packetSize <= (headerSize + MAX_MSG_SIZE + 1));
 
-	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, isSecure ? NETMSG_SECURE_CHAT : NETMSG_CHAT);
+	netcode::PackPacket* buffer = new netcode::PackPacket(packetSize, isSecret ? NETMSG_SECRET_CHAT : NETMSG_CHAT);
 
 	*buffer << packetSize;
 	*buffer << static_cast<uint8_t>(fromPlayer);

--- a/rts/Game/ChatMessage.h
+++ b/rts/Game/ChatMessage.h
@@ -13,7 +13,7 @@ namespace netcode {
 class ChatMessage
 {
 public:
-	ChatMessage(int from, int dest, const std::string& chat, bool isPrivate);
+	ChatMessage(int from, int dest, const std::string& chat, bool isSecure);
 	ChatMessage(std::shared_ptr<const netcode::RawPacket> packet);
 
 	const netcode::RawPacket* Pack() const;
@@ -28,7 +28,7 @@ public:
 	/// can be TO_ALLIES, TO_SPECTATORS, TO_EVERYONE, or a player number
 	int destination = -1;
 
-	bool isPrivate = false;
+	bool isSecure = false;
 
 	std::string msg;
 };

--- a/rts/Game/ChatMessage.h
+++ b/rts/Game/ChatMessage.h
@@ -13,7 +13,7 @@ namespace netcode {
 class ChatMessage
 {
 public:
-	ChatMessage(int from, int dest, const std::string& chat);
+	ChatMessage(int from, int dest, const std::string& chat, bool isPrivate);
 	ChatMessage(std::shared_ptr<const netcode::RawPacket> packet);
 
 	const netcode::RawPacket* Pack() const;
@@ -27,6 +27,8 @@ public:
 	int fromPlayer = -1;
 	/// can be TO_ALLIES, TO_SPECTATORS, TO_EVERYONE, or a player number
 	int destination = -1;
+
+	bool isPrivate = false;
 
 	std::string msg;
 };

--- a/rts/Game/ChatMessage.h
+++ b/rts/Game/ChatMessage.h
@@ -13,7 +13,7 @@ namespace netcode {
 class ChatMessage
 {
 public:
-	ChatMessage(int from, int dest, const std::string& chat, bool isSecure);
+	ChatMessage(int from, int dest, const std::string& chat, bool isSecret);
 	ChatMessage(std::shared_ptr<const netcode::RawPacket> packet);
 
 	const netcode::RawPacket* Pack() const;
@@ -28,7 +28,7 @@ public:
 	/// can be TO_ALLIES, TO_SPECTATORS, TO_EVERYONE, or a player number
 	int destination = -1;
 
-	bool isSecure = false;
+	bool isSecret = false;
 
 	std::string msg;
 };

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1898,7 +1898,12 @@ void CGame::SendNetChat(std::string message, int destination, bool isSecure)
 		}
 	}
 
-	ChatMessage buf(gu->myPlayerNum, destination, message, isPrivate);
+	if (isSecure && destination >= TO_ALLIES && destination <= TO_SPECTATORS) {
+		LOG_L(L_WARNING, "Secure message with broadcast destination");
+		return;
+	}
+
+	ChatMessage buf(gu->myPlayerNum, destination, message, isSecure);
 	clientNet->Send(buf.Pack());
 }
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1872,7 +1872,7 @@ void CGame::GameEnd(const std::vector<unsigned char>& winningAllyTeams, bool tim
 	}
 }
 
-void CGame::SendNetChat(std::string message, int destination)
+void CGame::SendNetChat(std::string message, int destination, bool isPrivate)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (message.empty())
@@ -1898,7 +1898,7 @@ void CGame::SendNetChat(std::string message, int destination)
 		}
 	}
 
-	ChatMessage buf(gu->myPlayerNum, destination, message);
+	ChatMessage buf(gu->myPlayerNum, destination, message, isPrivate);
 	clientNet->Send(buf.Pack());
 }
 

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1899,7 +1899,7 @@ void CGame::SendNetChat(std::string message, int destination, bool isSecret)
 	}
 
 	if (isSecret && destination >= ChatMessage::TO_ALLIES && destination <= ChatMessage::TO_SPECTATORS) {
-		LOG_L(L_WARNING, "Secure message with broadcast destination");
+		LOG_L(L_WARNING, "Secret message with broadcast destination");
 		return;
 	}
 
@@ -1980,7 +1980,10 @@ void CGame::HandleChatMsg(const ChatMessage& msg)
 			if (player->isFromDemo) {
 				LOG("%s whispered %s: %s", label.c_str(), playerHandler.Player(msg.destination)->name.c_str(), s.c_str());
 			} else if (msg.destination == gu->myPlayerNum && player->spectator == gu->spectating) {
-				LOG("%sPrivate: %s", label.c_str(), s.c_str());
+				if (msg.isSecret)
+					LOG("%sSecret: %s", label.c_str(), s.c_str());
+				else
+					LOG("%sPrivate: %s", label.c_str(), s.c_str());
 				Channels::UserInterface->PlaySample(chatSound, 5);
 			}
 			else if (player->playerNum == gu->myPlayerNum)

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1872,7 +1872,7 @@ void CGame::GameEnd(const std::vector<unsigned char>& winningAllyTeams, bool tim
 	}
 }
 
-void CGame::SendNetChat(std::string message, int destination, bool isPrivate)
+void CGame::SendNetChat(std::string message, int destination, bool isSecure)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (message.empty())

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1872,7 +1872,7 @@ void CGame::GameEnd(const std::vector<unsigned char>& winningAllyTeams, bool tim
 	}
 }
 
-void CGame::SendNetChat(std::string message, int destination, bool isSecure)
+void CGame::SendNetChat(std::string message, int destination, bool isSecret)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (message.empty())
@@ -1898,12 +1898,12 @@ void CGame::SendNetChat(std::string message, int destination, bool isSecure)
 		}
 	}
 
-	if (isSecure && destination >= TO_ALLIES && destination <= TO_SPECTATORS) {
+	if (isSecret && destination >= ChatMessage::TO_ALLIES && destination <= ChatMessage::TO_SPECTATORS) {
 		LOG_L(L_WARNING, "Secure message with broadcast destination");
 		return;
 	}
 
-	ChatMessage buf(gu->myPlayerNum, destination, message, isSecure);
+	ChatMessage buf(gu->myPlayerNum, destination, message, isSecret);
 	clientNet->Send(buf.Pack());
 }
 

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -85,7 +85,7 @@ public:
 	void AddTraffic(int playerID, int packetCode, int length);
 
 	/// Send a message to other players (allows prefixed messages with e.g. "a:...")
-	void SendNetChat(std::string message, int destination = -1, bool isSecure = false);
+	void SendNetChat(std::string message, int destination = -1, bool isSecret = false);
 
 	bool ProcessCommandText(const std::string& command);
 	bool ProcessAction(const Action& action, bool isRepeat = false);

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -85,7 +85,7 @@ public:
 	void AddTraffic(int playerID, int packetCode, int length);
 
 	/// Send a message to other players (allows prefixed messages with e.g. "a:...")
-	void SendNetChat(std::string message, int destination = -1, bool isPrivate = false);
+	void SendNetChat(std::string message, int destination = -1, bool isSecure = false);
 
 	bool ProcessCommandText(const std::string& command);
 	bool ProcessAction(const Action& action, bool isRepeat = false);

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -85,7 +85,7 @@ public:
 	void AddTraffic(int playerID, int packetCode, int length);
 
 	/// Send a message to other players (allows prefixed messages with e.g. "a:...")
-	void SendNetChat(std::string message, int destination = -1);
+	void SendNetChat(std::string message, int destination = -1, bool isPrivate = false);
 
 	bool ProcessCommandText(const std::string& command);
 	bool ProcessAction(const Action& action, bool isRepeat = false);

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -202,6 +202,8 @@ void CGameSetup::ResetState()
 	maxSpeed = 0.0f;
 	minSpeed = 0.0f;
 
+	interplayerSecrets = false;
+
 	startPosType = StartPos_Fixed;
 
 
@@ -631,6 +633,7 @@ bool CGameSetup::Init(const std::string& buf)
 	file.GetDef(maxUnitsPerTeam, "32000", "GAME\\ModOptions\\MaxUnits");
 	file.GetDef(disableMapDamage,    "0", "GAME\\ModOptions\\DisableMapDamage");
 	file.GetDef(ghostedBuildings,    "1", "GAME\\ModOptions\\GhostedBuildings");
+	file.GetDef(interplayerSecrets,  "0", "GAME\\ModOptions\\InterplayerSecrets");
 
 	file.GetDef(maxSpeed, "20.", "GAME\\ModOptions\\MaxSpeed");
 	file.GetDef(minSpeed, "0.1", "GAME\\ModOptions\\MinSpeed");

--- a/rts/Game/GameSetup.h
+++ b/rts/Game/GameSetup.h
@@ -77,6 +77,8 @@ public:
 
 		restrictedUnits = std::move(gs.restrictedUnits);
 
+		interplayerSecrets = gs.interplayerSecrets;
+
 		mapOptions = std::move(gs.mapOptions);
 		modOptions = std::move(gs.modOptions);
 		return *this;
@@ -218,6 +220,8 @@ public:
 	std::string setupText;
 	std::string reloadScript;
 	std::string demoName;
+
+	bool interplayerSecrets;
 
 	inline static bool forceOnlyLocal = false;
 private:

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -27,6 +27,7 @@
 #include "ExternalAI/AILibraryManager.h"
 #include "ExternalAI/SkirmishAIHandler.h"
 
+#include "Game/ChatMessage.h"
 #include "Game/Players/Player.h"
 #include "Game/Players/PlayerHandler.h"
 #include "Game/UI/CommandColors.h"
@@ -590,7 +591,7 @@ public:
 		if (!gameSetup->interplayerSecrets && playerID != SERVER_PLAYER) {
 			LOG_L(L_WARNING, "Sending secrets to other players disallowed by game configuration");
 		}
-		else if (playerID >= 0) {
+		else if (playerID == SERVER_PLAYER || playerHandler.IsValidPlayer(playerID)) {
 			std::string message = (args.size() == 2) ? std::move(args[1]) : "";
 			game->SendNetChat(std::move(message), playerID, true);
 		} else {

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -587,7 +587,10 @@ public:
 			return true;
 		}
 
-		if (playerID >= 0) {
+		if (!gameSetup->interplayerSecrets && playerID != SERVER_PLAYER) {
+			LOG_L(L_WARNING, "Sending secrets to other players disallowed by game configuration");
+		}
+		else if (playerID >= 0) {
 			std::string message = (args.size() == 2) ? std::move(args[1]) : "";
 			game->SendNetChat(std::move(message), playerID, true);
 		} else {

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -566,9 +566,9 @@ public:
 
 
 
-class SaySecureByPlayerIDActionExecutor : public IUnsyncedActionExecutor {
+class SaySecretByPlayerIDActionExecutor : public IUnsyncedActionExecutor {
 public:
-	SaySecureByPlayerIDActionExecutor() : IUnsyncedActionExecutor("SByNum", "Say something in private to a specific player, by player-ID") {
+	SaySecretByPlayerIDActionExecutor() : IUnsyncedActionExecutor("SByNum", "Say a secret to a specific player, by player-ID") {
 	}
 
 	bool Execute(const UnsyncedAction& action) const final {
@@ -3978,7 +3978,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<SayActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SayPrivateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SayPrivateByPlayerIDActionExecutor>());
-	AddActionExecutor(AllocActionExecutor<SaySecureByPlayerIDActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<SaySecretByPlayerIDActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<EchoActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SetActionExecutor>(true));
 	AddActionExecutor(AllocActionExecutor<SetActionExecutor>(false));

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -566,6 +566,40 @@ public:
 
 
 
+class SaySecureByPlayerIDActionExecutor : public IUnsyncedActionExecutor {
+public:
+	SaySecureByPlayerIDActionExecutor() : IUnsyncedActionExecutor("SByNum", "Say something in private to a specific player, by player-ID") {
+	}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		auto args = CSimpleParser::Tokenize(action.GetArgs(), 1);
+
+		if (args.size() == 0) {
+			LOG_L(L_WARNING, "/SByNum: wrong syntax (which is '/SByNum %%playerid')");
+			return true;
+		}
+
+		bool parseFailure;
+		const int playerID = StringToInt(args[0], &parseFailure);
+
+		if (parseFailure) {
+			LOG_L(L_WARNING, "/SByNum: wrong syntax (which is '/SByNum %%playerid')");
+			return true;
+		}
+
+		if (playerID >= 0) {
+			std::string message = (args.size() == 2) ? std::move(args[1]) : "";
+			game->SendNetChat(std::move(message), playerID, true);
+		} else {
+			LOG_L(L_WARNING, "Player-ID invalid: %i", playerID);
+		}
+
+		return true;
+	}
+};
+
+
+
 class EchoActionExecutor : public IUnsyncedActionExecutor {
 public:
 	EchoActionExecutor() : IUnsyncedActionExecutor("Echo", "Write a string to the log file") {
@@ -3944,6 +3978,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<SayActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SayPrivateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SayPrivateByPlayerIDActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<SaySecureByPlayerIDActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<EchoActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SetActionExecutor>(true));
 	AddActionExecutor(AllocActionExecutor<SetActionExecutor>(false));

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -27,7 +27,6 @@
 #include "ExternalAI/AILibraryManager.h"
 #include "ExternalAI/SkirmishAIHandler.h"
 
-#include "Game/ChatMessage.h"
 #include "Game/Players/Player.h"
 #include "Game/Players/PlayerHandler.h"
 #include "Game/UI/CommandColors.h"

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -630,7 +630,7 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
  */
 int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
 	if (lua_gettop(L) != 2 || !lua_isstring(L, 1))
-		return luaL_error(L, "Incorrect arguments to Spring.%s(message string, playerID integer)", __func__);
+		return luaL_error(L, "Incorrect arguments to Spring.SendPrivateChat(message string, playerID integer)");
 
 	const int playerID = luaL_checkint(L, 2);
 	if (!playerHandler.IsValidPlayer(playerID))

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -630,7 +630,7 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
  */
 int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
 	if (lua_gettop(L) != 2 || !lua_isstring(L, 1))
-		return luaL_error(L, std::format("Incorrect arguments to Spring.%s(message string, playerID integer)", __func__).c_str());
+		return luaL_error(L, "Incorrect arguments to Spring.%s(message string, playerID integer)", __func__);
 
 	const int playerID = luaL_checkint(L, 2);
 	if (!playerHandler.IsValidPlayer(playerID))

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -137,6 +137,7 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SendAllyChat);
 	REGISTER_LUA_CFUNC(SendSpectatorChat);
 	REGISTER_LUA_CFUNC(SendPrivateChat);
+	REGISTER_LUA_CFUNC(SendSecretChat);
 
 	REGISTER_LUA_CFUNC(LoadSoundDef);
 	REGISTER_LUA_CFUNC(PlaySoundFile);
@@ -619,6 +620,21 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
 	return 0;
 }
 
+
+/* Helper for direct sending to player */
+int SendDirectChat(lua_State* L, bool isSecret, const char* funcName) {
+	if (lua_gettop(L) != 2 || !lua_isstring(L, 1))
+		return luaL_error(L, std::format("Incorrect arguments to Spring.%s(message string, playerID integer)", funcName).c_str());
+
+	const int playerID = luaL_checkint(L, 2);
+	if (!playerHandler.IsValidPlayer(playerID))
+		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__, playerID);
+
+	game->SendNetChat(luaL_checksstring(L, 1), playerID, isSecret);
+	return 0;
+}
+
+
 /*** Sends a private chat message to a specific player ID.
  *
  * @function Spring.SendPrivateChat
@@ -627,16 +643,28 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
  * @return nil
  */
 int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
-	if (lua_gettop(L) != 2 || !lua_isstring(L, 1))
-		return luaL_error(L, "Incorrect arguments to Spring.SendPrivateChat(message string, playerID integer)");
-
-	const int playerID = luaL_checkint(L, 2);
-	if (!playerHandler.IsValidPlayer(playerID))
-		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__, playerID);
-
-	game->SendNetChat(luaL_checksstring(L, 1), playerID);
-	return 0;
+	SendDirectChat(L, false, __func__);
 }
+
+
+/*** Sends a secret chat message to a specific player ID.
+ *
+ * Goes direct to receiver and doesn't get stored in replays
+ * and doesn't broadcast to everyone.
+ *
+ * Sending to players usually disallowed by the server, unless
+ * 'AllowInterplayerSecrets' is set on the server.
+ *
+ * It can always be sent to the server player (with id: 255).
+ *
+ * @function Spring.SendSecretChat
+ * @param message string
+ * @param playerID integer
+ */
+int LuaUnsyncedCtrl::SendSecretChat(lua_State* L) {
+	SendDirectChat(L, true, __func__);
+}
+
 
 static void PrintMessage(lua_State* L, const string& msg)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -634,7 +634,7 @@ int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
 
 	const int playerID = luaL_checkint(L, 2);
 	if (!playerHandler.IsValidPlayer(playerID))
-		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__);
+		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__, playerID);
 
 	game->SendNetChat(luaL_checksstring(L, 1), playerID, false);
 	return 0;

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -620,7 +620,6 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
 	return 0;
 }
 
-
 /*** Sends a private chat message to a specific player ID.
  *
  * @function Spring.SendPrivateChat
@@ -639,7 +638,6 @@ int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
 	game->SendNetChat(luaL_checksstring(L, 1), playerID, false);
 	return 0;
 }
-
 
 /*** Sends a secret chat message to a specific player ID.
  *
@@ -669,7 +667,6 @@ int LuaUnsyncedCtrl::SendSecretChat(lua_State* L) {
 	game->SendNetChat(luaL_checksstring(L, 1), playerID, true);
 	return 0;
 }
-
 
 static void PrintMessage(lua_State* L, const string& msg)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -657,11 +657,11 @@ int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
  */
 int LuaUnsyncedCtrl::SendSecretChat(lua_State* L) {
 	if (lua_gettop(L) != 2 || !lua_isstring(L, 1))
-		return luaL_error(L, std::format("Incorrect arguments to Spring.%s(message string, playerID integer)", __func__).c_str());
+		return luaL_error(L, "Incorrect arguments to Spring.%s(message string, playerID integer)", __func__);
 
 	const int playerID = luaL_checkint(L, 2);
 	if (playerID != SERVER_PLAYER && !playerHandler.IsValidPlayer(playerID))
-		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__);
+		return luaL_error(L, "Error in function '%s': Invalid Player ID %d", __func__, playerID);
 
 	if (playerID != SERVER_PLAYER && !gameSetup->interplayerSecrets)
 		return luaL_error(L, "Error in function '%s': Game configuration disallows sending secrets to players", __func__);

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -29,6 +29,7 @@ class LuaUnsyncedCtrl {
 		static int SendAllyChat(lua_State* L);
 		static int SendSpectatorChat(lua_State* L);
 		static int SendPrivateChat(lua_State* L);
+		static int SendSecretChat(lua_State* L);
 
 		static int LoadSoundDef(lua_State* L);
 		static int PlaySoundFile(lua_State* L);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4310,7 +4310,7 @@ int LuaUnsyncedRead::GetPlayerTraffic(lua_State* L)
 		(playerID != gu->myPlayerNum) && // all  self  counts can be read
 		(packetID != -1) &&
 		(packetID != NETMSG_CHAT)     &&
-		(packetID != NETMSG_PRIVATE_CHAT) &&
+		(packetID != NETMSG_SECURE_CHAT) &&
 		(packetID != NETMSG_PAUSE)    &&
 		(packetID != NETMSG_LUAMSG)   &&
 		(packetID != NETMSG_STARTPOS) &&

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4310,7 +4310,7 @@ int LuaUnsyncedRead::GetPlayerTraffic(lua_State* L)
 		(playerID != gu->myPlayerNum) && // all  self  counts can be read
 		(packetID != -1) &&
 		(packetID != NETMSG_CHAT)     &&
-		(packetID != NETMSG_SECURE_CHAT) &&
+		(packetID != NETMSG_SECRET_CHAT) &&
 		(packetID != NETMSG_PAUSE)    &&
 		(packetID != NETMSG_LUAMSG)   &&
 		(packetID != NETMSG_STARTPOS) &&

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4310,6 +4310,7 @@ int LuaUnsyncedRead::GetPlayerTraffic(lua_State* L)
 		(playerID != gu->myPlayerNum) && // all  self  counts can be read
 		(packetID != -1) &&
 		(packetID != NETMSG_CHAT)     &&
+		(packetID != NETMSG_PRIVATE_CHAT) &&
 		(packetID != NETMSG_PAUSE)    &&
 		(packetID != NETMSG_LUAMSG)   &&
 		(packetID != NETMSG_STARTPOS) &&

--- a/rts/Net/AutohostInterface.cpp
+++ b/rts/Net/AutohostInterface.cpp
@@ -138,6 +138,17 @@ enum EVENT
 	PLAYER_DEFEATED = 14,
 
 	/**
+	 * Player has sent a secret chat message
+	 *
+	 *   (uint8 playernumber, uint8 destination, char[] text)
+	 *
+	 * Message should not be logged into public destinations, and shouldn't be forwarded to all players.
+	 *
+	 * destination works like PLAYER_CHAT but will only be sent to TO_SERVER and specific playerIds for now.
+	 */
+	PLAYER_SECRET_CHAT = 15,
+
+	/**
 	 * Message sent by Lua script
 	 *
 	 *   (uint8 magic = 50, uint16 msgsize, uint8 playernumber, uint16 script, uint8 uiMode, uint8[msgsize - 8] data)
@@ -318,12 +329,12 @@ void AutohostInterface::SendPlayerReady(uchar playerNum, uchar readyState)
 	Send(asio::buffer(&msg, 3 * sizeof(uchar)));
 }
 
-void AutohostInterface::SendPlayerChat(uchar playerNum, uchar destination, const std::string& chatmsg)
+void AutohostInterface::SendPlayerChat(uchar playerNum, uchar destination, const std::string& chatmsg, bool isSecret)
 {
 	if (autohost.is_open()) {
 		const auto msgsize = 3 * sizeof(uchar) + chatmsg.size();
 		std::vector<std::uint8_t> buffer(msgsize);
-		buffer[0] = PLAYER_CHAT;
+		buffer[0] = isSecret ? PLAYER_SECRET_CHAT : PLAYER_CHAT;
 		buffer[1] = playerNum;
 		buffer[2] = destination;
 		std::copy(chatmsg.begin(), chatmsg.end(), &buffer[3]);

--- a/rts/Net/AutohostInterface.cpp
+++ b/rts/Net/AutohostInterface.cpp
@@ -142,7 +142,10 @@ enum EVENT
 	 *
 	 *   (uint8 playernumber, uint8 destination, char[] text)
 	 *
-	 * Message should not be logged into public destinations, and shouldn't be forwarded to all players.
+	 * Message should not be:
+	 *  * Logged into public destinations
+	 *  * Forwarded to all players.
+	 *  * Sent to spectators.
 	 *
 	 * destination works like PLAYER_CHAT but will only be sent to TO_SERVER and specific playerIds for now.
 	 */

--- a/rts/Net/AutohostInterface.h
+++ b/rts/Net/AutohostInterface.h
@@ -40,7 +40,7 @@ public:
 	void SendPlayerJoined(uchar playerNum, const std::string& name);
 	void SendPlayerLeft(uchar playerNum, uchar reason);
 	void SendPlayerReady(uchar playerNum, uchar readyState);
-	void SendPlayerChat(uchar playerNum, uchar destination, const std::string& msg, bool isSecret = false);
+	void SendPlayerChat(uchar playerNum, uchar destination, const std::string& msg, bool isSecret);
 	void SendPlayerDefeated(uchar playerNum);
 
 	void Message(const std::string& message);

--- a/rts/Net/AutohostInterface.h
+++ b/rts/Net/AutohostInterface.h
@@ -40,7 +40,7 @@ public:
 	void SendPlayerJoined(uchar playerNum, const std::string& name);
 	void SendPlayerLeft(uchar playerNum, uchar reason);
 	void SendPlayerReady(uchar playerNum, uchar readyState);
-	void SendPlayerChat(uchar playerNum, uchar destination, const std::string& msg);
+	void SendPlayerChat(uchar playerNum, uchar destination, const std::string& msg, bool isSecret = false);
 	void SendPlayerDefeated(uchar playerNum);
 
 	void Message(const std::string& message);

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -75,7 +75,6 @@ CONFIG(bool, WhiteListAdditionalPlayers).defaultValue(true);
 CONFIG(bool, ServerRecordDemos).defaultValue(false).dedicatedValue(true);
 CONFIG(bool, ServerLogInfoMessages).defaultValue(false);
 CONFIG(bool, ServerLogDebugMessages).defaultValue(false);
-CONFIG(bool, AllowInterplayerSecrets).defaultValue(false);
 CONFIG(std::string, AutohostIP).defaultValue("127.0.0.1");
 
 
@@ -164,7 +163,7 @@ void CGameServer::Initialize()
 	whiteListAdditionalPlayers = configHandler->GetBool("WhiteListAdditionalPlayers");
 	logInfoMessages = configHandler->GetBool("ServerLogInfoMessages");
 	logDebugMessages = configHandler->GetBool("ServerLogDebugMessages");
-	allowInterplayerSecrets = configHandler->GetBool("AllowInterplayerSecrets");
+	allowInterplayerSecrets = myGameSetup->interplayerSecrets;
 
 	rng.Seed((myGameData->GetSetupText()).length());
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -564,9 +564,10 @@ void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet)
 
 void CGameServer::SendSecret(const ChatMessage& msg)
 {
-	int destPlayer = msg.destination;
+	const int fromPlayer = msg.fromPlayer;
+	const int destPlayer = msg.destination;
 
-	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[msg.fromPlayer].IsSpectator() && !players[destination].IsSpectator()) {
+	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[fromPlayer].IsSpectator()) {
 		players[destPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 }

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -567,7 +567,7 @@ void CGameServer::SendSecret(const ChatMessage& msg)
 	const int fromPlayer = msg.fromPlayer;
 	const int destPlayer = msg.destination;
 
-	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[fromPlayer].IsSpectator()) {
+	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[destPlayer].IsSpectator()) {
 		players[destPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 }

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -3088,7 +3088,9 @@ void CGameServer::GotChatMessage(const ChatMessage& msg)
 	if (msg.fromPlayer < 0 || msg.fromPlayer == SERVER_PLAYER)
 		return;
 
-	hostif->SendPlayerChat(msg.fromPlayer, msg.destination, msg.msg, msg.isSecret);
+	// do not forward interplayer secrets to autohost if they're not allowed.
+	if (!msg.isSecret || allowInterplayerSecrets || msg.destination == SERVER_PLAYER)
+		hostif->SendPlayerChat(msg.fromPlayer, msg.destination, msg.msg, msg.isSecret);
 }
 
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -547,7 +547,7 @@ bool CGameServer::SendDemoData(int targetFrameNum)
 	return ret;
 }
 
-void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet, bool isPrivate)
+void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet, bool isSecure)
 {
 	for (GameParticipant& p: players) {
 		p.SendData(packet);
@@ -1144,7 +1144,7 @@ void CGameServer::ProcessPacket(const unsigned playerNum, std::shared_ptr<const 
 			Broadcast(CBaseNetProtocol::Get().SendPathCheckSum(playerNum, playerCheckSum));
 		} break;
 
-		case NETMSG_PRIVATE_CHAT:
+		case NETMSG_SECURE_CHAT:
 		case NETMSG_CHAT: {
 			try {
 				ChatMessage msg(packet);

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -75,6 +75,7 @@ CONFIG(bool, WhiteListAdditionalPlayers).defaultValue(true);
 CONFIG(bool, ServerRecordDemos).defaultValue(false).dedicatedValue(true);
 CONFIG(bool, ServerLogInfoMessages).defaultValue(false);
 CONFIG(bool, ServerLogDebugMessages).defaultValue(false);
+CONFIG(bool, AllowInterplayerSecrets).defaultValue(false);
 CONFIG(std::string, AutohostIP).defaultValue("127.0.0.1");
 
 
@@ -163,6 +164,7 @@ void CGameServer::Initialize()
 	whiteListAdditionalPlayers = configHandler->GetBool("WhiteListAdditionalPlayers");
 	logInfoMessages = configHandler->GetBool("ServerLogInfoMessages");
 	logDebugMessages = configHandler->GetBool("ServerLogDebugMessages");
+	allowInterplayerSecrets = configHandler->GetBool("AllowInterplayerSecrets");
 
 	rng.Seed((myGameData->GetSetupText()).length());
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -3083,7 +3083,7 @@ void CGameServer::GotChatMessage(const ChatMessage& msg)
 	if (msg.fromPlayer < 0 || msg.fromPlayer == SERVER_PLAYER)
 		return;
 
-	hostif->SendPlayerChat(msg.fromPlayer, msg.destination, msg.msg);
+	hostif->SendPlayerChat(msg.fromPlayer, msg.destination, msg.msg, msg.isSecret);
 }
 
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -565,10 +565,10 @@ void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet)
 void CGameServer::SendSecret(const ChatMessage& msg)
 {
 	const int fromPlayer = msg.fromPlayer;
-	const int destPlayer = msg.destination;
+	const int toPlayer   = msg.destination;
 
-	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[destPlayer].IsSpectator()) {
-		players[destPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
+	if (allowInterplayerSecrets && toPlayer >= 0 && toPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[toPlayer].IsSpectator()) {
+		players[toPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 }
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -3066,7 +3066,7 @@ void CGameServer::GotChatMessage(const ChatMessage& msg)
 	if (msg.msg.empty())
 		return;
 	if (msg.isSecret)
-		SendDirect(std::shared_ptr<const RawPacket>(msg.Pack()), msg.destination);
+		SendSecret(std::shared_ptr<const RawPacket>(msg.Pack()), msg.destination);
 	else
 		Broadcast(std::shared_ptr<const RawPacket>(msg.Pack()));
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -566,7 +566,7 @@ void CGameServer::SendSecret(const ChatMessage& msg)
 {
 	int destPlayer = msg.destination;
 
-	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[msg.fromPlayer].IsSpectator()) {
+	if (allowInterplayerSecrets && destPlayer >= 0 && destPlayer < players.size() && !players[msg.fromPlayer].IsSpectator() && !players[destination].IsSpectator()) {
 		players[destPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 }

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -567,7 +567,13 @@ void CGameServer::SendSecret(const ChatMessage& msg)
 	const int fromPlayer = msg.fromPlayer;
 	const int toPlayer   = msg.destination;
 
-	if (allowInterplayerSecrets && toPlayer >= 0 && toPlayer < players.size() && !players[fromPlayer].IsSpectator() && !players[toPlayer].IsSpectator()) {
+	if (toPlayer < 0 || toPlayer >= players.size())
+		return;
+
+	// Allows the server to send.
+	// Usually it would use PrivateMessage -> SendSystemMessage instead, but may be needed
+	// in some situations like if autohost wants to send secret messages to players.
+	if (fromPlayer == SERVER_PLAYER || ( allowInterplayerSecrets && !players[fromPlayer].IsSpectator() && !players[toPlayer].IsSpectator() )) {
 		players[toPlayer].SendData(std::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 }

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -560,9 +560,9 @@ void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet)
 		demoRecorder->SaveToDemo(packet->data, packet->length, GetDemoTime());
 }
 
-void CGameServer::SendDirect(std::shared_ptr<const netcode::RawPacket> packet, int destination)
+void CGameServer::SendSecret(std::shared_ptr<const netcode::RawPacket> packet, int destination)
 {
-	if (destination < ChatMessage::TO_ALLIES)
+	if (destination >= 0 && destination < players.size())
 		players[destination].SendData(packet);
 }
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -547,7 +547,7 @@ bool CGameServer::SendDemoData(int targetFrameNum)
 	return ret;
 }
 
-void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet)
+void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet, bool isPrivate)
 {
 	for (GameParticipant& p: players) {
 		p.SendData(packet);
@@ -556,7 +556,7 @@ void CGameServer::Broadcast(std::shared_ptr<const netcode::RawPacket> packet)
 	if (canReconnect || allowSpecJoin || !gameHasStarted)
 		packetCache.push_back(packet);
 
-	if (demoRecorder != nullptr)
+	if (demoRecorder != nullptr && !isPrivate)
 		demoRecorder->SaveToDemo(packet->data, packet->length, GetDemoTime());
 }
 
@@ -3060,7 +3060,7 @@ void CGameServer::GotChatMessage(const ChatMessage& msg)
 	if (msg.msg.empty())
 		return;
 
-	Broadcast(std::shared_ptr<const RawPacket>(msg.Pack()));
+	Broadcast(std::shared_ptr<const RawPacket>(msg.Pack()), msg.isPrivate);
 
 	if (hostif == nullptr)
 		return;

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -849,10 +849,10 @@ void CGameServer::Update()
 
 		if (!msg.empty()) {
 			if (msg.at(0) != '/') { // normal chat message
-				GotChatMessage(ChatMessage(SERVER_PLAYER, ChatMessage::TO_EVERYONE, msg));
+				GotChatMessage(ChatMessage(SERVER_PLAYER, ChatMessage::TO_EVERYONE, msg, false));
 			}
 			else if (msg.at(0) == '/' && msg.size() > 1 && msg.at(1) == '/') { // chatmessage with prefixed '/'
-				GotChatMessage(ChatMessage(SERVER_PLAYER, ChatMessage::TO_EVERYONE, msg.substr(1)));
+				GotChatMessage(ChatMessage(SERVER_PLAYER, ChatMessage::TO_EVERYONE, msg.substr(1), false));
 			}
 			else if (msg.size() > 1) { // command
 				PushAction(Action(msg.substr(1)), true);
@@ -1144,6 +1144,7 @@ void CGameServer::ProcessPacket(const unsigned playerNum, std::shared_ptr<const 
 			Broadcast(CBaseNetProtocol::Get().SendPathCheckSum(playerNum, playerCheckSum));
 		} break;
 
+		case NETMSG_PRIVATE_CHAT:
 		case NETMSG_CHAT: {
 			try {
 				ChatMessage msg(packet);

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -173,7 +173,8 @@ private:
 	/// read data from demo and send it to clients
 	bool SendDemoData(int targetFrameNum);
 
-	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet, bool isPrivate = false);
+	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet);
+	void SendDirect(std::shared_ptr<const netcode::RawPacket> packet, int destination);
 
 	/**
 	 * @brief skip frames

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -173,7 +173,7 @@ private:
 	/// read data from demo and send it to clients
 	bool SendDemoData(int targetFrameNum);
 
-	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet);
+	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet, bool isPrivate = false);
 
 	/**
 	 * @brief skip frames

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -174,7 +174,7 @@ private:
 	bool SendDemoData(int targetFrameNum);
 
 	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet);
-	void SendDirect(std::shared_ptr<const netcode::RawPacket> packet, int destination);
+	void SendSecret(std::shared_ptr<const netcode::RawPacket> packet, int destination);
 
 	/**
 	 * @brief skip frames

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -174,7 +174,7 @@ private:
 	bool SendDemoData(int targetFrameNum);
 
 	void Broadcast(std::shared_ptr<const netcode::RawPacket> packet);
-	void SendSecret(std::shared_ptr<const netcode::RawPacket> packet, int destination);
+	void SendSecret(const ChatMessage& msg);
 
 	/**
 	 * @brief skip frames

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -281,6 +281,7 @@ private:
 
 	bool logInfoMessages = false;
 	bool logDebugMessages = false;
+	bool allowInterplayerSecrets = false;
 
 
 	/// If the server receives a command, it will forward it to clients if it is not in this set

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -479,7 +479,8 @@ void CGame::ClientReadNet()
 					const ChatMessage msg(packet);
 
 					HandleChatMsg(msg);
-					AddTraffic(msg.fromPlayer, packetCode, dataLength);
+					if (packetCode != NETMSG_PRIVATE_CHAT)
+						AddTraffic(msg.fromPlayer, packetCode, dataLength);
 				} catch (const netcode::UnpackPacketException& ex) {
 					LOG_L(L_ERROR, "[Game::%s][NETMSG_CHAT] exception \"%s\"", __func__, ex.what());
 				}

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -472,6 +472,7 @@ void CGame::ClientReadNet()
 				}
 			} break;
 
+			case NETMSG_PRIVATE_CHAT:
 			case NETMSG_CHAT: {
 				ZoneScopedN("Net::Chat");
 				try {

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -479,8 +479,7 @@ void CGame::ClientReadNet()
 					const ChatMessage msg(packet);
 
 					HandleChatMsg(msg);
-					if (packetCode != NETMSG_PRIVATE_CHAT)
-						AddTraffic(msg.fromPlayer, packetCode, dataLength);
+					AddTraffic(msg.fromPlayer, packetCode, dataLength);
 				} catch (const netcode::UnpackPacketException& ex) {
 					LOG_L(L_ERROR, "[Game::%s][NETMSG_CHAT] exception \"%s\"", __func__, ex.what());
 				}

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -472,7 +472,7 @@ void CGame::ClientReadNet()
 				}
 			} break;
 
-			case NETMSG_PRIVATE_CHAT:
+			case NETMSG_SECURE_CHAT:
 			case NETMSG_CHAT: {
 				ZoneScopedN("Net::Chat");
 				try {

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -472,7 +472,7 @@ void CGame::ClientReadNet()
 				}
 			} break;
 
-			case NETMSG_SECURE_CHAT:
+			case NETMSG_SECRET_CHAT:
 			case NETMSG_CHAT: {
 				ZoneScopedN("Net::Chat");
 				try {

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -626,7 +626,7 @@ CBaseNetProtocol::CBaseNetProtocol()
 	proto->AddType(NETMSG_SETPLAYERNUM, 2);
 	proto->AddType(NETMSG_PLAYERNAME, -1);
 	proto->AddType(NETMSG_CHAT, -1);
-	proto->AddType(NETMSG_SECURE_CHAT, -1);
+	proto->AddType(NETMSG_SECRET_CHAT, -1);
 	proto->AddType(NETMSG_RANDSEED, 5);
 	proto->AddType(NETMSG_GAMEID, 17);
 	proto->AddType(NETMSG_PATH_CHECKSUM, 1 + 1 + sizeof(uint32_t));

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -626,6 +626,7 @@ CBaseNetProtocol::CBaseNetProtocol()
 	proto->AddType(NETMSG_SETPLAYERNUM, 2);
 	proto->AddType(NETMSG_PLAYERNAME, -1);
 	proto->AddType(NETMSG_CHAT, -1);
+	proto->AddType(NETMSG_PRIVATE_CHAT, -1);
 	proto->AddType(NETMSG_RANDSEED, 5);
 	proto->AddType(NETMSG_GAMEID, 17);
 	proto->AddType(NETMSG_PATH_CHECKSUM, 1 + 1 + sizeof(uint32_t));

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -626,7 +626,7 @@ CBaseNetProtocol::CBaseNetProtocol()
 	proto->AddType(NETMSG_SETPLAYERNUM, 2);
 	proto->AddType(NETMSG_PLAYERNAME, -1);
 	proto->AddType(NETMSG_CHAT, -1);
-	proto->AddType(NETMSG_PRIVATE_CHAT, -1);
+	proto->AddType(NETMSG_SECURE_CHAT, -1);
 	proto->AddType(NETMSG_RANDSEED, 5);
 	proto->AddType(NETMSG_GAMEID, 17);
 	proto->AddType(NETMSG_PATH_CHECKSUM, 1 + 1 + sizeof(uint32_t));

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -96,6 +96,7 @@ enum NETMSG {
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
 
 	NETMSG_SECRET_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but secret, the servers should not log it into public destinations, and should also send just to the destination players.)
+				      // it can't be send to group destinations or spectators, and it also can't be sent to players unless AllowInterplayerSecrets.
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -96,7 +96,7 @@ enum NETMSG {
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
 
 	NETMSG_SECRET_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but secret, the servers should not log it into public destinations, and should also send just to the destination players.)
-				      // it can't be send to group destinations or spectators, and it also can't be sent to players unless AllowInterplayerSecrets.
+				      // it can't be sent to group destinations or spectators, and it also can't be sent to players unless AllowInterplayerSecrets.
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -94,7 +94,8 @@ enum NETMSG {
 	NETMSG_GAME_FRAME_PROGRESS= 77, // int32_t frameNum # this special packet skips queue & cache entirely, indicates current game progress for clients fast-forwarding to current point the game #
 
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
-	NETMSG_SECRET_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
+
+	NETMSG_SECRET_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but secret, the servers should not log it into public destinations, and should also send just to the destination players.)
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -94,6 +94,7 @@ enum NETMSG {
 	NETMSG_GAME_FRAME_PROGRESS= 77, // int32_t frameNum # this special packet skips queue & cache entirely, indicates current game progress for clients fast-forwarding to current point the game #
 
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
+	NETMSG_PRIVATE_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -94,7 +94,7 @@ enum NETMSG {
 	NETMSG_GAME_FRAME_PROGRESS= 77, // int32_t frameNum # this special packet skips queue & cache entirely, indicates current game progress for clients fast-forwarding to current point the game #
 
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
-	NETMSG_PRIVATE_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
+	NETMSG_SECURE_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -94,7 +94,7 @@ enum NETMSG {
 	NETMSG_GAME_FRAME_PROGRESS= 77, // int32_t frameNum # this special packet skips queue & cache entirely, indicates current game progress for clients fast-forwarding to current point the game #
 
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
-	NETMSG_SECURE_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
+	NETMSG_SECRET_CHAT     = 79,  // uint8_t from, dest; std::string message; (same as NETMSG_CHAT, but private)
 
 	NETMSG_LAST //max types of netmessages, internal only
 };

--- a/rts/Net/Protocol/NetProtocol.cpp
+++ b/rts/Net/Protocol/NetProtocol.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<const netcode::RawPacket> CNetProtocol::GetData(int frameNum)
 	if (ret->data[0] == NETMSG_GAMEDATA)
 		return ret;
 
-	if (ret->data[0] == NETMSG_SECURE_CHAT)
+	if (ret->data[0] == NETMSG_SECRET_CHAT)
 		return ret;
 
 	if (demoRecordPtr->IsValid())

--- a/rts/Net/Protocol/NetProtocol.cpp
+++ b/rts/Net/Protocol/NetProtocol.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<const netcode::RawPacket> CNetProtocol::GetData(int frameNum)
 	if (ret->data[0] == NETMSG_GAMEDATA)
 		return ret;
 
-	if (ret->data[0] == NETMSG_PRIVATE_CHAT)
+	if (ret->data[0] == NETMSG_SECURE_CHAT)
 		return ret;
 
 	if (demoRecordPtr->IsValid())

--- a/rts/Net/Protocol/NetProtocol.cpp
+++ b/rts/Net/Protocol/NetProtocol.cpp
@@ -136,6 +136,9 @@ std::shared_ptr<const netcode::RawPacket> CNetProtocol::GetData(int frameNum)
 	if (ret->data[0] == NETMSG_GAMEDATA)
 		return ret;
 
+	if (ret->data[0] == NETMSG_PRIVATE_CHAT)
+		return ret;
+
 	if (demoRecordPtr->IsValid())
 		demoRecordPtr->SaveToDemo(ret->data, ret->length, GetPacketTime(frameNum));
 


### PR DESCRIPTION
### Work done

- New `NETMSG_SECRET_CHAT` packet.
  - New type of chat message with some (light) "privacy guarantees".
- New `PLAYER_SECRET_CHAT = 15` autohost message type.
- `InterplayerSecretsForbidden`: server config option, disallows the below modoption. default: true
- `InterplayerSecrets`: modOption to control secrets among players. default: false
- Can be sent through the `/SByNum <id> <msg>` command.
- Also `Spring.SendSecretChat(msg, playerID)`

#### Related issues

- https://github.com/beyond-all-reason/RecoilEngine/issues/2040
- https://github.com/beyond-all-reason/Beyond-All-Reason/issues/5173

### Specs:

- Doesn't get logged into replays.
- By default Players can only send to 255.
  - unless AllowInterplayerSecrets is set, then player to player is allowed.
- Not for groupsend for now, although could be implemented.
- Spectators can't send or receive them.
- Server will forward to the destination player only.
- Appears with "Secret:" prefix in chat.
- They all get forwarded to the Autohost interface.

### How to test

- Set AllowInterplayerSecrets=0 or don't set it
   - Open multiplayer game
   - Do /SByNum 1 hello
      - shouldn't reach the other player
   - Do /SByNum 255 hello
      - reaches the server but you need autohost or some print to see it
   - quit
- Set AllowInterplayerSecrets=1
   - Do /SByNum 1 hello
      - reaches the other player
- When watching replays the secret messages shouldn't be there, also server didn't record it in replay.
- Check with demo parser to see secret messages are not there. 

### Remarks

- Unsure about the specs but the feature is more or less done, probably will need to polish the rules.
- It does go into infolog.txt, might be good to avoid this too.
- Might be good to have a lua api to send them too.
- Maybe should have a shortcode akin to `/w` for sending to usernames, but since more for sending to server not sure it's needed, could also just detect names and ids inside the `<id>` parameter of `/SByNum`.
- Maybe should log into the players own replay if they're the destination or source.