### PR TITLE
Address QTPFS desync

### DIFF
--- a/rts/Sim/Path/QTPFS/PathCache.cpp
+++ b/rts/Sim/Path/QTPFS/PathCache.cpp
@@ -123,8 +123,7 @@ bool QTPFS::PathCache::MarkDeadPaths(const SRectangle& r, const NodeLayer& nodeL
 
 		IPath* path = &pathView.get<IPath>(entity);
 
-		if (path->IsSynced() == false) { continue; }
-		assert(path->GetOwner() != nullptr);
+		if (path->GetOwner() == nullptr) { continue; }
 		if (path->GetPathType() != pathType) { continue; }
 
 		// LOG("%s: %x is processing", __func__, (int)entity);

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -555,7 +555,7 @@ void QTPFS::PathSearch::InitStartingSearchNodes() {
 	bwdPathConnected = false;
 
 	// max nodes is split between forward and reverse search.
-	if (synced){
+	if (pathOwner != nullptr){
 		float relativeModifier = std::max(MAP_RELATIVE_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearchedRelativeToMapOpenNodes);
 		int relativeLimit = nodeLayer->GetNumOpenNodes() * relativeModifier;
 		int absoluteLimit = std::max(MAP_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearched);
@@ -655,6 +655,8 @@ static float CircularEaseOut(float t) {
 
 void QTPFS::PathSearch::SetForwardSearchLimit() {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (pathOwner == nullptr) return;
+
 	auto& fwd = directionalSearchData[SearchThreadData::SEARCH_FORWARD];
 	auto& bwd = directionalSearchData[SearchThreadData::SEARCH_BACKWARD];
 
@@ -1207,6 +1209,7 @@ bool QTPFS::PathSearch::ExecutePathSearch() {
 
 bool QTPFS::PathSearch::ExecuteRawSearch() {
 	ZoneScoped;
+	assert(pathOwner != nullptr);
 	auto& fwd = directionalSearchData[SearchThreadData::SEARCH_FORWARD];
 
 	int2 nearestSquare;
@@ -2090,7 +2093,8 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 	//assert(path->NumPoints() - path->GetNodeList().size() == 1 + (-nodesWithoutPoints));
 	
 	uint32_t repathIndex = 0;
-	if (!haveFullPath) {
+	// Unowned paths do not allow repaths - they always perform a full path search.
+	if (!haveFullPath && pathOwner != nullptr) {
 		const float minRepathLength = modInfo.qtRefreshPathMinDist;
 		bool pathIsBigEnoughForRepath = (pathDist >= minRepathLength);
 

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -1450,7 +1450,7 @@ void QTPFS::PathSearch::IterateNodeNeighbors(const INode* curNode, unsigned int 
 		// Forbid the reverse search from trampling on it's preloaded nodes for path repair, because even though the
 		// search resticted is to an AABB, the remaining existing path can flow in and out of this region. If we
 		// connect the reverse in this particular scenario, it will create an infinite loop.
-		if ( (searchDir == SearchThreadData::SEARCH_BACKWARD) && (nextSearchNode->GetStepIndex() > 0) && doPathRepair ) {
+		if ( doPathRepair && (searchDir == SearchThreadData::SEARCH_BACKWARD) && (nextSearchNode->GetStepIndex() > 0) ) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2369
Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2366 

Prevent unsynced paths using PathRequeueSearch - this issue could lead to the PathRequeueSearch component order in being changed, which can impact the order in which paths are assessed and linked for path sharing.
 
And account for some synced paths not having an owner.

I am currently testing, and having desync'ed yet. I'm letting the test go long to further increase confidence.