### PR TITLE
Move std::unique_ptr member definitions out-of-line

### DIFF
--- a/rts/Rendering/Env/ISky.cpp
+++ b/rts/Rendering/Env/ISky.cpp
@@ -42,6 +42,8 @@ ISky::~ISky()
 	spring::SafeDelete(skyLight);
 }
 
+std::unique_ptr<ISky> ISky::sky = nullptr;
+
 
 
 void ISky::SetupFog() {

--- a/rts/Rendering/Env/ISky.h
+++ b/rts/Rendering/Env/ISky.h
@@ -67,7 +67,7 @@ public:
 protected:
 	float4 skyAxisAngle;
 protected:
-	static inline std::unique_ptr<ISky> sky = nullptr;
+	static std::unique_ptr<ISky> sky;
 
 	ISkyLight* skyLight;
 

--- a/rts/Rendering/Env/IWater.cpp
+++ b/rts/Rendering/Env/IWater.cpp
@@ -39,6 +39,8 @@ IWater::IWater()
 	CExplosionCreator::AddExplosionListener(this);
 }
 
+std::unique_ptr<IWater> IWater::water = nullptr;
+
 void IWater::ExplosionOccurred(const CExplosionParams& event) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	AddExplosion(event.pos, event.damages.GetDefault(), event.craterAreaOfEffect);

--- a/rts/Rendering/Env/IWater.h
+++ b/rts/Rendering/Env/IWater.h
@@ -52,7 +52,7 @@ protected:
 	void DrawRefractions(const double* clipPlaneEqs, bool drawGround, bool drawSky);
 
 protected:
-	static inline std::unique_ptr<IWater> water = nullptr;
+	static std::unique_ptr<IWater> water;
 
 	bool drawReflection;
 	bool drawRefraction;

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -322,8 +322,10 @@ private:
 	bool searchFontAttributes;
 	bool searchApplySubstitutions;
 
-	static inline std::unique_ptr<FtLibraryHandler> singleton = nullptr;
+	static std::unique_ptr<FtLibraryHandler> singleton;
 };
+
+std::unique_ptr<FtLibraryHandler> FtLibraryHandler::singleton = nullptr;
 #endif
 
 

--- a/rts/Rendering/Models/3DModelVAO.cpp
+++ b/rts/Rendering/Models/3DModelVAO.cpp
@@ -67,6 +67,8 @@ S3DModelVAO::S3DModelVAO()
 	instVBO.Unbind();
 }
 
+std::unique_ptr<S3DModelVAO> S3DModelVAO::instance = nullptr;
+
 void S3DModelVAO::ProcessVertices(const S3DModel* model)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Rendering/Models/3DModelVAO.h
+++ b/rts/Rendering/Models/3DModelVAO.h
@@ -107,7 +107,7 @@ private:
 	void EnableAttribs(bool inst) const;
 	void DisableAttribs() const;
 private:
-	inline static std::unique_ptr<S3DModelVAO> instance = nullptr;
+	static std::unique_ptr<S3DModelVAO> instance;
 private:
 	bool safeToDeleteVectors = false;
 

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -78,7 +78,7 @@ public:
 public:
 	static void Init(size_t size);
 	static void Kill();
-	static inline std::unique_ptr<ITexMemPool> texMemPool = {};
+	static std::unique_ptr<ITexMemPool> texMemPool;
 protected:
 	size_t numAllocs = 0;
 	size_t allocSize = 0;
@@ -88,6 +88,8 @@ protected:
 	// libIL is not thread-safe, neither are {Alloc,Free}
 	spring::mutex bmpMutex;
 };
+
+std::unique_ptr<ITexMemPool> ITexMemPool::texMemPool = {};
 
 class TexMemPool : public ITexMemPool {
 private:

--- a/rts/System/QueueToMain.h
+++ b/rts/System/QueueToMain.h
@@ -31,7 +31,7 @@ namespace spring {
         static bool Empty() { return functions.empty(); }
         static const auto& GetQueuedFunctions() { return functions; }
     private:
-        inline static std::vector<std::unique_ptr<QueuedFunction>> functions = {};
+        static std::vector<std::unique_ptr<QueuedFunction>> functions;
     };
 
     template <typename R, typename... Args>
@@ -58,4 +58,6 @@ namespace spring {
         FunctionType storedFunc;
         std::tuple<std::decay_t<Args>...> storedArgs;
     };
+
+    inline std::vector<std::unique_ptr<QueuedFunction>> QueuedFunction::functions = {};
 }


### PR DESCRIPTION
This is a small refactoring of `static inline` data members of type `std::unique_ptr<T>`, where `T` is a incomplete type. It stands in the way of enabling C++23 mode, because `std::unique_ptr` was made `constexpr` in C++23, which [for good reasons](https://github.com/llvm/llvm-project/issues/59966#issuecomment-1397716263) triggers instantiation of `std::unique_ptr` destructor  more eagerly, which fails when pointee type is incomplete.

This is a partial fix for #2021 and continuation of the effort started in #2023. The only untreated case is `SolLuaDataModel` in third-party code, for which I opened https://github.com/LoneBoco/RmlSolLua/pull/3

I tested this locally using Clang 22, but I should note that fixing this issue is not enough to compile with Clang 22 (in any language mode), because `fmt` needs to be upgraded to the latest release.