### PR TITLE
UpdateSkid(): Displace oldPos update to right before we call owner->Move()

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1619,6 +1619,11 @@ void CGroundMoveType::UpdateSkid()
 		}
 	}
 
+	// always update <oldPos> here so that <speed> does not make
+	// extreme jumps when the unit transitions from skidding back
+	// to non-skidding
+	oldPos = owner->pos;
+
 	// finally update speed.w
 	owner->SetSpeed(spd);
 	// translate before rotate, match terrain normal if not in air
@@ -1634,12 +1639,6 @@ void CGroundMoveType::UpdateSkid()
 	}
 
 	AdjustPosToWaterLine();
-
-	// always update <oldPos> here so that <speed> does not make
-	// extreme jumps when the unit transitions from skidding back
-	// to non-skidding
-	oldPos = owner->pos;
-
 	ASSERT_SANE_OWNER_SPEED(spd);
 	ASSERT_SYNCED(owner->midPos);
 }


### PR DESCRIPTION
So we successfully update with the f-1 value, not the f value; and OwnerMoved() can be called with the proper p(f) - p(f-1) vector

See: https://github.com/beyond-all-reason/RecoilEngine/issues/2796 for more