### PR TITLE
Allow feature destruction on Spring.SetFeatureHealth.

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4494,6 +4494,18 @@ int LuaSyncedCtrl::CreateFeature(lua_State* L)
 }
 
 
+// Internal helper method
+void LuaSyncedCtrl::DestroyFeatureCommon(lua_State* L, CFeature* feature)
+{
+	if (inDestroyFeature >= MAX_CMD_RECURSION_DEPTH)
+		luaL_error(L, "DestroyFeature() recursion is not permitted, max depth: %d", MAX_CMD_RECURSION_DEPTH);
+
+	inDestroyFeature++;
+	featureHandler.DeleteFeature(feature);
+	inDestroyFeature--;
+}
+
+
 /***
  * @function Spring.DestroyFeature
  * @param featureDefID integer
@@ -4506,12 +4518,7 @@ int LuaSyncedCtrl::DestroyFeature(lua_State* L)
 	if (feature == nullptr)
 		return 0;
 
-	if (inDestroyFeature >= MAX_CMD_RECURSION_DEPTH)
-		luaL_error(L, "DestroyFeature() recursion is not permitted, max depth: %d", MAX_CMD_RECURSION_DEPTH);
-
-	inDestroyFeature++;
-	featureHandler.DeleteFeature(feature);
-	inDestroyFeature--;
+	DestroyFeatureCommon(L, feature);
 
 	return 0;
 }
@@ -4568,6 +4575,7 @@ int LuaSyncedCtrl::SetFeatureUseAirLos(lua_State* L)
  * @function Spring.SetFeatureHealth
  * @param featureID integer
  * @param health number
+ * @param checkDestruction boolean? Whether to destroy feature if feature goes below 0 health. (Default: `false`)
  * @return nil
  */
 int LuaSyncedCtrl::SetFeatureHealth(lua_State* L)
@@ -4578,6 +4586,10 @@ int LuaSyncedCtrl::SetFeatureHealth(lua_State* L)
 		return 0;
 
 	feature->health = std::min(feature->maxHealth, luaL_checkfloat(L, 2));
+
+	if (feature->health <= 0.0f && luaL_optboolean(L, 3, false)) {
+		DestroyFeatureCommon(L, feature);
+	}
 	return 0;
 }
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4575,7 +4575,7 @@ int LuaSyncedCtrl::SetFeatureUseAirLos(lua_State* L)
  * @function Spring.SetFeatureHealth
  * @param featureID integer
  * @param health number
- * @param checkDestruction boolean? Whether to destroy feature if feature goes below 0 health. (Default: `false`)
+ * @param checkDestruction boolean? (Default: `false`) Whether to destroy feature if feature goes below 0 health.
  * @return nil
  */
 int LuaSyncedCtrl::SetFeatureHealth(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -4,6 +4,7 @@
 #define LUA_SYNCED_CTRL_H
 
 struct lua_State;
+class CFeature;
 
 constexpr int MAX_CMD_RECURSION_DEPTH = 16;
 
@@ -31,6 +32,8 @@ class LuaSyncedCtrl
 		inline static bool inHeightMap = false;
 		inline static bool inOriginalHeightMap = false;
 		inline static bool inSmoothMesh = false;
+
+		static void DestroyFeatureCommon(lua_State* L, CFeature* feature);
 
 	private:
 		// all LuaHandleSynced


### PR DESCRIPTION
### Work done

- Add optional feature destruction at Spring.SetFeatureHealth, when `health <= 0`.


### Related Issues/PRs

- Related https://github.com/beyond-all-reason/RecoilEngine/issues/2401
- https://github.com/beyond-all-reason/RecoilEngine/issues/1684
- https://github.com/beyond-all-reason/RecoilEngine/pull/2417
- https://github.com/beyond-all-reason/RecoilEngine/pull/2435

### Remarks

- At the moment health for the feature isn't checked after SetFeatureHealth, diverging from SetUnitHealth that eventually checks it and destroys.
  - This is because features aren't usually active (performing Update)
- Didn't do the destruction compulsory since it would break api behaviour backwards compatibility.
  - We can later make passing nil into 3rd parameter deprecated and finally set default to true if wanted, but I think that should be done once new api is adopted.
- Creating the wreck will have to be done through independently checking health and using CreateFeatureWreck, so as to not complicate the api.