### PR TITLE
Gameserver: don't interpret NETMSG_STARTPLAYING

### DIFF
--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -1461,11 +1461,6 @@ void CGameServer::ProcessPacket(const unsigned playerNum, std::shared_ptr<const 
 				Broadcast(CBaseNetProtocol::Get().SendDirectControlUpdate(inbuf[1], inbuf[2], *((short*)&inbuf[3]), *((short*)&inbuf[5])));
 			break;
 
-		case NETMSG_STARTPLAYING: {
-			if (players[a].isLocal && gameHasStarted)
-				CheckForGameStart(true);
-			break;
-		}
 		case NETMSG_TEAM: {
 			//TODO update players[] and teams[] and send all to hostif
 			const unsigned player = (unsigned)inbuf[1];


### PR DESCRIPTION
The code is incorrect (path always leads to assertion), nothing actually sends this, and nothing should send it because the way to start by a local player is `/forcestart` rather than a packet.