### PR TITLE
Don't call projectile draw methods for headless.

### DIFF
--- a/rts/Rendering/WorldDrawer.cpp
+++ b/rts/Rendering/WorldDrawer.cpp
@@ -343,7 +343,9 @@ void CWorldDrawer::DrawOpaqueObjects() const
 			SCOPED_TIMER("Draw::World::Decals");
 			SCOPED_GL_DEBUGGROUP("Draw::World::Decals");
 			groundDecals->Draw();
+#ifndef HEADLESS
 			projectileDrawer->DrawGroundFlashes();
+#endif
 		}
 		{
 			SCOPED_TIMER("Draw::World::Foliage");
@@ -412,7 +414,9 @@ void CWorldDrawer::DrawAlphaObjects() const
 	{
 		SCOPED_TIMER("Draw::World::Particles");
 		SCOPED_GL_DEBUGGROUP("Draw::World::Particles");
+#ifndef HEADLESS
 		projectileDrawer->DrawAlpha(!hasWaterRendering, true, false, false);
+#endif
 
 		if (hasWaterRendering)
 			glDisable(GL_CLIP_PLANE3);
@@ -451,7 +455,9 @@ void CWorldDrawer::DrawAlphaObjects() const
 	{
 		SCOPED_TIMER("Draw::World::Particles");
 		SCOPED_GL_DEBUGGROUP("Draw::World::Particles");
+#ifndef HEADLESS
 		projectileDrawer->DrawAlpha(true, false, false, false);
+#endif
 
 		glDisable(GL_CLIP_PLANE3);
 	}


### PR DESCRIPTION
These are making headless crash, unsure if this is the best solution, it's just what I used to make it not crash.

Maybe @lhog has some preference.

It could (probably better) be placed inside projectileDrawer itself, but also, maybe there's a better way to make it not crash while running to some extent.


### How to test

- Use https://github.com/saurtron/Beyond-All-Reason/tree/pr-test-runner bar branch
- Run as:
  -  `./spring-headless -isolation -write-dir $DATADIR -fullscreen -menu 'BYAR Chobby $VERSION' $DATADIR/games/BAR.sdd/tools/headless_testing/startscript.txt`