### PR TITLE
fix(MouseHandler): route XButtons (Mouse4/5) as keybinds instead of mouse ownership

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -334,6 +334,24 @@ void CMouseHandler::MousePress(int x, int y, int button)
 
 	pressedBitMask |= 1 << button;
 
+	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
+	if (isXButton) {
+
+		// 1. Lua first
+		if (luaInputReceiver->MousePress(x, y, button)) {
+			return;
+		}
+
+		// 2. GameInputReceiver via the same path as mouse buttons
+		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
+		if (activeControllerReceiver && activeControllerReceiver->MousePress(x, y, button)) {
+			// NOTE: X‑buttons bypass ownership so they can be pressed/released without stealing or confusing activeReceiver
+			return;
+		}
+		return;
+	}
+
+
 	if (activeReceiver != nullptr && activeReceiver->MousePress(x, y, button))
 		return;
 
@@ -500,6 +518,22 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 	}
 
 	if (RmlGui::ProcessMouseRelease(x, y, button)) {
+		return;
+	}
+
+	const bool isXButton = (button == SDL_BUTTON_X1 || button == SDL_BUTTON_X2);
+	if (isXButton) {
+
+		// 1. Lua first
+		luaInputReceiver->MouseRelease(x, y, button);
+
+		// 2. GameInputReceiver via the same path as mouse buttons
+		auto activeControllerReceiver = (activeController == nullptr) ? nullptr : activeController->GetInputReceiver();
+		if (activeControllerReceiver) {
+			activeControllerReceiver->MouseRelease(x, y, button);
+		}
+
+		// 3. Skip ownership funnel
 		return;
 	}
 


### PR DESCRIPTION
### Summary
Adjusts MouseHandler so that XButtons (Mouse4/5) are routed like keybinds instead of sharing mouse ownership.

### Rationale
When bound through uikeys, Mouse4/5 attempt to assign ownership to `GameInputReceiver`. This causes misrouting when pressed in combination with other mouse inputs. By routing them through the keybind path and bypassing ownership, XButtons can be pressed/released without stealing or confusing the active receiver.

### Scope
- Changes limited to `MouseHandler.cpp`
- No new binds or widget logic introduced
- Purely input routing fix

### Testing
- Verified bound mouse4 through uikeys allowed simultaneous mouse presses without skipped inputs of mouse4 or LMB
- Existing mouse button behavior unchanged

### Notes / Dependencies
- `Mouse Buildspacing` widget currently hardcodes MOUSE4/MOUSE5 for buildspacing changes; it should be disabled if testing MOUSE4/MOUSE5 with the uikeys system.
[gui_buildspacing.lua](https://github.com/beyond-all-reason/Beyond-All-Reason/blob/0218c6c52e49c2b98fc6c2084511d7f176106280/luaui/Widgets/gui_buildspacing.lua)