### PR TITLE
Remove headless exclusion for RmlGui::Update code

### DIFF
--- a/rts/Rml/Backends/RmlUi_Backend.cpp
+++ b/rts/Rml/Backends/RmlUi_Backend.cpp
@@ -356,7 +356,7 @@ void RmlGui::Update()
 	if (!RmlInitialized()) {
 		return;
 	}
-#ifndef HEADLESS
+
 	for (const auto& context : state->contexts) {
 		context->Update();
 	}
@@ -378,7 +378,6 @@ void RmlGui::Update()
 		}
 		state->contexts_to_remove.clear();
 	}
-#endif
 }
 
 void RmlGui::RenderFrame()


### PR DESCRIPTION
> Testing this currently requires reverting 70fe169d78098e465b2b89fc9c4f08ca95adefbc which causes a prior segfault in headless (at least in linux)

This should hopefully (I wasn't able to repro as described) fix https://github.com/beyond-all-reason/RecoilEngine/issues/2371 and https://github.com/beyond-all-reason/RecoilEngine/issues/2005

I did reproduce a similar crash which this is confirmed to fix.

This reinstates code that was marked for exclusion from headless that amongst 2 other things removes contexts marked for removal.

The 2 other things it does are:
 1. Update RmlUi contexts (this includes data models & dimensions)
 2. Reposition a specific context to be on top
 
Item 1 I believe should be left in place for headless for the updating of data models so that widgets continue to work as expected in headless. (believe it was excluded as recalculation of dimensions wasn't deemed required)

Item 2 apart from the condition check its unlikely this code would ever execute in headless anyway so doesn't seem worth specifically excluding it.