### PR TITLE
Separate unsynced path searches from synced path searches in QTPFS

### DIFF
--- a/rts/Sim/Path/HAPFS/PathManager.cpp
+++ b/rts/Sim/Path/HAPFS/PathManager.cpp
@@ -442,7 +442,7 @@ unsigned int CPathManager::RequestPath(
 	if (!IsFinalized())
 		return 0;
 
-	if (!immediateResult) {
+	if (synced && !immediateResult) {
 		assert(!ThreadPool::inMultiThreadedSection);
 
 		PathSearch* existingSearch = nullptr;

--- a/rts/Sim/Path/QTPFS/PathSearch.h
+++ b/rts/Sim/Path/QTPFS/PathSearch.h
@@ -270,6 +270,21 @@ public:
 		static float MAP_RELATIVE_MAX_NODES_SEARCHED;
 		static int MAP_MAX_NODES_SEARCHED;
 	};
+
+	// Because AI can request path searches at any time, we need to separate out unsynced path searches from synced
+	// searches. Even though unsynced searches are carried out immediately, they could be inserted and removed at
+	// different times relative to the insertion of synced searches, which means when the unsynced search is removed,
+	// it can cause the synced searches to be reordered. This matters because some searches are waiting on results from
+	// others in order to reuse results. If the order of the searches are changed, then on one machine a specific
+	// search could resolve on frame x and on another machine frame x + 1.
+	struct UnsyncedPathSearch : public PathSearch {
+		UnsyncedPathSearch() {
+			synced = false; // Mark this path as unsynced explicitly
+		}
+		UnsyncedPathSearch(unsigned int pathSearchType)
+			: PathSearch(pathSearchType)
+			{ synced = false; }
+	};
 }
 
 #endif

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -53,6 +53,7 @@ namespace Threading {
 
 	cpu_topology::ThreadPinPolicy GetChosenThreadPinPolicy() {
 		int configPinPolicy = configHandler->GetInt("ThreadPinPolicy");
+		LOG("ThreadPinPolicy == %d", configPinPolicy);
 		switch (configPinPolicy) {
 			case ConfigPinPolicy::None:
 				return cpu_topology::THREAD_PIN_POLICY_NONE;

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -53,7 +53,6 @@ namespace Threading {
 
 	cpu_topology::ThreadPinPolicy GetChosenThreadPinPolicy() {
 		int configPinPolicy = configHandler->GetInt("ThreadPinPolicy");
-		LOG("ThreadPinPolicy == %d", configPinPolicy);
 		switch (configPinPolicy) {
 			case ConfigPinPolicy::None:
 				return cpu_topology::THREAD_PIN_POLICY_NONE;


### PR DESCRIPTION
This should deal with the issue of AI commands unsyncing the game. I was only able to test to make sure no issues arise from the changes. I haven't been able to get Zero-K to run networked locally with AI to verify the desyncing behaviour.