### PR TITLE
Implement gl.DrawWaterReflections

### DIFF
--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -38,6 +38,7 @@
 
 #include "Game/Camera.h"
 #include "Game/CameraHandler.h"
+#include "Game/Game.h"
 #include "Game/UI/CommandColors.h"
 #include "Game/UI/MiniMap.h"
 #include "Map/BaseGroundDrawer.h"
@@ -370,6 +371,8 @@ bool LuaOpenGL::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetAtlasTexture);
 
 	REGISTER_LUA_CFUNC(GetEngineAtlasTextures);
+
+	REGISTER_LUA_CFUNC(DrawWaterReflections);
 
 	REGISTER_LUA_CFUNC(Shape);
 	REGISTER_LUA_CFUNC(BeginEnd);
@@ -5066,6 +5069,91 @@ int LuaOpenGL::GetEngineAtlasTextures(lua_State* L) {
 		luaL_error(L, "[%s] Invalid engine atlas (%s) is specified (only $explosions and $groundfx are supported)", __func__, atlasName.c_str());
 		return 0;
 	}
+}
+
+
+/******************************************************************************/
+
+
+/***
+ * @function gl.DrawWaterReflections
+ * @param drawSky bool?
+ * @param drawGround bool?
+ * @param drawUnits bool?
+ * @param drawFeatures bool?
+ * @param drawProjectiles bool?
+ * @param viewportX number?
+ * @param viewportY number?
+ */
+int LuaOpenGL::DrawWaterReflections(lua_State* L) {
+	const bool drawSky = luaL_optboolean(L, 1, true);
+	const bool drawGround = luaL_optboolean(L, 2, true);
+	const bool drawUnits = luaL_optboolean(L, 3, true);
+	const bool drawFeatures = luaL_optboolean(L, 4, true);
+	const bool drawProjectiles = luaL_optboolean(L, 5, true);
+	const int viewportX = luaL_optinteger(L, 6, globalRendering->viewSizeX);
+	const int viewportY = luaL_optinteger(L, 7, globalRendering->viewSizeY);
+
+	const auto& sky = ISky::GetSky();
+	glClearColor(sky->fogColor.x, sky->fogColor.y, sky->fogColor.z, 1.0f);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	glPushAttrib(GL_FOG_BIT);
+
+	CCamera* prvCam = CCameraHandler::GetSetActiveCamera(CCamera::CAMTYPE_UWREFL);
+	CCamera* curCam = CCameraHandler::GetActiveCamera();
+
+	curCam->CopyStateReflect(prvCam);
+	curCam->UpdateLoadViewport(0, 0, viewportX, viewportY);
+
+	const auto draw_mode = game->GetDrawMode();
+	game->SetDrawMode(CGame::gameReflectionDraw);
+	{
+		// opaque; do not clip skydome (is drawn in camera space)
+		if (drawSky)
+			ISky::GetSky()->Draw();
+
+		const double clipPlaneEqs[2 * 4] = {
+			0.0, 1.0, 0.0, 0.1, // ground; use d>0 to hide shoreline cracks
+			0.0, 1.0, 0.0, 0.0, // models
+		};
+
+		glEnable(GL_CLIP_PLANE2);
+		glClipPlane(GL_CLIP_PLANE2, &clipPlaneEqs[0]);
+
+		if (drawGround)
+			readMap->GetGroundDrawer()->Draw(DrawPass::WaterReflection);
+
+		// rest needs the plane in model-space; V is combined with P
+		glPushMatrix();
+		glLoadIdentity();
+		glClipPlane(GL_CLIP_PLANE2, &clipPlaneEqs[4]);
+		glPopMatrix();
+
+		if (drawUnits)
+			unitDrawer->Draw(true);
+		if (drawFeatures)
+			featureDrawer->Draw(true);
+		if (drawProjectiles)
+			projectileDrawer->DrawOpaque(true);
+
+		// transparent
+		// unitDrawer->DrawAlphaPass(true);
+		// featureDrawer->DrawAlphaPass(true);
+		// projectileDrawer->DrawAlpha(true, false, true, false);
+		// sun-disc does not blend well with water
+
+		glDisable(GL_CLIP_PLANE2);
+	}
+	game->SetDrawMode(draw_mode);
+
+	CCameraHandler::SetActiveCamera(prvCam->GetCamType());
+	prvCam->Update();
+	prvCam->LoadViewport();
+
+	glPopAttrib(); // GL_FOG_BIT
+
+	return 0;
 }
 
 

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5077,11 +5077,11 @@ int LuaOpenGL::GetEngineAtlasTextures(lua_State* L) {
 
 /***
  * @function gl.DrawWaterReflections
- * @param drawSky bool?
- * @param drawGround bool?
- * @param drawUnits bool?
- * @param drawFeatures bool?
- * @param drawProjectiles bool?
+ * @param drawSky boolean?
+ * @param drawGround boolean?
+ * @param drawUnits boolean?
+ * @param drawFeatures boolean?
+ * @param drawProjectiles boolean?
  * @param viewportX number?
  * @param viewportY number?
  */

--- a/rts/Lua/LuaOpenGL.h
+++ b/rts/Lua/LuaOpenGL.h
@@ -247,6 +247,8 @@ class LuaOpenGL {
 
 		static int GetEngineAtlasTextures(lua_State* L);
 
+		static int DrawWaterReflections(lua_State* L);
+
 		static int Shape(lua_State* L);
 		static int BeginEnd(lua_State* L);
 		static int Vertex(lua_State* L);


### PR DESCRIPTION
For [2533](https://github.com/beyond-all-reason/RecoilEngine/issues/2533)

Implement a function `gl.DrawWaterReflections` which is available to unsynced lua. It essentially replicates how [IWater::DrawReflections](https://github.com/beyond-all-reason/RecoilEngine/blob/391f1fbf06f69d3ebc32e31b50fc9c65f45da0a1/rts/Rendering/Env/IWater.cpp#L138) and [CBumpWater::DrawReflection](https://github.com/beyond-all-reason/RecoilEngine/blob/391f1fbf06f69d3ebc32e31b50fc9c65f45da0a1/rts/Rendering/Env/BumpWater.cpp#L1012) create reflections. It expects the caller to setup an fbo before calling it.

I have a [minimal example widget here](https://github.com/jacobguenther/RecoilOceanWaves/blob/main/ocean_waves/reflections_minimal_example.lua) showing how to use it and for testing.