### PR TITLE
fix: implement modifier-only chord bindings for action system

### DIFF
--- a/rts/Game/GameInputReceiver.cpp
+++ b/rts/Game/GameInputReceiver.cpp
@@ -35,7 +35,30 @@ bool CGameInputReceiver::KeyPressed(int keyCode, int scanCode, bool isRepeat)
 	curKeyCodeChain.push_back(kc, spring_gettime(), isRepeat);
 	curScanCodeChain.push_back(ks, spring_gettime(), isRepeat);
 
-	lastActionList = keyBindings.GetActionList(curKeyCodeChain, curScanCodeChain);
+	// --- NEW: modifier-only handling ---
+	ActionList modOnlyPresses;
+
+	if (kc.IsModifier()) {
+		auto modActions = keyBindings.GetModActionList();
+
+		for (auto& a : modActions) {
+			auto it = std::find_if(activeModOnly.begin(), activeModOnly.end(),
+								[&](const Action& existing) {
+									return existing.bindingIndex  == a.bindingIndex ;
+								});
+
+			if (it == activeModOnly.end()) {
+				modOnlyPresses.push_back(a);   // collect for unified handling
+				activeModOnly.push_back(a);
+			}
+		}
+	}
+	// -----------------------------------
+
+	// Build lastActionList as [mod-only presses] + [normal presses]
+	lastActionList = modOnlyPresses;
+	ActionList normal = keyBindings.GetActionList(curKeyCodeChain, curScanCodeChain);
+	lastActionList.insert(lastActionList.end(), normal.begin(), normal.end());
 
 	if (RmlGui::ProcessKeyPressed(keyCode, scanCode, isRepeat))
 		return false;
@@ -64,8 +87,35 @@ bool CGameInputReceiver::KeyReleased(int keyCode, int scanCode)
 	if (gameTextInput.ConsumeReleasedKey(keyCode, scanCode))
 		return false;
 
+	// --- NEW: modifier-only handling ---
+	ActionList releasedMods;
+	const CKeySet kc(keyCode, CKeySet::KSKeyCode);
+
+	if (kc.IsModifier()) {
+		auto modActions = keyBindings.GetModActionList();
+
+		for (auto it = activeModOnly.begin(); it != activeModOnly.end(); ) {
+			// check if this active action is still present in the current modActions
+			auto found = std::find_if(modActions.begin(), modActions.end(),
+									[&](const Action& a) {
+										return a.bindingIndex  == it->bindingIndex ;
+									});
+
+			if (found == modActions.end()) {
+				releasedMods.push_back(*it);   // collect for unified handling
+				it = activeModOnly.erase(it);
+			} else {
+				++it;
+			}
+		}
+	}
+	// -----------------------------------
+
+    // Build lastActionList as [mod-only releases] + [normal releases]
 	// update actionlist for lua consumer
-	lastActionList = keyBindings.GetActionList(keyCode, scanCode);
+    lastActionList = releasedMods;
+    ActionList normal = keyBindings.GetActionList(keyCode, scanCode);
+    lastActionList.insert(lastActionList.end(), normal.begin(), normal.end());
 
 	if (luaInputReceiver->KeyReleased(keyCode, scanCode))
 		return false;

--- a/rts/Game/GameInputReceiver.h
+++ b/rts/Game/GameInputReceiver.h
@@ -22,6 +22,7 @@ public:
 	ActionList lastActionList;
 private:
 	bool TryOnPressActions(bool isRepeat);
+	ActionList activeModOnly;
 
 	CTimedKeyChain curKeyCodeChain;
 	CTimedKeyChain curScanCodeChain;

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -330,6 +330,18 @@ void FilterByKeychain(const ActionList & in, const CKeyChain & kc, ActionList & 
 			out.push_back(action);
 }
 
+ActionList CKeyBindings::GetModActionList() const
+{
+    ActionList out;
+    unsigned char currentMods = CKeySet::GetCurrentModifiers();
+
+    for (const auto& [required, actions] : modOnlyBindings) {
+        if ((currentMods & required) == required) {
+            out.insert(out.end(), actions.begin(), actions.end());
+        }
+    }
+    return out;
+}
 
 void MergeActionListsByTrigger(const ActionList& actionListA, const ActionList& actionListB, ActionList & out)
 {
@@ -424,6 +436,7 @@ ActionList CKeyBindings::GetActionList(const CKeyChain& kc) const
 	if (kc.empty())
 		return out;
 
+	// normal + any lookups...
 	const auto & al = GetActionList(kc.back(), false);
 	FilterByKeychain(al, kc, out);
 
@@ -652,6 +665,22 @@ bool CKeyBindings::Bind(const std::string& keystr, const std::string& line)
 	if (statefulCommands.find(action.command) != statefulCommands.end())
 		ks.SetAnyBit();
 
+	// Handle mod-only chords separately
+	if (ks.Mod() & CKeySet::KS_MODONLY) {
+		unsigned char required = ks.Mod() & ~CKeySet::KS_MODONLY;
+		ActionList& al = modOnlyBindings[required];
+
+		auto it = std::find_if(al.begin(), al.end(), [&action](const Action& a) {
+			return action.line == a.line;
+		});
+
+		if (it == al.end()) {
+			action.bindingIndex = ++bindingsCount;
+			al.push_back(action);
+		}
+		return true;
+	}
+	// If not mod-only, fall back to normal binding maps
 	KeyMap& bindings = ks.IsKeyCode() ? codeBindings : scanBindings;
 	AddActionToKeyMap(bindings, action);
 

--- a/rts/Game/UI/KeyBindings.h
+++ b/rts/Game/UI/KeyBindings.h
@@ -40,6 +40,7 @@ class CKeyBindings : public CommandReceiver
 		void Print() const;
 		void LoadDefaults();
 
+		ActionList GetModActionList() const;
 		ActionList GetActionList() const;
 		ActionList GetActionList(int keyCode, int scanCode) const;
 		ActionList GetActionList(int keyCode, int scanCode, unsigned char modifiers) const;
@@ -79,6 +80,7 @@ class CKeyBindings : public CommandReceiver
 
 		KeyMap codeBindings;
 		KeyMap scanBindings;
+		std::unordered_map<unsigned char, ActionList> modOnlyBindings;
 		ActionMap hotkeys;
 		std::vector<std::string> loadStack;
 		int bindingsCount;

--- a/rts/Game/UI/KeySet.cpp
+++ b/rts/Game/UI/KeySet.cpp
@@ -153,15 +153,16 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 	Reset();
 
 	std::string s = StringToLower(token);
+	bool sawModifier = false;
 
-	// parse the modifiers
+	// parse the modifiers down to base
 	while (!s.empty()) {
 		if (ParseModifier(s, "up+",    "u+")) { LOG_L(L_DEPRECATED, "KeySet: Up modifier is deprecated"); } else
 		if (ParseModifier(s, "any+",   "*+")) { modifiers |= KS_ANYMOD; } else
-		if (ParseModifier(s, "alt+",   "a+")) { modifiers |= KS_ALT; } else
-		if (ParseModifier(s, "ctrl+",  "c+")) { modifiers |= KS_CTRL; } else
-		if (ParseModifier(s, "meta+",  "m+")) { modifiers |= KS_META; } else
-		if (ParseModifier(s, "shift+", "s+")) { modifiers |= KS_SHIFT; } else {
+		if (ParseModifier(s, "alt+",   "a+")) { modifiers |= KS_ALT;   sawModifier = true;} else
+		if (ParseModifier(s, "ctrl+",  "c+")) { modifiers |= KS_CTRL;  sawModifier = true;} else
+		if (ParseModifier(s, "meta+",  "m+")) { modifiers |= KS_META;  sawModifier = true;} else
+		if (ParseModifier(s, "shift+", "s+")) { modifiers |= KS_SHIFT; sawModifier = true;} else {
 			break;
 		}
 	}
@@ -176,6 +177,7 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 	if ((s.size() >= 2) && (s[0] == '\'') && (s[s.size() - 1] == '\''))
 		s = s.substr(1, s.size() - 2);
 
+	//parse base
 	if (s.find("0x") == 0) {
 		type = KSKeyCode;
 
@@ -207,13 +209,23 @@ bool CKeySet::Parse(const std::string& token, bool showerror)
 		if (showerror) LOG_L(L_ERROR, "KeySet: Bad keysym: %s", s.c_str());
 		return false;
 	}
+	
+	// mod only chords: receive KS_MODONLY flag
+	if(sawModifier) {
+		switch (key) {
+			case SDLK_LALT:   modifiers = (modifiers | KS_ALT   | KS_MODONLY) & ~KS_ANYMOD; break;
+			case SDLK_LCTRL:  modifiers = (modifiers | KS_CTRL  | KS_MODONLY) & ~KS_ANYMOD; break;
+			case SDLK_LSHIFT: modifiers = (modifiers | KS_SHIFT | KS_MODONLY) & ~KS_ANYMOD; break;
+			default: if (IsModifier()) {modifiers |= KS_ANYMOD;} // legacy fallback for other modifier chords
+		}
+	}
+	else if (IsModifier()) {modifiers |= KS_ANYMOD;} // single modifier binds path
+	// else if KS_ANYMOD and sawModifier, KS_ANDMOD?
 
-	if (IsModifier())
-		modifiers |= KS_ANYMOD;
-
+	//keyset with KS_ANYMOD keeps base, clears modifier flags for processing
 	if (AnyMod())
 		ClearModifiers();
-	
+
 	return true;
 }
 

--- a/rts/Game/UI/KeySet.h
+++ b/rts/Game/UI/KeySet.h
@@ -36,7 +36,8 @@ class CKeySet {
 			KS_META    = (1 << 2),
 			KS_SHIFT   = (1 << 3),
 			KS_ANYMOD  = (1 << 4),
-			//KS_RELEASE = (1 << 5) Deprecated, need rework for enabling separate release bindings
+			KS_MODONLY = (1 << 5), // new: indicates a modifier-only chord
+    		//KS_RELEASE = (1 << 6) Deprecated, need rework for enabling separate release bindings
 		};
 
 		int  Key()     const { return key; }


### PR DESCRIPTION
### Summary
Fixes handling of **modifier‑only chord keybinds** in the input system, ensuring they integrate correctly with the action system. Particularly, they now require all designated keys to be pressed, and `action released` is triggered when the conditions are no longer met, i.e. the player released the chord

### Rationale
Previously, modifier-only chords were treated internally the same as single-modifier keybinds, given the "any" flag and only the base key saved, all additional data stripped. This resulted in alt triggering (shift+alt) keybinds.

New changes:
Modifier chords are routed and processed so that both "shift released" and "alt released" both trigger `action released` for  (shift+alt) binds, which wasn't supported in the solely "base-key" centric binding system.

### Testing
Verified that modifier-only chords press and release correctly, allowing mirroring of legacy build state selection through the keybinding system. The other pr builds on this one and unhardcodes the hardcoded binds for build state changes.

`uikeys.txt`:
bind              shift  build_state line
bind         shift+ctrl  build_state circle
bind          shift+alt  build_state box
bind               ctrl  build_state axis_lock
bind     shift+ctrl+alt  build_state hollow_box

### Notes / Dependencies
https://github.com/beyond-all-reason/RecoilEngine/pull/2603 Build mode unhardcoding depends on this fix