### PR TITLE
Change id for NETMSG_MAPDRAW and fix comments.

### DIFF
--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -1138,6 +1138,10 @@ void CGame::ClientReadNet()
 
 			} break;
 
+			case NETMSG_MAPDRAW_OLD: {
+				LOG_L(L_WARNING, "[Game::%s] Invalid network opcode NETMSG_MAPDRAW_OLD(%d). Are you watching an old replay?", __func__, NETMSG_MAPDRAW_OLD);
+			} break;
+
 			case NETMSG_TEAM: {
 				ZoneScopedN("Net::Team");
 				const uint8_t playerNum = inbuf[1];

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -49,9 +49,10 @@ enum NETMSG {
 
 	NETMSG_PLAYERSTAT       = 29, // uint8_t playerNum; CPlayer::Statistics currentStats;
 	NETMSG_GAMEOVER         = 30, // uint8_t playerNum; std::vector<uint8_t> winningAllyTeams
-	NETMSG_MAPDRAW          = 31, // uint8_t messageSize =  8, playerNum, command = MapDrawAction::NET_ERASE; int16_t x, z;
-	                              // uint8_t messageSize = 12, playerNum, command = MapDrawAction::NET_LINE; int16_t x1, z1, x2, z2;
-	                              // /*messageSize*/   uint8_t playerNum, command = MapDrawAction::NET_POINT; int16_t x, z; std::string label;
+	//NETMSG_MAPDRAW_OLD	= 31, // old MAPDRAW with int16 coords
+	NETMSG_MAPDRAW          = 32, // uint8_t messageSize =  12, playerNum, command = MapDrawAction::NET_ERASE; int32_t x, z;
+	                              // uint8_t messageSize = 21, playerNum, command = MapDrawAction::NET_LINE; int32_t x1, z1, x2, z2, fromLua;
+	                              // /*messageSize*/   uint8_t playerNum, command = MapDrawAction::NET_POINT; int32_t x, z; fromLua, std::string label;
 	NETMSG_SYNCRESPONSE     = 33, // uint8_t playerNum; int32_t frameNum; uint32_t checksum;
 	NETMSG_SYSTEMMSG        = 35, // uint8_t playerNum, std::string message;
 	NETMSG_STARTPOS         = 36, // uint8_t playerNum, uint8_t myTeam, ready /*0: not ready, 1: ready, 2: don't update readiness*/; float x, y, z;

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -49,7 +49,7 @@ enum NETMSG {
 
 	NETMSG_PLAYERSTAT       = 29, // uint8_t playerNum; CPlayer::Statistics currentStats;
 	NETMSG_GAMEOVER         = 30, // uint8_t playerNum; std::vector<uint8_t> winningAllyTeams
-	//NETMSG_MAPDRAW_OLD	= 31, // old MAPDRAW with int16 coords
+	NETMSG_MAPDRAW_OLD	= 31, // old MAPDRAW with int16 coords
 	NETMSG_MAPDRAW          = 32, // uint8_t messageSize =  12, playerNum, command = MapDrawAction::NET_ERASE; int32_t x, z;
 	                              // uint8_t messageSize = 21, playerNum, command = MapDrawAction::NET_LINE; int32_t x1, z1, x2, z2, uint8_t fromLua;
 	                              // /*messageSize*/   uint8_t playerNum, command = MapDrawAction::NET_POINT; int32_t x, z; uint8_t fromLua, std::string label;

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -51,8 +51,8 @@ enum NETMSG {
 	NETMSG_GAMEOVER         = 30, // uint8_t playerNum; std::vector<uint8_t> winningAllyTeams
 	//NETMSG_MAPDRAW_OLD	= 31, // old MAPDRAW with int16 coords
 	NETMSG_MAPDRAW          = 32, // uint8_t messageSize =  12, playerNum, command = MapDrawAction::NET_ERASE; int32_t x, z;
-	                              // uint8_t messageSize = 21, playerNum, command = MapDrawAction::NET_LINE; int32_t x1, z1, x2, z2, fromLua;
-	                              // /*messageSize*/   uint8_t playerNum, command = MapDrawAction::NET_POINT; int32_t x, z; fromLua, std::string label;
+	                              // uint8_t messageSize = 21, playerNum, command = MapDrawAction::NET_LINE; int32_t x1, z1, x2, z2, uint8_t fromLua;
+	                              // /*messageSize*/   uint8_t playerNum, command = MapDrawAction::NET_POINT; int32_t x, z; uint8_t fromLua, std::string label;
 	NETMSG_SYNCRESPONSE     = 33, // uint8_t playerNum; int32_t frameNum; uint32_t checksum;
 	NETMSG_SYSTEMMSG        = 35, // uint8_t playerNum, std::string message;
 	NETMSG_STARTPOS         = 36, // uint8_t playerNum, uint8_t myTeam, ready /*0: not ready, 1: ready, 2: don't update readiness*/; float x, y, z;


### PR DESCRIPTION
### Work done

- NETMSG_MAPDRAW 31 -> NETMSG_MAPDRAW 32
- Also update comment since it wasn't updated, also "new" fromLua par wasn't documented there.
  - see 0a649e3bc01818fbe5684a32ab5d91c6cb6c42df
   - most tools broken because of fromLua parameter here since ages.

### Remarks

- Mostly relevant for independent demo file parsers.
  - for example https://github.com/beyond-all-reason/demo-parser/pull/23
- This was changed with https://github.com/beyond-all-reason/RecoilEngine/pull/1872
- A bit late to change it, but since this is new in rel2503 and didn't yet have a final release, I think still worth it to merge
  - I think tool devs will appreciate it.
- This way tools can differently parse the old and new MAPDRAW.
  - they are different size, and also point is variable size, so can't just autodetect by size... need to resort to checking engine version.
- Maybe id 32 is unused since ages, could use a later unused one, like 80+, but pbbly ok to use 32.
  - was removed in 2009 at 0.79/0.80: https://github.com/beyond-all-reason/RecoilEngine/commit/27db9602a28db206abc4cc02e32452a31e9e33b3
