### PR TITLE
BUG FIX: QTPFS Update map data before game start when terrain is changed after pathing system is loaded

### DIFF
--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -44,6 +44,7 @@ namespace QTPFS {
 		std::uint32_t GetPathCheckSum() const override { return pfsCheckSum; }
 
 		std::int64_t Finalize() override;
+		std::int64_t PostFinalizeRefresh() override;
 
 		bool PathUpdated(unsigned int pathID) override;
 		void ClearPathUpdated(unsigned int pathID) override;

--- a/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
@@ -124,7 +124,7 @@ void ScanWholeMap()
 {
     auto& comp = systemGlobals.GetSystemComponent<PathSpeedModInfoSystemComponent>();
 
-    // Scan whole map for initial max speed for hCost 
+    // Scan whole map for initial max speed for hCost
     comp.refreshTimeInFrames = 1;
     ScanForPathSpeedModInfo(-1);
     comp.refreshTimeInFrames = GAME_SPEED * 30;

--- a/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
@@ -115,13 +115,30 @@ void InitLayers() {
         auto& layer = QTPFS::registry.emplace<NodeLayerSpeedInfoSweep>(entity);
         layer.layerNum = counter++;
         layer.updateCurMaxSpeed = 0.f;
-        // LOG("%s: added %x:%x entity", __func__, entt::to_integral(entity), entt::to_version(entity));
+        // LOG("%s: added %x:%x entity for layer %d '%s'", __func__, entt::to_integral(entity), entt::to_version(entity)
+        //     , layer.layerNum, moveDefHandler.GetMoveDefByPathType(layer.layerNum)->name.c_str());
     });
+}
+
+void ScanWholeMap()
+{
+    auto& comp = systemGlobals.GetSystemComponent<PathSpeedModInfoSystemComponent>();
+
+    // Scan whole map for initial max speed for hCost 
+    comp.refreshTimeInFrames = 1;
+    ScanForPathSpeedModInfo(-1);
+    comp.refreshTimeInFrames = GAME_SPEED * 30;
 }
 
 void PathSpeedModInfoSystem::Init()
 {
     RECOIL_DETAILED_TRACY_ZONE;
+
+    if (systemGlobals.IsSystemActive<PathSpeedModInfoSystemComponent>()) {
+        ScanWholeMap();
+        return;
+    }
+
     auto& comp = systemGlobals.CreateSystemComponent<PathSpeedModInfoSystemComponent>();
     auto pm = dynamic_cast<QTPFS::PathManager*>(IPathManager::GetInstance(QTPFS_TYPE));
 
@@ -129,11 +146,8 @@ void PathSpeedModInfoSystem::Init()
 
     systemUtils.OnUpdate().connect<&PathSpeedModInfoSystem::Update>();
 
-    // Scan whole map for initial max speed for hCost 
-    comp.refreshTimeInFrames = 1;
-    ScanForPathSpeedModInfo(-1);
+    ScanWholeMap();
 
-    comp.refreshTimeInFrames = GAME_SPEED * 30;
     comp.startRefreshOnFrame = NEXT_FRAME_NEVER;
     comp.refeshDelayInFrames = GAME_SPEED;
 

--- a/rts/System/Ecs/Utils/SystemGlobalUtils.h
+++ b/rts/System/Ecs/Utils/SystemGlobalUtils.h
@@ -28,7 +28,12 @@ public:
     T& GetSystemComponent() { return registry.template get<T>(systemGlobalsEntity); }
 
     template<class T>
-    bool IsSystemActive() { return (nullptr != registry.template try_get<T>(systemGlobalsEntity)); }
+    bool IsSystemActive() {
+        if (! registry.valid(systemGlobalsEntity))
+            systemGlobalsEntity = registry.create();
+
+        return (nullptr != registry.template try_get<T>(systemGlobalsEntity));
+    }
 
     void ClearComponents() {
         if (registry.valid(systemGlobalsEntity))


### PR DESCRIPTION
Fixes [2479](https://github.com/beyond-all-reason/RecoilEngine/issues/2479)

QTPFS now has a PostFinalizeRefresh() stage, which will allow units to move correctly on randomly generated maps. Prior to this it would take about a minute into the match before the pathing system would adjust correctly. The reason this happens is that the random map starts off as a flat water map and then raises the land after the pathing system has initialized.
