### PR TITLE
feat(Synced): Add DropCurrentUnitAutoTargets for finer control

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3578,7 +3578,7 @@ int LuaSyncedCtrl::SetUnitTarget(lua_State* L)
 /***
  * @function Spring.DropCurrentUnitAutoTargets
  * @param unitID integer
- * @ return nil
+ * @return nil
  */
  
 int LuaSyncedCtrl::DropCurrentUnitAutoTargets(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -212,6 +212,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(ClearUnitGoal);
 	REGISTER_LUA_CFUNC(SetUnitNeutral);
 	REGISTER_LUA_CFUNC(SetUnitTarget);
+	REGISTER_LUA_CFUNC(DropCurrentUnitAutoTargets);
 	REGISTER_LUA_CFUNC(SetUnitMidAndAimPos);
 	REGISTER_LUA_CFUNC(SetUnitRadiusAndHeight);
 	REGISTER_LUA_CFUNC(SetUnitBuildeeRadius);
@@ -3572,6 +3573,23 @@ int LuaSyncedCtrl::SetUnitTarget(lua_State* L)
 		return 1;
 	}
 	return 0;
+}
+
+/***
+ * @function Spring.DropCurrentUnitAutoTargets
+ * @param unitID integer
+ * @ return nil
+ */
+ 
+void LuaSyncedCtrl::DropCurrentUnitAutoTargets(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+	if (unit == nullptr)
+		return 0;
+	
+	unit->DropCurrentAutoTarget();
+	
+	return 0,
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3581,7 +3581,7 @@ int LuaSyncedCtrl::SetUnitTarget(lua_State* L)
  * @ return nil
  */
  
-void LuaSyncedCtrl::DropCurrentUnitAutoTargets(lua_State* L)
+int LuaSyncedCtrl::DropCurrentUnitAutoTargets(lua_State* L)
 {
 	CUnit* unit = ParseUnit(L, __func__, 1);
 	if (unit == nullptr)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3589,7 +3589,7 @@ int LuaSyncedCtrl::DropCurrentUnitAutoTargets(lua_State* L)
 	
 	unit->DropCurrentAutoTarget();
 	
-	return 0,
+	return 0;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -123,7 +123,7 @@ class LuaSyncedCtrl
 		static int ClearUnitGoal(lua_State* L);
 		static int SetUnitNeutral(lua_State* L);
 		static int SetUnitTarget(lua_State* L);
-		static void DropCurrentAutoTargets(lua_State* L);
+		static int DropCurrentUnitAutoTargets(lua_State* L);
 		static int SetUnitMidAndAimPos(lua_State* L);
 		static int SetUnitRadiusAndHeight(lua_State* L);
 		static int SetUnitBuildeeRadius(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -123,6 +123,7 @@ class LuaSyncedCtrl
 		static int ClearUnitGoal(lua_State* L);
 		static int SetUnitNeutral(lua_State* L);
 		static int SetUnitTarget(lua_State* L);
+		static void DropCurrentAutoTargets(lua_State* L);
 		static int SetUnitMidAndAimPos(lua_State* L);
 		static int SetUnitRadiusAndHeight(lua_State* L);
 		static int SetUnitBuildeeRadius(lua_State* L);

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -858,13 +858,7 @@ bool CCommandAI::ExecuteStateCommand(const Command& c)
 	switch (c.GetID()) {
 		case CMD_FIRE_STATE: {
 			owner->fireState = (int)c.GetParam(0);
-			if (owner->fireState < FIRESTATE_FIREATWILL)
-			{
-				owner->DropCurrentAttackTarget();
-				for (CWeapon* w: owner->weapons) { /* Force unload weapons targets */
-					w->DropCurrentTarget();
-				}
-			}
+
 			SetCommandDescParam0(c);
 			selectedUnitsHandler.PossibleCommandChange(owner);
 			return true;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -858,7 +858,13 @@ bool CCommandAI::ExecuteStateCommand(const Command& c)
 	switch (c.GetID()) {
 		case CMD_FIRE_STATE: {
 			owner->fireState = (int)c.GetParam(0);
-
+			if (owner->fireState < FIRESTATE_FIREATWILL)
+			{
+				owner->DropCurrentAttackTarget();
+				for (CWeapon* w: owner->weapons) { /* Force unload weapons targets */
+					w->DropCurrentTarget();
+				}
+			}
 			SetCommandDescParam0(c);
 			selectedUnitsHandler.PossibleCommandChange(owner);
 			return true;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -860,10 +860,7 @@ bool CCommandAI::ExecuteStateCommand(const Command& c)
 			owner->fireState = (int)c.GetParam(0);
 			if (owner->fireState < FIRESTATE_FIREATWILL)
 			{
-				owner->DropCurrentAttackTarget();
-				for (CWeapon* w: owner->weapons) { /* Force unload weapons targets */
-					w->DropCurrentTarget();
-				}
+				owner->DropCurrentAutoTarget();
 			}
 			SetCommandDescParam0(c);
 			selectedUnitsHandler.PossibleCommandChange(owner);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1764,6 +1764,20 @@ bool CUnit::AttackGround(const float3& pos, bool isUserTarget, bool wantManualFi
 	return ret;
 }
 
+void CUnit::DropCurrentAutoTarget()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	if (curTarget.type == Target_Unit)
+		DeleteDeathDependence(curTarget.unit, DEPENDENCE_TARGET);
+	
+	if (!curTarget.isUserTarget)
+		curTarget = SWeaponTarget();
+	
+	for (CWeapon* w: weapons) {
+		if (!w->GetCurrentTarget().isUserTarget)
+			w->DropCurrentTarget();
+	}
+}
 
 void CUnit::DropCurrentAttackTarget()
 {

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -91,6 +91,9 @@ public:
 
 	bool AttackUnit(CUnit* unit, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
 	bool AttackGround(const float3& pos, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
+	
+	void DropCurrentAutoTarget();
+
 	void DropCurrentAttackTarget();
 
 	int GetBlockingMapID() const { return id; }


### PR DESCRIPTION
Meant to fix https://github.com/beyond-all-reason/RecoilEngine/issues/2674

Drop all autoacquired (non user) targets upon receiving a firestate < FIRESTATE_FIREATWILL state command