### PR TITLE
Add new gadget:SetUnitEngagementRange

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2796,11 +2796,21 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 	if (mCAI == nullptr)
 		return 0;
 
-	if (!lua_isnoneornil(L, 2))
-		mCAI->engagementRange = luaL_checkfloat(L, 2);
+	const int args = lua_gettop(L);
 
-	if (!lua_isnoneornil(L, 3))
-		mCAI->fightEngagementRange = luaL_checkfloat(L, 3);
+	if (args >= 2) {
+		if (lua_isnoneornil(L, 2) || (lua_isboolean(L, 2)))
+			mCAI->engagementRange = -1.0f;
+		else
+			mCAI->engagementRange = luaL_checkfloat(L, 2);
+	}
+
+	if (args >= 3) {
+		if (lua_isnoneornil(L, 3) || (lua_isboolean(L, 3)))
+			mCAI->fightEngagementRange = -1.0f;
+		else
+			mCAI->fightEngagementRange = luaL_checkfloat(L, 3);
+	}
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -69,6 +69,7 @@
 #include "Sim/Units/CommandAI/Command.h"
 #include "Sim/Units/CommandAI/CommandAI.h"
 #include "Sim/Units/CommandAI/FactoryCAI.h"
+#include "Sim/Units/CommandAI/MobileCAI.h"
 #include "Sim/Units/UnitTypes/ExtractorBuilding.h"
 #include "Sim/Weapons/PlasmaRepulser.h"
 #include "Sim/Weapons/Weapon.h"
@@ -207,6 +208,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitWeaponState);
 	REGISTER_LUA_CFUNC(SetUnitWeaponDamages);
 	REGISTER_LUA_CFUNC(SetUnitMaxRange);
+	REGISTER_LUA_CFUNC(SetUnitEngagementRange);
 	REGISTER_LUA_CFUNC(SetUnitExperience);
 	REGISTER_LUA_CFUNC(AddUnitExperience);
 	REGISTER_LUA_CFUNC(SetUnitArmored);
@@ -2772,6 +2774,36 @@ int LuaSyncedCtrl::SetUnitMaxRange(lua_State* L)
 	return 0;
 }
 
+/***
+ * @function Spring.SetUnitEngagementRange
+ * @param unitID integer
+ * @param idleSearchRadius number? optional idle auto-target search radius
+ * @param fightSearchRadius number? optional fight-move search radius
+ * @return nil
+ */
+int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
+{
+	// Sets the engagement search radius for a unit's auto-target selection.
+	// Overrides the default search radius the unit uses to automatically find
+	// targets when idle and when fight moving.
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	CMobileCAI* mCAI = dynamic_cast<CMobileCAI*>(unit->commandAI);
+
+	if (mCAI == nullptr)
+		return 0;
+
+	if (!lua_isnoneornil(L, 2))
+		mCAI->engagementRange = luaL_checkfloat(L, 2);
+
+	if (!lua_isnoneornil(L, 3))
+		mCAI->fightEngagementRange = luaL_checkfloat(L, 3);
+
+	return 0;
+}
 
 /***
  * @function Spring.SetUnitExperience

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2798,23 +2798,42 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 		return 0;
 
 	if (!lua_isnoneornil(L, 2)) {
-		if (lua_isboolean(L, 2))
+		if (lua_isboolean(L, 2) && !lua_toboolean(L, 2)) {
 			mCAI->idleEngagementRange = -1.0f;
-		else
-			mCAI->idleEngagementRange = luaL_checkfloat(L, 2);
+		} else {
+			if (lua_isboolean(L, 2) && lua_toboolean(L, 2))
+				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
+			const float idleEngagementRange = luaL_checkfloat(L, 2);
+			if (idleEngagementRange<0)
+				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
+			mCAI->idleEngagementRange = idleEngagementRange;
+		}
 	}
 
 	if (!lua_isnoneornil(L, 3)) {
-		if (lua_isboolean(L, 3))
+		if (lua_isboolean(L, 3) && !lua_toboolean(L, 3)) {
 			mCAI->fightEngagementRange = -1.0f;
-		else
-			mCAI->fightEngagementRange = luaL_checkfloat(L, 3);
+		} else {
+			if (lua_isboolean(L, 3) && lua_toboolean(L, 3))
+				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
+			const float fightEngagementRange = luaL_checkfloat(L, 3);
+			if (fightEngagementRange<0)
+				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
+			mCAI->fightEngagementRange = fightEngagementRange;
+		}
 	}
 
-	if (lua_isnoneornil(L, 4)) {
-		mCAI->engagementLeash = std::max(mCAI->fightEngagementRange, mCAI->idleEngagementRange);
-	} else {
-		mCAI->engagementLeash = luaL_checkfloat(L, 4);
+	if (!lua_isnoneornil(L, 4)) {
+		if (lua_isboolean(L, 4) && !lua_toboolean(L, 4)) {
+			mCAI->engagementLeash = -1.0f;
+		} else {
+			if (lua_isboolean(L, 4) && lua_toboolean(L, 4))
+				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
+			const float engagementLeash = luaL_checkfloat(L, 4);
+			if (engagementLeash<0)
+				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
+			mCAI->engagementLeash = engagementLeash;
+		}
 	}
 
 	return 0;

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -209,6 +209,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitWeaponDamages);
 	REGISTER_LUA_CFUNC(SetUnitMaxRange);
 	REGISTER_LUA_CFUNC(SetUnitEngagementRange);
+	REGISTER_LUA_CFUNC(SetUnitAutoTargetRate);
 	REGISTER_LUA_CFUNC(SetUnitExperience);
 	REGISTER_LUA_CFUNC(AddUnitExperience);
 	REGISTER_LUA_CFUNC(SetUnitArmored);
@@ -2775,17 +2776,17 @@ int LuaSyncedCtrl::SetUnitMaxRange(lua_State* L)
 }
 
 /***
- * @function Spring.SetUnitEngagementRange
+ * Overrides the default search radius the unit uses to automatically find targets when idle and when fight moving.
+ *
+ * @function Spring.SetUnitEngagementRange 
  * @param unitID integer
- * @param idleSearchRadius number? optional idle auto-target search radius
- * @param fightSearchRadius number? optional fight-move search radius
+ * @param idleSearchRadius number? optional idle auto-target search radius. Any boolean or negative value restores default behavior.
+ * @param fightSearchRadius number? optional fight-move search radius. Any boolean or negative value restores default behavior.
+ * @param engagementLeash number? optional disengage distance. By default it is the max of idleSearchRadius and fightSearchRadius, if any of them are set, overriding engine default disengage distance logic.
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 {
-	// Sets the engagement search radius for a unit's auto-target selection.
-	// Overrides the default search radius the unit uses to automatically find
-	// targets when idle and when fight moving.
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -2798,9 +2799,9 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 
 	if (!lua_isnoneornil(L, 2)) {
 		if (lua_isboolean(L, 2))
-			mCAI->engagementRange = -1.0f;
+			mCAI->idleEngagementRange = -1.0f;
 		else
-			mCAI->engagementRange = luaL_checkfloat(L, 2);
+			mCAI->idleEngagementRange = luaL_checkfloat(L, 2);
 	}
 
 	if (!lua_isnoneornil(L, 3)) {
@@ -2809,6 +2810,38 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 		else
 			mCAI->fightEngagementRange = luaL_checkfloat(L, 3);
 	}
+
+	if (lua_isnoneornil(L, 4)) {
+		mCAI->engagementLeash = std::max(mCAI->fightEngagementRange, mCAI->idleEngagementRange);
+	} else {
+		mCAI->engagementLeash = luaL_checkfloat(L, 4);
+	}
+
+	return 0;
+}
+
+/***
+ * @function Spring.SetUnitAutoTargetRate
+ * @param unitID integer
+ * @param timeout number? timeout in frames for auto-generated unit and weapon attack commands; pass false or nil to reset to default (GAME_SPEED * 5)
+ * @return nil
+ */
+int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	CMobileCAI* mCAI = dynamic_cast<CMobileCAI*>(unit->commandAI);
+
+	if (mCAI == nullptr)
+		return 0;
+
+	if (lua_isboolean(L, 2))
+		mCAI->attackCmdTimeout = 150;   // reset to default
+	else
+		mCAI->attackCmdTimeout = luaL_checkint(L, 2);
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2827,7 +2827,7 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
  * 
  * @function Spring.SetUnitAutoTargetRate
  * @param unitID integer
- * @param timeout number timeout in seconds for auto-generated unit and weapon attack commands; pass any boolean to reset to default
+ * @param autoTargetRate number in seconds for auto-generated unit and weapon attack commands to rescan for new targets; pass any boolean to reset to default
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
@@ -2837,10 +2837,15 @@ int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	if (lua_isboolean(L, 2) && !lua_toboolean(L, 2))
-		unit->commandAI->attackCmdTimeout = -1;   // reset to default
-	else
-		unit->commandAI->attackCmdTimeout = luaL_checkfloat(L, 2);
+	if (lua_isboolean(L, 2) && !lua_toboolean(L, 2)) {
+		if (!lua_toboolean(L, 2)) {
+			unit->commandAI->autoTargetRate = -1;   // reset to default
+		} else {
+			luaL_error(L, "Invalid Argument, got bool true, expected bool false to reset to default autoTargetRate");
+		}
+	} else {
+		unit->commandAI->autoTargetRate = luaL_checkfloat(L, 2);
+	}
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2780,9 +2780,9 @@ int LuaSyncedCtrl::SetUnitMaxRange(lua_State* L)
  *
  * @function Spring.SetUnitEngagementRange 
  * @param unitID integer
- * @param idleSearchRadius number? optional idle auto-target search radius. Any boolean or negative value restores default behavior.
- * @param fightSearchRadius number? optional fight-move search radius. Any boolean or negative value restores default behavior.
- * @param engagementLeash number? optional disengage distance. By default it is the max of idleSearchRadius and fightSearchRadius, if any of them are set, overriding engine default disengage distance logic.
+ * @param idleSearchRadius number? optional idle auto-target search radius. Passing bool false restores default behavior.
+ * @param fightSearchRadius number? optional fight-move search radius. Passing bool false restores default behavior.
+ * @param engagementLeash number? optional disengage distance. Disengage distance by default will use the max of idleSearchRadius and fightSearchRadius, if any of them are set, overriding engine default disengage distance logic.
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2796,16 +2796,14 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 	if (mCAI == nullptr)
 		return 0;
 
-	const int args = lua_gettop(L);
-
-	if (args >= 2 && !lua_isnoneornil(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		if (lua_isboolean(L, 2))
 			mCAI->engagementRange = -1.0f;
 		else
 			mCAI->engagementRange = luaL_checkfloat(L, 2);
 	}
 
-	if (args >= 3 && !lua_isnoneornil(L, 3)) {
+	if (!lua_isnoneornil(L, 3)) {
 		if (lua_isboolean(L, 3))
 			mCAI->fightEngagementRange = -1.0f;
 		else

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -133,6 +133,19 @@ inline void LuaSyncedCtrl::CheckAllowGameChanges(lua_State* L)
 	}
 }
 
+// Returns -1.0f for bool false (disabled), or a validated positive float.
+inline float LuaSyncedCtrl::CheckPositiveFloatOrDisable(lua_State* L, int idx)
+{
+    if (lua_isboolean(L, idx)) {
+        if (!lua_toboolean(L, idx))
+            return -1.0f;  // false == disabled
+        luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
+    }
+    const float value = luaL_checkfloat(L, idx);
+    if (value < 0)
+        luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
+    return value;
+}
 
 /******************************************************************************/
 /******************************************************************************/
@@ -2797,44 +2810,14 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 	if (mCAI == nullptr)
 		return 0;
 
-	if (!lua_isnoneornil(L, 2)) {
-		if (lua_isboolean(L, 2) && !lua_toboolean(L, 2)) {
-			mCAI->idleEngagementRange = -1.0f;
-		} else {
-			if (lua_isboolean(L, 2) && lua_toboolean(L, 2))
-				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
-			const float idleEngagementRange = luaL_checkfloat(L, 2);
-			if (idleEngagementRange<0)
-				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
-			mCAI->idleEngagementRange = idleEngagementRange;
-		}
-	}
+	if (!lua_isnoneornil(L, 2))
+    	mCAI->idleEngagementRange  = CheckPositiveFloatOrDisable(L, 2);
 
-	if (!lua_isnoneornil(L, 3)) {
-		if (lua_isboolean(L, 3) && !lua_toboolean(L, 3)) {
-			mCAI->fightEngagementRange = -1.0f;
-		} else {
-			if (lua_isboolean(L, 3) && lua_toboolean(L, 3))
-				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
-			const float fightEngagementRange = luaL_checkfloat(L, 3);
-			if (fightEngagementRange<0)
-				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
-			mCAI->fightEngagementRange = fightEngagementRange;
-		}
-	}
+	if (!lua_isnoneornil(L, 3))
+    	mCAI->fightEngagementRange = CheckPositiveFloatOrDisable(L, 3);
 
-	if (!lua_isnoneornil(L, 4)) {
-		if (lua_isboolean(L, 4) && !lua_toboolean(L, 4)) {
-			mCAI->engagementLeash = -1.0f;
-		} else {
-			if (lua_isboolean(L, 4) && lua_toboolean(L, 4))
-				luaL_error(L, "Invalid Argument, got bool true, expected a positive float or bool false");
-			const float engagementLeash = luaL_checkfloat(L, 4);
-			if (engagementLeash<0)
-				luaL_error(L, "Invalid Argument, got negative float, expected a positive float or bool false");
-			mCAI->engagementLeash = engagementLeash;
-		}
-	}
+	if (!lua_isnoneornil(L, 4))
+    	mCAI->engagementLeash      = CheckPositiveFloatOrDisable(L, 4);
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2827,7 +2827,7 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
  * 
  * @function Spring.SetUnitAutoTargetRate
  * @param unitID integer
- * @param timeout integer timeout in frames for auto-generated unit and weapon attack commands; pass any boolean to reset to default
+ * @param timeout number timeout in seconds for auto-generated unit and weapon attack commands; pass any boolean to reset to default
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
@@ -2840,7 +2840,7 @@ int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
 	if (lua_isboolean(L, 2) && !lua_toboolean(L, 2))
 		unit->commandAI->attackCmdTimeout = -1;   // reset to default
 	else
-		unit->commandAI->attackCmdTimeout = luaL_checkint(L, 2);
+		unit->commandAI->attackCmdTimeout = luaL_checkfloat(L, 2);
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2823,9 +2823,11 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 }
 
 /***
+ * Overrides the default rate for re-scanning for better targets. Defaults are (GAME_SPEED * 5 = 150 frames) for mobile unit autotarget, and 65 frames for weapon autotarget.
+ * 
  * @function Spring.SetUnitAutoTargetRate
  * @param unitID integer
- * @param timeout integer timeout in frames for auto-generated unit and weapon attack commands; pass any boolean to reset to default [(GAME_SPEED * 5 = 150) for unit autotarget, 65 for weapon autotarget].
+ * @param timeout integer timeout in frames for auto-generated unit and weapon attack commands; pass any boolean to reset to default
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
@@ -2835,7 +2837,7 @@ int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	if (lua_isboolean(L, 2))
+	if (lua_isboolean(L, 2) && !lua_toboolean(L, 2))
 		unit->commandAI->attackCmdTimeout = -1;   // reset to default
 	else
 		unit->commandAI->attackCmdTimeout = luaL_checkint(L, 2);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2798,15 +2798,15 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 
 	const int args = lua_gettop(L);
 
-	if (args >= 2) {
-		if (lua_isnoneornil(L, 2) || (lua_isboolean(L, 2)))
+	if (args >= 2 && !lua_isnoneornil(L, 2)) {
+		if (lua_isboolean(L, 2))
 			mCAI->engagementRange = -1.0f;
 		else
 			mCAI->engagementRange = luaL_checkfloat(L, 2);
 	}
 
-	if (args >= 3) {
-		if (lua_isnoneornil(L, 3) || (lua_isboolean(L, 3)))
+	if (args >= 3 && !lua_isnoneornil(L, 3)) {
+		if (lua_isboolean(L, 3))
 			mCAI->fightEngagementRange = -1.0f;
 		else
 			mCAI->fightEngagementRange = luaL_checkfloat(L, 3);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -2823,7 +2823,7 @@ int LuaSyncedCtrl::SetUnitEngagementRange(lua_State* L)
 /***
  * @function Spring.SetUnitAutoTargetRate
  * @param unitID integer
- * @param timeout number? timeout in frames for auto-generated unit and weapon attack commands; pass false or nil to reset to default (GAME_SPEED * 5)
+ * @param timeout integer timeout in frames for auto-generated unit and weapon attack commands; pass any boolean to reset to default [(GAME_SPEED * 5 = 150) for unit autotarget, 65 for weapon autotarget].
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
@@ -2833,15 +2833,10 @@ int LuaSyncedCtrl::SetUnitAutoTargetRate(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	CMobileCAI* mCAI = dynamic_cast<CMobileCAI*>(unit->commandAI);
-
-	if (mCAI == nullptr)
-		return 0;
-
 	if (lua_isboolean(L, 2))
-		mCAI->attackCmdTimeout = 150;   // reset to default
+		unit->commandAI->attackCmdTimeout = -1;   // reset to default
 	else
-		mCAI->attackCmdTimeout = luaL_checkint(L, 2);
+		unit->commandAI->attackCmdTimeout = luaL_checkint(L, 2);
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -13,6 +13,7 @@ class LuaSyncedCtrl
 	public:
 		static bool PushEntries(lua_State* L);
 		static void CheckAllowGameChanges(lua_State* L);
+		static float CheckPositiveFloatOrDisable(lua_State* L, int idx);
 
 	private:
 		/* Recursion counters: call-ins have a limit on

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -93,6 +93,7 @@ class LuaSyncedCtrl
 		static int SetUnitWeaponState(lua_State* L);
 		static int SetUnitWeaponDamages(lua_State* L);
 		static int SetUnitMaxRange(lua_State* L);
+		static int SetUnitEngagementRange(lua_State* L);
 		static int SetUnitExperience(lua_State* L);
 		static int AddUnitExperience(lua_State* L);
 		static int SetUnitArmored(lua_State* L);

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -94,6 +94,7 @@ class LuaSyncedCtrl
 		static int SetUnitWeaponDamages(lua_State* L);
 		static int SetUnitMaxRange(lua_State* L);
 		static int SetUnitEngagementRange(lua_State* L);
+		static int SetUnitAutoTargetRate(lua_State* L);
 		static int SetUnitExperience(lua_State* L);
 		static int AddUnitExperience(lua_State* L);
 		static int SetUnitArmored(lua_State* L);

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -225,8 +225,8 @@ bool CAirCAI::AirAutoGenerateTarget(AAirMoveType* myPlane) {
 	const bool isFlying = (myPlane->aircraftState == AAirMoveType::AIRCRAFT_FLYING);
 
 	float searchRadius;
-	if (engagementRange >= 0.0f) {
-		searchRadius = engagementRange;
+	if (idleEngagementRange >= 0.0f) {
+		searchRadius = idleEngagementRange;
 	}
 	else {
 		searchRadius = 1000.0f * owner->moveState;

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -224,8 +224,13 @@ bool CAirCAI::AirAutoGenerateTarget(AAirMoveType* myPlane) {
 	const bool autoAttack = ((owner->fireState >= FIRESTATE_FIREATWILL) && (owner->moveState != MOVESTATE_HOLDPOS));
 	const bool isFlying = (myPlane->aircraftState == AAirMoveType::AIRCRAFT_FLYING);
 
-	// float searchRadius = 500.0f * owner->moveState;
-	float searchRadius = 1000.0f * owner->moveState;
+	float searchRadius;
+	if (engagementRange >= 0.0f) {
+		searchRadius = engagementRange;
+	}
+	else {
+		searchRadius = 1000.0f * owner->moveState;
+	}
 
 	if (!ownerDef->canAttack || !autoAttack || owner->maxRange <= 0.0f)
 		return false;
@@ -330,7 +335,8 @@ void CAirCAI::ExecuteFight(Command& c)
 			const float3 ofs = owner->speed * 10.0f;
 			const float3 pos = ClosestPointOnLine(commandPos1, commandPos2, owner->pos + ofs);
 
-			enemy = CGameHelper::GetClosestEnemyAircraft(nullptr, pos, 1000.0f * owner->moveState, owner->allyteam);
+			const float fighterSearchRadius = (fightEngagementRange >= 0.0f) ? fightEngagementRange : 1000.0f * owner->moveState;
+			enemy = CGameHelper::GetClosestEnemyAircraft(nullptr, pos, fighterSearchRadius, owner->allyteam);
 		}
 
 		if (IsValidTarget(enemy, nullptr) && (owner->moveState != MOVESTATE_MANEUVER || LinePointDist(commandPos1, commandPos2, enemy->pos) < 1000)) {
@@ -358,8 +364,8 @@ void CAirCAI::ExecuteFight(Command& c)
 		{
 			const float3 ofs = owner->speed * 20.0f;
 			const float3 pos = ClosestPointOnLine(commandPos1, commandPos2, owner->pos + ofs);
-
-			if ((enemy = CGameHelper::GetClosestValidTarget(pos, 500.0f * owner->moveState, owner->allyteam, this)) != nullptr) {
+			const float groundSearchRadius = (fightEngagementRange >= 0.0f) ? fightEngagementRange : 500.0f * owner->moveState;
+			if ((enemy = CGameHelper::GetClosestValidTarget(pos, groundSearchRadius, owner->allyteam, this)) != nullptr) {
 				PushOrUpdateReturnFight();
 
 				// make the attack-command inherit <c>'s options

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -78,7 +78,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(inCommand),
 	CR_MEMBER(commandDeathDependences),
 	CR_MEMBER(targetLostTimer),
-	CR_MEMBER(attackCmdTimeout),
+	CR_MEMBER(autoTargetRate),
 
 	CR_PREALLOC(GetPreallocContainer)
 ))

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -78,6 +78,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(inCommand),
 	CR_MEMBER(commandDeathDependences),
 	CR_MEMBER(targetLostTimer),
+	CR_MEMBER(attackCmdTimeout),
 
 	CR_PREALLOC(GetPreallocContainer)
 ))

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -48,6 +48,7 @@ public:
 	void WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent = true);
 
 	virtual bool CanWeaponAutoTarget(const CWeapon* weapon) const { return true; }
+
 	virtual int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
 	virtual void SlowUpdate();
 	virtual void GiveCommandReal(const Command& c, bool fromSynced = true);
@@ -124,6 +125,7 @@ public:
 	int lastUserCommand;
 	int selfDCountdown;
 	int lastFinishCommand;
+	int attackCmdTimeout = -1;
 
 	CUnit* owner;
 	CUnit* orderTarget;

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -48,7 +48,6 @@ public:
 	void WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent = true);
 
 	virtual bool CanWeaponAutoTarget(const CWeapon* weapon) const { return true; }
-
 	virtual int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
 	virtual void SlowUpdate();
 	virtual void GiveCommandReal(const Command& c, bool fromSynced = true);
@@ -125,7 +124,7 @@ public:
 	int lastUserCommand;
 	int selfDCountdown;
 	int lastFinishCommand;
-	float attackCmdTimeout = -1.0f;
+	float autoTargetRate = -1.0f;
 
 	CUnit* owner;
 	CUnit* orderTarget;

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -125,7 +125,7 @@ public:
 	int lastUserCommand;
 	int selfDCountdown;
 	int lastFinishCommand;
-	int attackCmdTimeout = -1;
+	float attackCmdTimeout = -1.0f;
 
 	CUnit* owner;
 	CUnit* orderTarget;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -69,6 +69,9 @@ CR_REG_METADATA(CMobileCAI, (
 	CR_MEMBER(buggerOffRadius),
 	CR_MEMBER(repairBelowHealth),
 
+	CR_MEMBER(engagementRange),
+	CR_MEMBER(fightEngagementRange),
+
 	CR_MEMBER(tempOrder),
 	CR_MEMBER(slowGuard),
 	CR_MEMBER(moveDir),
@@ -545,8 +548,14 @@ void CMobileCAI::ExecuteFight(Command& c)
 	if (owner->unitDef->canAttack && owner->fireState >= FIRESTATE_FIREATWILL && !owner->weapons.empty()) {
 		const float3 curPosOnLine = ClosestPointOnLine(commandPos1, commandPos2, owner->pos);
 
-		const float leashRadius = 100.0f * owner->moveState * owner->moveState;
-		const float searchRadius = owner->maxRange + leashRadius;
+		float searchRadius;
+		if (fightEngagementRange >= 0.0f) {
+			searchRadius = fightEngagementRange;
+		}
+		else {
+			const float leashRadius = 100.0f * owner->moveState * owner->moveState;
+			searchRadius = owner->maxRange + leashRadius;
+		}
 
 		CUnit* enemy = CGameHelper::GetClosestValidTarget(curPosOnLine, searchRadius, owner->allyteam, this);
 
@@ -893,8 +902,9 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		const float3& closestPos = ClosestPointOnLine(commandPos1, commandPos2, owner->pos);
 
 		const float curTargetDist = LinePointDist(closestPos, commandPos2, orderTarget->pos);
-		const float maxTargetDist = (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
-
+		//const float maxTargetDist = (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
+		const float maxTargetDist = (engagementRange >= 0.0f) ? engagementRange : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
+		
 		if (owner->moveState < MOVESTATE_ROAM && curTargetDist > maxTargetDist) {
 			StopMoveAndFinishCommand();
 			return;
@@ -1205,8 +1215,14 @@ bool CMobileCAI::GenerateAttackCmd()
 	if (owner->fireState == FIRESTATE_HOLDFIRE)
 		return false;
 
-	float  extraRadius = 200.0f * owner->moveState * owner->moveState;
-	float searchRadius = owner->maxRange + extraRadius;
+	float searchRadius;
+	if (engagementRange >= 0.0f) {
+		searchRadius = engagementRange;
+	}
+	else {
+		float extraRadius = 200.0f * owner->moveState * owner->moveState;
+		searchRadius = owner->maxRange + extraRadius;
+	}
 
 	int newAttackTargetId = -1;
 
@@ -1260,7 +1276,8 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	c.SetTimeOut(gs->frameNum + GAME_SPEED * 5);
+	const int attackTimeout = math::floor(std::max(5.0f, 2 * searchRadius / owner->unitDef->speed));
+	c.SetTimeOut(gs->frameNum + GAME_SPEED * attackTimeout);
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -72,7 +72,6 @@ CR_REG_METADATA(CMobileCAI, (
 	CR_MEMBER(idleEngagementRange),
 	CR_MEMBER(fightEngagementRange),
 	CR_MEMBER(engagementLeash),
-	CR_MEMBER(attackCmdTimeout),
 
 	CR_MEMBER(tempOrder),
 	CR_MEMBER(slowGuard),
@@ -352,14 +351,15 @@ void CMobileCAI::SlowUpdate()
 	}
 
 	if (commandQue.empty()) {
+		// prevent infinite recursion if the attack order terminates directly
+		// while still allowing the unit to immediately execute an attack cmd acquired this slowupdate
 		if (lastAutoGenerateTargetFrame == gs->frameNum)
 			return;
 
 		lastAutoGenerateTargetFrame = gs->frameNum;
 		MobileAutoGenerateTarget();
 
-		// the attack order could terminate directly and thus cause a loop
-		if (commandQue.empty() || (commandQue.front()).GetID() == CMD_ATTACK)
+		if (commandQue.empty())
 			return;
 	}
 
@@ -1287,7 +1287,7 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	c.SetTimeOut(gs->frameNum + attackCmdTimeout);
+	c.SetTimeOut(gs->frameNum + (attackCmdTimeout >= 0 ? attackCmdTimeout : GAME_SPEED * 5));
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -1288,7 +1288,7 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	c.SetTimeOut(static_cast <int> (gs->frameNum + GAME_SPEED * (attackCmdTimeout >= 0 ? attackCmdTimeout : 5)));
+	c.SetTimeOut(static_cast <int> (gs->frameNum + GAME_SPEED * (autoTargetRate >= 0 ? autoTargetRate : 5)));
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -902,7 +902,6 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		const float3& closestPos = ClosestPointOnLine(commandPos1, commandPos2, owner->pos);
 
 		const float curTargetDist = LinePointDist(closestPos, commandPos2, orderTarget->pos);
-		//const float maxTargetDist = (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
 		const float maxTargetDist = (engagementRange >= 0.0f) ? engagementRange : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
 		
 		if (owner->moveState < MOVESTATE_ROAM && curTargetDist > maxTargetDist) {

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -69,8 +69,10 @@ CR_REG_METADATA(CMobileCAI, (
 	CR_MEMBER(buggerOffRadius),
 	CR_MEMBER(repairBelowHealth),
 
-	CR_MEMBER(engagementRange),
+	CR_MEMBER(idleEngagementRange),
 	CR_MEMBER(fightEngagementRange),
+	CR_MEMBER(engagementLeash),
+	CR_MEMBER(attackCmdTimeout),
 
 	CR_MEMBER(tempOrder),
 	CR_MEMBER(slowGuard),
@@ -345,6 +347,7 @@ void CMobileCAI::SlowUpdate()
 
 	if (!commandQue.empty() && commandQue.front().GetTimeOut() < gs->frameNum) {
 		StopMoveAndFinishCommand();
+		return;
 	}
 
 	if (commandQue.empty()) {
@@ -901,7 +904,12 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		const float3& closestPos = ClosestPointOnLine(commandPos1, commandPos2, owner->pos);
 
 		const float curTargetDist = LinePointDist(closestPos, commandPos2, orderTarget->pos);
-		const float maxTargetDist = (engagementRange >= 0.0f) ? engagementRange : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
+
+		// this is the only use of GetManeuverLeash() in the codebase
+		// it controls when a unit disengages from an attack target. 
+		// this value *can* be set game-side via SetMoveTypeData, but we also want sane default values, such that attack commands from idle or fight don't immediately cancel. 
+		// So, we assume game-side gives us permission to use engagementLeash (overriding GetManeuverLeash) if they use SetUnitEngagementRange to set an EngagementRange.
+		const float maxTargetDist = (engagementLeash >= 0.0f) ? engagementLeash : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
 		
 		if (owner->moveState < MOVESTATE_ROAM && curTargetDist > maxTargetDist) {
 			StopMoveAndFinishCommand();
@@ -1214,8 +1222,8 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	float searchRadius;
-	if (engagementRange >= 0.0f) {
-		searchRadius = engagementRange;
+	if (idleEngagementRange >= 0.0f) {
+		searchRadius = idleEngagementRange;
 	}
 	else {
 		float extraRadius = 200.0f * owner->moveState * owner->moveState;
@@ -1274,7 +1282,7 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	c.SetTimeOut(gs->frameNum + GAME_SPEED * 5);
+	c.SetTimeOut(gs->frameNum + attackCmdTimeout);
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -1288,7 +1288,7 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	c.SetTimeOut(gs->frameNum + (attackCmdTimeout >= 0 ? attackCmdTimeout : GAME_SPEED * 5));
+	c.SetTimeOut(static_cast <int> (gs->frameNum + GAME_SPEED * (attackCmdTimeout >= 0 ? attackCmdTimeout : 5)));
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -345,7 +345,6 @@ void CMobileCAI::SlowUpdate()
 
 	if (!commandQue.empty() && commandQue.front().GetTimeOut() < gs->frameNum) {
 		StopMoveAndFinishCommand();
-		return;
 	}
 
 	if (commandQue.empty()) {
@@ -1275,8 +1274,7 @@ bool CMobileCAI::GenerateAttackCmd()
 		return false;
 
 	Command c(CMD_ATTACK, INTERNAL_ORDER, newAttackTargetId);
-	const int attackTimeout = math::floor(std::max(5.0f, 2 * searchRadius / owner->unitDef->speed));
-	c.SetTimeOut(gs->frameNum + GAME_SPEED * attackTimeout);
+	c.SetTimeOut(gs->frameNum + GAME_SPEED * 5);
 	commandQue.push_front(c);
 
 	commandPos1 = owner->pos;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -85,6 +85,7 @@ CR_REG_METADATA(CMobileCAI, (
 	CR_MEMBER(lastBuggerOffTime),
 	CR_MEMBER(buggerOffAttempts),
 	CR_MEMBER(lastIdleCheck),
+	CR_MEMBER(lastAutoGenerateTargetFrame),
 
 	CR_PREALLOC(GetPreallocContainer)
 ))
@@ -351,6 +352,10 @@ void CMobileCAI::SlowUpdate()
 	}
 
 	if (commandQue.empty()) {
+		if (lastAutoGenerateTargetFrame == gs->frameNum)
+			return;
+
+		lastAutoGenerateTargetFrame = gs->frameNum;
 		MobileAutoGenerateTarget();
 
 		// the attack order could terminate directly and thus cause a loop

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -914,7 +914,8 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		// it controls when a unit disengages from an attack target. 
 		// this value *can* be set game-side via SetMoveTypeData, but we also want sane default values, such that attack commands from idle or fight don't immediately cancel. 
 		// So, we assume game-side gives us permission to use engagementLeash (overriding GetManeuverLeash) if they use SetUnitEngagementRange to set an EngagementRange.
-		const float maxTargetDist = (engagementLeash >= 0.0f) ? engagementLeash : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
+		const float maneuverLeash = (engagementLeash >= 0.0f) ? engagementLeash : std::max(idleEngagementRange, fightEngagementRange);
+		const float maxTargetDist = (maneuverLeash >= 0.0f) ? maneuverLeash : (owner->moveType->GetManeuverLeash() * owner->moveState + owner->maxRange);
 		
 		if (owner->moveState < MOVESTATE_ROAM && curTargetDist > maxTargetDist) {
 			StopMoveAndFinishCommand();

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -91,8 +91,10 @@ public:
 	float repairBelowHealth;
 
 	// Lua-settable engagement range overrides (-1 means use default)
-	float engagementRange = -1.0f;
+	float idleEngagementRange = -1.0f;
 	float fightEngagementRange = -1.0f;
+	float engagementLeash = -1.0f;
+	int attackCmdTimeout = 150;
 
 	bool tempOrder;
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -94,7 +94,6 @@ public:
 	float idleEngagementRange = -1.0f;
 	float fightEngagementRange = -1.0f;
 	float engagementLeash = -1.0f;
-	int attackCmdTimeout = 150;
 
 	bool tempOrder;
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -110,6 +110,7 @@ protected:
 	int lastBuggerOffTime = -BUGGER_OFF_TTL;
 	int lastIdleCheck = 0;
 	int buggerOffAttempts = 0;
+	int lastAutoGenerateTargetFrame = -1;
 
 	static constexpr int MAX_CLOSE_IN_RETRY_TICKS = 30;
 	static constexpr int BUGGER_OFF_TTL = 200;

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -90,6 +90,10 @@ public:
 	float buggerOffRadius;
 	float repairBelowHealth;
 
+	// Lua-settable engagement range overrides (-1 means use default)
+	float engagementRange = -1.0f;
+	float fightEngagementRange = -1.0f;
+
 	bool tempOrder;
 
 protected:

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -707,7 +707,7 @@ bool CWeapon::AllowWeaponAutoTarget() const
 	if (currentTarget.isUserTarget)
 		return false;
 
-	return (gs->frameNum > (lastTargetRetry + (owner->commandAI->attackCmdTimeout >= 0 ? owner->commandAI->attackCmdTimeout : 65)));
+	return (gs->frameNum > (lastTargetRetry + (owner->commandAI->attackCmdTimeout >= 0 ? GAME_SPEED * owner->commandAI->attackCmdTimeout : 65)));
 }
 
 bool CWeapon::AutoTarget()

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -707,7 +707,7 @@ bool CWeapon::AllowWeaponAutoTarget() const
 	if (currentTarget.isUserTarget)
 		return false;
 
-	return (gs->frameNum > (lastTargetRetry + (owner->commandAI->attackCmdTimeout >= 0 ? GAME_SPEED * owner->commandAI->attackCmdTimeout : 65)));
+	return (gs->frameNum > (lastTargetRetry + (owner->commandAI->autoTargetRate >= 0 ? GAME_SPEED * owner->commandAI->autoTargetRate : 65)));
 }
 
 bool CWeapon::AutoTarget()

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -707,7 +707,7 @@ bool CWeapon::AllowWeaponAutoTarget() const
 	if (currentTarget.isUserTarget)
 		return false;
 
-	return (gs->frameNum > (lastTargetRetry + 65));
+	return (gs->frameNum > (lastTargetRetry + (owner->commandAI->attackCmdTimeout >= 0 ? owner->commandAI->attackCmdTimeout : 65)));
 }
 
 bool CWeapon::AutoTarget()


### PR DESCRIPTION
https://github.com/beyond-all-reason/Beyond-All-Reason/issues/2777#issuecomment-3935439584

Expose the searchRadius (for target acquisition while idle) and leashRadius (for target acquisition while on fight) to gameside lua. 
[assisted by Claude Sonnet 4.6 for the lua function and for bug hunting]

Was previously magic constants (such as 100, 200, 500, 1000) multiplied by the unit's movestate (or movestate squared)

From my testing, I also had to change the attack command timeout from an arbitrary 5 seconds, to:
max(5 seconds, 2*(target acquisition range divided by unit speed))
[The 2 is still arbitrary, but it seems reasonable that the command should time out if it somehow lasts twice the time it would take to walk to the target].

Also depreciates the confusing and unintuitive overload here:
https://github.com/beyond-all-reason/RecoilEngine/issues/1623

