### PR TITLE
feat: Engine SetStartPosition enable/disable and Lua SetTeamStartPosition, etc

### DIFF
--- a/rts/Game/UI/StartPosSelecter.cpp
+++ b/rts/Game/UI/StartPosSelecter.cpp
@@ -16,6 +16,7 @@
 #include "Rendering/Fonts/glFont.h"
 #include "Net/Protocol/NetProtocol.h"
 #include "Sim/Misc/TeamHandler.h"
+#include "Sim/Misc/ModInfo.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -83,6 +84,11 @@ bool CStartPosSelecter::Ready(bool luaForcedReady)
 bool CStartPosSelecter::MousePress(int x, int y, int button)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+
+	if (modInfo.useStartPositionSelecter == false) {
+		return false;
+	}
+
 	// Not ready to process mouse clicks yet. Pass.
 	if (!game->IsDoneLoading())
 		return false;
@@ -105,92 +111,6 @@ bool CStartPosSelecter::MousePress(int x, int y, int button)
 
 	return true;
 }
-
-
-#if 0
-void CStartPosSelecter::DrawStartBox(GL::RenderDataBufferC* buffer, Shader::IProgramObject* shader) const
-{
-	RECOIL_DETAILED_TRACY_ZONE;
-	glAttribStatePtr->EnableDepthTest();
-
-	const AllyTeam& myStartData = teamHandler.GetAllyTeam(gu->myAllyTeam);
-
-	const float by = myStartData.startRectTop * mapDims.mapy * SQUARE_SIZE;
-	const float bx = myStartData.startRectLeft * mapDims.mapx * SQUARE_SIZE;
-
-	const float dy = (myStartData.startRectBottom - myStartData.startRectTop ) * mapDims.mapy * SQUARE_SIZE / 10;
-	const float dx = (myStartData.startRectRight  - myStartData.startRectLeft) * mapDims.mapx * SQUARE_SIZE / 10;
-
-	// draw starting-rectangle restrictions
-	for (int a = 0; a < 10; ++a) {
-		float3 pos1(bx + (a    ) * dx, 0.0f, by); // tl
-		float3 pos2(bx + (a + 1) * dx, 0.0f, by); // tr
-
-		pos1.y = CGround::GetHeightAboveWater(pos1.x, pos1.z, false);
-		pos2.y = CGround::GetHeightAboveWater(pos2.x, pos2.z, false);
-
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-
-
-		pos1 = float3(bx + (a    ) * dx, 0.0f, by + dy * 10.0f);
-		pos2 = float3(bx + (a + 1) * dx, 0.0f, by + dy * 10.0f);
-		pos1.y = CGround::GetHeightAboveWater(pos1.x, pos1.z, false);
-		pos2.y = CGround::GetHeightAboveWater(pos2.x, pos2.z, false);
-
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-
-
-		pos1 = float3(bx, 0.0f, by + dy * (a    ));
-		pos2 = float3(bx, 0.0f, by + dy * (a + 1));
-		pos1.y = CGround::GetHeightAboveWater(pos1.x, pos1.z, false);
-		pos2.y = CGround::GetHeightAboveWater(pos2.x, pos2.z, false);
-
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-
-
-		pos1 = float3(bx + dx * 10.0f, 0.0f, by + dy * (a    ));
-		pos2 = float3(bx + dx * 10.0f, 0.0f, by + dy * (a + 1));
-		pos1.y = CGround::GetHeightAboveWater(pos1.x, pos1.z, false);
-		pos2.y = CGround::GetHeightAboveWater(pos2.x, pos2.z, false);
-
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-
-		buffer->AddVertex({pos2 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1 + UpVector * 100.0f, {0.2f, 0.8f, 0.2f, 0.5f}});
-		buffer->AddVertex({pos1                    , {0.2f, 0.8f, 0.2f, 0.5f}});
-	}
-
-	shader->Enable();
-	GL::RenderDataBuffer::SetMatrixStackMode(shader, GL::RenderDataBuffer::ShaderTransformType::SHDR_TRANSFORM_ORTHO01);
-	//shader->SetUniformMatrix4x4<float>("u_movi_mat", false, CMatrix44f::Identity());
-	//shader->SetUniformMatrix4x4<float>("u_proj_mat", false, CMatrix44f::ClipOrthoProj01());
-	buffer->Submit(GL_TRIANGLES);
-	shader->Disable();
-
-	glAttribStatePtr->DisableDepthTest();
-}
-#endif
-
 
 void CStartPosSelecter::Draw()
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -142,6 +142,9 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GameOver);
 	REGISTER_LUA_CFUNC(SetGlobalLos);
 
+	REGISTER_LUA_CFUNC(SetPlayerReadyState);
+	REGISTER_LUA_CFUNC(SetTeamStartPosition);
+
 	REGISTER_LUA_CFUNC(AddTeamResource);
 	REGISTER_LUA_CFUNC(UseTeamResource);
 	REGISTER_LUA_CFUNC(SetTeamResource);
@@ -944,6 +947,63 @@ int LuaSyncedCtrl::AssignPlayerToTeam(lua_State* L)
 	return 0;
 }
 
+/*** Set the starting position of a team.
+ *
+ * If the position argument is outside the team's startbox, the position is clamped.
+ * 
+ * @function Spring.SetTeamStartPosition
+ * @param teamID integer
+ * @param x number left position (elmos)
+ * @param y number vertical position (elmos)
+ * @param z number top position (elmos)
+ * @return boolean true if the position was set, false if the teamID is invalid
+ */
+int LuaSyncedCtrl::SetTeamStartPosition(lua_State* L)
+{
+	const unsigned int teamID = luaL_checkint(L, 1);
+	float3 pickPos =
+		{ luaL_checkfloat(L, 2)
+		, luaL_checkfloat(L, 3)
+		, luaL_checkfloat(L, 4)
+	};
+
+	if (!teamHandler.IsValidTeam(teamID)) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	CTeam* team = teamHandler.Team(teamID);
+	team->ClampStartPosInStartBox(&pickPos);
+	team->SetStartPos(pickPos);
+
+	lua_pushboolean(L, true);
+	return 1;
+}
+
+/*** Set the ready state of a player.
+ *
+ * Use to mark a player (un)ready in the pregame phase.
+ *
+ * @function Spring.SetPlayerReadyState
+ * @param playerID integer
+ * @param ready boolean
+ * @return boolean true if the state was set, false if the playerID was invalid
+ */
+int LuaSyncedCtrl::SetPlayerReadyState(lua_State* L)
+{
+	const unsigned int playerID = luaL_checkint(L, 1);
+	const bool isReady = luaL_checkboolean(L, 2);
+
+	if (!playerHandler.IsValidPlayer(playerID)) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	playerHandler.Player(playerID)->SetReadyToStart(isReady);
+
+	lua_pushboolean(L, true);
+	return 1;
+}
 
 /*** Changes access to global line of sight for a team and its allies.
  *

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -43,6 +43,8 @@ class LuaSyncedCtrl
 		static int AssignPlayerToTeam(lua_State* L);
 		static int GameOver(lua_State* L);
 		static int SetGlobalLos(lua_State* L);
+		static int SetTeamStartPosition(lua_State* L);
+		static int SetPlayerReadyState(lua_State* L);
 
 		static int AddTeamResource(lua_State* L);
 		static int UseTeamResource(lua_State* L);

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -333,7 +333,9 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetWindowMinimized);
 	REGISTER_LUA_CFUNC(SetWindowMaximized);
 	REGISTER_LUA_CFUNC(SetMiniMapRotation);
-	
+
+	REGISTER_LUA_CFUNC(RequestStartPosition);
+
 	REGISTER_LUA_CFUNC(Yield);
 
 	return true;
@@ -716,6 +718,32 @@ int LuaUnsyncedCtrl::SendMessageToAllyTeam(lua_State* L)
 {
 	if (luaL_checkint(L, 1) == gu->myAllyTeam)
 		PrintMessage(L, luaL_checksstring(L, 2));
+
+	return 0;
+}
+
+/*** @function Spring.RequestStartPosition
+ *
+ * Requests a startpoint, as if clicking the spot with the native GUI.
+ *
+ * @param x number
+ * @param y number
+ * @param z number
+ * @param ready? boolean
+ */
+int LuaUnsyncedCtrl::RequestStartPosition(lua_State* L) {
+	const float3 pickPos =
+		{ luaL_checkfloat(L, 1)
+		, luaL_checkfloat(L, 2)
+		, luaL_checkfloat(L, 3)
+	};
+	const bool isReady = luaL_optboolean(L, 4, playerHandler.Player(gu->myPlayerNum)->IsReadyToStart());
+
+	const int readyState = isReady
+		? CPlayer::PLAYER_RDYSTATE_READIED
+		: CPlayer::PLAYER_RDYSTATE_UPDATED
+	;
+	clientNet->Send(CBaseNetProtocol::Get().SendStartPos(gu->myPlayerNum, gu->myTeam, readyState, pickPos.x, pickPos.y, pickPos.z));
 
 	return 0;
 }

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -25,6 +25,8 @@ class LuaUnsyncedCtrl {
 		static int SendMessageToAllyTeam(lua_State* L);
 		static int SendMessageToSpectators(lua_State* L);
 
+		static int RequestStartPosition(lua_State* L);
+
 		static int SendPublicChat(lua_State* L);
 		static int SendAllyChat(lua_State* L);
 		static int SendSpectatorChat(lua_State* L);

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -130,6 +130,8 @@ void CModInfo::ResetState()
 		allowTake = true;
 
 		allowEnginePlayerlist = true;
+
+		useStartPositionSelecter = true;
 	}
 	{
 		// make windChangeReportPeriod equal to EnvResourceHandler::WIND_UPDATE_RATE = 15 * GAME_SPEED;
@@ -190,6 +192,8 @@ void CModInfo::Init(const std::string& modFileName)
 		nativeExcessSharing = system.GetBool("nativeExcessSharing", nativeExcessSharing);
 		allowTake = system.GetBool("allowTake", allowTake);
 		allowEnginePlayerlist = system.GetBool("allowEnginePlayerlist", allowEnginePlayerlist);
+
+		useStartPositionSelecter = system.GetBool("useStartPositionSelecter", useStartPositionSelecter);
 	}
 
 	{

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -236,9 +236,11 @@ public:
 
 	// how often to report wind speed/direction to wind gens
 	int windChangeReportPeriod;
+
+	// If true, players can select their start position by clicking the map
+	bool useStartPositionSelecter;
 };
 
 extern CModInfo modInfo;
 
 #endif // MOD_INFO_H
-


### PR DESCRIPTION
Based on sprunk's advice, I adjusted the original https://github.com/beyond-all-reason/RecoilEngine/pull/2503 PR.

This PR:
- Makes it possible to disable the engine mouse click Start Position Mouse Selecter 
- This can be good to disable for games, because the engine is intercepting all mouse clicks during this phase
- When disabled, games can make their own Set Starting Position widgets (with added ["facing" for example](https://github.com/beyond-all-reason/Beyond-All-Reason/compare/master...WybrenKoelmans:Beyond-All-Reason:game-start-position?expand=1))

https://github.com/user-attachments/assets/0a437cd1-c86a-4e19-8116-978671226562

