### PR TITLE
Fix SDL2 bug: default audio device switch fails, causing SDL_AUDIODEV…

### DIFF
--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -347,12 +347,56 @@ bool CSound::Mute()
 
 void CSound::DeviceChanged(uint32_t sdlDeviceIndex)
 {
-	if (hasAlcSoftLoopBack && sdlDeviceIndex == sdlDeviceID) {
-		SDL_CloseAudioDevice(sdlDeviceIndex);
-		Kill();
-		Init();
+	// handles SDL_AUDIODEVICEREMOVED and SDL_AUDIODEVICEADDED
+
+	if (!hasAlcSoftLoopBack || sdlDeviceIndex != sdlDeviceID)
+		return;
+
+	LOG("[Sound::%s] SDL failed to handle device change, reopening", __func__);
+	// In the default Recoil configuration, the default audio device is initialized via SDL2. (hasAlcSoftLoopBack == true)
+	// Most device changes are handled seamlessly by SDL2.
+	// In these cases, no event is emitted — SDL2 switches the active audio device internally through the OS-specific audio backend (WASAPI, PulseAudio, etc.).
+	// However, with certain device changes a short dropout may occur, and SDL2 will emit the SDL_AUDIODEVICEREMOVED event.
+	// Shortly afterwards, the default device can usually be reinitialized.
+	
+	// This behavior can be reproduced on several test systems, for example when switching the Windows default device from monitor audio over HDMI to a sound card (HDMI->analog)
+
+	std::lock_guard<spring::recursive_mutex> lck(soundMutex);
+
+	LOG("[Sound::%s] Pausing audio", __func__);
+	SDL_PauseAudioDevice(sdlDeviceID, 1); // stop SDL-callback 'RenderSDLSamples'
+
+	LOG("[Sound::%s] Closing audio device", __func__);
+	SDL_CloseAudioDevice(sdlDeviceID);
+	sdlDeviceID = 0;
+
+	LOG("[Sound::%s] Attempt to reopen default device", __func__);
+	std::string configDeviceName;
+	// call IsSet; we do not want to create a default for snd_device
+	if (configHandler->IsSet("snd_device"))
+		configDeviceName = configHandler->GetString("snd_device");
+	SDL_AudioSpec obtainedSpec;
+	if (OpenSdlDevice(configDeviceName, obtainedSpec) == false)
+	{
+		LOG("[Sound::%s] Reopening device failed", __func__);
+		// Continue using our loopback device.
+		// It may later be reused by a subsequent SDL_AUDIODEVICEADDED event.
+
+		// Kill();
+		// Init(); // Destroys curContext and all sounds currently loaded by the game
+
 	}
 
+	// The OpenAL loopback device remains unchanged.
+	// In fact, obtainedSpec.channels, obtainedSpec.format, and obtainedSpec.freq may have been modified by SDL2.
+	// This means the loopback device continues to run with the old values.
+	// As a result, RenderSDLSamples() may need to resample the audio.
+	// The new frameSize is already taken into account inside RenderSDLSamples().
+	//
+	// ToDo: Once OpenAL-Soft is updated, we can make use of alcReopenDeviceSOFT, etc.
+
+	SDL_PauseAudioDevice(sdlDeviceID, 0);  // Resume SDL-callback 'RenderSDLSamples'
+	LOG("[Sound::%s] Reopened device", __func__);
 }
 
 void CSound::Iconified(bool state)
@@ -448,47 +492,16 @@ static const char* TypeName(ALCenum type)
 
 #endif
 
-
-
-void CSound::OpenLoopbackDevice(const std::string& deviceName)
+bool CSound::OpenSdlDevice(const std::string& deviceName, SDL_AudioSpec& obtainedSpec)
 {
-	assert(curDevice == nullptr);
-
-#ifndef ALC_SOFT_loopback
-	LOG("[Sound::%s] ALC_SOFT_loopback define was NOT set, expect audio to not work!", __func__);
-#endif
-
-	hasAlcSoftLoopBack = (alcIsExtensionPresent(nullptr, "ALC_SOFT_loopback") == AL_TRUE);
-	if (!hasAlcSoftLoopBack) {
-		LOG("[Sound::%s] ALC_SOFT_loopback extension NOT found using alcIsExtensionPresent(...)!", __func__);
-		return;
-	}
-
-#ifdef ALC_SOFT_loopback
-#define LOAD_PROC(x) ((x) = (decltype(x)) alcGetProcAddress(nullptr, #x))
-	LOAD_PROC(alcLoopbackOpenDeviceSOFT);
-	LOAD_PROC(alcIsRenderFormatSupportedSOFT);
-	LOAD_PROC(alcRenderSamplesSOFT);
-#undef LOAD_PROC
-
-	if (alcLoopbackOpenDeviceSOFT == nullptr || alcIsRenderFormatSupportedSOFT == nullptr || alcRenderSamplesSOFT == nullptr)
-		return;
-
-	if (!configHandler->GetBool("UseSDLAudio")) {
-		LOG("[Sound::%s] UseSDLAudio is NOT set, falling back to openal-soft backends", __func__);
-		return;
-	} else {
-		LOG("[Sound::%s] UseSDLAudio is set, rendering openal-soft audio to SDL buffer and let SDL audio handle the hardware", __func__);
-	}
-
 	if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
 		LOG("[Sound::%s] failed to initialize SDL audio, error:  \"%s\"", __func__, SDL_GetError());
-		return;
+		return false;
 	}
 
 	if (SDL_GetNumAudioDevices(0) <= 0) {
 		LOG("[Sound::%s] UseSDLAudio is set, but no SDL sound devices for playback can be found. Falling back to openal-soft backends", __func__);
-		return;
+		return false;
 	}
 
 	LOG("[Sound::%s] SDL audio device(s): ", __func__);
@@ -497,7 +510,6 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	}
 
 	SDL_AudioSpec desiredSpec;
-	SDL_AudioSpec obtainedSpec;
 
 	desiredSpec.format = AUDIO_S16SYS;
 	desiredSpec.freq = 44100;
@@ -542,16 +554,52 @@ void CSound::OpenLoopbackDevice(const std::string& deviceName)
 	if (sdlDeviceID == 0) {
 		LOG("[Sound::%s] failed to open SDL audio, error:  \"%s\"", __func__, SDL_GetError());
 		SDL_QuitSubSystem(SDL_INIT_AUDIO);
-		return;
+		return false;
 	}
 
 	// needs to be at least 1 or the callback will divide by 0
 	if ((frameSize = obtainedSpec.channels * SDL_AUDIO_BITSIZE(obtainedSpec.format) / 8) <= 0) {
 		LOG("[Sound::%s] failed to obtain valid SDL spec: numChannels=%d formatBits=%d", __func__, obtainedSpec.channels, SDL_AUDIO_BITSIZE(obtainedSpec.format));
 		Cleanup();
+		return false;
+	}
+
+	return true;
+}
+
+void CSound::OpenLoopbackDevice(const std::string& deviceName)
+{
+	assert(curDevice == nullptr);
+
+#ifndef ALC_SOFT_loopback
+	LOG("[Sound::%s] ALC_SOFT_loopback define was NOT set, expect audio to not work!", __func__);
+#endif
+
+	hasAlcSoftLoopBack = (alcIsExtensionPresent(nullptr, "ALC_SOFT_loopback") == AL_TRUE);
+	if (!hasAlcSoftLoopBack) {
+		LOG("[Sound::%s] ALC_SOFT_loopback extension NOT found using alcIsExtensionPresent(...)!", __func__);
 		return;
 	}
 
+#ifdef ALC_SOFT_loopback
+#define LOAD_PROC(x) ((x) = (decltype(x)) alcGetProcAddress(nullptr, #x))
+	LOAD_PROC(alcLoopbackOpenDeviceSOFT);
+	LOAD_PROC(alcIsRenderFormatSupportedSOFT);
+	LOAD_PROC(alcRenderSamplesSOFT);
+#undef LOAD_PROC
+
+	if (alcLoopbackOpenDeviceSOFT == nullptr || alcIsRenderFormatSupportedSOFT == nullptr || alcRenderSamplesSOFT == nullptr)
+		return;
+
+	if (!configHandler->GetBool("UseSDLAudio")) {
+		LOG("[Sound::%s] UseSDLAudio is NOT set, falling back to openal-soft backends", __func__);
+		return;
+	}
+
+	LOG("[Sound::%s] UseSDLAudio is set, rendering openal-soft audio to SDL buffer and let SDL audio handle the hardware", __func__);
+	SDL_AudioSpec obtainedSpec;
+	if (OpenSdlDevice(deviceName, obtainedSpec) == false)
+		return;
 
 	ALCint attrs[16];
 

--- a/rts/System/Sound/OpenAL/Sound.h
+++ b/rts/System/Sound/OpenAL/Sound.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <al.h>
 #include <alc.h>
+#include <SDL.h>
 
 #include "System/Sound/ISound.h"
 #include "System/float3.h"
@@ -79,6 +80,7 @@ private:
 private:
 	void Cleanup();
 	void OpenOpenALDevice(const std::string& deviceName);
+	bool OpenSdlDevice(const std::string& deviceName, SDL_AudioSpec& obtainedSpec);
 	void OpenLoopbackDevice(const std::string& deviceName);
 
 	void InitThread(int cfgMaxSounds);

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -1210,6 +1210,10 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 			LOG("[SpringApp::%s][SDL_AUDIODEVICEREMOVED][1] type=%u, which=%u, iscapture=%u", __func__, event.adevice.type, event.adevice.which, static_cast<uint32_t>(event.adevice.iscapture));
 			sound->DeviceChanged(event.adevice.which);
 		} break;
+		case SDL_AUDIODEVICEADDED: {
+			LOG("[SpringApp::%s][SDL_AUDIODEVICEADDED][1] type=%u, which=%u, iscapture=%u", __func__, event.adevice.type, event.adevice.which, static_cast<uint32_t>(event.adevice.iscapture));
+			sound->DeviceChanged(event.adevice.which);
+		} break;
 		case SDL_QUIT: {
 			gu->globalQuit = true;
 		} break;


### PR DESCRIPTION
Fix SDL2 bug: default audio device switch fails, causing SDL_AUDIODEVICEREMOVED on HDMI → analog switch

When switching the system default audio device (e.g. from HDMI to analog),
SDL2 may fail to migrate the stream properly. Despite using the default
device, SDL2 emits an SDL_AUDIODEVICEREMOVED event, even though the device
didn't truly become unavailable.

The behavior is documented by SDL2 developers:
“In many cases, SDL will quietly move to new default audio devices on
your behalf … In cases where it can’t be handled, closing the default
device and reopening it should give you the new default device.”
(https://discourse.libsdl.org/t/changing-audio-output-when-the-default-audio-playback-device-changes/22399)

This commit implements an automatic 'reopen on removal' workaround that
detects SDL_AUDIODEVICEREMOVED on the default device and reopens it to
restore functionality.

Additionally:
- The OpenAL context remains intact during device switches.
- If no default audio device is available when SDL_AUDIODEVICEREMOVED is
  triggered, audio playback can seamlessly continue once an
  SDL_AUDIODEVICEADDED event occurs.
