### PR TITLE
Expose Build Mode Selection to the Action System (req. modifier-only bindings fix)

### DIFF
--- a/rts/Game/GameInputReceiver.cpp
+++ b/rts/Game/GameInputReceiver.cpp
@@ -35,7 +35,30 @@ bool CGameInputReceiver::KeyPressed(int keyCode, int scanCode, bool isRepeat)
 	curKeyCodeChain.push_back(kc, spring_gettime(), isRepeat);
 	curScanCodeChain.push_back(ks, spring_gettime(), isRepeat);
 
-	lastActionList = keyBindings.GetActionList(curKeyCodeChain, curScanCodeChain);
+	// --- NEW: modifier-only handling ---
+	ActionList modOnlyPresses;
+
+	if (kc.IsModifier()) {
+		auto modActions = keyBindings.GetModActionList();
+
+		for (auto& a : modActions) {
+			auto it = std::find_if(activeModOnly.begin(), activeModOnly.end(),
+								[&](const Action& existing) {
+									return existing.bindingIndex  == a.bindingIndex ;
+								});
+
+			if (it == activeModOnly.end()) {
+				modOnlyPresses.push_back(a);   // collect for unified handling
+				activeModOnly.push_back(a);
+			}
+		}
+	}
+	// -----------------------------------
+
+	// Build lastActionList as [mod-only presses] + [normal presses]
+	lastActionList = modOnlyPresses;
+	ActionList normal = keyBindings.GetActionList(curKeyCodeChain, curScanCodeChain);
+	lastActionList.insert(lastActionList.end(), normal.begin(), normal.end());
 
 	if (RmlGui::ProcessKeyPressed(keyCode, scanCode, isRepeat))
 		return false;
@@ -64,8 +87,35 @@ bool CGameInputReceiver::KeyReleased(int keyCode, int scanCode)
 	if (gameTextInput.ConsumeReleasedKey(keyCode, scanCode))
 		return false;
 
+	// --- NEW: modifier-only handling ---
+	ActionList releasedMods;
+	const CKeySet kc(keyCode, CKeySet::KSKeyCode);
+
+	if (kc.IsModifier()) {
+		auto modActions = keyBindings.GetModActionList();
+
+		for (auto it = activeModOnly.begin(); it != activeModOnly.end(); ) {
+			// check if this active action is still present in the current modActions
+			auto found = std::find_if(modActions.begin(), modActions.end(),
+									[&](const Action& a) {
+										return a.bindingIndex  == it->bindingIndex ;
+									});
+
+			if (found == modActions.end()) {
+				releasedMods.push_back(*it);   // collect for unified handling
+				it = activeModOnly.erase(it);
+			} else {
+				++it;
+			}
+		}
+	}
+	// -----------------------------------
+
+    // Build lastActionList as [mod-only releases] + [normal releases]
 	// update actionlist for lua consumer
-	lastActionList = keyBindings.GetActionList(keyCode, scanCode);
+    lastActionList = releasedMods;
+    ActionList normal = keyBindings.GetActionList(keyCode, scanCode);
+    lastActionList.insert(lastActionList.end(), normal.begin(), normal.end());
 
 	if (luaInputReceiver->KeyReleased(keyCode, scanCode))
 		return false;

--- a/rts/Game/GameInputReceiver.h
+++ b/rts/Game/GameInputReceiver.h
@@ -22,6 +22,7 @@ public:
 	ActionList lastActionList;
 private:
 	bool TryOnPressActions(bool isRepeat);
+	ActionList activeModOnly;
 
 	CTimedKeyChain curKeyCodeChain;
 	CTimedKeyChain curScanCodeChain;

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2260,34 +2260,32 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			}
 
-			if (preview) {
-				unsigned char previewOpts = CreateOptions(button);
+			if (preview || buildInfos.size() == 1) {
 				buildCommands.clear();
-				return CheckCommand(buildInfos.back().CreateCommand(previewOpts));
+				return CheckCommand(buildInfos.back().CreateCommand(CreateOptions(button)));
 			}
+			else {
+				// multi-command + batching: issue all commands but last; last is returned
+				bool shiftHeld = GetQueueKeystate();
+				unsigned char baseOpts = CreateOptions(button);
 
-			// multi-command + batching: issue all commands but last; last is returned
-			bool shiftHeld = GetQueueKeystate();
-			unsigned char baseOpts = CreateOptions(button);
-
-			for (auto it = buildInfos.cbegin(), end = --buildInfos.cend(); it != end; ++it) {
-				unsigned char opts = baseOpts;
-
-				// First command clears previous commands if shift isn't held; otherwise append with shift
-				if (it == buildInfos.cbegin() && !shiftHeld) {
-					opts &= ~SHIFT_KEY;      // clear once
-				} else {
-					opts |= SHIFT_KEY;       // append
+				for (auto it = buildInfos.cbegin(), end = --buildInfos.cend(); it != end; ++it) {
+					unsigned char opts = baseOpts;
+					// First command clears previous commands if shift isn't held; otherwise append with shift
+					if (it == buildInfos.cbegin() && !shiftHeld) {
+						opts &= ~SHIFT_KEY;      // clear once
+					} else {
+						opts |= SHIFT_KEY;       // append
+					}
+					GiveCommand(it->CreateCommand(opts));
 				}
 
-				GiveCommand(it->CreateCommand(opts));
+				// last command option = append
+				unsigned char lastOpts = baseOpts;
+				lastOpts |= SHIFT_KEY;
+				buildCommands.clear();
+				return CheckCommand(buildInfos.back().CreateCommand(lastOpts));
 			}
-
-			// last command option = append
-			unsigned char lastOpts = baseOpts;
-			lastOpts |= SHIFT_KEY;
-			buildCommands.clear();
-			return CheckCommand(buildInfos.back().CreateCommand(lastOpts));
 		}
 
 		case CMDTYPE_ICON_UNIT: {
@@ -2631,26 +2629,27 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 }
 
 void CGuiHandler::BoxBuildPress() {
-
-	boxBuildMode = true;
-    // Only simulate mouse press if not already pressed
+    boxBuildMode = true;
+	// Only simulate mouse press if mouse not pressed
     if (!mouse->buttons[SDL_BUTTON_LEFT].pressed) {
         mouse->MousePress(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-		boxBuildPressed = true;
+        boxBuildClicking = true;
+        // GUI or minimap claims the press
+        boxBuildOwner = CInputReceiver::GetActiveReceiverRef();
     }
 }
 
 void CGuiHandler::BoxBuildRelease() {
-    // Only simulate release if BoxBuild owns the press
-    if (boxBuildPressed) {
+	// Only simulate release if mouse press was simulated
+    if (boxBuildClicking) {
+		// Fix Mouse4/Mouse5 bind release misrouting from cross‑receiver multipress by adjusting ownership (keybinds like F14 unaffected)
+        CInputReceiver::GetActiveReceiverRef() = boxBuildOwner;
         mouse->MouseRelease(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-		boxBuildPressed = false;
+        boxBuildClicking = false;
+        boxBuildOwner = nullptr;
     }
-
     boxBuildMode = false;
 }
-
-
 
 void CGuiHandler::ProcessFrontPositions(float3& pos0, const float3& pos1)
 {

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -61,6 +61,7 @@
 
 CONFIG(bool, MiniMapMarker).defaultValue(true).headlessValue(false);
 CONFIG(bool, InvertQueueKey).defaultValue(false);
+CONFIG(bool, useLegacyBuildUI).defaultValue(true);
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -80,6 +81,7 @@ CGuiHandler::CGuiHandler()
 
 	miniMapMarker = configHandler->GetBool("MiniMapMarker");
 	invertQueueKey = configHandler->GetBool("InvertQueueKey");
+	useLegacyBuildUI = configHandler->GetBool("useLegacyBuildUI");
 
 
 	autoShowMetal = mapInfo->gui.autoShowMetal;
@@ -139,6 +141,20 @@ void CGuiHandler::LoadDefaults()
 	frontByEnds = false;
 }
 
+void CGuiHandler::ConfigCommand(const std::string& line) {
+    const auto& words = CSimpleParser::Tokenize(line, 1);
+    if (words.empty())
+        return;
+
+    switch (hashStringLower(words[0].c_str())) {
+        case hashString("legacybuildui"): {
+            useLegacyBuildUI = (words.size() >= 2)
+                ? !!atoi(words[1].c_str())
+                : !useLegacyBuildUI;
+			LOG_L(L_WARNING, "[GuiHandler::ConfigCommand] legacybuildui set to %d", useLegacyBuildUI);
+        } break;
+    }
+}
 
 static bool SafeAtoF(float& var, const std::string& value)
 {
@@ -1316,26 +1332,18 @@ void CGuiHandler::MouseRelease(int x, int y, int button, const float3& cameraPos
 	FinishCommand(button);
 }
 
-CGuiHandler::BuildState CGuiHandler::ParseBuildState(const std::string& arg) {
-    if (arg == "box")  return BuildState::Box;
-    if (arg == "line") return BuildState::Line;
-    return BuildState::Default;
-}
-
-void CGuiHandler::EnableBuildModifier(BuildState s) {
-    activeBuildStates.insert(s);
-    buildState = ResolveBuildState();
-}
-
-void CGuiHandler::DisableBuildModifier(BuildState s) {
-    activeBuildStates.erase(s);
-    buildState = ResolveBuildState();
-}
-
-CGuiHandler::BuildState CGuiHandler::ResolveBuildState() const {
-    if (activeBuildStates.count(BuildState::Box))  return BuildState::Box;
-    if (activeBuildStates.count(BuildState::Line)) return BuildState::Line;
-    return BuildState::Default;
+CGuiHandler::BuildModifier CGuiHandler::ParseBuildModifier(const std::string& argIn)
+{
+    const std::string arg = StringToLower(argIn);
+    static const spring::unordered_map<std::string, BuildModifier> modMap = {
+        {"line",       MOD_LINE},
+        {"box",        MOD_BOX},
+        {"circle",     MOD_CIRCLE},
+        {"hollow_box", MOD_HOLLOW_BOX},
+        {"axis_lock",  MOD_AXIS_LOCK},
+    };
+    const auto it = modMap.find(arg);
+    return (it != modMap.end()) ? it->second : MOD_NONE;
 }
 
 bool CGuiHandler::SetActiveCommand(int cmdIndex, bool rightMouseButton)
@@ -2257,7 +2265,14 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			const BuildInfo bi(unitdef, cameraPos + mouseDir * dist, buildFacing);
 
-			if ((GetQueueKeystate() && (button == SDL_BUTTON_LEFT)) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box) {
+			const bool legacyMultiBuild =
+    			useLegacyBuildUI && GetQueueKeystate() && (button == SDL_BUTTON_LEFT);
+			const bool actionMultiBuild =
+				!useLegacyBuildUI && (button == SDL_BUTTON_LEFT) && (
+					(guihandler->activeBuildModifiers & (MOD_LINE | MOD_CIRCLE | MOD_BOX | MOD_HOLLOW_BOX)) != 0
+				);
+				
+			if (legacyMultiBuild || actionMultiBuild) {
 				const float3 camTracePos = mouse->buttons[SDL_BUTTON_LEFT].camPos;
 				const float3 camTraceDir = mouse->buttons[SDL_BUTTON_LEFT].dir;
 
@@ -2542,63 +2557,167 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 	buildInfos.clear();
 	buildInfos.reserve(16);
 
-	if (GetQueueKeystate() && KeyInput::GetKeyModState(KMOD_CTRL)) {
-		const CUnit* unit = nullptr;
-		const CFeature* feature = nullptr;
+	if (useLegacyBuildUI) {
+		if (GetQueueKeystate() && KeyInput::GetKeyModState(KMOD_CTRL)) {
+			const CUnit* unit = nullptr;
+			const CFeature* feature = nullptr;
 
-		TraceRay::GuiTraceRay(cameraPos, mouseDir, camera->GetFarPlaneDist() * 1.4f, nullptr, unit, feature, startInfo.def->floatOnWater);
+			TraceRay::GuiTraceRay(cameraPos, mouseDir, camera->GetFarPlaneDist() * 1.4f, nullptr, unit, feature, startInfo.def->floatOnWater);
 
-		if (unit != nullptr) {
-			other.def = unit->unitDef;
-			other.pos = unit->pos;
-			other.buildFacing = unit->buildFacing;
+			if (unit != nullptr) {
+				other.def = unit->unitDef;
+				other.pos = unit->pos;
+				other.buildFacing = unit->buildFacing;
+			} else {
+				const Command c = CGameHelper::GetBuildCommand(cameraPos, mouseDir);
+
+				if (c.GetID() < 0 && c.GetNumParams() == 4) {
+					other.pos = c.GetPos(0);
+					other.def = unitDefHandler->GetUnitDefByID(-c.GetID());
+					other.buildFacing = int(c.GetParam(3));
+				}
+			}
+		}
+
+		if (other.def && GetQueueKeystate() && KeyInput::GetKeyModState(KMOD_CTRL)) {
+			// circle build around building
+			const int oxsize = other.GetXSize() * SQUARE_SIZE;
+			const int ozsize = other.GetZSize() * SQUARE_SIZE;
+			const int xsize = startInfo.GetXSize() * SQUARE_SIZE;
+			const int zsize = startInfo.GetZSize() * SQUARE_SIZE;
+
+			start = end = CGameHelper::Pos2BuildPos(other, false);
+			start.x -= oxsize / 2;
+			start.z -= ozsize / 2;
+			end.x += oxsize / 2;
+			end.z += ozsize / 2;
+
+			const int nvert = 1 + (oxsize / xsize);
+			const int nhori = 1 + (ozsize / xsize);
+
+			FillRowOfBuildPos(startInfo, end.x   + zsize / 2, start.z + xsize / 2,      0,  xsize, nhori, 3, true, buildInfos);
+			FillRowOfBuildPos(startInfo, end.x   - xsize / 2, end.z   + zsize / 2, -xsize,      0, nvert, 2, true, buildInfos);
+			FillRowOfBuildPos(startInfo, start.x - zsize / 2, end.z   - xsize / 2,      0, -xsize, nhori, 1, true, buildInfos);
+			FillRowOfBuildPos(startInfo, start.x + xsize / 2, start.z - zsize / 2,  xsize,      0, nvert, 0, true, buildInfos);
 		} else {
-			const Command c = CGameHelper::GetBuildCommand(cameraPos, mouseDir);
+			// rectangle or line
+			const float3 delta = end - start;
 
-			if (c.GetID() < 0 && c.GetNumParams() == 4) {
-				other.pos = c.GetPos(0);
-				other.def = unitDefHandler->GetUnitDefByID(-c.GetID());
-				other.buildFacing = int(c.GetParam(3));
+			const float xsize = SQUARE_SIZE * (startInfo.GetXSize() + buildSpacing * 2);
+			const float zsize = SQUARE_SIZE * (startInfo.GetZSize() + buildSpacing * 2);
+
+			const int xnum = (int)((math::fabs(delta.x) + xsize * 1.4f)/xsize);
+			const int znum = (int)((math::fabs(delta.z) + zsize * 1.4f)/zsize);
+
+			float xstep = (int)((0 < delta.x) ? xsize : -xsize);
+			float zstep = (int)((0 < delta.z) ? zsize : -zsize);
+
+			if (KeyInput::GetKeyModState(KMOD_ALT)) {
+				// build a (filled or hollow) rectangle
+				if (KeyInput::GetKeyModState(KMOD_CTRL)) {
+					if ((1 < xnum) && (1 < znum)) {
+						// go "down" on the "left" side
+						FillRowOfBuildPos(startInfo, start.x                     , start.z + zstep             ,      0,  zstep, znum - 1, 0, false, buildInfos);
+						// go "right" on the "bottom" side
+						FillRowOfBuildPos(startInfo, start.x + xstep             , start.z + (znum - 1) * zstep,  xstep,      0, xnum - 1, 0, false, buildInfos);
+						// go "up" on the "right" side
+						FillRowOfBuildPos(startInfo, start.x + (xnum - 1) * xstep, start.z + (znum - 2) * zstep,      0, -zstep, znum - 1, 0, false, buildInfos);
+						// go "left" on the "top" side
+						FillRowOfBuildPos(startInfo, start.x + (xnum - 2) * xstep, start.z                     , -xstep,      0, xnum - 1, 0, false, buildInfos);
+					} else if (1 == xnum) {
+						FillRowOfBuildPos(startInfo, start.x, start.z, 0, zstep, znum, 0, false, buildInfos);
+					} else if (1 == znum) {
+						FillRowOfBuildPos(startInfo, start.x, start.z, xstep, 0, xnum, 0, false, buildInfos);
+					}
+				} else {
+					// filled
+					int zn = 0;
+					for (float z = start.z; zn < znum; ++zn) {
+						if (zn & 1) {
+							// every odd line "right" to "left"
+							FillRowOfBuildPos(startInfo, start.x + (xnum - 1) * xstep, z, -xstep, 0, xnum, 0, false, buildInfos);
+						} else {
+							// every even line "left" to "right"
+							FillRowOfBuildPos(startInfo, start.x                     , z,  xstep, 0, xnum, 0, false, buildInfos);
+						}
+						z += zstep;
+					}
+				}
+			} else {
+				// build a line
+				const bool xDominatesZ = (math::fabs(delta.x) > math::fabs(delta.z));
+
+				if (xDominatesZ) {
+					zstep = KeyInput::GetKeyModState(KMOD_CTRL) ? 0 : xstep * delta.z / (delta.x ? delta.x : 1);
+				} else {
+					xstep = KeyInput::GetKeyModState(KMOD_CTRL) ? 0 : zstep * delta.x / (delta.z ? delta.z : 1);
+				}
+
+				FillRowOfBuildPos(startInfo, start.x, start.z, xstep, zstep, xDominatesZ ? xnum : znum, 0, false, buildInfos);
 			}
 		}
 	}
+	else{
+		const bool circleMode = (activeBuildModifiers & MOD_CIRCLE);
+		// Circle build: first resolve anchor (unit or ghost) under cursor
+		if (circleMode) {
+			const CUnit* unit = nullptr;
+			const CFeature* feature = nullptr;
 
-	if (other.def && GetQueueKeystate() && KeyInput::GetKeyModState(KMOD_CTRL)) {
-		// circle build around building
-		const int oxsize = other.GetXSize() * SQUARE_SIZE;
-		const int ozsize = other.GetZSize() * SQUARE_SIZE;
-		const int xsize = startInfo.GetXSize() * SQUARE_SIZE;
-		const int zsize = startInfo.GetZSize() * SQUARE_SIZE;
+			TraceRay::GuiTraceRay(cameraPos, mouseDir, camera->GetFarPlaneDist() * 1.4f, nullptr, unit, feature, startInfo.def->floatOnWater);
 
-		start = end = CGameHelper::Pos2BuildPos(other, false);
-		start.x -= oxsize / 2;
-		start.z -= ozsize / 2;
-		end.x += oxsize / 2;
-		end.z += ozsize / 2;
+			if (unit != nullptr) {
+				other.def = unit->unitDef;
+				other.pos = unit->pos;
+				other.buildFacing = unit->buildFacing;
+			} else {
+				const Command c = CGameHelper::GetBuildCommand(cameraPos, mouseDir);
 
-		const int nvert = 1 + (oxsize / xsize);
-		const int nhori = 1 + (ozsize / xsize);
+				if (c.GetID() < 0 && c.GetNumParams() == 4) {
+					other.pos = c.GetPos(0);
+					other.def = unitDefHandler->GetUnitDefByID(-c.GetID());
+					other.buildFacing = int(c.GetParam(3));
+				}
+			}
+		}
+		// Circle build: if anchor found, circle build around building
+		if (other.def && circleMode) {
+			const int oxsize = other.GetXSize() * SQUARE_SIZE;
+			const int ozsize = other.GetZSize() * SQUARE_SIZE;
+			const int xsize = startInfo.GetXSize() * SQUARE_SIZE;
+			const int zsize = startInfo.GetZSize() * SQUARE_SIZE;
 
-		FillRowOfBuildPos(startInfo, end.x   + zsize / 2, start.z + xsize / 2,      0,  xsize, nhori, 3, true, buildInfos);
-		FillRowOfBuildPos(startInfo, end.x   - xsize / 2, end.z   + zsize / 2, -xsize,      0, nvert, 2, true, buildInfos);
-		FillRowOfBuildPos(startInfo, start.x - zsize / 2, end.z   - xsize / 2,      0, -xsize, nhori, 1, true, buildInfos);
-		FillRowOfBuildPos(startInfo, start.x + xsize / 2, start.z - zsize / 2,  xsize,      0, nvert, 0, true, buildInfos);
-	} else {
-		// rectangle or line
-		const float3 delta = end - start;
+			start = end = CGameHelper::Pos2BuildPos(other, false);
+			start.x -= oxsize / 2;
+			start.z -= ozsize / 2;
+			end.x += oxsize / 2;
+			end.z += ozsize / 2;
 
-		const float xsize = SQUARE_SIZE * (startInfo.GetXSize() + buildSpacing * 2);
-		const float zsize = SQUARE_SIZE * (startInfo.GetZSize() + buildSpacing * 2);
+			const int nvert = 1 + (oxsize / xsize);
+			const int nhori = 1 + (ozsize / xsize);
 
-		const int xnum = (int)((math::fabs(delta.x) + xsize * 1.4f)/xsize);
-		const int znum = (int)((math::fabs(delta.z) + zsize * 1.4f)/zsize);
+			FillRowOfBuildPos(startInfo, end.x   + zsize / 2, start.z + xsize / 2,      0,  xsize, nhori, 3, true, buildInfos);
+			FillRowOfBuildPos(startInfo, end.x   - xsize / 2, end.z   + zsize / 2, -xsize,      0, nvert, 2, true, buildInfos);
+			FillRowOfBuildPos(startInfo, start.x - zsize / 2, end.z   - xsize / 2,      0, -xsize, nhori, 1, true, buildInfos);
+			FillRowOfBuildPos(startInfo, start.x + xsize / 2, start.z - zsize / 2,  xsize,      0, nvert, 0, true, buildInfos);
+		} else if (!(activeBuildModifiers & (MOD_BOX | MOD_HOLLOW_BOX | MOD_LINE))) {
+        	// single build
+			FillRowOfBuildPos(startInfo, end.x, end.z, 0, 0, 1, 0, false, buildInfos);
+			//FillRowOfBuildPos(startInfo, start.x, start.z, 0, 0, 1, 0, false, buildInfos);
+		} else {
+			// sizing math
+			const float3 delta = end - start;
 
-		float xstep = (int)((0 < delta.x) ? xsize : -xsize);
-		float zstep = (int)((0 < delta.z) ? zsize : -zsize);
+			const float xsize = SQUARE_SIZE * (startInfo.GetXSize() + buildSpacing * 2);
+			const float zsize = SQUARE_SIZE * (startInfo.GetZSize() + buildSpacing * 2);
 
-		if (KeyInput::GetKeyModState(KMOD_ALT) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box){
-			// build a (filled or hollow) rectangle
-			if (KeyInput::GetKeyModState(KMOD_CTRL)) {
+			const int xnum = (int)((math::fabs(delta.x) + xsize * 1.4f)/xsize);
+			const int znum = (int)((math::fabs(delta.z) + zsize * 1.4f)/zsize);
+
+			float xstep = (int)((0 < delta.x) ? xsize : -xsize);
+			float zstep = (int)((0 < delta.z) ? zsize : -zsize);
+
+			if (activeBuildModifiers & MOD_HOLLOW_BOX) {
 				if ((1 < xnum) && (1 < znum)) {
 					// go "down" on the "left" side
 					FillRowOfBuildPos(startInfo, start.x                     , start.z + zstep             ,      0,  zstep, znum - 1, 0, false, buildInfos);
@@ -2613,8 +2732,7 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 				} else if (1 == znum) {
 					FillRowOfBuildPos(startInfo, start.x, start.z, xstep, 0, xnum, 0, false, buildInfos);
 				}
-			} else {
-				// filled
+			} else if (activeBuildModifiers & MOD_BOX) {
 				int zn = 0;
 				for (float z = start.z; zn < znum; ++zn) {
 					if (zn & 1) {
@@ -2627,20 +2745,19 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 					z += zstep;
 				}
 			}
-		} else {
-			// build a line
-			const bool xDominatesZ = (math::fabs(delta.x) > math::fabs(delta.z));
-
-			if (xDominatesZ) {
-				zstep = KeyInput::GetKeyModState(KMOD_CTRL) ? 0 : xstep * delta.z / (delta.x ? delta.x : 1);
-			} else {
-				xstep = KeyInput::GetKeyModState(KMOD_CTRL) ? 0 : zstep * delta.x / (delta.z ? delta.z : 1);
+			else {
+				// angled line transform
+				const bool xDominatesZ = (math::fabs(delta.x) > math::fabs(delta.z));
+				const bool axisLock    = (activeBuildModifiers & MOD_AXIS_LOCK) != 0;
+				if (xDominatesZ) {
+					zstep = axisLock  ? 0 : xstep * delta.z / (delta.x ? delta.x : 1);
+				} else {
+					xstep = axisLock  ? 0 : zstep * delta.x / (delta.z ? delta.z : 1);
+				}
+				FillRowOfBuildPos(startInfo, start.x, start.z, xstep, zstep, xDominatesZ ? xnum : znum, 0, false, buildInfos);
 			}
-
-			FillRowOfBuildPos(startInfo, start.x, start.z, xstep, zstep, xDominatesZ ? xnum : znum, 0, false, buildInfos);
 		}
 	}
-
 	return (buildInfos.size());
 }
 
@@ -3838,7 +3955,14 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 				const float3 cPos = tracePos + traceDir * rayTraceDist;
 
 				const CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
-				if ((GetQueueKeystate() && bp.pressed) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box) {
+				const bool legacyMultiBuild =
+					useLegacyBuildUI && GetQueueKeystate() && bp.pressed;
+
+				const bool actionMultiBuild =
+					!useLegacyBuildUI && bp.pressed && (
+						(guihandler->activeBuildModifiers & (MOD_LINE | MOD_CIRCLE | MOD_BOX | MOD_HOLLOW_BOX)) != 0
+					);
+				if (legacyMultiBuild || actionMultiBuild) {
 					const float bpDist = CGround::LineGroundWaterCol(bp.camPos, bp.dir, maxTraceDist, buildeeDef->floatOnWater, false);
 					const float3 bPos = bp.camPos + bp.dir * bpDist;
 					const BuildInfo cInfo = BuildInfo(buildeeDef, cPos, buildFacing);

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2257,35 +2257,30 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 				// TODO: maybe also check out-of-range for immobile builder?
 				if (!CGameHelper::TestUnitBuildSquare(buildInfos[0], feature, gu->myAllyTeam, false))
 					return defaultRet;
-
-			}
-
-			if (preview || buildInfos.size() == 1) {
 				buildCommands.clear();
 				return CheckCommand(buildInfos.back().CreateCommand(CreateOptions(button)));
 			}
-			else {
-				// multi-command + batching: issue all commands but last; last is returned
-				bool shiftHeld = GetQueueKeystate();
-				unsigned char baseOpts = CreateOptions(button);
 
+			// handle multi-command batching if not preview
+			unsigned char baseOpts = CreateOptions(button);
+			if (!preview) {
+				bool shiftHeld = GetQueueKeystate();
 				for (auto it = buildInfos.cbegin(), end = --buildInfos.cend(); it != end; ++it) {
 					unsigned char opts = baseOpts;
 					// First command clears previous commands if shift isn't held; otherwise append with shift
 					if (it == buildInfos.cbegin() && !shiftHeld) {
-						opts &= ~SHIFT_KEY;      // clear once
+						opts &= ~SHIFT_KEY;   // clear once
 					} else {
-						opts |= SHIFT_KEY;       // append
+						opts |= SHIFT_KEY;    // append
 					}
 					GiveCommand(it->CreateCommand(opts));
 				}
-
-				// last command option = append
-				unsigned char lastOpts = baseOpts;
-				lastOpts |= SHIFT_KEY;
-				buildCommands.clear();
-				return CheckCommand(buildInfos.back().CreateCommand(lastOpts));
 			}
+			// finalize: last command always acts as append in multibuild
+			unsigned char lastOpts = baseOpts;
+			lastOpts |= SHIFT_KEY;  // batching branch also appends last
+			buildCommands.clear();
+			return CheckCommand(buildInfos.back().CreateCommand(lastOpts));
 		}
 
 		case CMDTYPE_ICON_UNIT: {
@@ -2634,19 +2629,14 @@ void CGuiHandler::BoxBuildPress() {
     if (!mouse->buttons[SDL_BUTTON_LEFT].pressed) {
         mouse->MousePress(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
         boxBuildClicking = true;
-        // GUI or minimap claims the press
-        boxBuildOwner = CInputReceiver::GetActiveReceiverRef();
     }
 }
 
 void CGuiHandler::BoxBuildRelease() {
 	// Only simulate release if mouse press was simulated
     if (boxBuildClicking) {
-		// Fix Mouse4/Mouse5 bind release misrouting from cross‑receiver multipress by adjusting ownership (keybinds like F14 unaffected)
-        CInputReceiver::GetActiveReceiverRef() = boxBuildOwner;
         mouse->MouseRelease(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
         boxBuildClicking = false;
-        boxBuildOwner = nullptr;
     }
     boxBuildMode = false;
 }

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1316,6 +1316,27 @@ void CGuiHandler::MouseRelease(int x, int y, int button, const float3& cameraPos
 	FinishCommand(button);
 }
 
+CGuiHandler::BuildState CGuiHandler::ParseBuildState(const std::string& arg) {
+    if (arg == "box")  return BuildState::Box;
+    if (arg == "line") return BuildState::Line;
+    return BuildState::Default;
+}
+
+void CGuiHandler::EnableBuildModifier(BuildState s) {
+    activeBuildStates.insert(s);
+    buildState = ResolveBuildState();
+}
+
+void CGuiHandler::DisableBuildModifier(BuildState s) {
+    activeBuildStates.erase(s);
+    buildState = ResolveBuildState();
+}
+
+CGuiHandler::BuildState CGuiHandler::ResolveBuildState() const {
+    if (activeBuildStates.count(BuildState::Box))  return BuildState::Box;
+    if (activeBuildStates.count(BuildState::Line)) return BuildState::Line;
+    return BuildState::Default;
+}
 
 bool CGuiHandler::SetActiveCommand(int cmdIndex, bool rightMouseButton)
 {
@@ -2236,7 +2257,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			const BuildInfo bi(unitdef, cameraPos + mouseDir * dist, buildFacing);
 
-			if ((GetQueueKeystate() && (button == SDL_BUTTON_LEFT)) || boxBuildMode) {
+			if ((GetQueueKeystate() && (button == SDL_BUTTON_LEFT)) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box) {
 				const float3 camTracePos = mouse->buttons[SDL_BUTTON_LEFT].camPos;
 				const float3 camTraceDir = mouse->buttons[SDL_BUTTON_LEFT].dir;
 
@@ -2575,7 +2596,7 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 		float xstep = (int)((0 < delta.x) ? xsize : -xsize);
 		float zstep = (int)((0 < delta.z) ? zsize : -zsize);
 
-		if (KeyInput::GetKeyModState(KMOD_ALT) || boxBuildMode){
+		if (KeyInput::GetKeyModState(KMOD_ALT) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box){
 			// build a (filled or hollow) rectangle
 			if (KeyInput::GetKeyModState(KMOD_CTRL)) {
 				if ((1 < xnum) && (1 < znum)) {
@@ -2621,24 +2642,6 @@ size_t CGuiHandler::GetBuildPositions(const BuildInfo& startInfo, const BuildInf
 	}
 
 	return (buildInfos.size());
-}
-
-void CGuiHandler::BoxBuildPress() {
-    boxBuildMode = true;
-	// Only simulate mouse press if mouse not pressed
-    if (!mouse->buttons[SDL_BUTTON_LEFT].pressed) {
-        mouse->MousePress(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-        boxBuildClicking = true;
-    }
-}
-
-void CGuiHandler::BoxBuildRelease() {
-	// Only simulate release if mouse press was simulated
-    if (boxBuildClicking) {
-        mouse->MouseRelease(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-        boxBuildClicking = false;
-    }
-    boxBuildMode = false;
 }
 
 void CGuiHandler::ProcessFrontPositions(float3& pos0, const float3& pos1)
@@ -3835,7 +3838,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 				const float3 cPos = tracePos + traceDir * rayTraceDist;
 
 				const CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
-				if ((GetQueueKeystate() && bp.pressed) || boxBuildMode) {
+				if ((GetQueueKeystate() && bp.pressed) || guihandler->GetBuildState() == CGuiHandler::BuildState::Box) {
 					const float bpDist = CGround::LineGroundWaterCol(bp.camPos, bp.dir, maxTraceDist, buildeeDef->floatOnWater, false);
 					const float3 bPos = bp.camPos + bp.dir * bpDist;
 					const BuildInfo cInfo = BuildInfo(buildeeDef, cPos, buildFacing);

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -46,6 +46,10 @@ public:
 		MouseRelease(x, y, button, camera->GetPos(), mouse->dir);
 	}
 	void MouseRelease(int x, int y, int button, const float3& cameraPos, const float3& mouseDir);
+
+	void BoxBuildPress();
+    void BoxBuildRelease();
+	
 	bool IsAbove(int x, int y);
 	std::string GetTooltip(int x, int y);
 	std::string GetBuildTooltip() const;
@@ -251,6 +255,8 @@ private:
 		Box visual;
 		Box selection;
 	};
+    bool boxBuildMode = false;
+    bool boxBuildPressed = false;
 
 	std::string menuName;
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -257,7 +257,6 @@ private:
 	};
     bool boxBuildMode = false;
     bool boxBuildClicking = false;
-	CInputReceiver* boxBuildOwner = nullptr;
 
 	std::string menuName;
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -256,7 +256,8 @@ private:
 		Box selection;
 	};
     bool boxBuildMode = false;
-    bool boxBuildPressed = false;
+    bool boxBuildClicking = false;
+	CInputReceiver* boxBuildOwner = nullptr;
 
 	std::string menuName;
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -4,6 +4,7 @@
 #define GUI_HANDLER_H
 
 #include <vector>
+#include <set>
 
 #include "KeySet.h"
 #include "InputReceiver.h"
@@ -28,6 +29,12 @@ class CGuiHandler : public CInputReceiver {
 public:
 	CGuiHandler();
 
+	enum class BuildState {
+        Default,
+        Box,
+		Line
+        // add more later
+    };
 	void Update();
 
 	void Draw();
@@ -46,9 +53,6 @@ public:
 		MouseRelease(x, y, button, camera->GetPos(), mouse->dir);
 	}
 	void MouseRelease(int x, int y, int button, const float3& cameraPos, const float3& mouseDir);
-
-	void BoxBuildPress();
-    void BoxBuildRelease();
 	
 	bool IsAbove(int x, int y);
 	std::string GetTooltip(int x, int y);
@@ -88,6 +92,11 @@ public:
 
 	bool GetGatherMode() const { return gatherMode; }
 	void SetGatherMode(bool value) { gatherMode = value; }
+
+	BuildState GetBuildState() const { return buildState; }
+	static BuildState ParseBuildState(const std::string& arg);
+    void EnableBuildModifier(BuildState s);
+    void DisableBuildModifier(BuildState s);
 
 	bool GetOutlineFonts() const { return outlineFonts; }
 
@@ -174,6 +183,8 @@ private:
 	int  GetIconPosCommand(int slot) const;
 	int  ParseIconSlot(const std::string& text) const;
 
+	BuildState ResolveBuildState() const;
+
 
 public:
 	int inCommand = -1;
@@ -187,6 +198,9 @@ private:
 	int defaultCmdMemory = -1;
 	int explicitCommand = -1;
 	int curIconCommand = -1;
+
+	BuildState buildState = BuildState::Default;   // current effective state
+    std::set<BuildState> activeBuildStates;        // disjoint flags
 
 	int actionOffset = 0;
 
@@ -255,8 +269,6 @@ private:
 		Box visual;
 		Box selection;
 	};
-    bool boxBuildMode = false;
-    bool boxBuildClicking = false;
 
 	std::string menuName;
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -4,7 +4,6 @@
 #define GUI_HANDLER_H
 
 #include <vector>
-#include <set>
 
 #include "KeySet.h"
 #include "InputReceiver.h"
@@ -29,12 +28,14 @@ class CGuiHandler : public CInputReceiver {
 public:
 	CGuiHandler();
 
-	enum class BuildState {
-        Default,
-        Box,
-		Line
-        // add more later
-    };
+	enum BuildModifier : uint32_t {
+		MOD_NONE       = 0,
+		MOD_LINE       = 1 << 0,
+		MOD_BOX        = 1 << 1,
+		MOD_CIRCLE     = 1 << 2,
+		MOD_HOLLOW_BOX = 1 << 3,
+		MOD_AXIS_LOCK  = 1 << 5,
+	};
 	void Update();
 
 	void Draw();
@@ -75,6 +76,7 @@ public:
 
 	bool LoadConfig(const std::string& cfg);
 	bool LoadDefaultConfig() { return (LoadConfig(DEFAULT_GUI_CONFIG)); }
+	void ConfigCommand(const std::string& line);
 	bool ReloadConfigFromFile(const std::string& fileName);
 	bool ReloadConfigFromString(const std::string& cfg);
 
@@ -93,10 +95,9 @@ public:
 	bool GetGatherMode() const { return gatherMode; }
 	void SetGatherMode(bool value) { gatherMode = value; }
 
-	BuildState GetBuildState() const { return buildState; }
-	static BuildState ParseBuildState(const std::string& arg);
-    void EnableBuildModifier(BuildState s);
-    void DisableBuildModifier(BuildState s);
+    void EnableBuildModifier(BuildModifier m) {activeBuildModifiers |= m;}
+	void DisableBuildModifier(BuildModifier m) {activeBuildModifiers &= ~m;}
+	static BuildModifier ParseBuildModifier(const std::string& arg);
 
 	bool GetOutlineFonts() const { return outlineFonts; }
 
@@ -183,7 +184,7 @@ private:
 	int  GetIconPosCommand(int slot) const;
 	int  ParseIconSlot(const std::string& text) const;
 
-	BuildState ResolveBuildState() const;
+	
 
 
 public:
@@ -199,8 +200,8 @@ private:
 	int explicitCommand = -1;
 	int curIconCommand = -1;
 
-	BuildState buildState = BuildState::Default;   // current effective state
-    std::set<BuildState> activeBuildStates;        // disjoint flags
+	uint32_t activeBuildModifiers = MOD_NONE; // bitmask of active modifiers
+	bool useLegacyBuildUI = true;
 
 	int actionOffset = 0;
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -152,6 +152,7 @@ static const DefaultBinding defaultBindings[] = {
 	{ "Shift+]", "buildfacing dec"  },
 	{   "Any+z", "buildspacing inc" },
 	{   "Any+x", "buildspacing dec" },
+	{   "Any+F14", "boxbuild" },
 
 	{            "a", "attack"       },
 	{      "Shift+a", "attack"       },

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -330,6 +330,18 @@ void FilterByKeychain(const ActionList & in, const CKeyChain & kc, ActionList & 
 			out.push_back(action);
 }
 
+ActionList CKeyBindings::GetModActionList() const
+{
+    ActionList out;
+    unsigned char currentMods = CKeySet::GetCurrentModifiers();
+
+    for (const auto& [required, actions] : modOnlyBindings) {
+        if ((currentMods & required) == required) {
+            out.insert(out.end(), actions.begin(), actions.end());
+        }
+    }
+    return out;
+}
 
 void MergeActionListsByTrigger(const ActionList& actionListA, const ActionList& actionListB, ActionList & out)
 {
@@ -424,6 +436,7 @@ ActionList CKeyBindings::GetActionList(const CKeyChain& kc) const
 	if (kc.empty())
 		return out;
 
+	// normal + any lookups...
 	const auto & al = GetActionList(kc.back(), false);
 	FilterByKeychain(al, kc, out);
 
@@ -652,6 +665,22 @@ bool CKeyBindings::Bind(const std::string& keystr, const std::string& line)
 	if (statefulCommands.find(action.command) != statefulCommands.end())
 		ks.SetAnyBit();
 
+	// Handle mod-only chords separately
+	if (ks.Mod() & CKeySet::KS_MODONLY) {
+		unsigned char required = ks.Mod() & ~CKeySet::KS_MODONLY;
+		ActionList& al = modOnlyBindings[required];
+
+		auto it = std::find_if(al.begin(), al.end(), [&action](const Action& a) {
+			return action.line == a.line;
+		});
+
+		if (it == al.end()) {
+			action.bindingIndex = ++bindingsCount;
+			al.push_back(action);
+		}
+		return true;
+	}
+	// If not mod-only, fall back to normal binding maps
 	KeyMap& bindings = ks.IsKeyCode() ? codeBindings : scanBindings;
 	AddActionToKeyMap(bindings, action);
 

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -152,7 +152,6 @@ static const DefaultBinding defaultBindings[] = {
 	{ "Shift+]", "buildfacing dec"  },
 	{   "Any+z", "buildspacing inc" },
 	{   "Any+x", "buildspacing dec" },
-	{   "Any+F14", "boxbuild" },
 
 	{            "a", "attack"       },
 	{      "Shift+a", "attack"       },

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -40,6 +40,7 @@ class CKeyBindings : public CommandReceiver
 		void Print() const;
 		void LoadDefaults();
 
+		ActionList GetModActionList() const;
 		ActionList GetActionList() const;
 		ActionList GetActionList(int keyCode, int scanCode) const;
 		ActionList GetActionList(int keyCode, int scanCode, unsigned char modifiers) const;
@@ -79,6 +80,7 @@ class CKeyBindings : public CommandReceiver
 
 		KeyMap codeBindings;
 		KeyMap scanBindings;
+		std::unordered_map<unsigned char, ActionList> modOnlyBindings;
 		ActionMap hotkeys;
 		std::vector<std::string> loadStack;
 		int bindingsCount;

--- a/rts/Game/UI/KeySet.cpp
+++ b/rts/Game/UI/KeySet.cpp
@@ -153,15 +153,16 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 	Reset();
 
 	std::string s = StringToLower(token);
+	bool sawModifier = false;
 
-	// parse the modifiers
+	// parse the modifiers down to base
 	while (!s.empty()) {
 		if (ParseModifier(s, "up+",    "u+")) { LOG_L(L_DEPRECATED, "KeySet: Up modifier is deprecated"); } else
 		if (ParseModifier(s, "any+",   "*+")) { modifiers |= KS_ANYMOD; } else
-		if (ParseModifier(s, "alt+",   "a+")) { modifiers |= KS_ALT; } else
-		if (ParseModifier(s, "ctrl+",  "c+")) { modifiers |= KS_CTRL; } else
-		if (ParseModifier(s, "meta+",  "m+")) { modifiers |= KS_META; } else
-		if (ParseModifier(s, "shift+", "s+")) { modifiers |= KS_SHIFT; } else {
+		if (ParseModifier(s, "alt+",   "a+")) { modifiers |= KS_ALT;   sawModifier = true;} else
+		if (ParseModifier(s, "ctrl+",  "c+")) { modifiers |= KS_CTRL;  sawModifier = true;} else
+		if (ParseModifier(s, "meta+",  "m+")) { modifiers |= KS_META;  sawModifier = true;} else
+		if (ParseModifier(s, "shift+", "s+")) { modifiers |= KS_SHIFT; sawModifier = true;} else {
 			break;
 		}
 	}
@@ -176,6 +177,7 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 	if ((s.size() >= 2) && (s[0] == '\'') && (s[s.size() - 1] == '\''))
 		s = s.substr(1, s.size() - 2);
 
+	//parse base
 	if (s.find("0x") == 0) {
 		type = KSKeyCode;
 
@@ -207,13 +209,23 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 		if (showerror) LOG_L(L_ERROR, "KeySet: Bad keysym: %s", s.c_str());
 		return false;
 	}
+	
+	// mod only chords: receive KS_MODONLY flag
+	if(sawModifier) {
+		switch (key) {
+			case SDLK_LALT:   modifiers = (modifiers | KS_ALT   | KS_MODONLY) & ~KS_ANYMOD; break;
+			case SDLK_LCTRL:  modifiers = (modifiers | KS_CTRL  | KS_MODONLY) & ~KS_ANYMOD; break;
+			case SDLK_LSHIFT: modifiers = (modifiers | KS_SHIFT | KS_MODONLY) & ~KS_ANYMOD; break;
+			default: if (IsModifier()) {modifiers |= KS_ANYMOD;} // legacy fallback for other modifier chords
+		}
+	}
+	else if (IsModifier()) {modifiers |= KS_ANYMOD;} // single modifier binds path
+	// else if KS_ANYMOD and sawModifier, KS_ANDMOD?
 
-	if (IsModifier())
-		modifiers |= KS_ANYMOD;
-
+	//keyset with KS_ANYMOD keeps base, clears modifier flags for processing
 	if (AnyMod())
 		ClearModifiers();
-	
+
 	return true;
 }
 

--- a/rts/Game/UI/KeySet.h
+++ b/rts/Game/UI/KeySet.h
@@ -36,7 +36,8 @@ class CKeySet {
 			KS_META    = (1 << 2),
 			KS_SHIFT   = (1 << 3),
 			KS_ANYMOD  = (1 << 4),
-			//KS_RELEASE = (1 << 5) Deprecated, need rework for enabling separate release bindings
+			KS_MODONLY = (1 << 5), // new: indicates a modifier-only chord
+    		//KS_RELEASE = (1 << 6) Deprecated, need rework for enabling separate release bindings
 		};
 
 		int  Key()     const { return key; }

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -334,6 +334,24 @@ void CMouseHandler::MousePress(int x, int y, int button)
 
 	pressedBitMask |= 1 << button;
 
+	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
+	if (isXButton) {
+
+		// 1. Lua first
+		if (luaInputReceiver->MousePress(x, y, button)) {
+			return;
+		}
+
+		// 2. GameInputReceiver via the same path as mouse buttons
+		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
+		if (activeControllerReceiver && activeControllerReceiver->MousePress(x, y, button)) {
+			// NOTE: X‑buttons bypass ownership so they can be pressed/released without stealing or confusing activeReceiver
+			return;
+		}
+		return;
+	}
+
+
 	if (activeReceiver != nullptr && activeReceiver->MousePress(x, y, button))
 		return;
 
@@ -500,6 +518,22 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 	}
 
 	if (RmlGui::ProcessMouseRelease(x, y, button)) {
+		return;
+	}
+
+	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
+	if (isXButton) {
+
+		// 1. Lua first
+		luaInputReceiver->MouseRelease(x, y, button);
+
+		// 2. GameInputReceiver via the same path as mouse buttons
+		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
+		if (activeControllerReceiver) {
+			activeControllerReceiver->MouseRelease(x, y, button);
+		}
+
+		// 3. Skip ownership funnel
 		return;
 	}
 

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -334,24 +334,6 @@ void CMouseHandler::MousePress(int x, int y, int button)
 
 	pressedBitMask |= 1 << button;
 
-	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
-	if (isXButton) {
-
-		// 1. Lua first
-		if (luaInputReceiver->MousePress(x, y, button)) {
-			return;
-		}
-
-		// 2. GameInputReceiver via the same path as mouse buttons
-		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
-		if (activeControllerReceiver && activeControllerReceiver->MousePress(x, y, button)) {
-			// NOTE: X‑buttons bypass ownership so they can be pressed/released without stealing or confusing activeReceiver
-			return;
-		}
-		return;
-	}
-
-
 	if (activeReceiver != nullptr && activeReceiver->MousePress(x, y, button))
 		return;
 
@@ -518,22 +500,6 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 	}
 
 	if (RmlGui::ProcessMouseRelease(x, y, button)) {
-		return;
-	}
-
-	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
-	if (isXButton) {
-
-		// 1. Lua first
-		luaInputReceiver->MouseRelease(x, y, button);
-
-		// 2. GameInputReceiver via the same path as mouse buttons
-		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
-		if (activeControllerReceiver) {
-			activeControllerReceiver->MouseRelease(x, y, button);
-		}
-
-		// 3. Skip ownership funnel
 		return;
 	}
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -768,6 +768,27 @@ private:
 };
 
 
+class BoxBuildActionExecutor : public IUnsyncedActionExecutor {
+public:
+    BoxBuildActionExecutor()
+      : IUnsyncedActionExecutor("boxbuild", "Enables box build placement mode") {}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		if (!action.IsRepeat() && guihandler != nullptr)
+			guihandler->BoxBuildPress();
+		return false;
+	}
+
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		if (guihandler != nullptr)
+			guihandler->BoxBuildRelease();
+		return false;
+	}
+};
+
+
+
+
 
 class AIKillReloadActionExecutor : public IUnsyncedActionExecutor {
 public:
@@ -4219,6 +4240,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaGaia"));
 	AddActionExecutor(AllocActionExecutor<CommandListActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<CommandHelpActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<BoxBuildActionExecutor>());
 }
 
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -768,24 +768,61 @@ private:
 };
 
 
+class BuildStateActionExecutor : public IUnsyncedActionExecutor {
+public:
+    BuildStateActionExecutor()
+      : IUnsyncedActionExecutor(
+            "build_state",
+            "Toggles build placement modifiers (e.g. 'box', 'line')"
+        ) {}
+    bool Execute(const UnsyncedAction& action) const final {
+        if (!guihandler) return false;
+        guihandler->EnableBuildModifier(
+            CGuiHandler::ParseBuildState(action.GetArgs())
+        );
+        return true;
+    }
+    bool ExecuteRelease(const UnsyncedAction& action) const final {
+        if (!guihandler) return false;
+        guihandler->DisableBuildModifier(
+            CGuiHandler::ParseBuildState(action.GetArgs())
+        );
+        return true;
+    }
+};
+
 class BoxBuildActionExecutor : public IUnsyncedActionExecutor {
 public:
     BoxBuildActionExecutor()
-      : IUnsyncedActionExecutor("boxbuild", "Enables box build placement mode") {}
+      : IUnsyncedActionExecutor("boxbuild", "Shortcut for 'build_state box' + mouse click") {}
 
-	bool Execute(const UnsyncedAction& action) const final {
-		if (!action.IsRepeat() && guihandler != nullptr)
-			guihandler->BoxBuildPress();
-		return false;
-	}
+    mutable bool boxBuildClicking = false;
 
-	bool ExecuteRelease(const UnsyncedAction& action) const final {
-		if (guihandler != nullptr)
-			guihandler->BoxBuildRelease();
-		return false;
-	}
+    bool Execute(const UnsyncedAction& action) const final {
+        if (!action.IsRepeat() && guihandler != nullptr) {
+            // Enable 'build_state box'
+            guihandler->EnableBuildModifier(CGuiHandler::ParseBuildState("box"));
+
+            // Simulate mouse press if not already pressed
+            if (!mouse->buttons[SDL_BUTTON_LEFT].pressed) {
+                mouse->MousePress(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
+                boxBuildClicking = true;
+            }
+        }
+        return false;
+    }
+
+    bool ExecuteRelease(const UnsyncedAction& action) const final {
+        if (guihandler != nullptr) {
+            if (boxBuildClicking) {
+                mouse->MouseRelease(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
+                boxBuildClicking = false;
+            }
+			guihandler->DisableBuildModifier(CGuiHandler::ParseBuildState("box"));
+        }
+        return false;
+    }
 };
-
 
 
 
@@ -4240,6 +4277,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaGaia"));
 	AddActionExecutor(AllocActionExecutor<CommandListActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<CommandHelpActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<BuildStateActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<BoxBuildActionExecutor>());
 }
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -767,65 +767,46 @@ private:
 	bool halt;
 };
 
-
 class BuildStateActionExecutor : public IUnsyncedActionExecutor {
 public:
     BuildStateActionExecutor()
       : IUnsyncedActionExecutor(
             "build_state",
-            "Toggles build placement modifiers (e.g. 'box', 'line')"
+            "Toggles build placement modifiers (e.g. 'box', 'line', 'circle'. Lua commands: call 'box r' for release)"
         ) {}
     bool Execute(const UnsyncedAction& action) const final {
-        if (!guihandler) return false;
-        guihandler->EnableBuildModifier(
-            CGuiHandler::ParseBuildState(action.GetArgs())
-        );
-        return true;
-    }
-    bool ExecuteRelease(const UnsyncedAction& action) const final {
-        if (!guihandler) return false;
-        guihandler->DisableBuildModifier(
-            CGuiHandler::ParseBuildState(action.GetArgs())
-        );
-        return true;
-    }
+		if (!guihandler) return false;
+		const std::string& args = action.GetArgs();
+		const size_t spacePos = args.find(' ');
+		if (spacePos == std::string::npos) {
+			guihandler->EnableBuildModifier(CGuiHandler::ParseBuildModifier(args));
+		} else {
+			const std::string modStr = args.substr(0, spacePos);
+			guihandler->DisableBuildModifier(CGuiHandler::ParseBuildModifier(modStr));
+		}
+		return false;
+	}
+	bool ExecuteRelease(const UnsyncedAction& action) const final {
+		if (!guihandler) return false;
+		guihandler->DisableBuildModifier(CGuiHandler::ParseBuildModifier(action.GetArgs()));
+		return false;
+	}
 };
 
-class BoxBuildActionExecutor : public IUnsyncedActionExecutor {
+class GuiHandlerConfigCommandExecutor : public IUnsyncedActionExecutor {
 public:
-    BoxBuildActionExecutor()
-      : IUnsyncedActionExecutor("boxbuild", "Shortcut for 'build_state box' + mouse click") {}
-
-    mutable bool boxBuildClicking = false;
+    GuiHandlerConfigCommandExecutor()
+      : IUnsyncedActionExecutor("guihandler",
+            "Subcommands to control GUI handler config", false, {
+                {"legacybuildui [0|1]", "Enable (1) or disable (0) legacy build UI. No argument toggles."},
+            }) {}
 
     bool Execute(const UnsyncedAction& action) const final {
-        if (!action.IsRepeat() && guihandler != nullptr) {
-            // Enable 'build_state box'
-            guihandler->EnableBuildModifier(CGuiHandler::ParseBuildState("box"));
-
-            // Simulate mouse press if not already pressed
-            if (!mouse->buttons[SDL_BUTTON_LEFT].pressed) {
-                mouse->MousePress(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-                boxBuildClicking = true;
-            }
-        }
-        return false;
-    }
-
-    bool ExecuteRelease(const UnsyncedAction& action) const final {
-        if (guihandler != nullptr) {
-            if (boxBuildClicking) {
-                mouse->MouseRelease(mouse->lastx, mouse->lasty, SDL_BUTTON_LEFT);
-                boxBuildClicking = false;
-            }
-			guihandler->DisableBuildModifier(CGuiHandler::ParseBuildState("box"));
-        }
-        return false;
+        if (!guihandler) return false;
+        guihandler->ConfigCommand(action.GetArgs());
+        return true;
     }
 };
-
-
-
 
 class AIKillReloadActionExecutor : public IUnsyncedActionExecutor {
 public:
@@ -4278,7 +4259,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<CommandListActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<CommandHelpActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<BuildStateActionExecutor>());
-	AddActionExecutor(AllocActionExecutor<BoxBuildActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<GuiHandlerConfigCommandExecutor>());
 }
 
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -256,6 +256,8 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(SetMouseCursor);
 	REGISTER_LUA_CFUNC(WarpMouse);
+	REGISTER_LUA_CFUNC(EmulateMousePress);
+	REGISTER_LUA_CFUNC(EmulateMouseRelease);
 
 	REGISTER_LUA_CFUNC(SetClipboard);
 
@@ -3021,6 +3023,40 @@ int LuaUnsyncedCtrl::SetCustomCommandDrawData(lua_State* L)
  * Mouse
  * @section mouse
 ******************************************************************************/
+
+/*** @function Spring.EmulateMousePress
+ * @param x number  (screen X coordinate, origin top‑left)
+ * @param y number  (screen Y coordinate, origin top‑left)
+ * @param button number (1=left, 2=middle, 3=right)
+ * @return nil
+ */
+int LuaUnsyncedCtrl::EmulateMousePress(lua_State* L) {
+    const int x = luaL_checkint(L, 1);
+    const int y = globalRendering->viewSizeY - luaL_checkint(L, 2) - 1;
+    const int button = luaL_checkint(L, 3);
+
+    if (mouse != nullptr) {
+        mouse->MousePress(x, y, button);
+    }
+    return 0;
+}
+
+/*** @function Spring.EmulateMouseRelease
+ * @param x number  (screen X coordinate, origin top‑left)
+ * @param y number  (screen Y coordinate, origin top‑left)
+ * @param button number (1=left, 2=middle, 3=right)
+ * @return nil
+ */
+int LuaUnsyncedCtrl::EmulateMouseRelease(lua_State* L) {
+    const int x = luaL_checkint(L, 1);
+    const int y = globalRendering->viewSizeY - luaL_checkint(L, 2) - 1;
+    const int button = luaL_checkint(L, 3);
+
+    if (mouse != nullptr) {
+        mouse->MouseRelease(x, y, button);
+    }
+    return 0;
+}
 
 
 /*** @function Spring.WarpMouse

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -149,7 +149,9 @@ class LuaUnsyncedCtrl {
 		static int SetLosViewColors(lua_State* L);
 
 		static int SetNanoProjectileParams(lua_State* L);
-
+		
+    	static int EmulateMousePress(lua_State* L);
+    	static int EmulateMouseRelease(lua_State* L);
 		static int WarpMouse(lua_State* L);
 
 		static int SetMouseCursor(lua_State* L);


### PR DESCRIPTION
### Summary
Previously known as "feat: add BoxBuild bind"
Unhardcodes the bindings for build mode selection exposing them via the action system
Includes requested "legacy mode"
Initially focused on boxbuild action, expanded to unhardcoding all build modes and fixing/allowing modifier-only chord general binds; modifier-only chord bind fix was split out

### Rationale
To allow:
Improving ergonomics for players by allowing boxbuild to be triggered via keybinds using a widget.

Future Widget Intention:
When you press boxbuild intended for mouse button, it clicks and does the filled rectangle action.
To build rectangles of 4 windmills with one click of the boxbuild keybind.
Or you can also click with mouse, press boxbuild, and it changes the mode instead of pressing alt.

### Testing
Verified locally that the bind triggers correctly with F14. BoxBuild widget (not included) calls Spring.EmulateMousePress and Spring.EmulateMouseRelease and command "build_state box" and "build_state box r" to execute the boxbuild action.

`uikeys.txt`:
bind            Any+F14  boxbuild
bind              shift  build_state line
bind         shift+ctrl  build_state circle
bind          shift+alt  build_state box
bind               ctrl  build_state axis_lock
bind     shift+ctrl+alt  build_state hollow_box

### Notes / Dependencies
This PR builds on top of https://github.com/beyond-all-reason/RecoilEngine/pull/2623
-required for modifier-only key bindings (e.g. shift+alt) to work correctly in general

Corresponding widget has (no PR) in the **BAR main repo**.
Widget Testing Notes:
- `Line-Build Hotkey Ignore` widget must whitelist the keybind.
- `Line-Build Hotkey Ignore` can be temporarily disabled until a whitelist update is merged.
- `Mouse Buildspacing` widget currently hardcodes MOUSE4/MOUSE5 for buildspacing changes.
- `Mouse Buildspacing` should be disabled you wish to use MOUSE4/MOUSE5 with the uikeys system.
- The earlier MouseHandler fixes for missed inputs using mouse4/5 binds have been split into a separate PR:
https://github.com/beyond-all-reason/RecoilEngine/pull/2613

### Commands
In-game command "/guihandler legacybuildui" toggles legacy and unhardcoded behavior
build behavior matches legacy

### Status (last updated: Sep 6)
- EmulateMousePress/Release is added [here](https://github.com/beyond-all-reason/RecoilEngine/pull/3097) but PR is not updated