### PR TITLE
Add Spring.AddFeatureDamage

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4126,6 +4126,32 @@ int LuaSyncedCtrl::BuggerOff(lua_State* L)
 }
 
 
+static std::optional<std::tuple<float, int, CUnit*, int, float3> > ParseDamageParams(lua_State* L)
+{
+	const float damage    = luaL_checkfloat(L, 2);
+	const int paralyze    = luaL_optint(L, 3, 0);
+	const int attackerID  = luaL_optint(L, 4, -1);
+	const int weaponDefID = luaL_optint(L, 5, -1);
+	const float3 impulse  = float3(std::clamp(luaL_optfloat(L, 6, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
+	                               std::clamp(luaL_optfloat(L, 7, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
+	                               std::clamp(luaL_optfloat(L, 8, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE));
+
+	CUnit* attacker = nullptr;
+
+	if (attackerID >= 0) {
+		if (static_cast<size_t>(attackerID) >= unitHandler.MaxUnits())
+			return std::nullopt;
+
+		attacker = unitHandler.GetUnit(attackerID);
+	}
+
+	// -1 is allowed
+	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
+		return std::nullopt;
+	return std::make_tuple(damage, paralyze, attacker, weaponDefID, impulse);
+}
+
+
 /***
  * @function Spring.AddFeatureDamage
  *
@@ -4148,27 +4174,11 @@ int LuaSyncedCtrl::AddFeatureDamage(lua_State* L)
 	if (feature == nullptr)
 		return 0;
 
-	const float damage    = luaL_checkfloat(L, 2);
-	const int paralyze    = luaL_optint(L, 3, 0);
-	const int attackerID  = luaL_optint(L, 4, -1);
-	const int weaponDefID = luaL_optint(L, 5, -1);
-	const float3 impulse  = float3(std::clamp(luaL_optfloat(L, 6, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
-	                               std::clamp(luaL_optfloat(L, 7, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
-	                               std::clamp(luaL_optfloat(L, 8, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE));
-
-	CUnit* attacker = nullptr;
-
-	if (attackerID >= 0) {
-		if (static_cast<size_t>(attackerID) >= unitHandler.MaxUnits())
-			return 0;
-
-		attacker = unitHandler.GetUnit(attackerID);
-	}
-
-	// -1 is allowed
-	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
+	const auto damageParams = ParseDamageParams(L);
+	if (!damageParams)
 		return 0;
 
+	const auto [damage, paralyze, attacker, weaponDefID, impulse] = *damageParams;
 	DamageArray damages(damage);
 
 	if (paralyze)
@@ -4199,26 +4209,11 @@ int LuaSyncedCtrl::AddUnitDamage(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	const float damage    = luaL_checkfloat(L, 2);
-	const int paralyze    = luaL_optint(L, 3, 0);
-	const int attackerID  = luaL_optint(L, 4, -1);
-	const int weaponDefID = luaL_optint(L, 5, -1);
-	const float3 impulse  = float3(std::clamp(luaL_optfloat(L, 6, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
-	                               std::clamp(luaL_optfloat(L, 7, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
-	                               std::clamp(luaL_optfloat(L, 8, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE));
-
-	CUnit* attacker = nullptr;
-
-	if (attackerID >= 0) {
-		if (static_cast<size_t>(attackerID) >= unitHandler.MaxUnits())
-			return 0;
-
-		attacker = unitHandler.GetUnit(attackerID);
-	}
-
-	// -1 is allowed
-	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
+	const auto damageParams = ParseDamageParams(L);
+	if (!damageParams)
 		return 0;
+
+	const auto [damage, paralyze, attacker, weaponDefID, impulse] = *damageParams;
 
 	DamageArray damages;
 	damages.Set(unit->armorType, damage);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -228,6 +228,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetFactoryBuggerOff);
 	REGISTER_LUA_CFUNC(BuggerOff);
 
+	REGISTER_LUA_CFUNC(AddFeatureDamage);
 	REGISTER_LUA_CFUNC(AddUnitDamage);
 	REGISTER_LUA_CFUNC(AddUnitImpulse);
 	REGISTER_LUA_CFUNC(AddUnitSeismicPing);
@@ -4123,6 +4124,60 @@ int LuaSyncedCtrl::BuggerOff(lua_State* L)
 
 	return 0;
 }
+
+
+/***
+ * @function Spring.AddFeatureDamage
+ *
+ * @param featureID integer
+ * @param damage number
+ * @param paralyze number? (Default: `0`) equals to the paralyzetime in the WeaponDef.
+ * @param attackerID integer? (Default: `-1`)
+ * @param weaponID integer? (Default: `-1`)
+ * @param impulseX number?
+ * @param impulseY number?
+ * @param impulseZ number?
+ * @return nil
+ */
+int LuaSyncedCtrl::AddFeatureDamage(lua_State* L)
+{
+	CheckAllowGameChanges(L);
+
+	CFeature* feature = ParseFeature(L, __func__, 1);
+
+	if (feature == nullptr)
+		return 0;
+
+	const float damage    = luaL_checkfloat(L, 2);
+	const int paralyze    = luaL_optint(L, 3, 0);
+	const int attackerID  = luaL_optint(L, 4, -1);
+	const int weaponDefID = luaL_optint(L, 5, -1);
+	const float3 impulse  = float3(std::clamp(luaL_optfloat(L, 6, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
+	                               std::clamp(luaL_optfloat(L, 7, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE),
+	                               std::clamp(luaL_optfloat(L, 8, 0.0f), -MAX_EXPLOSION_IMPULSE, MAX_EXPLOSION_IMPULSE));
+
+	CUnit* attacker = nullptr;
+
+	if (attackerID >= 0) {
+		if (static_cast<size_t>(attackerID) >= unitHandler.MaxUnits())
+			return 0;
+
+		attacker = unitHandler.GetUnit(attackerID);
+	}
+
+	// -1 is allowed
+	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
+		return 0;
+
+	DamageArray damages(damage);
+
+	if (paralyze)
+		damages.paralyzeDamageTime = paralyze;
+
+	feature->DoDamage(damages, impulse, attacker, weaponDefID, -1);
+	return 0;
+}
+
 
 /***
  * @function Spring.AddUnitDamage

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4152,8 +4152,16 @@ static std::optional<std::tuple<float, int, CUnit*, int, float3> > ParseDamagePa
 }
 
 
-/***
+/*** Apply damage to feature
+ *
  * @function Spring.AddFeatureDamage
+ *
+ * Will trigger FeaturePreDamaged and FeatureDamaged callins.
+ *
+ * Won't do anything if paralyze is not zero, the feature is already marked for deletion, or in void.
+ *
+ * If health goes below 0 and featureDef is `destructable` the feature will be deleted and
+ * a wreck created.
  *
  * @param featureID integer
  * @param damage number
@@ -4163,7 +4171,9 @@ static std::optional<std::tuple<float, int, CUnit*, int, float3> > ParseDamagePa
  * @param impulseX number?
  * @param impulseY number?
  * @param impulseZ number?
- * @return nil
+ *
+ * @see SyncedCallins:FeaturePreDamaged
+ * @see SyncedCallins:FeatureDamaged
  */
 int LuaSyncedCtrl::AddFeatureDamage(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4145,7 +4145,7 @@ static std::optional<std::tuple<float, int, CUnit*, int, float3> > ParseDamagePa
 		attacker = unitHandler.GetUnit(attackerID);
 	}
 
-	// -1 is allowed
+	// negated values from 'CSolidObject::DamageType' also allowed
 	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
 		return std::nullopt;
 	return std::make_tuple(damage, paralyze, attacker, weaponDefID, impulse);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -136,6 +136,7 @@ class LuaSyncedCtrl
 		static int SetFactoryBuggerOff(lua_State* L);
 		static int BuggerOff(lua_State* L);
 
+		static int AddFeatureDamage(lua_State* L);
 		static int AddUnitDamage(lua_State* L);
 		static int AddUnitImpulse(lua_State* L);
 		static int AddUnitSeismicPing(lua_State* L);


### PR DESCRIPTION
### Work Done

* Adds Spring.AddFeatureDamage mirroring Spring.AddUnitDamage.

### Related PRs

* https://github.com/beyond-all-reason/Beyond-All-Reason/pull/5356/files
* https://github.com/beyond-all-reason/RecoilEngine/pull/2418

### Remarks

* Can be useful, and also helps in Feature getting the right behaviour when health goes < 0, as opposed to what happens when SetFeatureHealth is used, that one won't trigger some side effects as damage is expected to go through DoDamage.
  * Might be wanted to make SetFeatureHealth trigger side effects too/instead, but I think that one warrants some discussion as it can be more controversial (PR for that at [#2418](https://github.com/beyond-all-reason/RecoilEngine/pull/2418)), also features dont have SlowUpdate so would need to make side effects immediate (would be a slight difference to how SetUnitHealth works), or add some extra mechanism at featureHandler for this (pbbly too much just for this).