### PR TITLE
Add MiniMapNoteDuration setting to configure ping duration on the minimap

### DIFF
--- a/doc/site/_data/configs.json
+++ b/doc/site/_data/configs.json
@@ -1203,6 +1203,14 @@
     "defaultValue": 0,
     "type": "bool"
   },
+  "MiniMapNoteDuration": {
+    "declarationFile": "/spring/rts/Game/UI/MiniMap.cpp",
+    "declarationLine": 83,
+    "description": "Duration in seconds of a note (ping) on the MiniMap.",
+    "defaultValue": 2,
+    "minimumValue": 2,
+    "type": "float"
+  },
   "MiniMapCursorScale": {
     "declarationFile": "/spring/rts/Game/UI/MiniMap.cpp",
     "declarationLine": 60,

--- a/doc/site/changelogs/running-changelog.markdown
+++ b/doc/site/changelogs/running-changelog.markdown
@@ -21,6 +21,7 @@ Nothing changes in behaviour, but they are (and have been for a long time) a bad
 Use shaders as a replacement.
 
 # Features
+* it is now possible to set the duration of the minimap ping using the `MiniMapNoteDuration` setting.
 
 ### Camera callins
 * added `wupget:CameraRotationChanged(rotX, rotY, rotZ) → nil`.

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -214,6 +214,8 @@ protected:
 	Shader::IProgramObject* bgShader = nullptr;
 
 	CUnit* lastClicked = nullptr;
+
+	float minimapNoteDuration = 2.0f;
 };
 
 


### PR DESCRIPTION
[Screencast from 06-24-2025 04:30:37 PM.webm](https://github.com/user-attachments/assets/d457f003-52fa-4921-9646-1fcfa14e5f1b)

To test use `/set MiniMapNoteDuration 10` for example and ping the map. The ping should do the original 2 second animation, and then continue the "smaller" animation until the 10 second limit has been reached.

Ideally.. the animation would always cleanly end on the smallest frame, but I was too lazy to calculate the exact variable timing for it.