### PR TITLE
Put network protocol version in the demo header

### DIFF
--- a/rts/Game/GameVersion.h
+++ b/rts/Game/GameVersion.h
@@ -3,6 +3,7 @@
 #ifndef GAME_VERSION_H
 #define GAME_VERSION_H
 
+#include <cstdint>
 #include <string>
 
 /**
@@ -115,6 +116,15 @@ namespace SpringVersion
 	 * @see GetAdditional
 	 */
 	extern const std::string& GetFull();
+
+	/**
+	 * The version of the network/replay packet protocol.
+	 *
+	 * Increment whenever anything changes (new packet type,
+	 * new members in an existing packet type, different
+	 * meaning or layout of existing members, anything).
+	 */
+	static constexpr uint16_t NETWORK_VERSION = 2027;
 }
 
 #endif // GAME_VERSION_H

--- a/rts/Net/AutohostInterface.cpp
+++ b/rts/Net/AutohostInterface.cpp
@@ -38,7 +38,7 @@ enum EVENT
 	/**
 	 * Server has started
 	 *
-	 *   ()
+	 *   (uint16 networkVersion)
 	 */
 	SERVER_STARTED = 0,
 
@@ -236,9 +236,14 @@ std::string AutohostInterface::TryBindSocket(
 
 void AutohostInterface::SendStart()
 {
-	uchar msg = SERVER_STARTED;
+	const auto networkVersion {SpringVersion::NETWORK_VERSION};
 
-	Send(asio::buffer(&msg, sizeof(uchar)));
+	std::array <std::uint8_t, 1 + sizeof networkVersion> buffer;
+
+	buffer[0] = SERVER_STARTED;
+	memcpy(&buffer[1], &networkVersion, sizeof networkVersion);
+
+	Send(asio::buffer(buffer));
 }
 
 void AutohostInterface::SendQuit()

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -1902,8 +1902,8 @@ void CGameServer::HandleConnectionAttempts()
 			msg >> reconnect;
 			msg >> netloss;
 
-			if (netversion != NETWORK_VERSION)
-				throw netcode::UnpackPacketException(spring::format("Wrong network version: received %d, required %d", (int)netversion, (int)NETWORK_VERSION));
+			if (netversion != SpringVersion::NETWORK_VERSION)
+				throw netcode::UnpackPacketException(spring::format("Wrong network version: received %d, required %d", (int)netversion, (int)SpringVersion::NETWORK_VERSION));
 
 			BindConnection(udpListener->AcceptConnection(), name, passwd, version, platform, false, reconnect, netloss);
 		} catch (const netcode::UnpackPacketException& ex) {
@@ -2888,9 +2888,16 @@ unsigned CGameServer::BindConnection(
 
 	if (clientLink->CanReconnect())
 		canReconnect = true;
-	// first client to connect determines the reference version
-	// the proliferation of maintenance builds since 104.0 means
-	// comparing just NETWORK_VERSION is no longer strict enough
+
+	/* First client to connect determines the reference version.
+	 *
+	 * Ideally this would accept versions that sync with each other, but we
+	 * do not actually have a way to keep track of that.
+	 *
+	 * Historically this used to check for `SpringVersion::NETWORK_VERSION`,
+	 * but that just resolved to major (104 etc) so is not sufficient when
+	 * dev versions introduce sync changes. Perhaps it would be alright to
+	 * use that for dedi which doesn't care about sync either way though. */
 	if (refClientVersion.second.empty())
 		refClientVersion = {clientName, clientVersion};
 

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -243,7 +243,7 @@ PacketType CBaseNetProtocol::SendAttemptConnect(
 	bool reconnect
 ) {
 	const uint32_t payloadSize =
-		sizeof(NETWORK_VERSION) +
+		sizeof(SpringVersion::NETWORK_VERSION) +
 		sizeof(static_cast<uint8_t>(netloss)) +
 		sizeof(static_cast<uint8_t>(reconnect)) +
 		(name.size() + 1) +
@@ -255,7 +255,7 @@ PacketType CBaseNetProtocol::SendAttemptConnect(
 
 	PackPacket* packet = new PackPacket(packetSize, NETMSG_ATTEMPTCONNECT);
 	*packet << static_cast<uint16_t>(packetSize);
-	*packet << NETWORK_VERSION;
+	*packet << SpringVersion::NETWORK_VERSION;
 	*packet << name;
 	*packet << passwd;
 	*packet << version;

--- a/rts/Net/Protocol/BaseNetProtocol.h
+++ b/rts/Net/Protocol/BaseNetProtocol.h
@@ -26,7 +26,6 @@ struct PlayerStatistics;
 struct TeamStatistics;
 
 
-static const uint16_t NETWORK_VERSION = 2027;
 
 
 /**

--- a/rts/Net/Protocol/BaseNetProtocol.h
+++ b/rts/Net/Protocol/BaseNetProtocol.h
@@ -26,7 +26,7 @@ struct PlayerStatistics;
 struct TeamStatistics;
 
 
-static const uint16_t NETWORK_VERSION = atoi(SpringVersion::GetMajor().c_str());
+static const uint16_t NETWORK_VERSION = 2027;
 
 
 /**

--- a/rts/System/LoadSave/DemoReader.cpp
+++ b/rts/System/LoadSave/DemoReader.cpp
@@ -29,6 +29,8 @@ static bool CheckDemoHeader(const DemoFileHeader& fileHeader)
 
 	if (fileHeader.version != DEMOFILE_VERSION)
 		return false;
+	if (fileHeader.networkVersion != SpringVersion::NETWORK_VERSION)
+		return false;
 
 	if (fileHeader.headerSize != sizeof(DemoFileHeader))
 		return false;

--- a/rts/System/LoadSave/DemoRecorder.cpp
+++ b/rts/System/LoadSave/DemoRecorder.cpp
@@ -75,6 +75,7 @@ void CDemoRecorder::SetFileHeader()
 	fileHeader.teamStatElemSize = sizeof(TeamStatistics);
 	fileHeader.teamStatPeriod = TeamStatistics::statsPeriod;
 	fileHeader.winningAllyTeamsSize = 0;
+	fileHeader.networkVersion = SpringVersion::NETWORK_VERSION;
 }
 
 void CDemoRecorder::WriteDemoFile()

--- a/rts/System/LoadSave/demofile.h
+++ b/rts/System/LoadSave/demofile.h
@@ -70,6 +70,7 @@ struct DemoFileHeader
 	int teamStatElemSize;         ///< sizeof(CTeam::Statistics)
 	int teamStatPeriod;           ///< Interval (in seconds) between team stats.
 	int winningAllyTeamsSize;     ///< The size of the vector of the winning ally teams
+	std::uint16_t networkVersion; ///< The version of the replay/network packet protocol (`SpringVersion::NETWORK_VERSION`)
 
 
 	/// Change structure from host endian to little endian or vice versa.
@@ -89,6 +90,7 @@ struct DemoFileHeader
 		swabDWordInPlace(teamStatElemSize);
 		swabDWordInPlace(teamStatPeriod);
 		swabDWordInPlace(winningAllyTeamsSize);
+		swabDWordInPlace(networkVersion);
 	}
 };
 


### PR DESCRIPTION
See #2140.

Something to figure out would be how to tell autohosts this, since either modifying `SERVER_STARTED` or sending a different packet would be a breaking change. Perhaps just send two packets (`SERVER_STARTED` as-is, plus a new future-compatible one with metadata)?