### PR TITLE
Fonts FtLibraryHandler and FontHandler refactoring

### DIFF
--- a/rts/Rendering/CMakeLists.txt
+++ b/rts/Rendering/CMakeLists.txt
@@ -138,6 +138,7 @@ set(sources_engine_Rendering
 		"${CMAKE_CURRENT_SOURCE_DIR}/VerticalSync.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/WorldDrawer.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Fonts/FontHandler.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Fonts/FtLibraryHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Fonts/CFontTexture.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Fonts/glFont.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Fonts/glFontRenderer.cpp"

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -35,10 +35,6 @@
 
 static constexpr int FT_INTERNAL_DPI = 64;
 
-#ifdef HEADLESS
-typedef unsigned char FT_Byte;
-#endif
-
 using SizedFontKey = std::pair<std::string, int>;
 
 static spring::unordered_map<SizedFontKey, std::weak_ptr<FontFace>> fontFaceCache;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -10,14 +10,11 @@
 #include <cstring> // for memset, memcpy
 #include <string>
 #include <vector>
-#include <sstream>
 
 #include "FtIncludes.h"
 
 #include "Rendering/GL/myGL.h"
-#include "Rendering/GlobalRendering.h"
 #include "Rendering/Textures/Bitmap.h"
-#include "System/Config/ConfigHandler.h"
 #include "System/Exceptions.h"
 #include "System/EventHandler.h"
 #include "System/Log/ILog.h"
@@ -26,15 +23,11 @@
 #ifdef _DEBUG
 	#include "System/Platform/Threading.h"
 #endif
-#include "System/SafeUtil.h"
-#include "System/StringUtil.h"
-#include "System/TimeProfiler.h"
 #include "System/UnorderedMap.hpp"
 #include "System/float4.h"
 #include "System/ContainerUtil.h"
 #include "System/ScopedResource.h"
 #include "fmt/format.h"
-#include "fmt/printf.h"
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -1,7 +1,9 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "CFontTexture.h"
+
 #include "glFontRenderer.h"
+#include "FontHandler.h"
 #include "FontLogSection.h"
 
 #include <cstring> // for memset, memcpy
@@ -159,10 +161,6 @@ public:
 			ScopedOnceTimer timer(msg);
 			ZoneScopedNC("FtLibraryHandler::FontConfigInit", tracy::Color::Purple);
 
-			searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
-			searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
-			searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
-
 			FcBool res;
 			std::string errprefix = fmt::sprintf("[%s] Fontconfig(version %d.%d.%d) failed to initialize", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
 
@@ -258,7 +256,7 @@ public:
 	}
 	static bool InitSingletonFontconfig(bool console) { return singleton->InitFontconfig(console); }
 
-	static bool UseFontConfig() { return (configHandler == nullptr || configHandler->GetBool("UseFontConfigLib")); }
+	static bool UseFontConfig() { return fontHandler.useFontConfigLib; }
 
 	#ifdef USE_FONTCONFIG
 	// command-line CheckGenFontConfigFull invocation checks
@@ -300,13 +298,13 @@ public:
 		singleton->basePattern = FcPatternCreate();
 	}
 	static bool GetSearchSystemFonts() {
-		return singleton->searchSystemFonts;
+		return fontHandler.searchSystemFonts;
 	}
 	static bool GetSearchFontAttributes() {
-		return singleton->searchFontAttributes;
+		return fontHandler.searchFontAttributes;
 	}
 	static bool GetSearchApplySubstitutions() {
-		return singleton->searchApplySubstitutions;
+		return fontHandler.searchApplySubstitutions;
 	}
 	#endif
 private:
@@ -316,9 +314,6 @@ private:
 	FcFontSet *gameFontSet;
 	FcPattern *basePattern;
 	#endif
-	bool searchSystemFonts;
-	bool searchFontAttributes;
-	bool searchApplySubstitutions;
 
 	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
 };
@@ -911,7 +906,7 @@ void CFontTexture::PinFont(std::shared_ptr<FontFace>& face, const std::string& f
 	if (cached != pinnedRecentFonts.end()) {
 		cached->second.timestamp = time;
 	} else {
-		if (pinnedRecentFonts.size() >= maxPinnedFonts) {
+		if (pinnedRecentFonts.size() >= fontHandler.maxPinnedFonts) {
 			SizedFontKey* oldest;
 			float oldestTime = time;
 			for(auto &[key, timestampedFont]: pinnedRecentFonts) {
@@ -931,11 +926,6 @@ void CFontTexture::PinFont(std::shared_ptr<FontFace>& face, const std::string& f
 void CFontTexture::InitFonts()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-#ifndef HEADLESS
-	maxFontTries = configHandler ? configHandler->GetInt("MaxFontTries") : 5;
-	maxPinnedFonts = configHandler ? configHandler->GetInt("MaxPinnedFonts") : 10;
-	allowColorFonts = configHandler ? configHandler->GetBool("AllowColorFonts") : false;
-#endif
 }
 
 void CFontTexture::KillFonts()
@@ -1054,13 +1044,13 @@ void CFontTexture::LoadWantedGlyphs(const std::vector<char32_t>& wanted)
 	map.clear();
 
 	for (auto c : wanted) {
-		if (auto it = failedAttemptsToReplace.find(c); (it != failedAttemptsToReplace.end() && it->second == maxFontTries))
+		if (auto it = failedAttemptsToReplace.find(c); (it != failedAttemptsToReplace.end() && it->second == fontHandler.maxFontTries))
 			continue;
 
 		auto it = std::lower_bound(nonPrintableRanges.begin(), nonPrintableRanges.end(), c);
 		if (it != nonPrintableRanges.end() && !(c < *it)) {
 			LoadGlyph(shFace, c, 0);
-			failedAttemptsToReplace.emplace(c, maxFontTries);
+			failedAttemptsToReplace.emplace(c, fontHandler.maxFontTries);
 		}
 		else {
 			map.emplace_back(c);
@@ -1082,7 +1072,7 @@ void CFontTexture::LoadWantedGlyphs(const std::vector<char32_t>& wanted)
 		alreadyCheckedFonts.insert(GetFaceKey(*f));
 
 		for (std::size_t idx = 0; idx < map.size(); /*nop*/) {
-			if (auto it = failedAttemptsToReplace.find(map[idx]); (it != failedAttemptsToReplace.end() && it->second == maxFontTries)) {
+			if (auto it = failedAttemptsToReplace.find(map[idx]); (it != failedAttemptsToReplace.end() && it->second == fontHandler.maxFontTries)) {
 				// handle maxFontTries attempts case
 				LoadGlyph(shFace, map[idx], 0);
 				LOG_L(L_WARNING, "[CFontTexture::%s] Failed to load glyph %u after %d font replacement attempts", __func__, uint32_t(map[idx]), failedAttemptsToReplace[map[idx]]);
@@ -1213,7 +1203,7 @@ void CFontTexture::LoadGlyph(std::shared_ptr<FontFace>& f, char32_t ch, unsigned
 
 	// load glyph
 	auto flags = FT_LOAD_DEFAULT;
-	if (FT_HAS_COLOR(f->face) && allowColorFonts) {
+	if (FT_HAS_COLOR(f->face) && fontHandler.allowColorFonts) {
 		flags |= FT_LOAD_COLOR;
 	} else {
 		flags |= FT_LOAD_RENDER;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -5,6 +5,7 @@
 #include "glFontRenderer.h"
 #include "FontHandler.h"
 #include "FontLogSection.h"
+#include "FtLibraryHandler.h"
 
 #include <cstring> // for memset, memcpy
 #include <string>
@@ -93,253 +94,6 @@ static spring::unordered_map<SizedFontKey, TimestampedFont> pinnedRecentFonts;
 #include "NonPrintableSymbols.inl"
 
 
-#ifndef HEADLESS
-class FtLibraryHandler {
-public:
-	FtLibraryHandler()
-		: config(nullptr)
-		, lib(nullptr)
-		#ifdef USE_FONTCONFIG
-		, gameFontSet(nullptr)
-		, basePattern(nullptr)
-		#endif // USE_FONTCONFIG
-	{
-		const FT_Error error = FT_Init_FreeType(&lib);
-
-		if (error != 0) {
-			FT_Int version[3];
-			FT_Library_Version(lib, &version[0], &version[1], &version[2]);
-
-			std::string err = fmt::sprintf("[%s] FT_Init_FreeType failure (version %d.%d.%d) \"%s\"",
-						       __func__, version[0], version[1], version[2], GetFTError(error));
-			throw std::runtime_error(err);
-		}
-	}
-
-	~FtLibraryHandler() {
-		pinnedRecentFonts.clear();
-		FT_Done_FreeType(lib);
-
-		#ifdef USE_FONTCONFIG
-		if (!config)
-			return;
-
-		FcConfigDestroy(config);
-		if (gameFontSet) {
-			FcFontSetDestroy(gameFontSet);
-		}
-		if (basePattern) {
-			FcPatternDestroy(basePattern);
-		}
-		FcFini();
-		config = nullptr;
-		#endif
-	}
-
-	bool InitFontconfig(bool console) {
-		#ifdef USE_FONTCONFIG
-		auto LOG_MSG = [console](const std::string& fmt, bool isError, auto&&... args) {
-			if (console) {
-				std::string fmtNL = fmt + "\n";
-				printf(fmtNL.c_str(), args...);
-			}
-			else {
-				if (isError) {
-					LOG_L(L_ERROR, fmt.c_str(), args...);
-				}
-				else {
-					LOG(fmt.c_str(), args...);
-				}
-			}
-		};
-
-		if (!UseFontConfig())
-			return false;
-
-		{
-			std::string msg = fmt::sprintf("%s::FontConfigInit (version %d.%d.%d)", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
-			ScopedOnceTimer timer(msg);
-			ZoneScopedNC("FtLibraryHandler::FontConfigInit", tracy::Color::Purple);
-
-			FcBool res;
-			std::string errprefix = fmt::sprintf("[%s] Fontconfig(version %d.%d.%d) failed to initialize", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
-
-			// init configuration
-			FcConfigEnableHome(FcFalse);
-			config = FcConfigCreate();
-
-			// we cant directly use the usual fontconfig methods because those won't let us have both first our cache
-			// and system fonts included. also linux actually has system config files that can be used by fontconfig.
-
-			#ifdef _WIN32
-			static constexpr auto winFontPath = "%WINDIR%\\fonts";
-			const int neededSize = ExpandEnvironmentStrings(winFontPath, nullptr, 0);
-			std::vector <char> osFontsDir (neededSize);
-			ExpandEnvironmentStrings(winFontPath, osFontsDir.data(), osFontsDir.size());
-
-			static constexpr const char* configFmt = R"(<fontconfig><dir>%s</dir><cachedir>fontcache</cachedir></fontconfig>)";
-			const std::string configFmtVar = fmt::sprintf(configFmt, osFontsDir.data());
-			#else
-			const std::string configFmtVar = R"(<fontconfig><cachedir>fontcache</cachedir></fontconfig>)";
-			#endif
-
-			#ifdef _WIN32
-			// Explicitly set the config with xml for windows.
-			res = FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
-			#else
-			// Load system configuration (passing 0 here so fc will use the default os config file if possible).
-			res = FcConfigParseAndLoad(config, 0, true);
-			#endif
-			if (res) {
-				#ifndef _WIN32
-				// add local cache after system config for linux
-				FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
-				#endif
-
-				LOG_MSG("[%s] Using Fontconfig light init", false, __func__);
-
-				// build system fonts
-				res = FcConfigBuildFonts(config);
-				if (!res) {
-					LOG_MSG("%s fonts", true, errprefix.c_str());
-					InitFailed();
-					return false;
-				}
-			} else {
-				// Can't load step by step to use our cache, so retry with general
-				// fontconfig init method, that has a few extra fallbacks.
-
-				// Init everything. Normally this would be enough, but the method before
-				// accounts for situations where system config is borked due to incompatible
-				// lib and system config files.
-				FcConfig *fcConfig = FcInitLoadConfigAndFonts();
-				if (fcConfig) {
-					FcConfigDestroy(config); // release previous config
-					config = fcConfig;
-
-					// add our cache at the back of the new config.
-					FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
-				} else {
-					LOG_MSG("%s config and fonts. No system fallbacks will be available", false, errprefix.c_str());
-				}
-			}
-
-			gameFontSet = FcFontSetCreate();
-			basePattern = FcPatternCreate();
-
-			// init app fonts dir
-			res = FcConfigAppFontAddDir(config, reinterpret_cast<const FcChar8*>("fonts"));
-			if (!res) {
-				LOG_MSG("%s font dir", true, errprefix.c_str());
-				InitFailed();
-				return false;
-			}
-
-			// print cache dirs
-			auto dirs = FcConfigGetCacheDirs(config);
-			FcStrListFirst(dirs);
-			for (FcChar8* dir = FcStrListNext(dirs); dir != nullptr; dir = FcStrListNext(dirs)) {
-				LOG_MSG("[%s] Using Fontconfig cache dir \"%s\"", false, __func__, dir);
-			}
-			FcStrListDone(dirs);
-		}
-
-		#endif // USE_FONTCONFIG
-
-		return true;
-	}
-
-	void InitFailed() {
-		FcConfigDestroy(config);
-		FcFini();
-		config = nullptr;
-	}
-	static bool InitSingletonFontconfig(bool console) { return singleton->InitFontconfig(console); }
-
-	static bool UseFontConfig() { return fontHandler.useFontConfigLib; }
-
-	#ifdef USE_FONTCONFIG
-	// command-line CheckGenFontConfigFull invocation checks
-	static bool CheckFontConfig() { return (UseFontConfig() && FcConfigUptoDate(GetFCConfig())); }
-	#else
-
-	static bool CheckFontConfig() { return false; }
-	static bool CheckGenFontConfig(bool fromCons) { return false; }
-	#endif
-
-	static FT_Library& GetLibrary() {
-		if (singleton == nullptr)
-			singleton = std::make_unique<FtLibraryHandler>();
-
-		return singleton->lib;
-	};
-	static FcConfig* GetFCConfig() {
-		if (singleton == nullptr)
-			singleton = std::make_unique<FtLibraryHandler>();
-
-		return singleton->config;
-	}
-	static inline bool CanUseFontConfig() {
-		return GetFCConfig() != nullptr;
-	}
-	#ifdef USE_FONTCONFIG
-	static FcFontSet *GetGameFontSet() {
-		return singleton->gameFontSet;
-	}
-	static FcPattern *GetBasePattern() {
-		return singleton->basePattern;
-	}
-	static void ClearGameFontSet() {
-		FcFontSetDestroy(singleton->gameFontSet);
-		singleton->gameFontSet = FcFontSetCreate();
-	}
-	static void ClearBasePattern() {
-		FcPatternDestroy(singleton->basePattern);
-		singleton->basePattern = FcPatternCreate();
-	}
-	static bool GetSearchSystemFonts() {
-		return fontHandler.searchSystemFonts;
-	}
-	static bool GetSearchFontAttributes() {
-		return fontHandler.searchFontAttributes;
-	}
-	static bool GetSearchApplySubstitutions() {
-		return fontHandler.searchApplySubstitutions;
-	}
-	#endif
-private:
-	FcConfig* config;
-	FT_Library lib;
-	#ifdef USE_FONTCONFIG
-	FcFontSet *gameFontSet;
-	FcPattern *basePattern;
-	#endif
-
-	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
-};
-#endif
-
-
-
-void FtLibraryHandlerProxy::InitFtLibrary()
-{
-	RECOIL_DETAILED_TRACY_ZONE;
-#ifndef HEADLESS
-	FtLibraryHandler::GetLibrary();
-#endif
-}
-
-bool FtLibraryHandlerProxy::InitFontconfig(bool console)
-{
-	RECOIL_DETAILED_TRACY_ZONE;
-#ifndef HEADLESS
-	return FtLibraryHandler::InitSingletonFontconfig(console);
-#else
-	return false;
-#endif
-}
-
-
 /*******************************************************************************/
 /*******************************************************************************/
 /*******************************************************************************/
@@ -394,7 +148,7 @@ static std::shared_ptr<FontFace> LoadFontFace(const std::string& fontfile)
 
 	// load the font
 	FT_Face face_ = nullptr;
-	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), fontMem.get()->data(), filesize, 0, &face_);
+	FT_Error error = FtLibraryHandlerProxy::NewMemoryFace(fontMem.get()->data(), filesize, 0, &face_);
 	auto face = spring::ScopedResource(
 		face_,
 		[](FT_Face f) { if (f) FT_Done_Face(f); }
@@ -462,7 +216,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	if (characters.empty())
 		return nullptr;
 
-	if (!FtLibraryHandler::CanUseFontConfig())
+	if (!FtLibraryHandlerProxy::CanUseFontConfig())
 		return nullptr;
 
 	// create list of wanted characters
@@ -477,7 +231,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 
 	// create properties of the wanted font starting from our priorities pattern.
 	auto pattern = spring::ScopedResource(
-		FcPatternDuplicate(FtLibraryHandler::GetBasePattern()),
+		FcPatternDuplicate(FtLibraryHandlerProxy::GetBasePattern()),
 		[](FcPattern* p) { if (p) FcPatternDestroy(p); }
 	);
 
@@ -507,7 +261,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 			[](FcBlanks* b) { if (b) FcBlanksDestroy(b); }
 		);
 
-		if (FtLibraryHandler::GetSearchFontAttributes()) {
+		if (fontHandler.searchFontAttributes) {
 			auto origPattern = spring::ScopedResource(
 				FcFreeTypeQueryFace(origFace, ftname, 0, blanks),
 				[](FcPattern* p) { if (p) FcPatternDestroy(p); }
@@ -536,7 +290,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	}
 
 	FcDefaultSubstitute(pattern);
-	if (FtLibraryHandler::GetSearchApplySubstitutions() && !FcConfigSubstitute(FtLibraryHandler::GetFCConfig(), pattern, FcMatchPattern))
+	if (fontHandler.searchApplySubstitutions && !FcConfigSubstitute(FtLibraryHandlerProxy::GetFCConfig(), pattern, FcMatchPattern))
 	{
 		return nullptr;
 	}
@@ -545,12 +299,12 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	typedef std::unique_ptr<FcFontSet, decltype(&FcFontSetDestroy)> ScopedFcFontSet;
 
 	int nFonts = 0;
-	bool loadMore = FtLibraryHandler::GetSearchSystemFonts();
+	bool loadMore = fontHandler.searchSystemFonts;
 	FcResult res;
 
 	// first search game fonts
-	FcFontSet *sets[] = { FtLibraryHandler::GetGameFontSet() };
-	ScopedFcFontSet fs(FcFontSetSort(FtLibraryHandler::GetFCConfig(), sets, 1, pattern, FcFalse, nullptr, &res), &FcFontSetDestroy);
+	FcFontSet *sets[] = { FtLibraryHandlerProxy::GetGameFontSet() };
+	ScopedFcFontSet fs(FcFontSetSort(FtLibraryHandlerProxy::GetFCConfig(), sets, 1, pattern, FcFalse, nullptr, &res), &FcFontSetDestroy);
 
 	if (fs != nullptr && res == FcResultMatch)
 		nFonts = fs->nfont;
@@ -560,7 +314,7 @@ static std::shared_ptr<FontFace> GetFontForCharacters(const std::vector<char32_t
 	while (i < nFonts || loadMore) {
 		if (i == nFonts) {
 			// now search system fonts
-			fs = ScopedFcFontSet(FcFontSort(FtLibraryHandler::GetFCConfig(), pattern, FcFalse, nullptr, &res), &FcFontSetDestroy);
+			fs = ScopedFcFontSet(FcFontSort(FtLibraryHandlerProxy::GetFCConfig(), pattern, FcFalse, nullptr, &res), &FcFontSetDestroy);
 			if (fs == nullptr || res != FcResultMatch)
 				return nullptr;
 			loadMore = false;
@@ -762,10 +516,10 @@ CFontTexture::~CFontTexture()
 bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 {
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
-	if (!FtLibraryHandler::CanUseFontConfig())
+	if (!FtLibraryHandlerProxy::CanUseFontConfig())
 		return false;
 
-	FcFontSet *set = FtLibraryHandler::GetGameFontSet();
+	FcFontSet *set = FtLibraryHandlerProxy::GetGameFontSet();
 
 	// Check if font already loaded
 	for (int i=0; set && i < set->nfont; ++i) {
@@ -798,12 +552,12 @@ bool CFontTexture::AddFallbackFont(const std::string& fontfile)
 		return false;
 	}
 	// needed?:
-	//FcConfigSubstitute(FtLibraryHandler::GetFCConfig(), pattern, FcMatchScan);
+	//FcConfigSubstitute(FtLibraryHandlerProxy::GetFCConfig(), pattern, FcMatchScan);
 
 	// Add to priority fonts pattern
 	FcChar8* family = nullptr;
 	if (FcPatternGetString( pattern, FC_FAMILY , 0, &family ) == FcResultMatch) {
-		FcPattern *basePattern = FtLibraryHandler::GetBasePattern();
+		FcPattern *basePattern = FtLibraryHandlerProxy::GetBasePattern();
 		FcPatternAddString(basePattern, FC_FAMILY, family);
 	} else {
 		LOG_L(L_WARNING, "[%s] could not add priority for %s", __func__, fontfile.c_str());
@@ -826,11 +580,11 @@ void CFontTexture::ClearFallbackFonts()
 {
 	pinnedRecentFonts.clear();
 #if defined(USE_FONTCONFIG) && !defined(HEADLESS)
-	if (!FtLibraryHandler::CanUseFontConfig())
+	if (!FtLibraryHandlerProxy::CanUseFontConfig())
 		return;
 
-	FtLibraryHandler::ClearBasePattern();
-	FtLibraryHandler::ClearGameFontSet();
+	FtLibraryHandlerProxy::ClearBasePattern();
+	FtLibraryHandlerProxy::ClearGameFontSet();
 
 	needsClearGlyphs = true;
 #endif
@@ -931,6 +685,9 @@ void CFontTexture::InitFonts()
 void CFontTexture::KillFonts()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+
+	pinnedRecentFonts.clear();
+
 	// check unused fonts
 	std::erase_if(allFonts, [](std::weak_ptr<CFontTexture> item) { return item.expired(); });
 

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -6,12 +6,11 @@
 #include "FontHandler.h"
 #include "FontLogSection.h"
 #include "FtLibraryHandler.h"
+#include "FtIncludes.h"
 
 #include <cstring> // for memset, memcpy
 #include <string>
 #include <vector>
-
-#include "FtIncludes.h"
 
 #include "Rendering/GL/myGL.h"
 #include "Rendering/Textures/Bitmap.h"

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -12,14 +12,7 @@
 #include <vector>
 #include <sstream>
 
-#ifndef HEADLESS
-	#include <ft2build.h>
-	#include FT_FREETYPE_H
-	#ifdef USE_FONTCONFIG
-		#include <fontconfig/fontconfig.h>
-		#include <fontconfig/fcfreetype.h>
-	#endif
-#endif // HEADLESS
+#include "FtIncludes.h"
 
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GlobalRendering.h"
@@ -46,31 +39,6 @@
 #include "System/Misc/TracyDefs.h"
 
 #define SUPPORT_AMD_HACKS_HERE
-
-#ifndef HEADLESS
-	#undef __FTERRORS_H__
-	#define FT_ERRORDEF( e, v, s )  { e, s },
-	#define FT_ERROR_START_LIST     {
-	#define FT_ERROR_END_LIST       { 0, 0 } };
-	struct FTErrorRecord {
-		int          err_code;
-		const char*  err_msg;
-	} static errorTable[] =
-	#include FT_ERRORS_H
-
-	struct IgnoreMe {}; // MSVC IntelliSense is confused by #include FT_ERRORS_H above. This seems to fix it.
-
-	static const char* GetFTError(FT_Error e) {
-		const auto it = std::find_if(std::begin(errorTable), std::end(errorTable), [e](FTErrorRecord er) { return er.err_code == e; });
-		if (it != std::end(errorTable))
-			return it->err_msg;
-
-		return "Unknown error";
-	}
-#endif // HEADLESS
-
-
-
 
 static constexpr int FT_INTERNAL_DPI = 64;
 

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -191,9 +191,6 @@ private:
 	int curTextureUpdate = 0;
 	int lastTextureUpdate = 0;
 	bool needsTextureUpload = true;
-	inline static int maxFontTries = 0;
-	inline static int maxPinnedFonts = 0;
-	inline static int allowColorFonts = 0;
 #endif
 	std::shared_ptr<FontFace> shFace;
 

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -13,18 +13,10 @@
 #include "System/UnorderedMap.hpp"
 #include "System/UnorderedSet.hpp"
 #include "System/Threading/WrappedSync.h"
+#include "CFtLibraryHandler.h"
 
 
-struct FT_FaceRec_;
-typedef struct FT_FaceRec_* FT_Face;
 class CBitmap;
-
-class FtLibraryHandlerProxy {
-public:
-	static void InitFtLibrary();
-	static bool InitFontconfig(bool console);
-};
-
 
 struct IGlyphRect { //FIXME use SRect or float4
 	IGlyphRect():

--- a/rts/Rendering/Fonts/CFontTexture.h
+++ b/rts/Rendering/Fonts/CFontTexture.h
@@ -13,7 +13,7 @@
 #include "System/UnorderedMap.hpp"
 #include "System/UnorderedSet.hpp"
 #include "System/Threading/WrappedSync.h"
-#include "CFtLibraryHandler.h"
+#include "FtLibraryHandler.h"
 
 
 class CBitmap;

--- a/rts/Rendering/Fonts/FontHandler.cpp
+++ b/rts/Rendering/Fonts/FontHandler.cpp
@@ -1,6 +1,9 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "FontHandler.h"
+#include "FtLibraryHandler.h"
+#include "CFontTexture.h"
+#include "glFont.h"
 
 #include "System/Config/ConfigHandler.h"
 
@@ -21,7 +24,7 @@ CFontHandler::CFontHandler()
 }
 
 
-bool CFontHandler::Init()
+bool CFontHandler::Init(bool fullInit)
 {
 	if (configHandler != nullptr) {
 		maxFontTries = configHandler->GetInt("MaxFontTries");
@@ -42,7 +45,21 @@ bool CFontHandler::Init()
 		searchFontAttributes = true;
 		searchApplySubstitutions = true;
 	}
-	return true;
+	FtLibraryHandlerProxy::InitFtLibrary();
+
+	bool res = FtLibraryHandlerProxy::InitFontconfig(!fullInit);
+	if (!fullInit)
+		return res;
+
+	CFontTexture::InitFonts();
+	return CglFont::LoadConfigFonts();
 }
 
 
+void CFontHandler::Kill()
+{
+	font      = {};
+	smallFont = {};
+
+	CFontTexture::KillFonts();
+}

--- a/rts/Rendering/Fonts/FontHandler.cpp
+++ b/rts/Rendering/Fonts/FontHandler.cpp
@@ -24,37 +24,35 @@ CFontHandler::CFontHandler()
 }
 
 
-bool CFontHandler::Init(bool fullInit)
+bool CFontHandler::Init(bool console)
 {
-	if (configHandler != nullptr) {
-		maxFontTries = configHandler->GetInt("MaxFontTries");
-		maxPinnedFonts = configHandler->GetInt("MaxPinnedFonts");
-		disableOldColorIndicators = configHandler->GetBool("TextDisableOldColorIndicators");
-		allowColorFonts = configHandler->GetBool("AllowColorFonts");
-		useFontConfigLib = configHandler->GetBool("UseFontConfigLib");
-		searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
-		searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
-		searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
-	} else {
-		maxFontTries = 5;
-		maxPinnedFonts = 10;
-		allowColorFonts = false;
-		disableOldColorIndicators = false;
-		useFontConfigLib = true;
-		searchSystemFonts = true;
-		searchFontAttributes = true;
-		searchApplySubstitutions = true;
-	}
 	FtLibraryHandlerProxy::InitFtLibrary();
 
-	bool res = FtLibraryHandlerProxy::InitFontconfig(!fullInit);
-	if (!fullInit)
-		return res;
+	return FtLibraryHandlerProxy::InitFontconfig(console);
+}
+
+bool CFontHandler::FullInit()
+{
+	assert(configHandler != nullptr);
+
+	LoadConfig();
+	Init(false);
 
 	CFontTexture::InitFonts();
 	return CglFont::LoadConfigFonts();
 }
 
+void CFontHandler::LoadConfig()
+{
+	maxFontTries = configHandler->GetInt("MaxFontTries");
+	maxPinnedFonts = configHandler->GetInt("MaxPinnedFonts");
+	disableOldColorIndicators = configHandler->GetBool("TextDisableOldColorIndicators");
+	allowColorFonts = configHandler->GetBool("AllowColorFonts");
+	useFontConfigLib = configHandler->GetBool("UseFontConfigLib");
+	searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
+	searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
+	searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
+}
 
 void CFontHandler::Kill()
 {

--- a/rts/Rendering/Fonts/FontHandler.cpp
+++ b/rts/Rendering/Fonts/FontHandler.cpp
@@ -4,6 +4,13 @@
 
 #include "System/Config/ConfigHandler.h"
 
+CONFIG(bool, UseFontConfigLib).defaultValue(true).description("Whether the system fontconfig library (if present and enabled at compile-time) should be used for handling fonts.");
+CONFIG(bool, UseFontConfigSystemFonts).defaultValue(true).description("Whether the system fonts will be searched by fontconfig.");
+CONFIG(bool, FontConfigSearchAttributes).defaultValue(true).description("Whether the font characteristics will used to refine the search by fontconfig. Results in better glyph matches in some cases, but has a nontrivial performance cost.");
+CONFIG(bool, FontConfigApplySubstitutions).defaultValue(true).description("[EXPERIMENTAL] In case it's disabled FcConfigSubstitute is not getting called, this might break non-ASCII font rendering.");
+CONFIG(int, MaxFontTries).defaultValue(5).description("Represents the maximum number of attempts to search for a glyph replacement using the FontConfig library (lower = foreign glyphs may fail to render, higher = searching for foreign glyphs can lag the game).");
+CONFIG(int, MaxPinnedFonts).defaultValue(10).description("Maximum number of fonts to pin to cache. Increasing this will eventually use more memory, but can alleviate processing spikes when rendering new glyphs.");
+CONFIG(bool, AllowColorFonts).defaultValue(false).description("Allow working with colored fonts (experimental).");
 CONFIG(bool, TextDisableOldColorIndicators).defaultValue(false).description("Disable support for old color indicators. The old color indicators don't allow writing some characters.");
 
 CFontHandler fontHandler;
@@ -16,8 +23,25 @@ CFontHandler::CFontHandler()
 
 bool CFontHandler::Init()
 {
-	if (configHandler != nullptr)
+	if (configHandler != nullptr) {
+		maxFontTries = configHandler->GetInt("MaxFontTries");
+		maxPinnedFonts = configHandler->GetInt("MaxPinnedFonts");
 		disableOldColorIndicators = configHandler->GetBool("TextDisableOldColorIndicators");
+		allowColorFonts = configHandler->GetBool("AllowColorFonts");
+		useFontConfigLib = configHandler->GetBool("UseFontConfigLib");
+		searchSystemFonts = configHandler->GetBool("UseFontConfigSystemFonts");
+		searchFontAttributes = configHandler->GetBool("FontConfigSearchAttributes");
+		searchApplySubstitutions = configHandler->GetBool("FontConfigApplySubstitutions");
+	} else {
+		maxFontTries = 5;
+		maxPinnedFonts = 10;
+		allowColorFonts = false;
+		disableOldColorIndicators = false;
+		useFontConfigLib = true;
+		searchSystemFonts = true;
+		searchFontAttributes = true;
+		searchApplySubstitutions = true;
+	}
 	return true;
 }
 

--- a/rts/Rendering/Fonts/FontHandler.h
+++ b/rts/Rendering/Fonts/FontHandler.h
@@ -3,15 +3,14 @@
 #ifndef _FONT_HANDLER_H
 #define _FONT_HANDLER_H
 
-#include <string>
-
 #include "System/Misc/NonCopyable.h"
 
 class CFontHandler : public spring::noncopyable
 {
 public:
 	CFontHandler();
-	bool Init();
+	bool Init(bool fullInit);
+	void Kill();
 
 	bool disableOldColorIndicators = false;
 	int maxFontTries = 0;

--- a/rts/Rendering/Fonts/FontHandler.h
+++ b/rts/Rendering/Fonts/FontHandler.h
@@ -14,6 +14,13 @@ public:
 	bool Init();
 
 	bool disableOldColorIndicators = false;
+	int maxFontTries = 0;
+	int maxPinnedFonts = 0;
+	bool allowColorFonts = 0;
+	bool useFontConfigLib = false;
+	bool searchSystemFonts = true;
+	bool searchFontAttributes = true;
+	bool searchApplySubstitutions = true;
 };
 
 extern CFontHandler fontHandler;

--- a/rts/Rendering/Fonts/FontHandler.h
+++ b/rts/Rendering/Fonts/FontHandler.h
@@ -9,17 +9,21 @@ class CFontHandler : public spring::noncopyable
 {
 public:
 	CFontHandler();
-	bool Init(bool fullInit);
+	bool Init(bool console);
+	bool FullInit();
 	void Kill();
 
 	bool disableOldColorIndicators = false;
-	int maxFontTries = 0;
-	int maxPinnedFonts = 0;
-	bool allowColorFonts = 0;
-	bool useFontConfigLib = false;
+	int maxFontTries = 5;
+	int maxPinnedFonts = 10;
+	bool allowColorFonts = false;
+	bool useFontConfigLib = true;
 	bool searchSystemFonts = true;
 	bool searchFontAttributes = true;
 	bool searchApplySubstitutions = true;
+
+private:
+	void LoadConfig();
 };
 
 extern CFontHandler fontHandler;

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -1,3 +1,5 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
 #ifndef _FT_INCLUDES_H
 #define _FT_INCLUDES_H
 

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -1,20 +1,17 @@
 #ifndef _FT_INCLUDES_H
 #define _FT_INCLUDES_H
 
-#ifndef HEADLESS
+#ifdef HEADLESS
+	typedef unsigned char FT_Byte;
+#else  // not HEADLESS
 	#include <ft2build.h>
 	#include FT_FREETYPE_H
 	#ifdef USE_FONTCONFIG
 		#include <fontconfig/fontconfig.h>
 		#include <fontconfig/fcfreetype.h>
 	#endif
-#endif // HEADLESS
 
-#ifdef HEADLESS
-typedef unsigned char FT_Byte;
-#endif
-
-#ifndef HEADLESS
+	// FtError helper code
 	#include <algorithm>
 	#include <iterator>
 

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -1,0 +1,35 @@
+#ifndef _FT_INCLUDES_H
+#define _FT_INCLUDES_H
+
+#ifndef HEADLESS
+	#include <ft2build.h>
+	#include FT_FREETYPE_H
+	#ifdef USE_FONTCONFIG
+		#include <fontconfig/fontconfig.h>
+		#include <fontconfig/fcfreetype.h>
+	#endif
+#endif // HEADLESS
+
+#ifndef HEADLESS
+	#undef __FTERRORS_H__
+	#define FT_ERRORDEF( e, v, s )  { e, s },
+	#define FT_ERROR_START_LIST     {
+	#define FT_ERROR_END_LIST       { 0, 0 } };
+	struct FTErrorRecord {
+		int          err_code;
+		const char*  err_msg;
+	} static errorTable[] =
+	#include FT_ERRORS_H
+
+	struct IgnoreMe {}; // MSVC IntelliSense is confused by #include FT_ERRORS_H above. This seems to fix it.
+
+	static const char* GetFTError(FT_Error e) {
+		const auto it = std::find_if(std::begin(errorTable), std::end(errorTable), [e](FTErrorRecord er) { return er.err_code == e; });
+		if (it != std::end(errorTable))
+			return it->err_msg;
+
+		return "Unknown error";
+	}
+#endif // HEADLESS
+
+#endif // FT_INCLUDES_H

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -10,6 +10,10 @@
 	#endif
 #endif // HEADLESS
 
+#ifdef HEADLESS
+typedef unsigned char FT_Byte;
+#endif
+
 #ifndef HEADLESS
 	#include <algorithm>
 	#include <iterator>

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -12,6 +12,7 @@
 
 #ifndef HEADLESS
 	#include <algorithm>
+	#include <iterator>
 
 	#undef __FTERRORS_H__
 	#define FT_ERRORDEF( e, v, s )  { e, s },

--- a/rts/Rendering/Fonts/FtIncludes.h
+++ b/rts/Rendering/Fonts/FtIncludes.h
@@ -11,6 +11,8 @@
 #endif // HEADLESS
 
 #ifndef HEADLESS
+	#include <algorithm>
+
 	#undef __FTERRORS_H__
 	#define FT_ERRORDEF( e, v, s )  { e, s },
 	#define FT_ERROR_START_LIST     {

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -11,7 +11,7 @@
 
 #include "System/Misc/TracyDefs.h"
 #ifdef _WIN32
-	#include <windows.h>
+	#include <windows.h>	// ExpandEnvironmentStrings
 #endif
 
 #ifndef HEADLESS

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -6,20 +6,12 @@
 #include "FontHandler.h"
 #include "FontLogSection.h"
 #include "FtLibraryHandler.h"
+#include "FtIncludes.h"
 
 #include <cstring> // for memset, memcpy
 #include <string>
 #include <vector>
 #include <sstream>
-
-#ifndef HEADLESS
-	#include <ft2build.h>
-	#include FT_FREETYPE_H
-	#ifdef USE_FONTCONFIG
-		#include <fontconfig/fontconfig.h>
-		#include <fontconfig/fcfreetype.h>
-	#endif
-#endif // HEADLESS
 
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GlobalRendering.h"
@@ -46,30 +38,6 @@
 #include "System/Misc/TracyDefs.h"
 
 #define SUPPORT_AMD_HACKS_HERE
-
-#ifndef HEADLESS
-	#undef __FTERRORS_H__
-	#define FT_ERRORDEF( e, v, s )  { e, s },
-	#define FT_ERROR_START_LIST     {
-	#define FT_ERROR_END_LIST       { 0, 0 } };
-	struct FTErrorRecord {
-		int          err_code;
-		const char*  err_msg;
-	} static errorTable[] =
-	#include FT_ERRORS_H
-
-	struct IgnoreMe {}; // MSVC IntelliSense is confused by #include FT_ERRORS_H above. This seems to fix it.
-
-	static const char* GetFTError(FT_Error e) {
-		const auto it = std::find_if(std::begin(errorTable), std::end(errorTable), [e](FTErrorRecord er) { return er.err_code == e; });
-		if (it != std::end(errorTable))
-			return it->err_msg;
-
-		return "Unknown error";
-	}
-#endif // HEADLESS
-
-
 
 #ifndef HEADLESS
 class FtLibraryHandler {

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -301,31 +301,21 @@ FcConfig* FtLibraryHandlerProxy::GetFCConfig() {
 #endif
 }
 
-FcFontSet* FtLibraryHandlerProxy::GetGameFontSet() {
 #ifndef HEADLESS
+FcFontSet* FtLibraryHandlerProxy::GetGameFontSet() {
 	return FtLibraryHandler::GetGameFontSet();
-#else
-	return nullptr;
-#endif
 }
 
 FcPattern* FtLibraryHandlerProxy::GetBasePattern() {
-#ifndef HEADLESS
 	return FtLibraryHandler::GetBasePattern();
-#else
-	return nullptr;
-#endif
 }
 
 void FtLibraryHandlerProxy::ClearGameFontSet() {
-#ifndef HEADLESS
 	FtLibraryHandler::ClearGameFontSet();
-#endif
 }
 
 void FtLibraryHandlerProxy::ClearBasePattern() {
-#ifndef HEADLESS
 	FtLibraryHandler::ClearBasePattern();
-#endif
 }
+#endif
 

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -10,6 +10,9 @@
 #include "fmt/printf.h"
 
 #include "System/Misc/TracyDefs.h"
+#ifdef _WIN32
+	#include <userenv.h>
+#endif
 
 #ifndef HEADLESS
 class FtLibraryHandler {

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -1,43 +1,14 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#include "CFontTexture.h"
-
-#include "glFontRenderer.h"
 #include "FontHandler.h"
-#include "FontLogSection.h"
 #include "FtLibraryHandler.h"
 #include "FtIncludes.h"
 
-#include <cstring> // for memset, memcpy
-#include <string>
-#include <vector>
-#include <sstream>
-
-#include "Rendering/GL/myGL.h"
-#include "Rendering/GlobalRendering.h"
-#include "Rendering/Textures/Bitmap.h"
-#include "System/Config/ConfigHandler.h"
-#include "System/Exceptions.h"
-#include "System/EventHandler.h"
 #include "System/Log/ILog.h"
-#include "System/FileSystem/FileHandler.h"
-#include "System/Threading/ThreadPool.h"
-#ifdef _DEBUG
-	#include "System/Platform/Threading.h"
-#endif
-#include "System/SafeUtil.h"
-#include "System/StringUtil.h"
 #include "System/TimeProfiler.h"
-#include "System/UnorderedMap.hpp"
-#include "System/float4.h"
-#include "System/ContainerUtil.h"
-#include "System/ScopedResource.h"
-#include "fmt/format.h"
 #include "fmt/printf.h"
 
 #include "System/Misc/TracyDefs.h"
-
-#define SUPPORT_AMD_HACKS_HERE
 
 #ifndef HEADLESS
 class FtLibraryHandler {

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -286,7 +286,7 @@ void FtLibraryHandlerProxy::ClearBasePattern() {
 
 int FtLibraryHandlerProxy::NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface)
 {
-	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), file_base, file_size, 0, aface);
+	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), file_base, file_size, face_index, aface);
 	return error;
 }
 #endif

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -1,0 +1,363 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "CFontTexture.h"
+
+#include "glFontRenderer.h"
+#include "FontHandler.h"
+#include "FontLogSection.h"
+#include "FtLibraryHandler.h"
+
+#include <cstring> // for memset, memcpy
+#include <string>
+#include <vector>
+#include <sstream>
+
+#ifndef HEADLESS
+	#include <ft2build.h>
+	#include FT_FREETYPE_H
+	#ifdef USE_FONTCONFIG
+		#include <fontconfig/fontconfig.h>
+		#include <fontconfig/fcfreetype.h>
+	#endif
+#endif // HEADLESS
+
+#include "Rendering/GL/myGL.h"
+#include "Rendering/GlobalRendering.h"
+#include "Rendering/Textures/Bitmap.h"
+#include "System/Config/ConfigHandler.h"
+#include "System/Exceptions.h"
+#include "System/EventHandler.h"
+#include "System/Log/ILog.h"
+#include "System/FileSystem/FileHandler.h"
+#include "System/Threading/ThreadPool.h"
+#ifdef _DEBUG
+	#include "System/Platform/Threading.h"
+#endif
+#include "System/SafeUtil.h"
+#include "System/StringUtil.h"
+#include "System/TimeProfiler.h"
+#include "System/UnorderedMap.hpp"
+#include "System/float4.h"
+#include "System/ContainerUtil.h"
+#include "System/ScopedResource.h"
+#include "fmt/format.h"
+#include "fmt/printf.h"
+
+#include "System/Misc/TracyDefs.h"
+
+#define SUPPORT_AMD_HACKS_HERE
+
+#ifndef HEADLESS
+	#undef __FTERRORS_H__
+	#define FT_ERRORDEF( e, v, s )  { e, s },
+	#define FT_ERROR_START_LIST     {
+	#define FT_ERROR_END_LIST       { 0, 0 } };
+	struct FTErrorRecord {
+		int          err_code;
+		const char*  err_msg;
+	} static errorTable[] =
+	#include FT_ERRORS_H
+
+	struct IgnoreMe {}; // MSVC IntelliSense is confused by #include FT_ERRORS_H above. This seems to fix it.
+
+	static const char* GetFTError(FT_Error e) {
+		const auto it = std::find_if(std::begin(errorTable), std::end(errorTable), [e](FTErrorRecord er) { return er.err_code == e; });
+		if (it != std::end(errorTable))
+			return it->err_msg;
+
+		return "Unknown error";
+	}
+#endif // HEADLESS
+
+
+
+#ifndef HEADLESS
+class FtLibraryHandler {
+public:
+	FtLibraryHandler()
+		: config(nullptr)
+		, lib(nullptr)
+		#ifdef USE_FONTCONFIG
+		, gameFontSet(nullptr)
+		, basePattern(nullptr)
+		#endif // USE_FONTCONFIG
+	{
+		const FT_Error error = FT_Init_FreeType(&lib);
+
+		if (error != 0) {
+			FT_Int version[3];
+			FT_Library_Version(lib, &version[0], &version[1], &version[2]);
+
+			std::string err = fmt::sprintf("[%s] FT_Init_FreeType failure (version %d.%d.%d) \"%s\"",
+						       __func__, version[0], version[1], version[2], GetFTError(error));
+			throw std::runtime_error(err);
+		}
+	}
+
+	~FtLibraryHandler() {
+		FT_Done_FreeType(lib);
+
+		#ifdef USE_FONTCONFIG
+		if (!config)
+			return;
+
+		FcConfigDestroy(config);
+		if (gameFontSet) {
+			FcFontSetDestroy(gameFontSet);
+		}
+		if (basePattern) {
+			FcPatternDestroy(basePattern);
+		}
+		FcFini();
+		config = nullptr;
+		#endif
+	}
+
+	bool InitFontconfig(bool console) {
+		#ifdef USE_FONTCONFIG
+		auto LOG_MSG = [console](const std::string& fmt, bool isError, auto&&... args) {
+			if (console) {
+				std::string fmtNL = fmt + "\n";
+				printf(fmtNL.c_str(), args...);
+			}
+			else {
+				if (isError) {
+					LOG_L(L_ERROR, fmt.c_str(), args...);
+				}
+				else {
+					LOG(fmt.c_str(), args...);
+				}
+			}
+		};
+
+		if (!UseFontConfig())
+			return false;
+
+		{
+			std::string msg = fmt::sprintf("%s::FontConfigInit (version %d.%d.%d)", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
+			ScopedOnceTimer timer(msg);
+			ZoneScopedNC("FtLibraryHandler::FontConfigInit", tracy::Color::Purple);
+
+			FcBool res;
+			std::string errprefix = fmt::sprintf("[%s] Fontconfig(version %d.%d.%d) failed to initialize", __func__, FC_MAJOR, FC_MINOR, FC_REVISION);
+
+			// init configuration
+			FcConfigEnableHome(FcFalse);
+			config = FcConfigCreate();
+
+			// we cant directly use the usual fontconfig methods because those won't let us have both first our cache
+			// and system fonts included. also linux actually has system config files that can be used by fontconfig.
+
+			#ifdef _WIN32
+			static constexpr auto winFontPath = "%WINDIR%\\fonts";
+			const int neededSize = ExpandEnvironmentStrings(winFontPath, nullptr, 0);
+			std::vector <char> osFontsDir (neededSize);
+			ExpandEnvironmentStrings(winFontPath, osFontsDir.data(), osFontsDir.size());
+
+			static constexpr const char* configFmt = R"(<fontconfig><dir>%s</dir><cachedir>fontcache</cachedir></fontconfig>)";
+			const std::string configFmtVar = fmt::sprintf(configFmt, osFontsDir.data());
+			#else
+			const std::string configFmtVar = R"(<fontconfig><cachedir>fontcache</cachedir></fontconfig>)";
+			#endif
+
+			#ifdef _WIN32
+			// Explicitly set the config with xml for windows.
+			res = FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
+			#else
+			// Load system configuration (passing 0 here so fc will use the default os config file if possible).
+			res = FcConfigParseAndLoad(config, 0, true);
+			#endif
+			if (res) {
+				#ifndef _WIN32
+				// add local cache after system config for linux
+				FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
+				#endif
+
+				LOG_MSG("[%s] Using Fontconfig light init", false, __func__);
+
+				// build system fonts
+				res = FcConfigBuildFonts(config);
+				if (!res) {
+					LOG_MSG("%s fonts", true, errprefix.c_str());
+					InitFailed();
+					return false;
+				}
+			} else {
+				// Can't load step by step to use our cache, so retry with general
+				// fontconfig init method, that has a few extra fallbacks.
+
+				// Init everything. Normally this would be enough, but the method before
+				// accounts for situations where system config is borked due to incompatible
+				// lib and system config files.
+				FcConfig *fcConfig = FcInitLoadConfigAndFonts();
+				if (fcConfig) {
+					FcConfigDestroy(config); // release previous config
+					config = fcConfig;
+
+					// add our cache at the back of the new config.
+					FcConfigParseAndLoadFromMemory(config, reinterpret_cast<const FcChar8*>(configFmtVar.c_str()), FcTrue);
+				} else {
+					LOG_MSG("%s config and fonts. No system fallbacks will be available", false, errprefix.c_str());
+				}
+			}
+
+			gameFontSet = FcFontSetCreate();
+			basePattern = FcPatternCreate();
+
+			// init app fonts dir
+			res = FcConfigAppFontAddDir(config, reinterpret_cast<const FcChar8*>("fonts"));
+			if (!res) {
+				LOG_MSG("%s font dir", true, errprefix.c_str());
+				InitFailed();
+				return false;
+			}
+
+			// print cache dirs
+			auto dirs = FcConfigGetCacheDirs(config);
+			FcStrListFirst(dirs);
+			for (FcChar8* dir = FcStrListNext(dirs); dir != nullptr; dir = FcStrListNext(dirs)) {
+				LOG_MSG("[%s] Using Fontconfig cache dir \"%s\"", false, __func__, dir);
+			}
+			FcStrListDone(dirs);
+		}
+
+		#endif // USE_FONTCONFIG
+
+		return true;
+	}
+
+	void InitFailed() {
+		FcConfigDestroy(config);
+		FcFini();
+		config = nullptr;
+	}
+	static bool InitSingletonFontconfig(bool console) { return singleton->InitFontconfig(console); }
+
+	static bool UseFontConfig() { return fontHandler.useFontConfigLib; }
+
+	#ifdef USE_FONTCONFIG
+	// command-line CheckGenFontConfigFull invocation checks
+	static bool CheckFontConfig() { return (UseFontConfig() && FcConfigUptoDate(GetFCConfig())); }
+	#else
+
+	static bool CheckFontConfig() { return false; }
+	static bool CheckGenFontConfig(bool fromCons) { return false; }
+	#endif
+
+	static FT_Library& GetLibrary() {
+		if (singleton == nullptr)
+			singleton = std::make_unique<FtLibraryHandler>();
+
+		return singleton->lib;
+	};
+	static FcConfig* GetFCConfig() {
+		if (singleton == nullptr)
+			singleton = std::make_unique<FtLibraryHandler>();
+
+		return singleton->config;
+	}
+	static inline bool CanUseFontConfig() {
+		return GetFCConfig() != nullptr;
+	}
+	#ifdef USE_FONTCONFIG
+	static FcFontSet *GetGameFontSet() {
+		return singleton->gameFontSet;
+	}
+	static FcPattern *GetBasePattern() {
+		return singleton->basePattern;
+	}
+	static void ClearGameFontSet() {
+		FcFontSetDestroy(singleton->gameFontSet);
+		singleton->gameFontSet = FcFontSetCreate();
+	}
+	static void ClearBasePattern() {
+		FcPatternDestroy(singleton->basePattern);
+		singleton->basePattern = FcPatternCreate();
+	}
+	#endif
+private:
+	FcConfig* config;
+	FT_Library lib;
+	#ifdef USE_FONTCONFIG
+	FcFontSet *gameFontSet;
+	FcPattern *basePattern;
+	#endif
+
+	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
+};
+#endif
+
+
+
+void FtLibraryHandlerProxy::InitFtLibrary()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+#ifndef HEADLESS
+	FtLibraryHandler::GetLibrary();
+#endif
+}
+
+bool FtLibraryHandlerProxy::InitFontconfig(bool console)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+#ifndef HEADLESS
+	return FtLibraryHandler::InitSingletonFontconfig(console);
+#else
+	return false;
+#endif
+}
+
+
+#ifndef HEADLESS
+int FtLibraryHandlerProxy::NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface)
+{
+	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), file_base, file_size, 0, aface);
+	return error;
+}
+#endif
+
+bool FtLibraryHandlerProxy::CanUseFontConfig()
+{
+#ifndef HEADLESS
+	return FtLibraryHandler::CanUseFontConfig();
+#else
+	return false;
+#endif
+}
+
+FcConfig* FtLibraryHandlerProxy::GetFCConfig() {
+#ifndef HEADLESS
+	return FtLibraryHandler::GetFCConfig();
+#else
+	return nullptr;
+#endif
+}
+
+FcFontSet* FtLibraryHandlerProxy::GetGameFontSet() {
+#ifndef HEADLESS
+	return FtLibraryHandler::GetGameFontSet();
+#else
+	return nullptr;
+#endif
+}
+
+FcPattern* FtLibraryHandlerProxy::GetBasePattern() {
+#ifndef HEADLESS
+	return FtLibraryHandler::GetBasePattern();
+#else
+	return nullptr;
+#endif
+}
+
+void FtLibraryHandlerProxy::ClearGameFontSet() {
+#ifndef HEADLESS
+	FtLibraryHandler::ClearGameFontSet();
+#endif
+}
+
+void FtLibraryHandlerProxy::ClearBasePattern() {
+#ifndef HEADLESS
+	FtLibraryHandler::ClearBasePattern();
+#endif
+}
+

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "FontHandler.h"
 #include "FtLibraryHandler.h"
+#include "FontLogSection.h"
 #include "FtIncludes.h"
 
 #include "System/Log/ILog.h"

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -11,7 +11,7 @@
 
 #include "System/Misc/TracyDefs.h"
 #ifdef _WIN32
-	#include <userenv.h>
+	#include <windows.h>
 #endif
 
 #ifndef HEADLESS

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -1,4 +1,4 @@
-/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
 
 #include "FontHandler.h"
 #include "FtLibraryHandler.h"

--- a/rts/Rendering/Fonts/FtLibraryHandler.cpp
+++ b/rts/Rendering/Fonts/FtLibraryHandler.cpp
@@ -250,15 +250,6 @@ bool FtLibraryHandlerProxy::InitFontconfig(bool console)
 #endif
 }
 
-
-#ifndef HEADLESS
-int FtLibraryHandlerProxy::NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface)
-{
-	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), file_base, file_size, 0, aface);
-	return error;
-}
-#endif
-
 bool FtLibraryHandlerProxy::CanUseFontConfig()
 {
 #ifndef HEADLESS
@@ -291,6 +282,12 @@ void FtLibraryHandlerProxy::ClearGameFontSet() {
 
 void FtLibraryHandlerProxy::ClearBasePattern() {
 	FtLibraryHandler::ClearBasePattern();
+}
+
+int FtLibraryHandlerProxy::NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface)
+{
+	FT_Error error = FT_New_Memory_Face(FtLibraryHandler::GetLibrary(), file_base, file_size, 0, aface);
+	return error;
 }
 #endif
 

--- a/rts/Rendering/Fonts/FtLibraryHandler.h
+++ b/rts/Rendering/Fonts/FtLibraryHandler.h
@@ -1,5 +1,5 @@
-#ifndef _CFT_LIBRARY_HANDLER_H
-#define _CFT_LIBRARY_HANDLER_H
+#ifndef _FT_LIBRARY_HANDLER_H
+#define _FT_LIBRARY_HANDLER_H
 
 //struct FcFontSet;
 //struct FcPattern;
@@ -25,4 +25,4 @@ public:
 	static FcConfig* GetFCConfig();
 };
 
-#endif // CFT_LIBRARY_HANDLER_H
+#endif // FT_LIBRARY_HANDLER_H

--- a/rts/Rendering/Fonts/FtLibraryHandler.h
+++ b/rts/Rendering/Fonts/FtLibraryHandler.h
@@ -1,11 +1,9 @@
 #ifndef _FT_LIBRARY_HANDLER_H
 #define _FT_LIBRARY_HANDLER_H
 
-//struct FcFontSet;
-//struct FcPattern;
-//struct FcConfig;
 struct FT_FaceRec_;
 typedef struct FT_FaceRec_* FT_Face;
+
 typedef struct _FcConfig    FcConfig;
 typedef struct _FcFontSet    FcFontSet;
 typedef struct _FcPattern    FcPattern;

--- a/rts/Rendering/Fonts/FtLibraryHandler.h
+++ b/rts/Rendering/Fonts/FtLibraryHandler.h
@@ -12,15 +12,17 @@ class FtLibraryHandlerProxy {
 public:
 	static void InitFtLibrary();
 	static bool InitFontconfig(bool console);
+
+	static FcConfig* GetFCConfig();
+	static bool CanUseFontConfig();
+
 #ifndef HEADLESS
 	static int NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface);
-#endif
-	static bool CanUseFontConfig();
 	static FcFontSet* GetGameFontSet();
 	static FcPattern* GetBasePattern();
 	static void ClearGameFontSet();
 	static void ClearBasePattern();
-	static FcConfig* GetFCConfig();
+#endif
 };
 
 #endif // FT_LIBRARY_HANDLER_H

--- a/rts/Rendering/Fonts/FtLibraryHandler.h
+++ b/rts/Rendering/Fonts/FtLibraryHandler.h
@@ -1,3 +1,5 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
 #ifndef _FT_LIBRARY_HANDLER_H
 #define _FT_LIBRARY_HANDLER_H
 

--- a/rts/Rendering/Fonts/FtLibraryHandler.h
+++ b/rts/Rendering/Fonts/FtLibraryHandler.h
@@ -1,0 +1,28 @@
+#ifndef _CFT_LIBRARY_HANDLER_H
+#define _CFT_LIBRARY_HANDLER_H
+
+//struct FcFontSet;
+//struct FcPattern;
+//struct FcConfig;
+struct FT_FaceRec_;
+typedef struct FT_FaceRec_* FT_Face;
+typedef struct _FcConfig    FcConfig;
+typedef struct _FcFontSet    FcFontSet;
+typedef struct _FcPattern    FcPattern;
+
+class FtLibraryHandlerProxy {
+public:
+	static void InitFtLibrary();
+	static bool InitFontconfig(bool console);
+#ifndef HEADLESS
+	static int NewMemoryFace(const unsigned char* file_base, signed long file_size, signed long face_index, FT_Face *aface);
+#endif
+	static bool CanUseFontConfig();
+	static FcFontSet* GetGameFontSet();
+	static FcPattern* GetBasePattern();
+	static void ClearGameFontSet();
+	static void ClearBasePattern();
+	static FcConfig* GetFCConfig();
+};
+
+#endif // CFT_LIBRARY_HANDLER_H

--- a/rts/Rendering/Fonts/glFont.cpp
+++ b/rts/Rendering/Fonts/glFont.cpp
@@ -31,7 +31,6 @@ CONFIG(int,      FontOutlineWidth).defaultValue(2).description("Sets the width o
 CONFIG(int, SmallFontOutlineWidth).defaultValue(2).description("see FontOutlineWidth");
 CONFIG(float,      FontOutlineWeight).defaultValue(25.0f).description("Sets the opacity of Spring engine text, such as the title screen version number, clock, and basic UI. Does not affect LuaUI elements.");
 CONFIG(float, SmallFontOutlineWeight).defaultValue(10.0f).description("see FontOutlineWeight");
-CONFIG(bool, AllowColorFonts).defaultValue(false).description("Allow working with colored fonts (experimental).");
 
 std::shared_ptr<CglFont> font = nullptr;
 std::shared_ptr<CglFont> smallFont = nullptr;

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -107,12 +107,6 @@ CONFIG(unsigned, SetCoreAffinity).defaultValue(0).safemodeValue(1).description("
 CONFIG(unsigned, TextureMemPoolSize).defaultValue(512).minimumValue(0).description("Set to 0 to disable, otherwise specify a predefined memory to serve Bitmap allocation requests");
 CONFIG(bool, UseLuaMemPools).defaultValue(true).description("Whether Lua VM memory allocations are made from pools.");
 CONFIG(bool, UseHighResTimer).defaultValue(false).description("On Windows, sets whether Spring will use low- or high-resolution timer functions for tasks like graphical interpolation between game frames.");
-CONFIG(bool, UseFontConfigLib).defaultValue(true).description("Whether the system fontconfig library (if present and enabled at compile-time) should be used for handling fonts.");
-CONFIG(bool, UseFontConfigSystemFonts).defaultValue(true).description("Whether the system fonts will be searched by fontconfig.");
-CONFIG(bool, FontConfigSearchAttributes).defaultValue(true).description("Whether the font characteristics will used to refine the search by fontconfig. Results in better glyph matches in some cases, but has a nontrivial performance cost.");
-CONFIG(bool, FontConfigApplySubstitutions).defaultValue(true).description("[EXPERIMENTAL] In case it's disabled FcConfigSubstitute is not getting called, this might break non-ASCII font rendering.");
-CONFIG(int, MaxFontTries).defaultValue(5).description("Represents the maximum number of attempts to search for a glyph replacement using the FontConfig library (lower = foreign glyphs may fail to render, higher = searching for foreign glyphs can lag the game).");
-CONFIG(int, MaxPinnedFonts).defaultValue(10).description("Maximum number of fonts to pin to cache. Increasing this will eventually use more memory, but can alleviate processing spikes when rendering new glyphs.");
 
 CONFIG(std::string, name).defaultValue(UnnamedPlayerName).description("Sets your name in the game. Since this is overridden by lobbies with your lobby username when playing, it usually only comes up when viewing replays or starting the engine directly for testing purposes.");
 CONFIG(std::string, DefaultStartScript).defaultValue("").description("filename of script.txt to use when no command line parameters are specified.");

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -48,6 +48,7 @@
 #include "Net/Protocol/NetProtocol.h" // clientNet
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/Fonts/FontHandler.h"
+#include "Rendering/Fonts/CFtLibraryHandler.h"
 #include "Rendering/Fonts/glFont.h"
 #include "Rendering/GL/FBO.h"
 #include "Rendering/Models/ModelsMemStorage.h"

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -47,9 +47,8 @@
 #include "Net/GameServer.h"
 #include "Net/Protocol/NetProtocol.h" // clientNet
 #include "Rendering/GlobalRendering.h"
-#include "Rendering/Fonts/FontHandler.h"
-#include "Rendering/Fonts/FtLibraryHandler.h"
 #include "Rendering/Fonts/glFont.h"
+#include "Rendering/Fonts/FontHandler.h"
 #include "Rendering/GL/FBO.h"
 #include "Rendering/Models/ModelsMemStorage.h"
 #include "Rendering/GL/RenderBuffers.h"
@@ -336,11 +335,7 @@ bool SpringApp::InitPlatformLibs()
 
 bool SpringApp::InitFonts()
 {
-	fontHandler.Init();
-	FtLibraryHandlerProxy::InitFtLibrary();
-	FtLibraryHandlerProxy::InitFontconfig(false);
-	CFontTexture::InitFonts();
-	return CglFont::LoadConfigFonts();
+	return fontHandler.Init(true);
 /*
 	using namespace std::chrono_literals;
 	auto future = std::async(std::launch::async, []() {
@@ -366,12 +361,9 @@ bool SpringApp::InitFonts()
 
 void SpringApp::CleanFonts()
 {
-	font      = {};
-	smallFont = {};
-
 	// Can't leave it to default program destructor as the order of object destruction is not guaranteed.
 	// E.g.: Bitmap memory pool can be destroyed before fonts causing null ptr exception
-	CFontTexture::KillFonts();
+	fontHandler.Kill();
 }
 
 bool SpringApp::InitFileSystem()
@@ -486,8 +478,7 @@ void SpringApp::ParseCmdLine(int argc, char* argv[])
 			spring_clock::PushTickRate();
 			spring_time::setstarttime(spring_time::gettime(true));
 		}
-		FtLibraryHandlerProxy::InitFtLibrary();
-		if (FtLibraryHandlerProxy::InitFontconfig(true)) {
+		if (fontHandler.Init(false)) {
 			printf("[FtLibraryHandler::GenFontConfig] is succesfull\n");
 			exit(spring::EXIT_CODE_SUCCESS);
 		}

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -335,7 +335,7 @@ bool SpringApp::InitPlatformLibs()
 
 bool SpringApp::InitFonts()
 {
-	return fontHandler.Init(true);
+	return fontHandler.FullInit();
 /*
 	using namespace std::chrono_literals;
 	auto future = std::async(std::launch::async, []() {
@@ -478,7 +478,7 @@ void SpringApp::ParseCmdLine(int argc, char* argv[])
 			spring_clock::PushTickRate();
 			spring_time::setstarttime(spring_time::gettime(true));
 		}
-		if (fontHandler.Init(false)) {
+		if (fontHandler.Init(true)) {
 			printf("[FtLibraryHandler::GenFontConfig] is succesfull\n");
 			exit(spring::EXIT_CODE_SUCCESS);
 		}

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -48,7 +48,7 @@
 #include "Net/Protocol/NetProtocol.h" // clientNet
 #include "Rendering/GlobalRendering.h"
 #include "Rendering/Fonts/FontHandler.h"
-#include "Rendering/Fonts/CFtLibraryHandler.h"
+#include "Rendering/Fonts/FtLibraryHandler.h"
 #include "Rendering/Fonts/glFont.h"
 #include "Rendering/GL/FBO.h"
 #include "Rendering/Models/ModelsMemStorage.h"

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -47,8 +47,8 @@
 #include "Net/GameServer.h"
 #include "Net/Protocol/NetProtocol.h" // clientNet
 #include "Rendering/GlobalRendering.h"
-#include "Rendering/Fonts/glFont.h"
 #include "Rendering/Fonts/FontHandler.h"
+#include "Rendering/Fonts/glFont.h"
 #include "Rendering/GL/FBO.h"
 #include "Rendering/Models/ModelsMemStorage.h"
 #include "Rendering/GL/RenderBuffers.h"


### PR DESCRIPTION
### Work done

- Separate FtLibraryHandler into its own file.
- Move some global font config options to fontHandler.
- Centralize font Init/Kill at fontHandler.

### Remarks

- At the moment font global/static code is haphazardly split among CFontTexture, glFont, SpringApp..., with the recently introduced fontHandler I'm moving some more of that logic there.
- Also split FtLibraryHandler into a separate file, since it feels out of place inside CFontTexture.
  - Extended FtLibraryHandlerProxy api to ensure ft and fc includes don't leak out of cpp files and to have a bit better decoupling.

### Next steps

- Some more candidate code to moving out is all the default fonts code at glFont.
  - Will move that in a later PR, so as to limit scope of this one.
  - Probably directly under fontHandler too, but could also create a new module for those.
- There's still more work to do re: refactoring fonts, consider this a start and everyone is welcome here to voice any remarks or ideas for the future or whatever.