### PR TITLE
Add/UseResourceRaw(teamID, resourceType, amount)

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -146,9 +146,9 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetTeamStartPosition);
 
 	REGISTER_LUA_CFUNC(AddTeamResource);
-	REGISTER_LUA_CFUNC(AddResourceRaw);
 	REGISTER_LUA_CFUNC(UseTeamResource);
-	REGISTER_LUA_CFUNC(UseResourceRaw);
+	REGISTER_LUA_CFUNC(AdjustTeamResourceStats);
+	REGISTER_LUA_CFUNC(AdjustUnitResourceStats);
 	REGISTER_LUA_CFUNC(SetTeamResource);
 	REGISTER_LUA_CFUNC(SetTeamShareLevel);
 	REGISTER_LUA_CFUNC(ShareTeamResource);
@@ -1135,8 +1135,7 @@ int LuaSyncedCtrl::SetWind(lua_State* L)
 	return 0;
 }
 
-/*** Adds metal or energy resources to the specified team.
- * Counts as production in post-game graph statistics.
+/*** Silently adds metal or energy resources to the specified team.
  *
  * @function Spring.AddTeamResource
  * @param teamID integer
@@ -1144,7 +1143,7 @@ int LuaSyncedCtrl::SetWind(lua_State* L)
  * @param amount number
  * @return nil
  */
-int LuaSyncedCtrl::AddResourceRaw(lua_State* L)
+int LuaSyncedCtrl::AddTeamResource(lua_State* L)
 {
 	const int teamID = luaL_checkint(L, 1);
 
@@ -1171,8 +1170,15 @@ int LuaSyncedCtrl::AddResourceRaw(lua_State* L)
 
 	return 0;
 }
-
-int LuaSyncedCtrl::UseResourceRaw(lua_State* L)
+/*** Silently removes metal or energy resources to the specified team.
+ *
+ * @function Spring.UseTeamResource
+ * @param teamID integer
+ * @param type ResourceName
+ * @param amount number
+ * @return nil
+ */
+int LuaSyncedCtrl::UseTeamResource(lua_State* L)
 {
 	const int teamID = luaL_checkint(L, 1);
 
@@ -1200,7 +1206,17 @@ int LuaSyncedCtrl::UseResourceRaw(lua_State* L)
 	return 0;
 }
 
-int LuaSyncedCtrl::AddTeamResource(lua_State* L)
+/*** Adds (or removes in case of value < 0) value to the team's resource stats
+*
+@function Spring.AdjustTeamResourceStats
+@param teamID integer
+@param type resourceName
+@param stat resourceStatName
+@param amount number
+@return nil
+*/
+
+int LuaSyncedCtrl::AdjustTeamResourceStats(lua_State* L)
 {
 	const int teamID = luaL_checkint(L, 1);
 
@@ -1209,120 +1225,81 @@ int LuaSyncedCtrl::AddTeamResource(lua_State* L)
 
 	if (!CanControlTeam(L, teamID))
 		return 0;
-
+		
 	CTeam* team = teamHandler.Team(teamID);
-
+	
 	if (team == nullptr)
 		return 0;
 
 	const char* type = luaL_checkstring(L, 2);
-
-	const float value = max(0.0f, luaL_checkfloat(L, 3));
+	const char* stat = luaL_checkstring(L, 3);
+	const float value = luaL_checkfloat(L, 4);
 
 	switch (type[0]) {
-		case 'm': { team->AddMetal (value); } break;
-		case 'e': { team->AddEnergy(value); } break;
-		default : {                         } break;
+		case 'm': { // metal
+			switch (stat[0]) {
+				case 'o': team->resExcess.metal    += value; break;
+				case 'r': team->resReceived.metal  += value; break;
+				case 's': team->resSent.metal      += value; break;
+				case 'e': team->resExpense.metal      += value; break;
+				case 'i': team->resIncome.metal  += value; break;
+				case 'p': team->resPull.metal  += value; break;
+				default: break;
+			}
+			break;
+		}
+
+		case 'e': { // energy
+			switch (stat[0]) {
+				case 'o': team->resExcess.energy    += value; break;
+				case 'r': team->resReceived.energy  += value; break;
+				case 's': team->resSent.energy      += value; break;
+				case 'e': team->resExpense.energy      += value; break;
+				case 'i': team->resIncome.energy  += value; break;
+				case 'p': team->resPull.energy  += value; break;
+				default: break;
+			}
+			break;
+		}
+		default: break;
 	}
 
-	return 0;
+    return 0;
 }
 
-/***
- * Consumes metal or energy resources of the specified team.
- * Counts as usage in post-game graph statistics.
- *
- * @function Spring.UseTeamResource
- * @param teamID integer
- * @param type ResourceName Resource type.
- * @param amount number Amount of resource to use.
- * @return boolean hadEnough
- * True if enough of the resource type was available and was consumed, otherwise false.
- */
-/***
- * Consumes metal and/or energy resources of the specified team.
- * Counts as usage in post-game graph statistics.
- *
- * @function Spring.UseTeamResource
- * @param teamID integer
- * @param amount ResourceUsage
- * @return boolean hadEnough
- * True if enough of the resource type(s) were available and was consumed, otherwise false.
- */
-int LuaSyncedCtrl::UseTeamResource(lua_State* L)
+int LuaSyncedCtrl::AdjustUnitResourceStats(lua_State* L)
 {
-	const int teamID = luaL_checkint(L, 1);
+	CUnit* unit = ParseUnit(L, __func__, 1);
 
-	if (!teamHandler.IsValidTeam(teamID))
+	if (unit == nullptr)
 		return 0;
 
-	if (!CanControlTeam(L, teamID))
-		return 0;
+	const char* type = luaL_checkstring(L, 2);
+	const char* stat = luaL_checkstring(L, 3);
+	const float value = luaL_checkfloat(L, 4);
 
-	CTeam* team = teamHandler.Team(teamID);
-
-	if (team == nullptr)
-		return 0;
-
-	if (lua_isstring(L, 2)) {
-		const char* type = lua_tostring(L, 2);
-
-		const float value = std::max(0.0f, luaL_checkfloat(L, 3));
-
-		switch (type[0]) {
-			case 'm': {
-				team->resPull.metal += value;
-				lua_pushboolean(L, team->UseMetal(value));
-				return 1;
-			} break;
-			case 'e': {
-				team->resPull.energy += value;
-				lua_pushboolean(L, team->UseEnergy(value));
-				return 1;
-			} break;
-			default: {
-			} break;
-		}
-
-		return 0;
-	}
-
-	if (lua_istable(L, 2)) {
-		float metal  = 0.0f;
-		float energy = 0.0f;
-
-		constexpr int tableIdx = 2;
-
-		for (lua_pushnil(L); lua_next(L, tableIdx) != 0; lua_pop(L, 1)) {
-			if (!lua_israwstring(L, LUA_TABLE_KEY_INDEX) || !lua_isnumber(L, LUA_TABLE_VALUE_INDEX))
-				continue;
-
-			const char* key = lua_tostring(L, LUA_TABLE_KEY_INDEX);
-			const float value = lua_tofloat(L, LUA_TABLE_VALUE_INDEX);
-
-			switch (key[0]) {
-				case 'm': { metal  = std::max(0.0f, value); } break;
-				case 'e': { energy = std::max(0.0f, value); } break;
-				default : {                                 } break;
+	switch (type[0]) {
+		case 'm': { // metal
+			switch (stat[0]) {
+				case 'u': unit->resourcesUseI.metal    += value; break;
+				case 'm': unit->resourcesMakeI.metal  += value; break;
+				default: break;
 			}
+			break;
 		}
 
-		team->resPull.metal  += metal;
-		team->resPull.energy += energy;
-
-		if ((team->res.metal >= metal) && (team->res.energy >= energy)) {
-			team->UseMetal(metal);
-			team->UseEnergy(energy);
-			lua_pushboolean(L, true);
-		} else {
-			lua_pushboolean(L, false);
+		case 'e': { // energy
+			switch (stat[0]) {
+				case 'u': unit->resourcesUseI.energy    += value; break;
+				case 'm': unit->resourcesMakeI.energy  += value; break;
+				default: break;
+			}
+			break;
 		}
-
-		return 1;
+		default: break;
 	}
 
-	luaL_error(L, "bad arguments");
-	return 0;
+    return 0;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -146,7 +146,9 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetTeamStartPosition);
 
 	REGISTER_LUA_CFUNC(AddTeamResource);
+	REGISTER_LUA_CFUNC(AddResourceRaw);
 	REGISTER_LUA_CFUNC(UseTeamResource);
+	REGISTER_LUA_CFUNC(UseResourceRaw);
 	REGISTER_LUA_CFUNC(SetTeamResource);
 	REGISTER_LUA_CFUNC(SetTeamShareLevel);
 	REGISTER_LUA_CFUNC(ShareTeamResource);
@@ -1142,6 +1144,62 @@ int LuaSyncedCtrl::SetWind(lua_State* L)
  * @param amount number
  * @return nil
  */
+int LuaSyncedCtrl::AddResourceRaw(lua_State* L)
+{
+	const int teamID = luaL_checkint(L, 1);
+
+	if (!teamHandler.IsValidTeam(teamID))
+		return 0;
+
+	if (!CanControlTeam(L, teamID))
+		return 0;
+
+	CTeam* team = teamHandler.Team(teamID);
+
+	if (team == nullptr)
+		return 0;
+
+	const char* type = luaL_checkstring(L, 2);
+
+	const float value = max(0.0f, luaL_checkfloat(L, 3));
+
+	switch (type[0]) {
+		case 'm': { team->res.metal += value; } break;
+		case 'e': { team->res.energy += value; } break;
+		default : {                         } break;
+	}
+
+	return 0;
+}
+
+int LuaSyncedCtrl::UseResourceRaw(lua_State* L)
+{
+	const int teamID = luaL_checkint(L, 1);
+
+	if (!teamHandler.IsValidTeam(teamID))
+		return 0;
+
+	if (!CanControlTeam(L, teamID))
+		return 0;
+
+	CTeam* team = teamHandler.Team(teamID);
+
+	if (team == nullptr)
+		return 0;
+
+	const char* type = luaL_checkstring(L, 2);
+
+	const float value = max(0.0f, luaL_checkfloat(L, 3));
+
+	switch (type[0]) {
+		case 'm': { team->res.metal -= value; } break;
+		case 'e': { team->res.energy -= value; } break;
+		default : {                         } break;
+	}
+
+	return 0;
+}
+
 int LuaSyncedCtrl::AddTeamResource(lua_State* L)
 {
 	const int teamID = luaL_checkint(L, 1);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -48,8 +48,8 @@ class LuaSyncedCtrl
 
 		static int AddTeamResource(lua_State* L);
 		static int UseTeamResource(lua_State* L);
-		static int AddResourceRaw(lua_State* L);
-		static int UseResourceRaw(lua_State* L);
+		static int AdjustTeamResourceStats(lua_State* L);
+		static int AdjustUnitResourceStats(lua_State* L);
 		static int SetTeamResource(lua_State* L);
 		static int SetTeamShareLevel(lua_State* L);
 		static int ShareTeamResource(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -48,6 +48,8 @@ class LuaSyncedCtrl
 
 		static int AddTeamResource(lua_State* L);
 		static int UseTeamResource(lua_State* L);
+		static int AddResourceRaw(lua_State* L);
+		static int UseResourceRaw(lua_State* L);
 		static int SetTeamResource(lua_State* L);
 		static int SetTeamShareLevel(lua_State* L);
 		static int ShareTeamResource(lua_State* L);

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -49,6 +49,7 @@ CR_REG_METADATA(CTeam, (
 	CR_MEMBER(resPrevSent),
 	CR_MEMBER(resReceived),
 	CR_MEMBER(resPrevReceived),
+	CR_MEMBER(resExcess),
 	CR_MEMBER(resPrevExcess),
 	CR_MEMBER(nextHistoryEntry),
 	CR_MEMBER(statHistory),
@@ -325,6 +326,11 @@ void CTeam::ResetResourceState()
 	resPrevReceived.metal = resReceived.metal; resReceived.metal = 0.0f;
 	resPrevSent.energy = resSent.energy; resSent.energy = 0.0f;
 	resPrevReceived.energy = resReceived.energy; resReceived.energy = 0.0f;
+
+	// reset the excess accumulators after logging into previous stats
+	resPrevExcess.energy = resExcess.energy; resExcess.energy = 0.0f;
+	resPrevExcess.metal = resExcess.metal; resExcess.metal = 0.0f;
+
 }
 
 void CTeam::SlowUpdate()
@@ -354,6 +360,8 @@ void CTeam::SlowUpdate()
 	currentStats.energyProduced += resPrevIncome.energy;
 	currentStats.metalUsed  += resPrevExpense.metal;
 	currentStats.energyUsed += resPrevExpense.energy;
+	currentStats.metalExcess += resPrevExcess.metal; // Log previous excess into currentStats
+	currentStats.energyExcess += resPrevExcess.energy; // Log previous excess into currentStats
 
 	res.metal  += resDelayedShare.metal;  resDelayedShare.metal  = 0.0f;
 	res.energy += resDelayedShare.energy; resDelayedShare.energy = 0.0f;
@@ -395,19 +403,15 @@ void CTeam::SlowUpdate()
 	}
 
 	// clamp resource levels to storage capacity
+	// we did not need to accumulate excess as excess was only handled here up until now
+	// But if we want to be able to add excess value to the logs, we need to register resExcess accumulator and process that excess just like we would any other stat
 	if (res.metal > resStorage.metal) {
-		resPrevExcess.metal = (res.metal - resStorage.metal);
-		currentStats.metalExcess += resPrevExcess.metal;
+		resExcess.metal += (res.metal - resStorage.metal); // Accumulate excess into the accumulator
 		res.metal = resStorage.metal;
-	} else {
-		resPrevExcess.metal = 0;
 	}
 	if (res.energy > resStorage.energy) {
-		resPrevExcess.energy = (res.energy - resStorage.energy);
-		currentStats.energyExcess += resPrevExcess.energy;
+		resExcess.energy += (res.energy - resStorage.energy); // Accumulate excess into the accumulator
 		res.energy = resStorage.energy;
-	} else {
-		resPrevExcess.energy = 0;
 	}
 
 	// make sure the stats update is always in a SlowUpdate

--- a/rts/Sim/Misc/Team.h
+++ b/rts/Sim/Misc/Team.h
@@ -91,6 +91,7 @@ public:
 	SResourcePack resDelayedShare; //< excess that might be shared next SlowUpdate
 	SResourcePack resSent,     resPrevSent;
 	SResourcePack resReceived, resPrevReceived;
+	SResourcePack resExcess;
 	SResourcePack resPrevExcess;
 
 	int nextHistoryEntry;


### PR DESCRIPTION
Create a function to silently add or remove resources, regardless of current or storage, and without showing into endgame stats

A custom function from gadget can be made to almost replicate this but would still be constrained by resCurrent and resStorage values.

I think the edge cases where we'd really "need" (in opposition to "want") to ignore such limitations are niche.

Still, an exemple of use case:
> We know there is un upcoming income (ie in an "instantaneous" allowfeaturebuildstep reclaim frame)
> We want to partially negate it, but not entirely (ie apply a 50% taxatation on the income)
> We have to do it simultaneously, delaying the "tax" could involve allowed buildsteps / weapon firing that otherwise wouldn't have been allowed.
> We can't delay the profitable outcome to wether or not the "tax" has been paid beforehand.
> We UseResourceRaw beforehand (setting us in a res < 0 situation) and our profit instantly pops, setting us back in a res > 0 situation

Another exemple would be.
local energy, metal = excess that have been previously registered and accumulated via teamresourceexcess
AddResourceRaw(teamID, "m", metal)
AddResourceRaw(teamID, "e", energy)
=> We can now burn through those resources via ShareTeamResources or any kind of UseResource() up until we reached resShare level, rather than having to pull 2 different functions for wether we're dealing with excess or storage-resShare values.