### PR TITLE
Add primary axis to cylinder volumes in defs

### DIFF
--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -853,6 +853,14 @@ int LuaUtils::PushColVolTable(lua_State* L, const CollisionVolume* vol) {
 			break;
 		case CollisionVolume::COLVOL_TYPE_CYLINDER:
 			HSTR_PUSH_CSTRING(L, "type", "cylinder");
+
+			switch (vol->GetPrimaryAxis()) {
+				case CollisionVolume::COLVOL_AXIS_X: LuaPushNamedNumber(L, "primaryAxis", 1); break;
+				case CollisionVolume::COLVOL_AXIS_Y: LuaPushNamedNumber(L, "primaryAxis", 2); break;
+				case CollisionVolume::COLVOL_AXIS_Z: LuaPushNamedNumber(L, "primaryAxis", 3); break;
+				default: assert(false);
+			}
+
 			break;
 		case CollisionVolume::COLVOL_TYPE_BOX:
 			HSTR_PUSH_CSTRING(L, "type", "box");
@@ -884,7 +892,7 @@ int LuaUtils::PushColVolData(lua_State* L, const CollisionVolume* vol) {
 	lua_pushnumber(L, vol->GetOffsets().z);
 	lua_pushnumber(L, vol->GetVolumeType());
 	lua_pushnumber(L, int(vol->UseContHitTest()));
-	lua_pushnumber(L, vol->GetPrimaryAxis());
+	lua_pushnumber(L, vol->GetPrimaryAxis()); // FIXME: x = 0, should be 1
 	lua_pushboolean(L, vol->IgnoreHits());
 	return 10;
 }


### PR DESCRIPTION
* `UnitDefs[i].collisionVolume.primaryAxis`
* `UnitDefs[i].selectionVolume.primaryAxis`
* `FeatureDefs[i].collisionVolume.primaryAxis`
* `FeatureDefs[i].selectionVolume.primaryAxis`

Returns the primary axis of a cylinder: x = 1, y = 2, z = 3. Present only if volume.type == "cylinder", nil otherwise.