### PR TITLE
Fix RmlUi crash when reloading stylesheets with documents containing scripts in head section

### DIFF
--- a/rts/Rml/SolLua/plugin/SolLuaDocument.cpp
+++ b/rts/Rml/SolLua/plugin/SolLuaDocument.cpp
@@ -63,6 +63,11 @@ namespace Rml::SolLua
 	void SolLuaDocument::LoadInlineScript(const Rml::String& content, const Rml::String& source_path, int source_line)
 	{
 		auto* context = GetContext();
+		if (context == nullptr)
+		{
+			// A context isn't present in the case of reloading stylesheets which reprocesses the whole head section.
+			return;
+		}
 
 		Rml::String buffer{ "--" };
 		buffer.append("[");

--- a/rts/Rml/SolLua/plugin/SolLuaDocument.cpp
+++ b/rts/Rml/SolLua/plugin/SolLuaDocument.cpp
@@ -63,11 +63,9 @@ namespace Rml::SolLua
 	void SolLuaDocument::LoadInlineScript(const Rml::String& content, const Rml::String& source_path, int source_line)
 	{
 		auto* context = GetContext();
-		if (context == nullptr)
-		{
-			// A context isn't present in the case of reloading stylesheets which reprocesses the whole head section.
-			return;
-		}
+
+		// A context isn't present in the case of reloading stylesheets which reprocesses the whole head section.
+		if (context == nullptr) return;
 
 		Rml::String buffer{ "--" };
 		buffer.append("[");


### PR DESCRIPTION
When calling ReloadStyleSheet on a document RmlUi reprocesses the head section of the document in a disconnected copy so a context isn't present. If this head section also includes scripts it will also try to re-process these causing LoadInlineScript in SolLua to be called without a context present, leading to a null pointer exception and engine crash.