### PR TITLE
Some TemplateUtils.hpp improvements from other branches

### DIFF
--- a/rts/System/TemplateUtils.hpp
+++ b/rts/System/TemplateUtils.hpp
@@ -283,13 +283,14 @@ namespace spring {
 		type_list_exec_at_impl(index, std::forward<TypeList>(typeList), std::forward<Func>(f), std::make_index_sequence<TypeListDecayed::size>{});
 	}
 
+	// Executes f with each type in the type list, returns tuple of results (void return returns nothing)
 	template<typename... T, typename F>
 	constexpr decltype(auto) type_list_exec_all(type_list_t<T...>, F&& f) {
 		if constexpr (std::is_void_v<return_type_t<F>>) {
-			std::forward_as_tuple(f(T{})...);
+			(f(T{}), ...);
 		}
 		else {
-			(f(T{}), ...);
+			return std::forward_as_tuple(f(T{})...);
 		}
 	}
 
@@ -307,6 +308,9 @@ namespace spring {
 			throw std::out_of_range("tuple index out of range");
 	}
 
+	// Executes function f with the tuple element at the given index.
+	// NOTE: Unlike the previous recursive implementation, this version throws std::out_of_range
+	// if index >= tuple size, rather than silently doing nothing.
 	template<typename Tuple, typename Func>
 	inline void tuple_exec_at(size_t index, Tuple& t, Func&& f)
 	{
@@ -375,12 +379,6 @@ namespace spring {
 
 	template<auto FuncPtr, typename... FallbackSignature>
 	using func_ptr_signature_t = typename func_ptr_signature<FuncPtr, FallbackSignature...>::type;
-
-	template<class T>
-	constexpr T& as_mutable(const T& t) noexcept
-	{
-		return const_cast<std::decay_t<T>&>(t);
-	}
 };
 
 namespace Recoil {

--- a/rts/System/TemplateUtils.hpp
+++ b/rts/System/TemplateUtils.hpp
@@ -309,8 +309,7 @@ namespace spring {
 	}
 
 	// Executes function f with the tuple element at the given index.
-	// NOTE: Unlike the previous recursive implementation, this version throws std::out_of_range
-	// if index >= tuple size, rather than silently doing nothing.
+	// throws std::out_of_range if index >= tuple size
 	template<typename Tuple, typename Func>
 	inline void tuple_exec_at(size_t index, Tuple& t, Func&& f)
 	{


### PR DESCRIPTION
# TemplateUtils.hpp Improvements

## Summary
Improvements to `rts/System/TemplateUtils.hpp` with modern C++ type manipulation utilities.

## Changes

### 1. Modern tuple iteration
- Replaced recursive `tuple_exec_at` with index-sequence-based implementation
- More compile-time efficient, better code generation

### 2. Type list infrastructure
Added comprehensive type list utilities:
- `type_list_t<Ts...>` - Type list wrapper struct
- `type_list_element_t<N, List>` - Access Nth type in list
- `type_list_concat_t<Lists...>` - Concatenate multiple type lists
- `type_list_filter_t<Pred, List>` - Filter types by predicate
- `type_in_list_v<T, List>` - Check if type exists in list

### 3. Enhanced function traits
- Renamed `return_type` to `function_traits` 
- Added `arg_types` to extract parameter types
- Preserved backward-compatible `return_type_t` alias
- Added new `arg_types_t` helper

### 4. Other improvements
- Added `type_list_exec_at` - Execute function with type from type list by index
- Added `type_list_exec_all` - Execute function with all types in a type list
- Cleaned up code style

## Breaking Changes
- `tuple_exec_at` now throws `std::out_of_range` for invalid indices instead of silently doing nothing (documented in code)