### PR TITLE
QTPFS Background Threaded Pathing

### DIFF
--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/Systems/RemoveDeadPathsSystem.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/Systems/RequeuePathsSystem.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Path/QTPFS/Systems/SyncUpdatedPathsSystem.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/HAPFS/IPathFinder.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/HAPFS/PathCache.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Path/HAPFS/PathEstimator.cpp"

--- a/rts/Sim/Path/QTPFS/Components/SyncUpdatedPaths.h
+++ b/rts/Sim/Path/QTPFS/Components/SyncUpdatedPaths.h
@@ -1,0 +1,23 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef QTPFS_SYSTEMS_SYNC_UPDATED_PATHS_H__
+#define QTPFS_SYSTEMS_SYNC_UPDATED_PATHS_H__
+
+// #include <cstddef>
+#include "System/Ecs/Components/BaseComponents.h"
+#include "System/Threading/ThreadPool.h"
+
+namespace QTPFS {
+
+
+typedef TaskPool<ForBackgroundTaskGroup, std::function<void(int)> &>::FuncTaskGroupPtr BackgroundTaskPtr;
+
+struct SyncUpdatedPathsComponent {
+	static constexpr std::size_t page_size = 1;
+
+	BackgroundTaskPtr backgroundTask;
+};
+
+}
+
+#endif

--- a/rts/Sim/Path/QTPFS/Path.h
+++ b/rts/Sim/Path/QTPFS/Path.h
@@ -391,6 +391,9 @@ namespace QTPFS {
 			SetSynced(false); // Mark this path as unsynced explicitly
 		}
 	};
+
+	// Used by the search system to avoid clashes with other engine systems.
+	struct SearchModeIPath : public IPath {};
 }
 
 #endif

--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -92,6 +92,9 @@ namespace QTPFS {
 
 		const spring::unordered_map<unsigned int, PathSearchTrace::Execution*>& GetPathTraces() const { return pathTraces; }
 
+		void RemovePathFromShared(QTPFS::entity entity);
+		void RemovePathFromPartialShared(QTPFS::entity entity);
+
 	private:
 		void MapChanged(int x1, int z1, int x2, int z2);
 
@@ -123,8 +126,6 @@ namespace QTPFS {
 		void UpdateNodeLayer(unsigned int layerNum, const SRectangle& r, int currentThread);
 
 		bool InitializeSearch(QTPFS::entity searchEntity);
-		void RemovePathFromShared(QTPFS::entity entity);
-		void RemovePathFromPartialShared(QTPFS::entity entity);
 		void RemovePathSearch(QTPFS::entity pathEntity);
 
 		void ReadyQueuedSearches();
@@ -153,7 +154,8 @@ namespace QTPFS {
 		bool ExecuteSearch(
 			PathSearch* search,
 			NodeLayer& nodeLayer,
-			unsigned int pathType
+			unsigned int pathType,
+			bool immediateSearch
 		);
 
 		unsigned int ExecuteImmediateSearch(unsigned int pathId);

--- a/rts/Sim/Path/QTPFS/Systems/SyncUpdatedPathsSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/SyncUpdatedPathsSystem.cpp
@@ -1,0 +1,117 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "SyncUpdatedPathsSystem.h"
+
+#include "Sim/Path/IPathManager.h"
+#include "Sim/Path/QTPFS/Components/Path.h"
+#include "Sim/Path/QTPFS/Components/SyncUpdatedPaths.h"
+#include "Sim/Path/QTPFS/PathManager.h"
+#include "Sim/Path/QTPFS/Registry.h"
+
+#include "System/Ecs/EcsMain.h"
+#include "System/Ecs/Utils/SystemGlobalUtils.h"
+#include "System/TimeProfiler.h"
+#include "System/Log/ILog.h"
+
+#include "System/Misc/TracyDefs.h"
+
+using namespace SystemGlobals;
+using namespace QTPFS;
+
+
+void SyncUpdatedPathsSystem::Init()
+{
+    RECOIL_DETAILED_TRACY_ZONE;
+    auto& comp = systemGlobals.CreateSystemComponent<SyncUpdatedPathsComponent>();
+    systemUtils.OnUpdate().connect<&SyncUpdatedPathsSystem::Update>();
+}
+
+void SyncUpdatedPathsSystem::Update()
+{
+    SCOPED_TIMER("ECS::SyncUpdatedPathsSystem::Update");
+
+    auto* pm = dynamic_cast<PathManager*>(pathManager);
+    auto& comp = systemGlobals.GetSystemComponent<SyncUpdatedPathsComponent>();
+
+    // Ensure any outstanding pathing tasks are completed before synchronisation.
+	if (comp.backgroundTask)
+		wait_for_mt_background(comp.backgroundTask);
+
+	auto completePath = [pm](QTPFS::entity pathEntity, IPath* path){
+
+        // Transfer search update path, to the simulation-visible path.
+        (*path) = std::move(registry.get<SearchModeIPath>(pathEntity));
+
+		// inform the movement system that the path has been changed.
+		if (registry.all_of<PathUpdatedCounterIncrease>(pathEntity)) {
+			path->SetNumPathUpdates(path->GetNumPathUpdates() + 1);
+			path->SetNextPointIndex(0);
+			registry.remove<PathUpdatedCounterIncrease>(pathEntity);
+		}
+		registry.remove<PathIsTemp>(pathEntity);
+		registry.remove<PathIsDirty>(pathEntity);
+		registry.remove<PathSearchRef>(pathEntity);
+
+		// If the node data wasn't recorded, then the path isn't shareable.
+		if (!path->IsBoundingBoxOverriden() || path->GetNodeList().size() == 0) {
+			pm->RemovePathFromShared(pathEntity);
+			pm->RemovePathFromPartialShared(pathEntity);
+		}
+	};
+
+    auto pathView = registry.group<PathSearch, ProcessPath>();
+
+	for (auto pathSearchEntity : pathView) {
+		assert(registry.valid(pathSearchEntity));
+		assert(registry.all_of<PathSearch>(pathSearchEntity));
+
+		PathSearch* search = &pathView.get<PathSearch>(pathSearchEntity);
+		QTPFS::entity pathEntity = (QTPFS::entity)search->GetID();
+		if (registry.valid(pathEntity)) {
+			// Only owned paths should be actioned in this function.
+			IPath* path = registry.try_get<IPath>(pathEntity);
+			if (path != nullptr) {
+				if (search->PathWasFound()) {
+					completePath(pathEntity, path);
+					// LOG("%s: %x - path found", __func__, entt::to_integral(pathEntity));
+				} else {
+					if (search->rawPathCheck) {
+						registry.remove<PathSearchRef>(pathEntity);
+						registry.remove<PathIsDirty>(pathEntity);
+
+						// adding a new search doesn't break this loop because new paths do not
+						// have the tag ProcessPath and so don't impact this group view.
+						pm->RequeueSearch(path, false, true, search->tryPathRepair);
+						// LOG("%s: %x - raw path check failed", __func__, entt::to_integral(pathEntity));
+					} else if (search->pathRequestWaiting) {
+						// nothing to do - it will be rerun next frame
+						// LOG("%s: %x - waiting for partial root path", __func__, entt::to_integral(pathEntity));
+						// continue;
+						registry.remove<PathSearchRef>(pathEntity);
+						pm->RequeueSearch(path, false, search->allowPartialSearch, false);
+					} else if (search->rejectPartialSearch) {
+						registry.remove<PathSearchRef>(pathEntity);
+						pm->RequeueSearch(path, false, false, false);
+					}
+					else {
+						// LOG("%s: %x - search failed", __func__, entt::to_integral(pathEntity));
+						// Don't invalid the path, now, give the unit the chance to escape from
+						// being stuck inside something.
+						// DeletePathEntity(pathEntity);
+						path->SetBoundingBox();
+						completePath(pathEntity, path);
+					}
+				}
+			}
+		}
+
+		// LOG("%s: delete search %x", __func__, entt::to_integral(pathSearchEntity));
+		if (registry.valid(pathSearchEntity))
+			registry.destroy(pathSearchEntity);
+	}
+}
+
+void SyncUpdatedPathsSystem::Shutdown() {
+    RECOIL_DETAILED_TRACY_ZONE;
+    systemUtils.OnUpdate().disconnect<&SyncUpdatedPathsSystem::Update>();
+}

--- a/rts/Sim/Path/QTPFS/Systems/SyncUpdatedPathsSystem.h
+++ b/rts/Sim/Path/QTPFS/Systems/SyncUpdatedPathsSystem.h
@@ -1,0 +1,17 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef SYNC_UPDATED_PATHS_SYSTEM_H__
+#define SYNC_UPDATED_PATHS_SYSTEM_H__
+
+namespace QTPFS {
+
+class SyncUpdatedPathsSystem {
+public:
+    static void Init();
+    static void Update();
+    static void Shutdown();
+};
+
+}
+
+#endif

--- a/rts/System/Sync/SyncChecker.h
+++ b/rts/System/Sync/SyncChecker.h
@@ -3,8 +3,6 @@
 #ifndef SYNCCHECKER_H
 #define SYNCCHECKER_H
 
-#ifdef SYNCCHECK
-
 #include "System/SpringHash.h"
 
 #include <cassert>
@@ -68,7 +66,5 @@ class CSyncChecker {
 		static std::array<unsigned, MAX_SYNC_HISTORY_FRAMES> logFrames;
 #endif // SYNC_HISTORY
 };
-
-#endif // SYNCDEBUG
 
 #endif // SYNCDEBUGGER_H

--- a/rts/System/Sync/SyncedPrimitiveBase.h
+++ b/rts/System/Sync/SyncedPrimitiveBase.h
@@ -63,13 +63,8 @@ namespace Sync {
 
 }
 
-#if !defined(NDEBUG) && defined(SYNCCHECK)
 #  define ENTER_SYNCED_CODE() CSyncChecker::EnterSyncedCode()
 #  define LEAVE_SYNCED_CODE() CSyncChecker::LeaveSyncedCode()
-#else
-#  define ENTER_SYNCED_CODE()
-#  define LEAVE_SYNCED_CODE()
-#endif
 
 #ifdef SYNCDEBUG
 #  define ASSERT_SYNCED(x) Sync::AssertDebugger(x, "assert(" #x ")")


### PR DESCRIPTION
A performance optimization that runs the QTPFS path requests on the worker threads while other systems are running. This works because the QTPFS path searches run on data independent of the rest of the simulation. I.e. the QTPFS Quad Trees are only updated as known points in time.

A new synced background task is available. This will run individual execute steps and then reschedule in case there are other regular multi-thread tasks to perform (such a unit movement and collision.) When there are no regular/foreground synced tasks then the synced background tasks are run.

The idea, is to make use of the unused worker thread time, to improve overall simulation performance. It also should reduce the impact of activity spikes in pathing requests, which is inherently a spikey activity.

Running the Pathing Benchmark (on 3 units per cycle) I get these results:

Average Simulation time on current engine: 9.9ms
Average Simulation time with background pathing: 8.4ms

The spread was wider typically by about 1ms. I suspect that may be due to memory contention of heterogeneous multi-threading and the impact on other systems running simultaneously.

I feel we so gather volunteers to carry out further testing and comparisons to better understand the full impact of these changes and whether this should be used going forward.

Here's a Tracy example of an massive set of overkill pathing requests. Rather than process them all and hold the simulation up, here the work is started while the other parts of simulation is running, and continues through the unsynced/drawing time as well, until it gets to the next frame and hits the synchronization point. At this point the main thread gets involved with delivering the work as well as the worker thread since this is now holding up the simulation.

![image](https://github.com/user-attachments/assets/4aef218e-6c18-4347-8128-9312bc885ac1)

This is a super nasty example, with a lot of units, and the paths are long, and have little-no-sharing potential. Not likely to happen in real matches, but it is good to showcase how this approach works. The time shown here is also about x2 worse than it would be because of the performance impact of using Tracy to trace every node search.

Due to the requirement of running fully isolated from all other simulation state, only QTPFS path searches currently qualify for background threading. Even HAPFS will not be able to use this feature because it relies directly on the height map and ground blocking map during search time. QTPFS has to derive its own quad-tree from those same data sources, which means it controls when and who the pathing map data is updated.