### PR TITLE
Clear CSMFGroundTextures::squares explicitly ...

### DIFF
--- a/rts/Map/SMF/SMFGroundTextures.cpp
+++ b/rts/Map/SMF/SMFGroundTextures.cpp
@@ -86,6 +86,12 @@ CSMFGroundTextures::CSMFGroundTextures(CSMFReadMap* rm): smfMap(rm)
 	}
 }
 
+CSMFGroundTextures::~CSMFGroundTextures()
+{
+	// explicitly kill textures, as doing so in the static destructor is too late (GLAD is already unloaded)
+	squares.clear();
+}
+
 void CSMFGroundTextures::LoadTiles(CSMFMapFile& file)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Map/SMF/SMFGroundTextures.h
+++ b/rts/Map/SMF/SMFGroundTextures.h
@@ -15,6 +15,7 @@ class CSMFGroundTextures: public CBaseGroundTextures
 {
 public:
 	CSMFGroundTextures(CSMFReadMap* rm);
+	~CSMFGroundTextures() override;
 
 	void DrawUpdate();
 	bool SetSquareLuaTexture(int texSquareX, int texSquareY, int texID);


### PR DESCRIPTION
... to avoid doing so during the destruction of the static objects (during which GLAD is already unloaded).
Fixes: https://github.com/beyond-all-reason/RecoilEngine/issues/2402