### PR TITLE
Fix: feature 3d models stuck at 0,0,0 before the battle starts

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -477,10 +477,16 @@ void CGame::Load(const std::string& mapFileName)
 			}
 			LEAVE_SYNCED_CODE();
 		}
-		// Update height bounds and pathing after pregame or a saved game load.
+		// Update height bounds, pathing and added/features units after pregame or a saved game load.
 		{
 			ENTER_SYNCED_CODE();
 			extractorHandler.PostFinalizeRefresh();
+
+			// update features / units in case they need to be rendered before the sim starts
+			// (e.g. during start position selection)
+			featureHandler.UpdatePostFrame();
+			unitHandler.UpdatePostFrame();
+
 			//needed in case pre-game terraform changed the map
 			readMap->UpdateHeightBounds();
 			Watchdog::ClearTimer(WDT_LOAD);

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -80,8 +80,8 @@ protected:
 	std::array<ModelRenderContainer<T>, MODELTYPE_CNT> modelRenderers;
 
 	std::vector<T*> unsortedObjects;
-	std::unordered_map<T*, ScopedTransformMemAlloc> scTransMemAllocMap;
-	std::unordered_map<const T*, int32_t> lastSyncedFrameUpload;
+	spring::unordered_map<const T*, ScopedTransformMemAlloc> scTransMemAllocMap;
+	spring::unordered_map<const T*, int32_t> lastSyncedFrameUpload;
 
 	bool& mtModelDrawer;
 };
@@ -128,7 +128,8 @@ inline void CModelDrawerDataBase<T>::AddObject(const T* co, bool add)
 
 	const uint32_t numMatrices = ((o->model ? o->model->numPieces : 0) + 1u) * 2;
 	scTransMemAllocMap.emplace(o, ScopedTransformMemAlloc(numMatrices));
-	lastSyncedFrameUpload.emplace(o, -1);
+	static constexpr auto INITIAL_FRAME_NUM = std::numeric_limits<decltype(lastSyncedFrameUpload)::mapped_type>::lowest();
+	lastSyncedFrameUpload.emplace(o, INITIAL_FRAME_NUM); //set to INITIAL_FRAME_NUM to update at least once before the sim starts
 
 	modelUniformsStorage.AddObject(co);
 }

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -128,7 +128,7 @@ inline void CModelDrawerDataBase<T>::AddObject(const T* co, bool add)
 
 	const uint32_t numMatrices = ((o->model ? o->model->numPieces : 0) + 1u) * 2;
 	scTransMemAllocMap.emplace(o, ScopedTransformMemAlloc(numMatrices));
-	static constexpr auto INITIAL_FRAME_NUM = std::numeric_limits<decltype(lastSyncedFrameUpload)::mapped_type>::lowest();
+	static constexpr auto INITIAL_FRAME_NUM = std::numeric_limits<typename decltype(lastSyncedFrameUpload)::mapped_type>::lowest();
 	lastSyncedFrameUpload.emplace(o, INITIAL_FRAME_NUM); //set to INITIAL_FRAME_NUM to update at least once before the sim starts
 
 	modelUniformsStorage.AddObject(co);

--- a/rts/System/SpringHashMap.hpp
+++ b/rts/System/SpringHashMap.hpp
@@ -363,6 +363,22 @@ public:
 			return { iterator(this, bucket), true };
 		}
 	}
+	std::pair<iterator, bool> emplace(const KeyT& key, ValueT&& value)
+	{
+		check_expand_need();
+
+		auto bucket = find_or_allocate(key);
+
+		if (_states[bucket] == State::FILLED) {
+			return { iterator(this, bucket), false };
+		}
+		else {
+			_states[bucket] = State::FILLED;
+			new(_pairs + bucket) PairT(key, std::move(value));
+			_num_filled++;
+			return { iterator(this, bucket), true };
+		}
+	}
 
 	std::pair<iterator, bool> insert(const std::pair<KeyT, ValueT>& p)
 	{


### PR DESCRIPTION
* Fix incorrect rendering of features / units before the sim starts
* Also switch to faster spring::unordered_map from std in `CModelDrawerDataBase`, modify `SpringHashMap` to allow for this change
* Fixes https://github.com/beyond-all-reason/RecoilEngine/issues/2523