### PR TITLE
Fix incorrect number of CPUs being detected on Linux with offline CPUs

### DIFF
--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -118,10 +118,7 @@ namespace Threading {
 	static std::uint32_t CalcCoreAffinityMask(const cpu_set_t* cpuSet) {
 		std::uint32_t coreMask = 0;
 
-		// without the min(..., 32), `(1 << n)` could overflow
-		const int numCPUs = std::min(CPU_COUNT(&cpusSystem), 32);
-
-		for (int n = numCPUs - 1; n >= 0; --n) {
+		for (int n = 31; n >= 0; --n) {
 			if (CPU_ISSET(n, cpuSet))
 				coreMask |= (1 << n);
 		}
@@ -132,10 +129,8 @@ namespace Threading {
 	static void SetWantedCoreAffinityMask(cpu_set_t* cpuDstSet, std::uint32_t coreMask) {
 		CPU_ZERO(cpuDstSet);
 
-		const int numCPUs = std::min(CPU_COUNT(&cpusSystem), 32);
-
-		for (int n = numCPUs - 1; n >= 0; --n) {
-			if ((coreMask & (1 << n)) != 0)
+		for (int n = 31; n >= 0; --n) {
+			if (((coreMask & (1 << n)) != 0) && CPU_ISSET(n, &cpusSystem))
 				CPU_SET(n, cpuDstSet);
 		}
 


### PR DESCRIPTION
The bug should be easily reproducible on any Linux system with a CPU that supports SMT (hyperthreading). The following command will disable SMT by off-lining the SMT siblings. This can also be done at boot time by passing `nosmt` to the kernel.

```
echo off | sudo tee /sys/devices/system/cpu/smt/control
```

There's two bugs I'm fixing here, separated into two commits. Both are in Linux specific parts of the code.

The first is in building the CPU topology. It was using `_SC_NPROCESSORS_CONF` which is number of configured CPUs, not number of online CPUs. This would cause it to detect in my case 16 physical and 16 logical CPUs on my 8 core CPU with SMT disabled.

The second bug is in setting thread affinity. This code assumed the bitset returned by `sched_getaffinity()` are always contiguous which is not the case if some CPUs are offlined. In my case, the oddly numbered CPUs are offlined as SMT siblings. This bug caused the thread affinity to be 0x55 instead of 0x5555.

Logs showing the bug on `master`:

```
[t=00:00:00.006889] ============== <User System> ==============
[t=00:00:00.006895]   Spring Engine Version: 2025.06.04-21-g92655e5 master
[t=00:00:00.006901]       Build Environment: gcc libstdc++ version 20230711
[t=00:00:00.006906]        Compiler Version: gcc-13.1.0
[t=00:00:00.006914]        Operating System: Linux 6.1.0-38-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.147-1 (2025-08-02) (x86_64)
[t=00:00:00.006971]         Hardware Config: AMD Ryzen 7 1700 Eight-Core Processor; 15931MB RAM
[t=00:00:00.006976]        Binary Word Size: 64-bit (native)
[t=00:00:00.006982]           Process Clock: std::chrono::high_resolution_clock
[t=00:00:00.006988]      Physical CPU Cores: 16
[t=00:00:00.006993]       Logical CPU Cores: 16
[t=00:00:00.006998] ============== </User System> ==============

[t=00:00:01.042996] [ThreadPool::SetThreadCount][1] wanted=8 current=1 maximum=16 (init=1)
[t=00:00:01.044265] [ThreadPool::SetThreadCount][2] workers=7
[t=00:00:01.044277] CPU Affinity Mask Details detected:
[t=00:00:01.044283] -- Performance Core Mask:      0x0000ffff
[t=00:00:01.044288] -- Efficiency  Core Mask:      0x00000000
[t=00:00:01.044294] -- Hyper Thread/SMT Low Mask:  0x00000000
[t=00:00:01.044299] -- Hyper Thread/SMT High Mask: 0x00000000
[t=00:00:01.044304] -- Optimal Cache Mask:         0x00005555
[t=00:00:01.044326] [ThreadPool] Main thread affinity requested as 0x00000000
[t=00:00:01.044428] [Threading] Worker 1 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044449] [Threading] Worker 4 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044476] [Threading] Worker 6 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044496] [Threading] Worker 3 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044502] [Threading] Worker 7 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044524] [Threading] Worker 5 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044427] [Threading] Worker 2 thread CPU affinity mask set: 0x55 (config is 5555)
[t=00:00:01.044761] [Threading] Main thread CPU affinity mask set: 0x55 (config is 5555)
```

Logs from this branch showing corrected behavior:

```
[t=00:00:00.006299] ============== <User System> ==============
[t=00:00:00.006305]   Spring Engine Version: 2025.06.04-21-g92655e5 master
[t=00:00:00.006310]       Build Environment: gcc libstdc++ version 20230711
[t=00:00:00.006316]        Compiler Version: gcc-13.1.0
[t=00:00:00.006325]        Operating System: Linux 6.1.0-38-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.147-1 (2025-08-02) (x86_64)
[t=00:00:00.006386]         Hardware Config: AMD Ryzen 7 1700 Eight-Core Processor; 15931MB RAM
[t=00:00:00.006392]        Binary Word Size: 64-bit (native)
[t=00:00:00.006397]           Process Clock: std::chrono::high_resolution_clock
[t=00:00:00.006402]      Physical CPU Cores: 8
[t=00:00:00.006407]       Logical CPU Cores: 8
[t=00:00:00.006412] ============== </User System> ==============

[t=00:00:01.075523] CPU Affinity Mask Details detected:
[t=00:00:01.075537] -- Performance Core Mask:      0x00005555
[t=00:00:01.075549] -- Efficiency  Core Mask:      0x00000000
[t=00:00:01.075561] -- Hyper Thread/SMT Low Mask:  0x00000000
[t=00:00:01.075573] -- Hyper Thread/SMT High Mask: 0x00000000
[t=00:00:01.075585] -- Optimal Cache Mask:         0x00005555
[t=00:00:01.075621] [ThreadPool] Main thread affinity requested as 0x00000000
[t=00:00:01.075680] [Threading] Worker 1 thread CPU affinity mask set: 0x5555
[t=00:00:01.075691] [Threading] Worker 2 thread CPU affinity mask set: 0x5555
[t=00:00:01.075713] [Threading] Worker 6 thread CPU affinity mask set: 0x5555
[t=00:00:01.075759] [Threading] Worker 5 thread CPU affinity mask set: 0x5555
[t=00:00:01.075789] [Threading] Worker 4 thread CPU affinity mask set: 0x5555
[t=00:00:01.075725] [Threading] Worker 7 thread CPU affinity mask set: 0x5555
[t=00:00:01.075926] [Threading] Worker 3 thread CPU affinity mask set: 0x5555
[t=00:00:01.075962] [Threading] Main thread CPU affinity mask set: 0x5555
```

I also tested both branches with SMT enabled and behavior is un-changed. With SMT enabled, it correctly recognized 8 physical 16 virtual and sets thread affinity to 0xffff.