### PR TITLE
Fix beyond-all-reason/RecoilEngine#2374 crash when performing luaui reload. 

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -175,8 +175,11 @@ bool CGuiHandler::EnableLuaUI(bool enableCommand)
 		}
 	}
 
-	RmlGui::Reload();
-	CLuaUI::ReloadHandler();
+	LOG_L(L_NOTICE, "[GUIHandler] Reloading LuaUI/RmlGui", __func__);
+	CLuaUI::FreeHandler();
+	RmlGui::Shutdown();
+	//CLuaUI load also initialises RmlGui
+	CLuaUI::LoadFreeHandler();
 
 	if (luaUI != nullptr) {
 		LayoutIcons(false);


### PR DESCRIPTION
Splits RmlGui/CLuaUI reload to correctly sequence the unload and reload or LUA and RmlUi.

Issue was caused by widget shutdown callin being called after RmlGui was shutdown