### PR TITLE
Fix movement bugs with commandFire weapons

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1759,7 +1759,7 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, boo
 		// salvo if they have more orders queued
 		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY)) {
 			orderFinished = true;
-			StopMove();
+			StopMove(); // additional fix for https://springrts.com/mantis/view.php?id=4131
 		} 
 		
 		if (weapon->noAutoTarget && !(c.GetOpts() & META_KEY) && haveGroundAttackCmd && HasMoreMoveCommands())

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1757,10 +1757,11 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, boo
 		// manual fire or attack commands with meta will only fire a single salvo
 		// noAutoTarget weapons finish an attack commands after a
 		// salvo if they have more orders queued
-		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY))
+		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY)) {
 			orderFinished = true;
 			StopMove();
-
+		} 
+		
 		if (weapon->noAutoTarget && !(c.GetOpts() & META_KEY) && haveGroundAttackCmd && HasMoreMoveCommands())
 			orderFinished = true;
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1759,6 +1759,7 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, boo
 		// salvo if they have more orders queued
 		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY))
 			orderFinished = true;
+			StopMove();
 
 		if (weapon->noAutoTarget && !(c.GetOpts() & META_KEY) && haveGroundAttackCmd && HasMoreMoveCommands())
 			orderFinished = true;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -342,7 +342,7 @@ void CMobileCAI::SlowUpdate()
 
 	if (!commandQue.empty() && commandQue.front().GetTimeOut() < gs->frameNum) {
 		StopMoveAndFinishCommand();
-		//return;
+		return;
 	}
 
 	if (commandQue.empty()) {
@@ -845,7 +845,7 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 		assert(owner->unitDef->canManualFire);
 
 		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, true)) {
-			// StopMoveAndKeepPointing calls StopMove before KeepPointingTo
+			// Command fire weapon in range. Stop moving. May take a few frames to actually fire due to aiming animation.
 			StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
 		} 
 		return;
@@ -874,6 +874,10 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 		owner->moveType->KeepPointingTo(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
 	}
 
+	// TODO: expose this unconditional "do not approach the target any closer" value to lua
+	//if (attackVec.SqLength2D() >= Square(owner->maxRange * 0.9f))
+	//	return;
+	
 	// no weapon succeeded with AttackGround, keep approaching target
 	SetGoal(c.GetPos(0), owner->pos);
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -845,15 +845,8 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 
 		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, true)) {
 			// StopMoveAndKeepPointing calls StopMove before KeepPointingTo
-			// but we want to call it *after* KeepPointingTo to prevent 4131
-			owner->moveType->KeepPointingTo(attackPos, owner->maxRange * 0.9f, true);
-			StopMove();
-		} else {
-			// we are out of range of CMD_MANUALFIRE, perhaps either still out of range, or an animation brought us out of range
-			// ok to call if a goal already exists, SetGoal checks if owner already has a goal to this position
-			SetGoal(c.GetPos(0), owner->pos); 
-		}
-
+			StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
+		} 
 		return;
 	}
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -784,8 +784,7 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 		return;
 	}
 
-	// aircraft and strafeToAttack units care about this 90% of max range threshold
-	// TODO: have this 0.9f be setable by lua or unitdef? Or reconsider how strafeToAttack and IsHoveringAirUnit shoud work?
+	// do not get any closer than 90% of the unit's maxRange (settable via SetUnitMaxRange)
 	if (targetMidPosDist2D < (owner->maxRange * 0.9f)) {
 		if (owner->unitDef->IsHoveringAirUnit() || (targetMidPosVec.SqLength2D() < 1024) || tryOwnerRotation) {
 			StopMove();
@@ -809,9 +808,8 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 			goalDiff += orderTarget->pos;
 
 			SetGoal(goalDiff, owner->pos);
-			return;
 		}
-
+		return;
 	}
 
 	// not a temporary order or not on hold-position; close in on target more
@@ -874,9 +872,11 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 		owner->moveType->KeepPointingTo(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
 	}
 
-	// TODO: expose this unconditional "do not approach the target any closer" value to lua
-	//if (attackVec.SqLength2D() >= Square(owner->maxRange * 0.9f))
-	//	return;
+	// do not get any closer than 90% of the unit's maxRange (settable via SetUnitMaxRange)
+	if (attackVec.SqLength2D() <= Square(owner->maxRange * 0.9f))
+		owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false);
+		StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
+		return;
 	
 	// no weapon succeeded with AttackGround, keep approaching target
 	SetGoal(c.GetPos(0), owner->pos);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -847,6 +847,11 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 			// StopMoveAndKeepPointing calls StopMove before KeepPointingTo
 			// but we want to keep trying to move towards the target until we successfully fire. StopMove is called after we fire.
 			owner->moveType->KeepPointingTo(attackPos, owner->maxRange * 0.9f, true);
+			StopMove();
+		} else {
+			// we are out of range of CMD_MANUALFIRE, perhaps either still out of range, or an animation brought us out of range, set a movegoal 
+			// ok to call if a goal already exists, SetGoal checks if owner already has a goal to this position
+			SetGoal(c.GetPos(0), owner->pos); 
 		}
 
 		return;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -845,9 +845,8 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 
 		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, true)) {
 			// StopMoveAndKeepPointing calls StopMove before KeepPointingTo
-			// but we want to call it *after* KeepPointingTo to prevent 4131
+			// but we want to keep trying to move towards the target until we successfully fire. StopMove is called after we fire.
 			owner->moveType->KeepPointingTo(attackPos, owner->maxRange * 0.9f, true);
-			StopMove();
 		}
 
 		return;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -342,7 +342,7 @@ void CMobileCAI::SlowUpdate()
 
 	if (!commandQue.empty() && commandQue.front().GetTimeOut() < gs->frameNum) {
 		StopMoveAndFinishCommand();
-		return;
+		//return;
 	}
 
 	if (commandQue.empty()) {
@@ -784,7 +784,8 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 		return;
 	}
 
-	// target is probably close enough
+	// aircraft and strafeToAttack units care about this 90% of max range threshold
+	// TODO: have this 0.9f be setable by lua or unitdef? Or reconsider how strafeToAttack and IsHoveringAirUnit shoud work?
 	if (targetMidPosDist2D < (owner->maxRange * 0.9f)) {
 		if (owner->unitDef->IsHoveringAirUnit() || (targetMidPosVec.SqLength2D() < 1024) || tryOwnerRotation) {
 			StopMove();
@@ -808,9 +809,9 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 			goalDiff += orderTarget->pos;
 
 			SetGoal(goalDiff, owner->pos);
+			return;
 		}
 
-		return;
 	}
 
 	// not a temporary order or not on hold-position; close in on target more
@@ -873,11 +874,9 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 		owner->moveType->KeepPointingTo(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
 	}
 
-	if (attackVec.SqLength2D() >= Square(owner->maxRange * 0.9f))
-		return;
+	// no weapon succeeded with AttackGround, keep approaching target
+	SetGoal(c.GetPos(0), owner->pos);
 
-	owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false);
-	StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
 }
 
 void CMobileCAI::ExecuteAttack(Command& c)

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -845,11 +845,11 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 
 		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, true)) {
 			// StopMoveAndKeepPointing calls StopMove before KeepPointingTo
-			// but we want to keep trying to move towards the target until we successfully fire. StopMove is called after we fire.
+			// but we want to call it *after* KeepPointingTo to prevent 4131
 			owner->moveType->KeepPointingTo(attackPos, owner->maxRange * 0.9f, true);
 			StopMove();
 		} else {
-			// we are out of range of CMD_MANUALFIRE, perhaps either still out of range, or an animation brought us out of range, set a movegoal 
+			// we are out of range of CMD_MANUALFIRE, perhaps either still out of range, or an animation brought us out of range
 			// ok to call if a goal already exists, SetGoal checks if owner already has a goal to this position
 			SetGoal(c.GetPos(0), owner->pos); 
 		}

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -809,6 +809,7 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 
 			SetGoal(goalDiff, owner->pos);
 		}
+
 		return;
 	}
 
@@ -845,39 +846,40 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, true)) {
 			// Command fire weapon in range. Stop moving. May take a few frames to actually fire due to aiming animation.
 			StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
-		} 
-		return;
-	}
-
-	for (CWeapon* w: owner->weapons) {
-		// NOTE:
-		//   we call TryTargetHeading which is less restrictive than TryTarget
-		//   (eg. the former succeeds even if the unit has not already aligned
-		//   itself with <attackVec>)
-		if (!w->TryTargetHeading(attackHeading, attackTgtInfo))
-			continue;
-
-		if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false)) {
-			StopMoveAndKeepPointing(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
 			return;
-		}
+		} 
+	} else {
+		for (CWeapon* w: owner->weapons) {
+			// NOTE:
+			//   we call TryTargetHeading which is less restrictive than TryTarget
+			//   (eg. the former succeeds even if the unit has not already aligned
+			//   itself with <attackVec>)
+			if (!w->TryTargetHeading(attackHeading, attackTgtInfo))
+				continue;
 
-		// for gunships, this pitches the nose down such that
-		// TryTargetRotate (which also checks range for itself)
-		// has a bigger chance of succeeding
-		//
-		// hence it must be called as soon as we get in range
-		// and may not depend on what TryTargetRotate returns
-		// (otherwise we might never get a firing solution)
-		owner->moveType->KeepPointingTo(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
+			if (owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false)) {
+				StopMoveAndKeepPointing(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
+				return;
+			}
+
+			// for gunships, this pitches the nose down such that
+			// TryTargetRotate (which also checks range for itself)
+			// has a bigger chance of succeeding
+			//
+			// hence it must be called as soon as we get in range
+			// and may not depend on what TryTargetRotate returns
+			// (otherwise we might never get a firing solution)
+			owner->moveType->KeepPointingTo(attackTgtInfo.groundPos, owner->maxRange * 0.9f, true);
+		}
 	}
 
 	// do not get any closer than 90% of the unit's maxRange (settable via SetUnitMaxRange)
-	if (attackVec.SqLength2D() <= Square(owner->maxRange * 0.9f))
+	if (attackVec.SqLength2D() <= Square(owner->maxRange * 0.9f)) {
 		owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false);
 		StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
 		return;
-	
+	}
+
 	// no weapon succeeded with AttackGround, keep approaching target
 	SetGoal(c.GetPos(0), owner->pos);
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -332,24 +332,6 @@ void CWeapon::Update()
 			AutoTarget();
 	}
 
-	// handle movegoals if the weapon is commandFire/manualfire
-	// CAI only checks if the target is shootable on SlowUpdates, 
-	// so it is too slow at issuing new movegoals if the weaponMuzzlePos is moved out of range before the weapon fires
-	if (weaponDef->manualfire && owner->moveType->IsAtGoal() && owner->curTarget.type != Target_None) {
-		if (!Attack(owner->curTarget)) {
-			switch (owner->curTarget.type) {
-				case Target_Unit: {
-					owner->commandAI->SetGoal(owner->curTarget.pos)
-					break
-				}
-				case Target_Pos: {
-					owner->commandAI->SetGoal(owner->curTarget.groundPos)
-					break
-				}
-			}
-		}
-	}
-
 	// SlowUpdate() only generates targets when we are in range
 	// esp. for bombs this is often too late (SlowUpdate gets only called twice per second)
 	// so check unit's target this check every frame (unit target has highest priority even in SlowUpdate!)
@@ -357,6 +339,20 @@ void CWeapon::Update()
 		Attack(owner->curTarget);
 
 	currentTargetPos = GetLeadTargetPos(currentTarget);
+
+	// handle movegoals if the weapon is commandFire/manualfire
+	// CAI only checks if the target is shootable on SlowUpdates, 
+	// so it is too slow at issuing new movegoals if the weaponMuzzlePos is moved out of range before the weapon fires
+	if (weaponDef->manualfire && owner->moveType->IsAtGoal() && owner->curTarget.type != Target_None) {
+		if (!Attack(owner->curTarget)) {
+			// check if owner already has a move order to this position with the same radius
+			if (owner->moveType->IsMovingTowards(currentTargetPos, SQUARE_SIZE, true))
+				return;
+
+			// give new move order
+			owner->moveType->StartMoving(currentTargetPos, SQUARE_SIZE);
+		}
+	}
 
 	if (!UpdateStockpile())
 		return;

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -340,20 +340,6 @@ void CWeapon::Update()
 
 	currentTargetPos = GetLeadTargetPos(currentTarget);
 
-	// handle movegoals if the weapon is commandFire/manualfire
-	// CAI only checks if the target is shootable on SlowUpdates, 
-	// so it is too slow at issuing new movegoals if the weaponMuzzlePos is moved out of range before the weapon fires
-	if (weaponDef->manualfire && owner->moveType->IsAtGoal() && owner->curTarget.type != Target_None) {
-		if (!Attack(owner->curTarget)) {
-			// check if owner already has a move order to this position with the same radius
-			if (owner->moveType->IsMovingTowards(currentTargetPos, SQUARE_SIZE, true))
-				return;
-
-			// give new move order
-			owner->moveType->StartMoving(currentTargetPos, SQUARE_SIZE);
-		}
-	}
-
 	if (!UpdateStockpile())
 		return;
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -332,6 +332,24 @@ void CWeapon::Update()
 			AutoTarget();
 	}
 
+	// handle movegoals if the weapon is commandFire/manualfire
+	// CAI only checks if the target is shootable on SlowUpdates, 
+	// so it is too slow at issuing new movegoals if the weaponMuzzlePos is moved out of range before the weapon fires
+	if (weaponDef->manualfire && owner->moveType->IsAtGoal() && owner->curTarget.type != Target_None) {
+		if (!Attack(owner->curTarget)) {
+			switch (owner->curTarget.type) {
+				case Target_Unit: {
+					owner->commandAI->SetGoal(owner->curTarget.pos)
+					break
+				}
+				case Target_Pos: {
+					owner->commandAI->SetGoal(owner->curTarget.groundPos)
+					break
+				}
+			}
+		}
+	}
+
 	// SlowUpdate() only generates targets when we are in range
 	// esp. for bombs this is often too late (SlowUpdate gets only called twice per second)
 	// so check unit's target this check every frame (unit target has highest priority even in SlowUpdate!)


### PR DESCRIPTION
PR to address this issue (units *sometimes* continue walking towards the commandfire location even after firing):
https://github.com/beyond-all-reason/RecoilEngine/issues/693

And to address misc reporting on the BAR discord that commander units that use the commandFire Dgun do *not* always automatically walk forward enough to fire the Dgun.

The fix is to relocate the commandFire StopMove(); function to *after* it has fired, so it does not trigger too early, and so it can properly clear any move goals set in the frames after the MobileCAI `KeepPointingTo` line, while during the AimWeaponX animation, and before it fires.

In my testing with the PR, I was unable to produce an instance of a BAR commander continuing to walk towards a Dgun target after it fired, and was unable to produce an instance of a BAR commander stationary and starting at a Dgun target without firing. 

(AI disclosure, Claude Code Opus 4.6 pointed me to the right code locations, but the relocation of StopMove() was by hand)