### PR TITLE
Elongated Footprint Support

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2838,7 +2838,6 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 
 	{
 		const float  colRadiusSum = collider->hasElongatedFootprint ? collider->footprintMaxRadius + collideeRadius : colliderRadius + collideeRadius;
-		//const float  colRadiusSum = colliderRadius + collideeRadius;
 		const float   sepDistance = separationVector.Length() + 0.1f;
 		const float   penDistance = std::min(sepDistance - colRadiusSum, 0.0f);
 		const float  colSlideSign = -Sign(collidee->pos.dot(rgt) - pos.dot(rgt));

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -219,21 +219,18 @@ static CGroundMoveType::MemberData gmtMemberData = {
 // For CUnit*, prefer the pre-computed fields (footprintHalfExtents, footprintMaxRadius)
 // where available. These helpers exist for CSolidObject* paths (SAT, features).
 
-/// Axis stretch factor: 0 for square, approaches 1 for extremely elongated.
+// Axis stretch factor: 0 for square, approaches 1 for extremely elongated.
 static float CalcFootprintStretchFactor(const int2& footprint) {
 	return static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y);
 }
 
-/// Half-extents as a float2 in world units (x, z).
-/// Subtracts 1 square per axis before halving, matching the MoveDef size pattern.
+// Half-extents as a float2 in world units (x, z).
+// Subtracts 1 square per axis before halving, matching the MoveDef centering method.
 static float2 CalcFootprintHalfExtents(const int2& footprint) {
 	return float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
 }
 
-// Returns the radius of an oriented rectangle (halfX x halfZ) projected onto a separation
-// direction — an ellipse approximation of the OBB extents. Gives a direction-aware radius:
-// tight on the sides, long nose-to-nose, without requiring SAT.
-// Formula: sqrt( (halfX * |dir·right|)² + (halfZ * |dir·front|)² )
+// Gives a direction-aware radius (ellipse):
 static float CalcProjectedFootprintRadius(const CSolidObject* obj, const float2& halfExtents, const float3& dir) {
 	const float dx = math::fabs(dir.dot(obj->rightdir)) * halfExtents.x;
 	const float dz = math::fabs(dir.dot(obj->frontdir)) * halfExtents.y;
@@ -2555,23 +2552,22 @@ void CGroundMoveType::HandleObjectCollisions()
 	forceFromStaticCollidees = ZeroVector;
 	hasOBBCollision = false;
 
-	// NOTE:
-	//   use the collider's UnitDef footprint as radius for collision
-	//   detection (its MoveDef footprint may be smaller for pathfinding)
-	//   Pre-computed on CUnit from the original UnitDef footprint.
-	const float colliderFootPrintRadius = collider->footprintMaxRadius;
+	const float colliderMoveDefRadius = colliderMD->CalcFootPrintMaxInteriorRadius();
+
+	//   Also send the collider's UnitDef footprint for collision detection
+	//   (its MoveDef footprint may be smaller for pathfinding)
+	//   Pre-computed on CUnit from the UnitDef footprint.
+	//const float colliderFootPrintRadius = collider->footprintMaxRadius;
 	const float colliderAxisStretchFact = collider->hasElongatedFootprint
 		? CalcFootprintStretchFactor(collider->footprint)
 		: 0.0f;
-	// Use the MoveDef (pathfinding) footprint radius for separation checks and push forces.
-	// This prevents elongated footprints (e.g. 3x10) from pushing units away in all directions
-	// like a 10x10 circle — collision detection (SAT) still uses the full oriented footprint.
-	const float colliderMoveDefRadius = colliderMD->CalcFootPrintMinExteriorRadius();
+	HandleUnitCollisions(collider, {collider->speed.w, colliderMoveDefRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
+	HandleFeatureCollisions(collider, {collider->speed.w, colliderMoveDefRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
 
-	const ColliderParams colliderParams = {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius};
+	//const ColliderParams colliderParams = {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius};
 
-	HandleUnitCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
-	HandleFeatureCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
+	//HandleUnitCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
+	//HandleFeatureCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
 
 	if (forceStaticObjectCheck) {
 		MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -2607,9 +2603,7 @@ void CGroundMoveType::HandleObjectCollisions()
 
 	// When the nose/tail of an elongated unit overlaps a blocked square, drop unit-push
 	// forces and rely solely on static-collision response. This prevents other units from
-	// pushing an elongated unit's nose further into a building — the same principle as the
-	// positionStuck fallback above, but for OBB-zone overlap that the MoveDef footprint
-	// cannot detect.
+	// pushing an elongated unit's nose further into a building
 	if (hasOBBCollision) {
 		resultantForces = forceFromStaticCollidees;
 		if (resultantForces.SqLength() > maxPushForceSq)
@@ -2679,13 +2673,9 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		float3 intersectSqrSumPosition;
 
 		const float3 rightDir2D = (rgt * XZVector).SafeNormalize();
-		const float3 frontDir2D = (collider->frontdir * XZVector).SafeNormalize();
 		const float3 speedDir2D = (vel * XZVector).SafeNormalize();
 
-		// OBB half-extents in world-space for oriented footprint (used for nose/tail push-out)
-		// Uses the pre-computed footprintHalfExtents (from UnitDef dimensions), NOT xsize/zsize
-		// which are overridden to match the MoveDef during GroundMoveType initialization.
-		// squareRadius is added to account for the blocked square's own half-extent.
+		// OBB half-extents in world-space for oriented footprint 
 		// Only needed for elongated units; square units skip OBB logic entirely.
 		const float obbHalfX = collider->hasElongatedFootprint ? collider->footprintHalfExtents.x + squareRadius : 0.0f;
 		const float obbHalfZ = collider->hasElongatedFootprint ? collider->footprintHalfExtents.y + squareRadius : 0.0f;
@@ -2713,6 +2703,13 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		int xmin, xmax, zmin, zmax;
 
 		if (collider->hasElongatedFootprint) {
+
+			const float3 frontDir2D = (collider->frontdir * XZVector).SafeNormalize();
+			// OBB half-extents in world-space for oriented footprint 
+			// Only needed for elongated units; square units skip OBB logic entirely.
+			const float obbHalfX = collider->hasElongatedFootprint ? collider->footprintHalfExtents.x + squareRadius : 0.0f;
+			const float obbHalfZ = collider->hasElongatedFootprint ? collider->footprintHalfExtents.y + squareRadius : 0.0f;
+
 			// Widen the scan to cover the AABB of the unit's oriented OBB so that squares
 			// overlapping the nose/tail (which lie outside the axis-aligned MoveDef zone) are
 			// also visited. Without this, long ships can phase their nose through buildings.
@@ -2767,13 +2764,28 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 				const float3 squareVec = pos - squarePos;
 
 
-				const float  squareColRadiusSum = colliderRadius + squareRadius;
+				const float  squareColRadiusSum = collider->hasElongatedFootprint ? collider->footprintMaxRadius + squareRadius : colliderRadius + squareRadius;
 				const float   squareSepDistance = squareVec.Length2D() + 0.1f;
 				const float   squarePenDistance = std::min(squareSepDistance - squareColRadiusSum, 0.0f);
 				// const float  squareColSlideSign = -Sign(squarePos.dot(rightDir2D) - pos.dot(rightDir2D));
 
-				// NOTE: realMinX/realMaxX are absolute grid coords; compare against xabs/zabs (also absolute)
-				const bool inMoveDefZone = (xabs >= realMinX && xabs <= realMaxX && zabs >= realMinZ && zabs <= realMaxZ);
+				if (collider->hasElongatedFootprint) {
+					// NOTE: realMinX/realMaxX are absolute grid coords; compare against xabs/zabs (also absolute)
+					const bool inMoveDefZone = (xabs >= realMinX && xabs <= realMaxX && zabs >= realMinZ && zabs <= realMaxZ);
+					if (!inMoveDefZone) {
+						hasOBBCollision |= true;
+					}
+				}
+
+				if (intersectSize > 1) {
+					intersectDistance = std::min(intersectDistance, squarePenDistance);
+					intersectSqrSumPosition += (squarePos * XZVector);
+					intersectSqrCount++;
+				}
+				if (checkYardMap && !positionStuck)
+					positionStuck = true;
+
+				/*
 				if (inMoveDefZone) {
 					if (intersectSize > 1) {
 						intersectDistance = std::min(intersectDistance, squarePenDistance);
@@ -2828,6 +2840,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 						}
 					}
 				}
+				*/
 
 				// ignore squares behind us (relative to velocity vector)
 				if (squareVec.dot(vel) > 0.0f)
@@ -2904,7 +2917,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 
 void CGroundMoveType::HandleUnitCollisions(
 	CUnit* collider,
-	const ColliderParams& colliderParams,
+	const float3& colliderParams,
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
@@ -2917,7 +2930,7 @@ void CGroundMoveType::HandleUnitCollisions(
 	const bool allowCAU = modInfo.allowCrushingAlliedUnits;
 	const bool allowPEU = modInfo.allowPushingEnemyUnits;
 	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
-	const bool forceSAT = (colliderParams.axisStretchFactor > 0.1f);
+	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
 
@@ -2926,8 +2939,8 @@ void CGroundMoveType::HandleUnitCollisions(
 	const float colliderSeparationDist = (pushResistant && pushResistanceBlockActive) ? 0.f : colliderUD->separationDistance;
 
 	// Account for units that are larger than one's self.
-	const float maxCollisionRadius = colliderParams.footprintRadius + moveDefHandler.GetLargestFootPrintSizeH();
-	const float searchRadius = colliderParams.speed + maxCollisionRadius + colliderSeparationDist;
+	const float maxCollisionRadius = colliderParams.y + moveDefHandler.GetLargestFootPrintSizeH();
+	const float searchRadius = colliderParams.x + maxCollisionRadius + colliderSeparationDist;
 
 	MoveTypes::CheckCollisionQuery colliderInfo(collider);
 	if ( !colliderMD->overrideUnitWaterline )
@@ -2971,12 +2984,19 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collidee->loadingTransportId == collider->id) continue;
 
 		// mobile collidees have xsize/zsize overridden by MoveDef, so use the pre-computed
-		// footprintMaxRadius (from original UnitDef values).
-		const float collDist = (collideeMobile)
-			? collidee->footprintMaxRadius
-			: collidee->CalcFootPrintMaxInteriorRadius();
-		const float2 collideeParams = {collidee->speed.w, collDist};
+		// footprintMaxRadius (from original UnitDef values) for enlongated units.
+		// for unit "separation", assume enlongated units have an ellipse shape.
+		// and that the "separation" distance acts from this ellipse.
+		const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
+		const float colliderCircleRadius = (collider->hasElongatedFootprint) ? CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D) : colliderParams.y;
+		const float collideeCircleRadius = (!collideeMobile) ? collidee->CalcFootPrintMaxInteriorRadius() :
+							   (collidee->hasElongatedFootprint) ? CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D) : collideeMD->CalcFootPrintMaxInteriorRadius();
 
+		const float2 collideeParams = { collidee->speed.w, collideeCircleRadius };
+		const float4 separationVect = { collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius) };
+		//const float collideeCircleRadius = collidee->hasElongatedFootprint ? collidee->footprintMaxRadius : collideeParams.y;
+		
+		/*
 		// Compute a direction-aware collision radius for each unit by projecting its oriented
 		// footprint rectangle onto the separation direction (ellipse approximation of the OBB).
 		// This makes a 3x10 ship collide like a 3x10 shape — tight on the sides, long nose-to-nose —
@@ -3001,6 +3021,10 @@ void CGroundMoveType::HandleUnitCollisions(
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius)};
 
 		const int collisionFunc = (allowSAT && (forceSAT || collideeElongated));
+		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
+		*/ 
+		
+		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collidee->hasElongatedFootprint)));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 
 		// Separation zone also uses projected radii (+ MoveDef base for push forces)
@@ -3041,7 +3065,7 @@ void CGroundMoveType::HandleUnitCollisions(
 			// const bool ignoreCollidee = (collideeYields && alliedCollision);
 
 			crushCollidee |= (!alliedCollision || allowCAU);
-			crushCollidee &= ((colliderParams.speed * collider->mass) > (collideeParams.x * collidee->mass));
+			crushCollidee &= ((colliderParams.x * collider->mass) > (collideeParams.x * collidee->mass));
 
 			if (crushCollidee && !CMoveMath::CrushResistant(*colliderMD, collidee)) {
 				auto& events = Sim::registry.get<UnitCrushEvents>(owner->entityReference);
@@ -3082,7 +3106,7 @@ void CGroundMoveType::HandleUnitCollisions(
 			const bool allowNewPath = (!atEndOfPath && !atGoal);
 			const bool checkYardMap = ((pushCollider || pushCollidee) || collideeUD->IsFactoryUnit());
 
-			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.moveDefRadius, collideeParams.y,  separationVect, allowNewPath, checkYardMap, false, curThread)) {
+			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.y, collideeParams.y,  separationVect, allowNewPath, checkYardMap, false, curThread)) {
 				ReRequestPath(false);
 			}
 
@@ -3092,27 +3116,24 @@ void CGroundMoveType::HandleUnitCollisions(
 		const bool moveCollider = ((pushCollider || !pushCollidee) && colliderMobile);
 		if (moveCollider) {
 			if (isCollision) {
-				// Use projected radii for push magnitude — correct for elongated footprints
-				const ColliderParams colliderPushParams = {colliderParams.speed, colliderCircleRadius, colliderParams.axisStretchFactor, colliderCircleRadius};
-				const float2 collideePushParams  = {collidee->speed.w, collideeCircleRadius};
-				const float4 pushSepVect = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
-				forceFromMovingCollidees += CalculatePushVector(colliderPushParams, collideePushParams, allowUCO, pushSepVect, collider, collidee);
+				const float3 colliderParams1 = { colliderParams.x, colliderCircleRadius, colliderParams.z };
+				forceFromMovingCollidees += CalculatePushVector(colliderParams1, collideeParams, allowUCO, separationVect, collider, collidee);
 			} else {
 				// push units away from each other though they are not colliding.
-				const ColliderParams colliderParams2 = {colliderParams.speed, colliderCircleRadius + separationDist * 0.5f, colliderParams.axisStretchFactor, colliderCircleRadius + separationDist * 0.5f};
-				const float2 collideeParams2  = {collidee->speed.w, collideeCircleRadius + separationDist * 0.5f};
-				const float4 separationVect2  = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
+				const float3 colliderParams2 = { colliderParams.x, colliderCircleRadius + separationDist * 0.5f, colliderParams.z };
+				const float2 collideeParams2 = { collidee->speed.w, collideeCircleRadius + separationDist * 0.5f };
+				const float4 separationVect2 = { static_cast<float3>(separationVect), Square(colliderParams.y + collideeParams.y) };
 				forceFromMovingCollidees += CalculatePushVector(colliderParams2, collideeParams2, allowUCO, separationVect2, collider, collidee);
 			}
 		}
 	}
 }
 
-float3 CGroundMoveType::CalculatePushVector(const ColliderParams &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
+float3 CGroundMoveType::CalculatePushVector(const float3 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
 {
-    const float colliderRelRadius = colliderParams.footprintRadius / (colliderParams.footprintRadius + collideeParams.y);
-    const float collideeRelRadius = collideeParams.y / (colliderParams.footprintRadius + collideeParams.y);
-    const float collisionRadiusSum = allowUCO ? (colliderParams.footprintRadius * colliderRelRadius + collideeParams.y * collideeRelRadius) : (colliderParams.footprintRadius + collideeParams.y);
+    const float colliderRelRadius = colliderParams.y / (colliderParams.y + collideeParams.y);
+    const float collideeRelRadius = collideeParams.y / (colliderParams.y + collideeParams.y);
+    const float collisionRadiusSum = allowUCO ? (colliderParams.y * colliderRelRadius + collideeParams.y * collideeRelRadius) : (colliderParams.y + collideeParams.y);
 
     const float sepDistance = separationVect.Length() + 0.1f;
     const float penDistance = std::max(collisionRadiusSum - sepDistance, 1.0f);
@@ -3124,7 +3145,7 @@ float3 CGroundMoveType::CalculatePushVector(const ColliderParams &colliderParams
     const float
         m1 = collider->mass,
         m2 = collidee->mass,
-        v1 = std::max(1.0f, colliderParams.speed),
+        v1 = std::max(1.0f, colliderParams.x),
         v2 = std::max(1.0f, collideeParams.x),
         c1 = 1.0f + (1.0f - math::fabs(collider->frontdir.dot(-sepDirection))) * 5.0f,
         c2 = 1.0f + (1.0f - math::fabs(collidee->frontdir.dot(sepDirection))) * 5.0f,
@@ -3157,14 +3178,14 @@ float3 CGroundMoveType::CalculatePushVector(const ColliderParams &colliderParams
 
 void CGroundMoveType::HandleFeatureCollisions(
 	CUnit* collider,
-	const ColliderParams& colliderParams,
+	const float3& colliderParams,
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
-	const bool forceSAT = (colliderParams.axisStretchFactor > 0.1f);
+	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
 	MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -3172,14 +3193,14 @@ void CGroundMoveType::HandleFeatureCollisions(
 	// copy on purpose, since DoDamage below can call Lua
 	QuadFieldQuery qfQuery;
 	qfQuery.threadOwner = curThread;
-	quadField.GetFeaturesExact(qfQuery, collider->pos, colliderParams.speed + (colliderParams.footprintRadius * 2.0f));
+	quadField.GetFeaturesExact(qfQuery, collider->pos, colliderParams.x + (colliderParams.y * 2.0f));
 
 	for (CFeature* collidee: *qfQuery.features) {
 		// const FeatureDef* collideeFD = collidee->def;
 
 		// use the collidee's Feature (not FeatureDef) footprint as radius
 		const float2 collideeParams = {0.0f, collidee->CalcFootPrintMaxInteriorRadius()};
-		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.footprintRadius + collideeParams.y)};
+		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
 		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collidee->CalcFootPrintAxisStretchFactor() > 0.1f))](separationVect, collider, collidee, colliderMD, nullptr))
 			continue;
@@ -3203,7 +3224,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		}
 
 		if (!collidee->IsMoving()) {
-			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.moveDefRadius, collideeParams.y,  separationVect, (!atEndOfPath && !atGoal), true, false, curThread)) {
+			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.y, collideeParams.y,  separationVect, (!atEndOfPath && !atGoal), true, false, curThread)) {
 				ReRequestPath(false);
 			}
 
@@ -3211,7 +3232,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		}
 
 		const float  sepDistance    = separationVect.Length() + 0.1f;
-		const float  penDistance    = std::max((colliderParams.footprintRadius + collideeParams.y) - sepDistance, 1.0f);
+		const float  penDistance    = std::max((colliderParams.y + collideeParams.y) - sepDistance, 1.0f);
 		const float  sepResponse    = std::min(SQUARE_SIZE * 2.0f, penDistance * 0.5f);
 
 		const float3 sepDirection   = separationVect / sepDistance;
@@ -3223,7 +3244,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		const float
 			m1 = collider->mass,
 			m2 = collidee->mass * 10000.0f,
-			v1 = std::max(1.0f, colliderParams.speed),
+			v1 = std::max(1.0f, colliderParams.x),
 			v2 = 1.0f,
 			c1 = (1.0f - math::fabs( collider->frontdir.dot(-sepDirection))) * 5.0f,
 			c2 = (1.0f - math::fabs(-collider->frontdir.dot( sepDirection))) * 5.0f,

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2764,16 +2764,24 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					const bool inMoveDefZone = (xabs >= realMinX && xabs <= realMaxX && zabs >= realMinZ && zabs <= realMaxZ);
 					if (!inMoveDefZone) {
 						hasOBBCollision = true;
+						// OBB nose/tail squares must also contribute to the push-out force
+						const float3 pushDir = (pos - squarePos).SafeNormalize2D();
+						const float intoWall = std::min(0.0f, vel.dot(pushDir)); // negative = moving toward square
+						forceFromStaticCollidees += pushDir * (intoWall * squarePenDistance / squareColRadiusSum);
 					}
+
 				}
 
-				if (intersectSize > 1) {
-					intersectDistance = std::min(intersectDistance, squarePenDistance);
-					intersectSqrSumPosition += (squarePos * XZVector);
-					intersectSqrCount++;
+				if (x >= realMinX && x <= realMaxX && z >= realMinZ && z <= realMaxZ) {
+			
+					if (intersectSize > 1) {
+						intersectDistance = std::min(intersectDistance, squarePenDistance);
+						intersectSqrSumPosition += (squarePos * XZVector);
+						intersectSqrCount++;
+					}
+					if (checkYardMap && !positionStuck)
+						positionStuck = true;
 				}
-				if (checkYardMap && !positionStuck)
-					positionStuck = true;
 
 				// ignore squares behind us (relative to velocity vector)
 				if (squareVec.dot(vel) > 0.0f)

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2935,7 +2935,7 @@ void CGroundMoveType::HandleUnitCollisions(
 	const float colliderSeparationDist = (pushResistant && pushResistanceBlockActive) ? 0.f : colliderUD->separationDistance;
 
 	// Account for units that are larger than one's self.
-	const float maxCollisionRadius = colliderParams.y + moveDefHandler.GetLargestFootPrintSizeH();
+	const float maxCollisionRadius = collider->hasElongatedFootprint ? collider->footprintMaxRadius + moveDefHandler.GetLargestFootPrintSizeH() : colliderParams.y + moveDefHandler.GetLargestFootPrintSizeH();
 	const float searchRadius = colliderParams.x + maxCollisionRadius + colliderSeparationDist;
 
 	MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -2984,7 +2984,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
 		const float colliderCircleRadius = (collider->hasElongatedFootprint) ? CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D) : colliderParams.y;
 		const float collideeCircleRadius = (!collideeMobile) ? collidee->CalcFootPrintMaxInteriorRadius() :
-							   (collidee->hasElongatedFootprint) ? CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D) : collideeMD->CalcFootPrintMaxInteriorRadius();
+							   (collidee->hasElongatedFootprint) ? CalcProjectedFootprintRadius(collidee, collidee->footprintHalfExtents, sepDir2D) : collideeMD->CalcFootPrintMaxInteriorRadius();
 
 		const float2 collideeParams = { collidee->speed.w, collideeCircleRadius };
 		const float4 separationVect = { collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius) };

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2650,7 +2650,13 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		float3 intersectSqrSumPosition;
 
 		const float3 rightDir2D = (rgt * XZVector).SafeNormalize();
+		const float3 frontDir2D = (collider->frontdir * XZVector).SafeNormalize();
 		const float3 speedDir2D = (vel * XZVector).SafeNormalize();
+
+		// OBB half-extents in world-space for oriented footprint (used for nose/tail push-out)
+		// These are based on the unit's actual xsize/zsize, not just the MoveDef zone.
+		const float obbHalfX = (collider->xsize * 0.5f * SQUARE_SIZE) + squareRadius;
+		const float obbHalfZ = (collider->zsize * 0.5f * SQUARE_SIZE) + squareRadius;
 
 		const int xmid = (pos.x + vel.x) / SQUARE_SIZE;
 		const int zmid = (pos.z + vel.z) / SQUARE_SIZE;
@@ -2672,8 +2678,19 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		const int zsh = colliderMD->zsizeh * (checkYardMap || (checkTerrain && colliderMD->allowTerrainCollisions));
 		const int intersectSize = colliderMD->xsize;
 
-		const int xmin = std::min(-1, -xsh), xmax = std::max(1, xsh);
-		const int zmin = std::min(-1, -zsh), zmax = std::max(1, zsh);
+		// Widen the scan to cover the AABB of the unit's oriented OBB so that squares
+		// overlapping the nose/tail (which lie outside the axis-aligned MoveDef zone) are
+		// also visited. Without this, long ships can phase their nose through buildings.
+		const int obbHalfXSq = static_cast<int>(std::ceil(obbHalfX / SQUARE_SIZE));
+		const int obbHalfZSq = static_cast<int>(std::ceil(obbHalfZ / SQUARE_SIZE));
+		// AABB of rotated OBB in grid squares
+		const int obbAABBX = static_cast<int>(std::ceil(
+			math::fabs(frontDir2D.x) * obbHalfZSq + math::fabs(rightDir2D.x) * obbHalfXSq));
+		const int obbAABBZ = static_cast<int>(std::ceil(
+			math::fabs(frontDir2D.z) * obbHalfZSq + math::fabs(rightDir2D.z) * obbHalfXSq));
+
+		const int xmin = std::min(-1, -std::max(xsh, obbAABBX)), xmax = std::max(1, std::max(xsh, obbAABBX));
+		const int zmin = std::min(-1, -std::max(zsh, obbAABBZ)), zmax = std::max(1, std::max(zsh, obbAABBZ));
 
 		if (DEBUG_DRAWING_ENABLED){
 			geometryLock.lock();
@@ -2716,7 +2733,9 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 				const float   squarePenDistance = std::min(squareSepDistance - squareColRadiusSum, 0.0f);
 				// const float  squareColSlideSign = -Sign(squarePos.dot(rightDir2D) - pos.dot(rightDir2D));
 
-				if (x >= realMinX && x <= realMaxX && z >= realMinZ && z <= realMaxZ){
+				// NOTE: realMinX/realMaxX are absolute grid coords; compare against xabs/zabs (also absolute)
+				const bool inMoveDefZone = (xabs >= realMinX && xabs <= realMaxX && zabs >= realMinZ && zabs <= realMaxZ);
+				if (inMoveDefZone) {
 					if (intersectSize > 1) {
 						intersectDistance = std::min(intersectDistance, squarePenDistance);
 						intersectSqrSumPosition += (squarePos * XZVector);
@@ -2724,6 +2743,50 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					}
 					if (checkYardMap && !positionStuck)
 						positionStuck = true;
+				} else {
+					// Square is outside the axis-aligned MoveDef zone but may still overlap
+					// the unit's oriented bounding box (OBB). This handles long ships whose
+					// nose/tail extends well beyond the MoveDef footprint center.
+					//
+					// We cannot use squarePenDistance (sphere distance from unit center) here
+					// because nose/tail squares are far from center, so squareSepDistance >
+					// squareColRadiusSum and squarePenDistance == 0 -- no force would result.
+					//
+					// Instead, compute penetration in OBB-local space and apply a direct
+					// axial push force. positionStuck is NOT set here to keep pathfinder and
+					// collision detection in agreement.
+					const float3 squareVec2D = squareVec * XZVector; // pos - squarePos, in XZ
+					const float signedFront = squareVec2D.dot(frontDir2D); // +ve = square is in front of center
+					const float signedRight = squareVec2D.dot(rightDir2D);
+					const float absFront = math::fabs(signedFront);
+					const float absRight = math::fabs(signedRight);
+
+					if (absFront <= obbHalfZ && absRight <= obbHalfX) {
+						// Penetration depth along each OBB axis (positive = inside OBB)
+						const float penDepthFront = obbHalfZ - absFront;
+						const float penDepthRight = obbHalfX - absRight;
+
+						// Push along whichever axis has the least penetration (shallowest exit).
+						// For a nose-first collision, penDepthFront will be small (square just
+						// entered the nose) and penDepthRight will be large (square is well
+						// inside laterally) -- so we push along frontDir, backward.
+						//
+						// The push magnitude includes the velocity component along the push
+						// axis so that the force always exceeds the speed driving the unit
+						// into the building. Without this, penetration depth ≈ velocity and
+						// the nose settles into a jittery steady-state inside the structure.
+						float3 obbPushVec;
+						if (penDepthFront <= penDepthRight) {
+							// Exit via front/back face -- push unit along frontDir
+							const float velComponent = math::fabs(vel.dot(frontDir2D));
+							obbPushVec = frontDir2D * (Sign(signedFront) * (penDepthFront + velComponent));
+						} else {
+							// Exit via side face -- push unit along rightDir
+							const float velComponent = math::fabs(vel.dot(rightDir2D));
+							obbPushVec = rightDir2D * (Sign(signedRight) * (penDepthRight + velComponent));
+						}
+						forceFromStaticCollidees += obbPushVec;
+					}
 				}
 
 				// ignore squares behind us (relative to velocity vector)

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2766,7 +2766,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 						hasOBBCollision = true;
 						// OBB nose/tail squares must also contribute to the push-out force
 						const float3 pushDir = (pos - squarePos).SafeNormalize2D();
-						const float vmag = std::abs(vel.dot(pushDir)); // negative = moving toward square
+						const float vmag = std::abs(vel.dot(pushDir));
 						forceFromStaticCollidees += pushDir * (-vmag * 0.5f * squarePenDistance / squareColRadiusSum);
 					}
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -144,7 +144,7 @@ CR_REG_METADATA(CGroundMoveType, (
 	CR_MEMBER(resultantForces),
 	CR_MEMBER(forceFromMovingCollidees),
 	CR_MEMBER(forceFromStaticCollidees),
-	CR_MEMBER(forceFromOBBCollidees),
+	CR_MEMBER(hasOBBCollision),
 
 	CR_MEMBER(pathID),
 	CR_MEMBER(nextPathId),
@@ -213,8 +213,32 @@ static CGroundMoveType::MemberData gmtMemberData = {
 	}},
 };
 
+// Helpers for footprint-based collision calculations.
+// Mobile units have xsize/zsize overridden by MoveDef, so these read from the
+// original UnitDef footprint (int2) to get the true physical shape.
+// For CUnit*, prefer the pre-computed fields (footprintHalfExtents, footprintMaxRadius)
+// where available. These helpers exist for CSolidObject* paths (SAT, features).
 
+/// Axis stretch factor: 0 for square, approaches 1 for extremely elongated.
+static float CalcFootprintStretchFactor(const int2& footprint) {
+	return static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y);
+}
 
+/// Half-extents as a float2 in world units (x, z).
+/// Subtracts 1 square per axis before halving, matching the MoveDef size pattern.
+static float2 CalcFootprintHalfExtents(const int2& footprint) {
+	return float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
+}
+
+// Returns the radius of an oriented rectangle (halfX x halfZ) projected onto a separation
+// direction — an ellipse approximation of the OBB extents. Gives a direction-aware radius:
+// tight on the sides, long nose-to-nose, without requiring SAT.
+// Formula: sqrt( (halfX * |dir·right|)² + (halfZ * |dir·front|)² )
+static float CalcProjectedFootprintRadius(const CSolidObject* obj, const float2& halfExtents, const float3& dir) {
+	const float dx = math::fabs(dir.dot(obj->rightdir)) * halfExtents.x;
+	const float dz = math::fabs(dir.dot(obj->frontdir)) * halfExtents.y;
+	return math::sqrt(dx * dx + dz * dz);
+}
 
 namespace SAT {
 	static float CalcSeparatingDist(
@@ -239,13 +263,12 @@ namespace SAT {
 		const float3& separationVec
 	) {
 		// collider is always a mobile unit whose xsize/zsize were overridden by MoveDef,
-		// so use footprint (original UnitDef values) for the collision shape
-		// Subtract 1 square per axis before halving to match MoveDef size construction.
-		const float2 colliderSize = float2(collider->footprint.x - 1, collider->footprint.y - 1) * (0.5f * SQUARE_SIZE);
+		// so use the original UnitDef footprint for the collision shape.
+		const float2 colliderSize = CalcFootprintHalfExtents(collider->footprint);
 		// collidee may be a mobile unit (MoveDef override), immobile unit, or feature;
 		// mobile units need footprint, others have correct xsize/zsize already
 		const float2 collideeSize = (collideeMD != nullptr)
-			? float2(collidee->footprint.x - 1, collidee->footprint.y - 1) * (0.5f * SQUARE_SIZE)
+			? CalcFootprintHalfExtents(collidee->footprint)
 			: collidee->GetFootPrint(0.5f * SQUARE_SIZE);
 
 		// true if no overlap on at least one axis
@@ -258,39 +281,6 @@ namespace SAT {
 		return haveAxis;
 	}
 };
-
-
-// Helpers for footprint-based collision calculations.
-// Mobile units have xsize/zsize overridden by MoveDef, so these read from the
-// original UnitDef footprint (int2) to get the true physical shape.
-
-/// Axis stretch factor: 0 for square, approaches 1 for extremely elongated.
-static float CalcFootprintStretchFactor(const int2& footprint) {
-	return static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y);
-}
-
-/// Max half-extent in world units — the radius of the bounding circle.
-/// Subtracts 1 square (SQUARE_SIZE) from each axis before halving, matching the
-/// pattern used by MoveDef to construct its interior radius.
-static float CalcFootprintMaxRadius(const int2& footprint) {
-	return (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
-}
-
-/// Half-extents as a float2 in world units (x, z).
-/// Subtracts 1 square per axis before halving, matching the MoveDef size pattern.
-static float2 CalcFootprintHalfExtents(const int2& footprint) {
-	return float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
-}
-
-// Returns the radius of an oriented rectangle (halfX x halfZ) projected onto a separation
-// direction — an ellipse approximation of the OBB extents. Gives a direction-aware radius:
-// tight on the sides, long nose-to-nose, without requiring SAT.
-// Formula: sqrt( (halfX * |dir·right|)² + (halfZ * |dir·front|)² )
-static float CalcProjectedFootprintRadius(const CSolidObject* obj, const float2& halfExtents, const float3& dir) {
-	const float dx = math::fabs(dir.dot(obj->rightdir)) * halfExtents.x;
-	const float dz = math::fabs(dir.dot(obj->frontdir)) * halfExtents.y;
-	return math::sqrt(dx * dx + dz * dz);
-}
 
 static bool CheckCollisionExclSAT(
 	const float4& separationVec,
@@ -2563,14 +2553,13 @@ void CGroundMoveType::HandleObjectCollisions()
 	resultantForces = ZeroVector;
 	forceFromMovingCollidees = ZeroVector;
 	forceFromStaticCollidees = ZeroVector;
-	forceFromOBBCollidees = ZeroVector;
+	hasOBBCollision = false;
 
 	// NOTE:
 	//   use the collider's UnitDef footprint as radius for collision
 	//   detection (its MoveDef footprint may be smaller for pathfinding)
-	//   must read from footprint directly since xsize/zsize are overridden
-	//   to match the MoveDef during GroundMoveType initialization
-	const float colliderFootPrintRadius = CalcFootprintMaxRadius(collider->footprint);
+	//   Pre-computed on CUnit from the original UnitDef footprint.
+	const float colliderFootPrintRadius = collider->footprintMaxRadius;
 	const float colliderAxisStretchFact = collider->hasElongatedFootprint
 		? CalcFootprintStretchFactor(collider->footprint)
 		: 0.0f;
@@ -2616,20 +2605,12 @@ void CGroundMoveType::HandleObjectCollisions()
 			(resultantForces.Normalize()) *= maxSpeed;
 	}
 
-	// OBB nose/tail forces correct physical overlap between the unit's
-	// oriented bounding box and blocked squares. These must be prioritized
-	// because:
-	// 1. UpdatePos validates against the MoveDef footprint, which is smaller
-	//    than the physical OBB — backward pushes from nose collisions can
-	//    land on squares still "blocked" in MoveDef terms, zeroing the result.
-	// 2. In blob scenarios, forceFromMovingCollidees (unit-push) can overpower
-	//    the static collision component, pushing the nose into buildings.
-	//
-	// When OBB overlap is detected, drop unit-push forces (like positionStuck
-	// does for MoveDef-zone overlap) so the building collision response wins.
-	// Then unconditionally add the OBB force to ensure the nose is pushed out
-	// even if the base static forces alone are insufficient.
-	if (!forceFromOBBCollidees.same(ZeroVector)) {
+	// When the nose/tail of an elongated unit overlaps a blocked square, drop unit-push
+	// forces and rely solely on static-collision response. This prevents other units from
+	// pushing an elongated unit's nose further into a building — the same principle as the
+	// positionStuck fallback above, but for OBB-zone overlap that the MoveDef footprint
+	// cannot detect.
+	if (hasOBBCollision) {
 		resultantForces = forceFromStaticCollidees;
 		if (resultantForces.SqLength() > maxPushForceSq)
 			(resultantForces.Normalize()) *= maxSpeed;
@@ -2702,14 +2683,12 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		const float3 speedDir2D = (vel * XZVector).SafeNormalize();
 
 		// OBB half-extents in world-space for oriented footprint (used for nose/tail push-out)
-		// Must use collider->footprint (UnitDef dimensions), NOT collider->xsize/zsize
+		// Uses the pre-computed footprintHalfExtents (from UnitDef dimensions), NOT xsize/zsize
 		// which are overridden to match the MoveDef during GroundMoveType initialization.
-		// Using xsize/zsize would give a near-square OBB matching the (small) MoveDef
-		// instead of the actual elongated physical shape, causing nose squares to fall
-		// outside the OBB and receive no collision response.
+		// squareRadius is added to account for the blocked square's own half-extent.
 		// Only needed for elongated units; square units skip OBB logic entirely.
-		const float obbHalfX = collider->hasElongatedFootprint ? ((collider->footprint.x - 1) * 0.5f * SQUARE_SIZE) + squareRadius : 0.0f;
-		const float obbHalfZ = collider->hasElongatedFootprint ? ((collider->footprint.y - 1) * 0.5f * SQUARE_SIZE) + squareRadius : 0.0f;
+		const float obbHalfX = collider->hasElongatedFootprint ? collider->footprintHalfExtents.x + squareRadius : 0.0f;
+		const float obbHalfZ = collider->hasElongatedFootprint ? collider->footprintHalfExtents.y + squareRadius : 0.0f;
 
 		const int xmid = (pos.x + vel.x) / SQUARE_SIZE;
 		const int zmid = (pos.z + vel.z) / SQUARE_SIZE;
@@ -2804,19 +2783,33 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					if (checkYardMap && !positionStuck)
 						positionStuck = true;
 				} else if (collider->hasElongatedFootprint) {
-					// Square is outside the axis-aligned MoveDef zone but may still overlap
-					// the unit's oriented bounding box (OBB). This handles long ships whose
-					// nose/tail extends well beyond the MoveDef footprint center.
+					// --- OBB nose/tail collision response for elongated units ---
 					//
-					// We cannot use squarePenDistance (sphere distance from unit center) here
-					// because nose/tail squares are far from center, so squareSepDistance >
-					// squareColRadiusSum and squarePenDistance == 0 -- no force would result.
+					// WHY THIS EXISTS (not redundant with SAT):
+					// SAT (Separating Axis Theorem) determines whether two objects'
+					// bounding boxes overlap — it answers "is there a collision?"
+					// That detection gates entry into HandleStaticObjectCollision.
 					//
-					// Instead, compute penetration in OBB-local space and apply a direct
-					// axial push force. positionStuck is NOT set here to keep pathfinder and
-					// collision detection in agreement.
-					const float3 squareVec2D = squareVec * XZVector; // pos - squarePos, in XZ
-					const float signedFront = squareVec2D.dot(frontDir2D); // +ve = square is in front of center
+					// Once inside, this per-square scan determines the *response
+					// direction*. The MoveDef-zone scan (above) only covers the
+					// axis-aligned MoveDef footprint, which is typically much smaller
+					// than the actual elongated physical shape (e.g. 3×3 MoveDef for
+					// a 3×10 ship). The nose and tail extend beyond the MoveDef zone
+					// and can overlap blocked squares that the MoveDef scan never visits.
+					//
+					// Without this branch, the nose clips through buildings because:
+					// - squarePenDistance is computed from the unit's *center*, so
+					//   nose/tail squares are far away and produce zero penetration
+					// - the MoveDef scan range doesn't reach nose/tail squares at all
+					//
+					// The OBB branch computes penetration in the unit's local coordinate
+					// frame, producing an axial push along the front/back direction.
+					// Only nose/tail squares fire (penDepthFront <= penDepthRight) to
+					// avoid lateral forces from side-body squares, which would cause
+					// oscillation in hallways. Lateral clearance is the MoveDef-zone
+					// strafe/bounce system's responsibility.
+					const float3 squareVec2D = squareVec * XZVector;
+					const float signedFront = squareVec2D.dot(frontDir2D);
 					const float signedRight = squareVec2D.dot(rightDir2D);
 					const float absFront = math::fabs(signedFront);
 					const float absRight = math::fabs(signedRight);
@@ -2825,42 +2818,20 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 						const float penDepthFront = obbHalfZ - absFront;
 						const float penDepthRight = obbHalfX - absRight;
 
-						// --- NEW: Only apply OBB push for nose/tail squares ---
-						// The MoveDef zone covers the unit's center body. OBB logic
-						// exists specifically for nose/tail overhang beyond that zone.
-						// Body-side squares (high penDepthFront = deep along the length,
-						// meaning the square is near the center) create opposing lateral
-						// forces in hallways. Skip them — they're the MoveDef zone's job.
-						//
-						// A square is "nose/tail" if penDepthFront is small relative to
-						// penDepthRight, i.e. it's near the front/back face of the OBB.
-						// We only fire when penDepthFront is the minimum axis — this is
-						// already the nose-collision case in the original logic.
+						// Only push for nose/tail squares (front face is the shallow axis).
+						// Side-face squares (penDepthRight < penDepthFront) are skipped —
+						// they sit alongside the body and would create opposing lateral
+						// forces from both walls of a hallway.
 						if (penDepthFront <= penDepthRight) {
-							//const float velComponent = math::fabs(vel.dot(frontDir2D));
-							float3 obbPushVec = frontDir2D * (Sign(signedFront) * (penDepthFront));
-							forceFromStaticCollidees += obbPushVec;
-							forceFromOBBCollidees += obbPushVec;
-							//limitSpeedForTurning = std::max(limitSpeedForTurning, (short)2);
+							forceFromStaticCollidees += frontDir2D * (Sign(signedFront) * penDepthFront);
+							hasOBBCollision = true;
 						}
-						// Side-face pushes (penDepthRight < penDepthFront) are deliberately
-						// skipped for OBB-zone squares. These squares are alongside the body
-						// and in a hallway produce opposing lateral forces from both walls.
-						// The MoveDef-zone strafe/bounce system handles lateral clearance.
 					}
 				}
 
 				// ignore squares behind us (relative to velocity vector)
 				if (squareVec.dot(vel) > 0.0f)
 					continue;
-
-				// Only accumulate strafe/bounce for squares within the MoveDef zone.
-				// OBB-zone squares outside the MoveDef zone are handled by their own
-				// push logic above; letting them feed into strafe/bounce causes
-				// oscillation in hallways because the expanded scan picks up wall
-				// squares on both sides whose lateral components flip frame-to-frame.
-				//if (!inMoveDefZone)
-				//	continue;
 
 				// this tends to cancel out too much on average
 				// strafeVec += (rightDir2D * sqColSlideSign);
@@ -2999,10 +2970,10 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collider->loadingTransportId == collidee->id) continue;
 		if (collidee->loadingTransportId == collider->id) continue;
 
-		// mobile collidees have xsize/zsize overridden by MoveDef, so use footprint (original UnitDef values)
-		// Subtract 1 square before halving to match MoveDef size construction.
+		// mobile collidees have xsize/zsize overridden by MoveDef, so use the pre-computed
+		// footprintMaxRadius (from original UnitDef values).
 		const float collDist = (collideeMobile)
-			? (std::max(collidee->footprint.x, collidee->footprint.y) - 1) * 0.5f * SQUARE_SIZE
+			? collidee->footprintMaxRadius
 			: collidee->CalcFootPrintMaxInteriorRadius();
 		const float2 collideeParams = {collidee->speed.w, collDist};
 
@@ -3020,12 +2991,10 @@ void CGroundMoveType::HandleUnitCollisions(
 			const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
 
 			if (colliderElongated) {
-				const float2 colliderHalfFP = float2(collider->footprint.x - 1, collider->footprint.y - 1) * (0.5f * SQUARE_SIZE);
-				colliderCircleRadius = CalcProjectedFootprintRadius(collider, colliderHalfFP, sepDir2D);
+				colliderCircleRadius = CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D);
 			}
 			if (collideeElongated) {
-				const float2 collideeHalfFP = float2(collidee->footprint.x - 1, collidee->footprint.y - 1) * (0.5f * SQUARE_SIZE);
-				collideeCircleRadius = CalcProjectedFootprintRadius(collidee, collideeHalfFP, sepDir2D);
+				collideeCircleRadius = CalcProjectedFootprintRadius(collidee, collidee->footprintHalfExtents, sepDir2D);
 			}
 		}
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -237,9 +237,8 @@ namespace SAT {
 		const MoveDef* collideeMD,
 		const float3& separationVec
 	) {
-		// const float2 colliderSize = (colliderMD != nullptr)? colliderMD->GetFootPrint(0.5f * SQUARE_SIZE): collider->GetFootPrint(0.5f * SQUARE_SIZE);
-		const float2 colliderSize =                          colliderMD->GetFootPrint(0.5f * SQUARE_SIZE)                                            ;
-		const float2 collideeSize = (collideeMD != nullptr)? collideeMD->GetFootPrint(0.5f * SQUARE_SIZE): collidee->GetFootPrint(0.5f * SQUARE_SIZE);
+		const float2 colliderSize = collider->GetFootPrint(0.5f * SQUARE_SIZE);
+		const float2 collideeSize = collidee->GetFootPrint(0.5f * SQUARE_SIZE);
 
 		// true if no overlap on at least one axis
 		bool haveAxis = false;
@@ -2526,10 +2525,10 @@ void CGroundMoveType::HandleObjectCollisions()
 	forceFromStaticCollidees = ZeroVector;
 
 	// NOTE:
-	//   use the collider's MoveDef footprint as radius since it is
-	//   always mobile (its UnitDef footprint size may be different)
-	const float colliderFootPrintRadius = colliderMD->CalcFootPrintMaxInteriorRadius();
-	const float colliderAxisStretchFact = colliderMD->CalcFootPrintAxisStretchFactor();
+	//   use the collider's UnitDef footprint as radius for collision
+	//   detection (its MoveDef footprint may be smaller for pathfinding)
+	const float colliderFootPrintRadius = collider->CalcFootPrintMaxInteriorRadius();
+	const float colliderAxisStretchFact = collider->CalcFootPrintAxisStretchFactor();
 
 	HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
 	HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
@@ -2846,11 +2845,11 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collider->loadingTransportId == collidee->id) continue;
 		if (collidee->loadingTransportId == collider->id) continue;
 
-		const float collDist = (collideeMobile) ? collideeMD->CalcFootPrintMaxInteriorRadius() : collidee->CalcFootPrintMaxInteriorRadius();
+		const float collDist = collidee->CalcFootPrintMaxInteriorRadius();
 		const float2 collideeParams = {collidee->speed.w, collDist};
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f)));
+		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collidee->CalcFootPrintAxisStretchFactor() > 0.1f)));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 
 		// check for separation

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2675,11 +2675,6 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		const float3 rightDir2D = (rgt * XZVector).SafeNormalize();
 		const float3 speedDir2D = (vel * XZVector).SafeNormalize();
 
-		// OBB half-extents in world-space for oriented footprint 
-		// Only needed for elongated units; square units skip OBB logic entirely.
-		const float obbHalfX = collider->hasElongatedFootprint ? collider->footprintHalfExtents.x + squareRadius : 0.0f;
-		const float obbHalfZ = collider->hasElongatedFootprint ? collider->footprintHalfExtents.y + squareRadius : 0.0f;
-
 		const int xmid = (pos.x + vel.x) / SQUARE_SIZE;
 		const int zmid = (pos.z + vel.z) / SQUARE_SIZE;
 
@@ -2773,7 +2768,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					// NOTE: realMinX/realMaxX are absolute grid coords; compare against xabs/zabs (also absolute)
 					const bool inMoveDefZone = (xabs >= realMinX && xabs <= realMaxX && zabs >= realMinZ && zabs <= realMaxZ);
 					if (!inMoveDefZone) {
-						hasOBBCollision |= true;
+						hasOBBCollision = true;
 					}
 				}
 
@@ -2896,7 +2891,8 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 	}
 
 	{
-		const float  colRadiusSum = colliderRadius + collideeRadius;
+		const float  colRadiusSum = collider->hasElongatedFootprint ? collider->footprintMaxRadius + collideeRadius : colliderRadius + collideeRadius;
+		//const float  colRadiusSum = colliderRadius + collideeRadius;
 		const float   sepDistance = separationVector.Length() + 0.1f;
 		const float   penDistance = std::min(sepDistance - colRadiusSum, 0.0f);
 		const float  colSlideSign = -Sign(collidee->pos.dot(rgt) - pos.dot(rgt));
@@ -2917,7 +2913,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 
 void CGroundMoveType::HandleUnitCollisions(
 	CUnit* collider,
-	const float3& colliderParams,
+	const float3& colliderParams, // .x := speed, .y := radius, .z := fpstretch
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
@@ -2983,8 +2979,6 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collider->loadingTransportId == collidee->id) continue;
 		if (collidee->loadingTransportId == collider->id) continue;
 
-		// mobile collidees have xsize/zsize overridden by MoveDef, so use the pre-computed
-		// footprintMaxRadius (from original UnitDef values) for enlongated units.
 		// for unit "separation", assume enlongated units have an ellipse shape.
 		// and that the "separation" distance acts from this ellipse.
 		const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
@@ -3116,13 +3110,13 @@ void CGroundMoveType::HandleUnitCollisions(
 		const bool moveCollider = ((pushCollider || !pushCollidee) && colliderMobile);
 		if (moveCollider) {
 			if (isCollision) {
-				const float3 colliderParams1 = { colliderParams.x, colliderCircleRadius, colliderParams.z };
+				const float3 colliderParams1 = {colliderParams.x, colliderCircleRadius, colliderParams.z};
 				forceFromMovingCollidees += CalculatePushVector(colliderParams1, collideeParams, allowUCO, separationVect, collider, collidee);
 			} else {
 				// push units away from each other though they are not colliding.
-				const float3 colliderParams2 = { colliderParams.x, colliderCircleRadius + separationDist * 0.5f, colliderParams.z };
-				const float2 collideeParams2 = { collidee->speed.w, collideeCircleRadius + separationDist * 0.5f };
-				const float4 separationVect2 = { static_cast<float3>(separationVect), Square(colliderParams.y + collideeParams.y) };
+				const float3 colliderParams2 = {colliderParams.x, colliderCircleRadius + separationDist * 0.5f, colliderParams.z};
+				const float2 collideeParams2 = {collidee->speed.w, collideeCircleRadius + separationDist * 0.5f};
+				const float4 separationVect2 = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
 				forceFromMovingCollidees += CalculatePushVector(colliderParams2, collideeParams2, allowUCO, separationVect2, collider, collidee);
 			}
 		}

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2564,11 +2564,6 @@ void CGroundMoveType::HandleObjectCollisions()
 	HandleUnitCollisions(collider, {collider->speed.w, colliderMoveDefRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
 	HandleFeatureCollisions(collider, {collider->speed.w, colliderMoveDefRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
 
-	//const ColliderParams colliderParams = {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius};
-
-	//HandleUnitCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
-	//HandleFeatureCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
-
 	if (forceStaticObjectCheck) {
 		MoveTypes::CheckCollisionQuery colliderInfo(collider);
 		positionStuck |= !colliderMD->TestMoveSquare(colliderInfo, owner->pos, owner->speed, true, false, true, nullptr, nullptr, curThread);
@@ -2780,63 +2775,6 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 				if (checkYardMap && !positionStuck)
 					positionStuck = true;
 
-				/*
-				if (inMoveDefZone) {
-					if (intersectSize > 1) {
-						intersectDistance = std::min(intersectDistance, squarePenDistance);
-						intersectSqrSumPosition += (squarePos * XZVector);
-						intersectSqrCount++;
-					}
-					if (checkYardMap && !positionStuck)
-						positionStuck = true;
-				} else if (collider->hasElongatedFootprint) {
-					// --- OBB nose/tail collision response for elongated units ---
-					//
-					// WHY THIS EXISTS (not redundant with SAT):
-					// SAT (Separating Axis Theorem) determines whether two objects'
-					// bounding boxes overlap — it answers "is there a collision?"
-					// That detection gates entry into HandleStaticObjectCollision.
-					//
-					// Once inside, this per-square scan determines the *response
-					// direction*. The MoveDef-zone scan (above) only covers the
-					// axis-aligned MoveDef footprint, which is typically much smaller
-					// than the actual elongated physical shape (e.g. 3×3 MoveDef for
-					// a 3×10 ship). The nose and tail extend beyond the MoveDef zone
-					// and can overlap blocked squares that the MoveDef scan never visits.
-					//
-					// Without this branch, the nose clips through buildings because:
-					// - squarePenDistance is computed from the unit's *center*, so
-					//   nose/tail squares are far away and produce zero penetration
-					// - the MoveDef scan range doesn't reach nose/tail squares at all
-					//
-					// The OBB branch computes penetration in the unit's local coordinate
-					// frame, producing an axial push along the front/back direction.
-					// Only nose/tail squares fire (penDepthFront <= penDepthRight) to
-					// avoid lateral forces from side-body squares, which would cause
-					// oscillation in hallways. Lateral clearance is the MoveDef-zone
-					// strafe/bounce system's responsibility.
-					const float3 squareVec2D = squareVec * XZVector;
-					const float signedFront = squareVec2D.dot(frontDir2D);
-					const float signedRight = squareVec2D.dot(rightDir2D);
-					const float absFront = math::fabs(signedFront);
-					const float absRight = math::fabs(signedRight);
-
-					if (absFront <= obbHalfZ && absRight <= obbHalfX) {
-						const float penDepthFront = obbHalfZ - absFront;
-						const float penDepthRight = obbHalfX - absRight;
-
-						// Only push for nose/tail squares (front face is the shallow axis).
-						// Side-face squares (penDepthRight < penDepthFront) are skipped —
-						// they sit alongside the body and would create opposing lateral
-						// forces from both walls of a hallway.
-						if (penDepthFront <= penDepthRight) {
-							forceFromStaticCollidees += frontDir2D * (Sign(signedFront) * penDepthFront);
-							hasOBBCollision = true;
-						}
-					}
-				}
-				*/
-
 				// ignore squares behind us (relative to velocity vector)
 				if (squareVec.dot(vel) > 0.0f)
 					continue;
@@ -2988,36 +2926,7 @@ void CGroundMoveType::HandleUnitCollisions(
 
 		const float2 collideeParams = { collidee->speed.w, collideeCircleRadius };
 		const float4 separationVect = { collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius) };
-		//const float collideeCircleRadius = collidee->hasElongatedFootprint ? collidee->footprintMaxRadius : collideeParams.y;
-		
-		/*
-		// Compute a direction-aware collision radius for each unit by projecting its oriented
-		// footprint rectangle onto the separation direction (ellipse approximation of the OBB).
-		// This makes a 3x10 ship collide like a 3x10 shape — tight on the sides, long nose-to-nose —
-		// without needing SAT. Falls back to isotropic max-radius for non-mobile/non-elongated units.
-		const bool colliderElongated = collider->hasElongatedFootprint;
-		const bool collideeElongated = collideeMobile && collidee->hasElongatedFootprint;
-
-		float colliderCircleRadius = colliderParams.footprintRadius;
-		float collideeCircleRadius = collDist;
-
-		if (colliderElongated || collideeElongated) {
-			const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
-
-			if (colliderElongated) {
-				colliderCircleRadius = CalcProjectedFootprintRadius(collider, collider->footprintHalfExtents, sepDir2D);
-			}
-			if (collideeElongated) {
-				collideeCircleRadius = CalcProjectedFootprintRadius(collidee, collidee->footprintHalfExtents, sepDir2D);
-			}
-		}
-
-		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius)};
-
-		const int collisionFunc = (allowSAT && (forceSAT || collideeElongated));
-		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
-		*/ 
-		
+				
 		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collidee->hasElongatedFootprint)));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -144,6 +144,7 @@ CR_REG_METADATA(CGroundMoveType, (
 	CR_MEMBER(resultantForces),
 	CR_MEMBER(forceFromMovingCollidees),
 	CR_MEMBER(forceFromStaticCollidees),
+	CR_MEMBER(forceFromOBBCollidees),
 
 	CR_MEMBER(pathID),
 	CR_MEMBER(nextPathId),
@@ -239,11 +240,12 @@ namespace SAT {
 	) {
 		// collider is always a mobile unit whose xsize/zsize were overridden by MoveDef,
 		// so use footprint (original UnitDef values) for the collision shape
-		const float2 colliderSize = float2(collider->footprint) * (0.5f * SQUARE_SIZE);
+		// Subtract 1 square per axis before halving to match MoveDef size construction.
+		const float2 colliderSize = float2(collider->footprint.x - 1, collider->footprint.y - 1) * (0.5f * SQUARE_SIZE);
 		// collidee may be a mobile unit (MoveDef override), immobile unit, or feature;
 		// mobile units need footprint, others have correct xsize/zsize already
 		const float2 collideeSize = (collideeMD != nullptr)
-			? float2(collidee->footprint) * (0.5f * SQUARE_SIZE)
+			? float2(collidee->footprint.x - 1, collidee->footprint.y - 1) * (0.5f * SQUARE_SIZE)
 			: collidee->GetFootPrint(0.5f * SQUARE_SIZE);
 
 		// true if no overlap on at least one axis
@@ -257,6 +259,28 @@ namespace SAT {
 	}
 };
 
+
+// Helpers for footprint-based collision calculations.
+// Mobile units have xsize/zsize overridden by MoveDef, so these read from the
+// original UnitDef footprint (int2) to get the true physical shape.
+
+/// Axis stretch factor: 0 for square, approaches 1 for extremely elongated.
+static float CalcFootprintStretchFactor(const int2& footprint) {
+	return static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y);
+}
+
+/// Max half-extent in world units — the radius of the bounding circle.
+/// Subtracts 1 square (SQUARE_SIZE) from each axis before halving, matching the
+/// pattern used by MoveDef to construct its interior radius.
+static float CalcFootprintMaxRadius(const int2& footprint) {
+	return (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
+}
+
+/// Half-extents as a float2 in world units (x, z).
+/// Subtracts 1 square per axis before halving, matching the MoveDef size pattern.
+static float2 CalcFootprintHalfExtents(const int2& footprint) {
+	return float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
+}
 
 // Returns the radius of an oriented rectangle (halfX x halfZ) projected onto a separation
 // direction — an ellipse approximation of the OBB extents. Gives a direction-aware radius:
@@ -2539,21 +2563,26 @@ void CGroundMoveType::HandleObjectCollisions()
 	resultantForces = ZeroVector;
 	forceFromMovingCollidees = ZeroVector;
 	forceFromStaticCollidees = ZeroVector;
+	forceFromOBBCollidees = ZeroVector;
 
 	// NOTE:
 	//   use the collider's UnitDef footprint as radius for collision
 	//   detection (its MoveDef footprint may be smaller for pathfinding)
 	//   must read from footprint directly since xsize/zsize are overridden
 	//   to match the MoveDef during GroundMoveType initialization
-	const float colliderFootPrintRadius = std::max(collider->footprint.x, collider->footprint.y) * 0.5f * SQUARE_SIZE;
-	const float colliderAxisStretchFact = std::abs(collider->footprint.x - collider->footprint.y) * 1.0f / (collider->footprint.x + collider->footprint.y);
+	const float colliderFootPrintRadius = CalcFootprintMaxRadius(collider->footprint);
+	const float colliderAxisStretchFact = collider->hasElongatedFootprint
+		? CalcFootprintStretchFactor(collider->footprint)
+		: 0.0f;
 	// Use the MoveDef (pathfinding) footprint radius for separation checks and push forces.
 	// This prevents elongated footprints (e.g. 3x10) from pushing units away in all directions
 	// like a 10x10 circle — collision detection (SAT) still uses the full oriented footprint.
 	const float colliderMoveDefRadius = colliderMD->CalcFootPrintMinExteriorRadius();
 
-	HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius}, colliderUD, colliderMD, curThread);
-	HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius}, colliderUD, colliderMD, curThread);
+	const ColliderParams colliderParams = {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius};
+
+	HandleUnitCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
+	HandleFeatureCollisions(collider, colliderParams, colliderUD, colliderMD, curThread);
 
 	if (forceStaticObjectCheck) {
 		MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -2582,6 +2611,25 @@ void CGroundMoveType::HandleObjectCollisions()
 	UpdatePos(owner, tryForce, resultantForces, curThread);
 
 	if (resultantForces.same(ZeroVector) && positionStuck){
+		resultantForces = forceFromStaticCollidees;
+		if (resultantForces.SqLength() > maxPushForceSq)
+			(resultantForces.Normalize()) *= maxSpeed;
+	}
+
+	// OBB nose/tail forces correct physical overlap between the unit's
+	// oriented bounding box and blocked squares. These must be prioritized
+	// because:
+	// 1. UpdatePos validates against the MoveDef footprint, which is smaller
+	//    than the physical OBB — backward pushes from nose collisions can
+	//    land on squares still "blocked" in MoveDef terms, zeroing the result.
+	// 2. In blob scenarios, forceFromMovingCollidees (unit-push) can overpower
+	//    the static collision component, pushing the nose into buildings.
+	//
+	// When OBB overlap is detected, drop unit-push forces (like positionStuck
+	// does for MoveDef-zone overlap) so the building collision response wins.
+	// Then unconditionally add the OBB force to ensure the nose is pushed out
+	// even if the base static forces alone are insufficient.
+	if (!forceFromOBBCollidees.same(ZeroVector)) {
 		resultantForces = forceFromStaticCollidees;
 		if (resultantForces.SqLength() > maxPushForceSq)
 			(resultantForces.Normalize()) *= maxSpeed;
@@ -2654,9 +2702,14 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		const float3 speedDir2D = (vel * XZVector).SafeNormalize();
 
 		// OBB half-extents in world-space for oriented footprint (used for nose/tail push-out)
-		// These are based on the unit's actual xsize/zsize, not just the MoveDef zone.
-		const float obbHalfX = (collider->xsize * 0.5f * SQUARE_SIZE) + squareRadius;
-		const float obbHalfZ = (collider->zsize * 0.5f * SQUARE_SIZE) + squareRadius;
+		// Must use collider->footprint (UnitDef dimensions), NOT collider->xsize/zsize
+		// which are overridden to match the MoveDef during GroundMoveType initialization.
+		// Using xsize/zsize would give a near-square OBB matching the (small) MoveDef
+		// instead of the actual elongated physical shape, causing nose squares to fall
+		// outside the OBB and receive no collision response.
+		// Only needed for elongated units; square units skip OBB logic entirely.
+		const float obbHalfX = collider->hasElongatedFootprint ? ((collider->footprint.x - 1) * 0.5f * SQUARE_SIZE) + squareRadius : 0.0f;
+		const float obbHalfZ = collider->hasElongatedFootprint ? ((collider->footprint.y - 1) * 0.5f * SQUARE_SIZE) + squareRadius : 0.0f;
 
 		const int xmid = (pos.x + vel.x) / SQUARE_SIZE;
 		const int zmid = (pos.z + vel.z) / SQUARE_SIZE;
@@ -2678,19 +2731,26 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 		const int zsh = colliderMD->zsizeh * (checkYardMap || (checkTerrain && colliderMD->allowTerrainCollisions));
 		const int intersectSize = colliderMD->xsize;
 
-		// Widen the scan to cover the AABB of the unit's oriented OBB so that squares
-		// overlapping the nose/tail (which lie outside the axis-aligned MoveDef zone) are
-		// also visited. Without this, long ships can phase their nose through buildings.
-		const int obbHalfXSq = static_cast<int>(std::ceil(obbHalfX / SQUARE_SIZE));
-		const int obbHalfZSq = static_cast<int>(std::ceil(obbHalfZ / SQUARE_SIZE));
-		// AABB of rotated OBB in grid squares
-		const int obbAABBX = static_cast<int>(std::ceil(
-			math::fabs(frontDir2D.x) * obbHalfZSq + math::fabs(rightDir2D.x) * obbHalfXSq));
-		const int obbAABBZ = static_cast<int>(std::ceil(
-			math::fabs(frontDir2D.z) * obbHalfZSq + math::fabs(rightDir2D.z) * obbHalfXSq));
+		int xmin, xmax, zmin, zmax;
 
-		const int xmin = std::min(-1, -std::max(xsh, obbAABBX)), xmax = std::max(1, std::max(xsh, obbAABBX));
-		const int zmin = std::min(-1, -std::max(zsh, obbAABBZ)), zmax = std::max(1, std::max(zsh, obbAABBZ));
+		if (collider->hasElongatedFootprint) {
+			// Widen the scan to cover the AABB of the unit's oriented OBB so that squares
+			// overlapping the nose/tail (which lie outside the axis-aligned MoveDef zone) are
+			// also visited. Without this, long ships can phase their nose through buildings.
+			const int obbHalfXSq = static_cast<int>(std::ceil(obbHalfX / SQUARE_SIZE));
+			const int obbHalfZSq = static_cast<int>(std::ceil(obbHalfZ / SQUARE_SIZE));
+			// AABB of rotated OBB in grid squares
+			const int obbAABBX = static_cast<int>(std::ceil(
+				math::fabs(frontDir2D.x) * obbHalfZSq + math::fabs(rightDir2D.x) * obbHalfXSq));
+			const int obbAABBZ = static_cast<int>(std::ceil(
+				math::fabs(frontDir2D.z) * obbHalfZSq + math::fabs(rightDir2D.z) * obbHalfXSq));
+
+			xmin = std::min(-1, -std::max(xsh, obbAABBX)); xmax = std::max(1, std::max(xsh, obbAABBX));
+			zmin = std::min(-1, -std::max(zsh, obbAABBZ)); zmax = std::max(1, std::max(zsh, obbAABBZ));
+		} else {
+			xmin = std::min(-1, -xsh); xmax = std::max(1, xsh);
+			zmin = std::min(-1, -zsh); zmax = std::max(1, zsh);
+		}
 
 		if (DEBUG_DRAWING_ENABLED){
 			geometryLock.lock();
@@ -2743,7 +2803,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					}
 					if (checkYardMap && !positionStuck)
 						positionStuck = true;
-				} else {
+				} else if (collider->hasElongatedFootprint) {
 					// Square is outside the axis-aligned MoveDef zone but may still overlap
 					// the unit's oriented bounding box (OBB). This handles long ships whose
 					// nose/tail extends well beyond the MoveDef footprint center.
@@ -2762,36 +2822,45 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 					const float absRight = math::fabs(signedRight);
 
 					if (absFront <= obbHalfZ && absRight <= obbHalfX) {
-						// Penetration depth along each OBB axis (positive = inside OBB)
 						const float penDepthFront = obbHalfZ - absFront;
 						const float penDepthRight = obbHalfX - absRight;
 
-						// Push along whichever axis has the least penetration (shallowest exit).
-						// For a nose-first collision, penDepthFront will be small (square just
-						// entered the nose) and penDepthRight will be large (square is well
-						// inside laterally) -- so we push along frontDir, backward.
+						// --- NEW: Only apply OBB push for nose/tail squares ---
+						// The MoveDef zone covers the unit's center body. OBB logic
+						// exists specifically for nose/tail overhang beyond that zone.
+						// Body-side squares (high penDepthFront = deep along the length,
+						// meaning the square is near the center) create opposing lateral
+						// forces in hallways. Skip them — they're the MoveDef zone's job.
 						//
-						// The push magnitude includes the velocity component along the push
-						// axis so that the force always exceeds the speed driving the unit
-						// into the building. Without this, penetration depth ≈ velocity and
-						// the nose settles into a jittery steady-state inside the structure.
-						float3 obbPushVec;
+						// A square is "nose/tail" if penDepthFront is small relative to
+						// penDepthRight, i.e. it's near the front/back face of the OBB.
+						// We only fire when penDepthFront is the minimum axis — this is
+						// already the nose-collision case in the original logic.
 						if (penDepthFront <= penDepthRight) {
-							// Exit via front/back face -- push unit along frontDir
-							const float velComponent = math::fabs(vel.dot(frontDir2D));
-							obbPushVec = frontDir2D * (Sign(signedFront) * (penDepthFront + velComponent));
-						} else {
-							// Exit via side face -- push unit along rightDir
-							const float velComponent = math::fabs(vel.dot(rightDir2D));
-							obbPushVec = rightDir2D * (Sign(signedRight) * (penDepthRight + velComponent));
+							//const float velComponent = math::fabs(vel.dot(frontDir2D));
+							float3 obbPushVec = frontDir2D * (Sign(signedFront) * (penDepthFront));
+							forceFromStaticCollidees += obbPushVec;
+							forceFromOBBCollidees += obbPushVec;
+							//limitSpeedForTurning = std::max(limitSpeedForTurning, (short)2);
 						}
-						forceFromStaticCollidees += obbPushVec;
+						// Side-face pushes (penDepthRight < penDepthFront) are deliberately
+						// skipped for OBB-zone squares. These squares are alongside the body
+						// and in a hallway produce opposing lateral forces from both walls.
+						// The MoveDef-zone strafe/bounce system handles lateral clearance.
 					}
 				}
 
 				// ignore squares behind us (relative to velocity vector)
 				if (squareVec.dot(vel) > 0.0f)
 					continue;
+
+				// Only accumulate strafe/bounce for squares within the MoveDef zone.
+				// OBB-zone squares outside the MoveDef zone are handled by their own
+				// push logic above; letting them feed into strafe/bounce causes
+				// oscillation in hallways because the expanded scan picks up wall
+				// squares on both sides whose lateral components flip frame-to-frame.
+				//if (!inMoveDefZone)
+				//	continue;
 
 				// this tends to cancel out too much on average
 				// strafeVec += (rightDir2D * sqColSlideSign);
@@ -2864,7 +2933,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 
 void CGroundMoveType::HandleUnitCollisions(
 	CUnit* collider,
-	const float4& colliderParams, // .x := speed, .y := footprintRadius, .z := fpstretch, .w := moveDefRadius
+	const ColliderParams& colliderParams,
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
@@ -2877,7 +2946,7 @@ void CGroundMoveType::HandleUnitCollisions(
 	const bool allowCAU = modInfo.allowCrushingAlliedUnits;
 	const bool allowPEU = modInfo.allowPushingEnemyUnits;
 	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
-	const bool forceSAT = (colliderParams.z > 0.1f);
+	const bool forceSAT = (colliderParams.axisStretchFactor > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
 
@@ -2886,8 +2955,8 @@ void CGroundMoveType::HandleUnitCollisions(
 	const float colliderSeparationDist = (pushResistant && pushResistanceBlockActive) ? 0.f : colliderUD->separationDistance;
 
 	// Account for units that are larger than one's self.
-	const float maxCollisionRadius = colliderParams.y + moveDefHandler.GetLargestFootPrintSizeH();
-	const float searchRadius = colliderParams.x + maxCollisionRadius + colliderSeparationDist;
+	const float maxCollisionRadius = colliderParams.footprintRadius + moveDefHandler.GetLargestFootPrintSizeH();
+	const float searchRadius = colliderParams.speed + maxCollisionRadius + colliderSeparationDist;
 
 	MoveTypes::CheckCollisionQuery colliderInfo(collider);
 	if ( !colliderMD->overrideUnitWaterline )
@@ -2931,8 +3000,9 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collidee->loadingTransportId == collider->id) continue;
 
 		// mobile collidees have xsize/zsize overridden by MoveDef, so use footprint (original UnitDef values)
+		// Subtract 1 square before halving to match MoveDef size construction.
 		const float collDist = (collideeMobile)
-			? std::max(collidee->footprint.x, collidee->footprint.y) * 0.5f * SQUARE_SIZE
+			? (std::max(collidee->footprint.x, collidee->footprint.y) - 1) * 0.5f * SQUARE_SIZE
 			: collidee->CalcFootPrintMaxInteriorRadius();
 		const float2 collideeParams = {collidee->speed.w, collDist};
 
@@ -2940,28 +3010,28 @@ void CGroundMoveType::HandleUnitCollisions(
 		// footprint rectangle onto the separation direction (ellipse approximation of the OBB).
 		// This makes a 3x10 ship collide like a 3x10 shape — tight on the sides, long nose-to-nose —
 		// without needing SAT. Falls back to isotropic max-radius for non-mobile/non-elongated units.
-		const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
+		const bool colliderElongated = collider->hasElongatedFootprint;
+		const bool collideeElongated = collideeMobile && collidee->hasElongatedFootprint;
 
-		const float2 colliderHalfFP  = float2(collider->footprint) * (0.5f * SQUARE_SIZE);
-		const float2 collideeHalfFP  = (collideeMobile)
-			? float2(collidee->footprint) * (0.5f * SQUARE_SIZE)
-			: float2(collDist, collDist);
+		float colliderCircleRadius = colliderParams.footprintRadius;
+		float collideeCircleRadius = collDist;
 
-		const float collideeAxisStretch   = (collideeMobile)
-			? std::abs(collidee->footprint.x - collidee->footprint.y) * 1.0f / (collidee->footprint.x + collidee->footprint.y)
-			: 0.0f;
+		if (colliderElongated || collideeElongated) {
+			const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
 
-		// Use projected radius when the unit is elongated enough to matter
-		const float colliderCircleRadius = (colliderParams.z > 0.1f)
-			? CalcProjectedFootprintRadius(collider, colliderHalfFP, sepDir2D)
-			: colliderParams.y;
-		const float collideeCircleRadius = (collideeAxisStretch > 0.1f)
-			? CalcProjectedFootprintRadius(collidee, collideeHalfFP, sepDir2D)
-			: collDist;
+			if (colliderElongated) {
+				const float2 colliderHalfFP = float2(collider->footprint.x - 1, collider->footprint.y - 1) * (0.5f * SQUARE_SIZE);
+				colliderCircleRadius = CalcProjectedFootprintRadius(collider, colliderHalfFP, sepDir2D);
+			}
+			if (collideeElongated) {
+				const float2 collideeHalfFP = float2(collidee->footprint.x - 1, collidee->footprint.y - 1) * (0.5f * SQUARE_SIZE);
+				collideeCircleRadius = CalcProjectedFootprintRadius(collidee, collideeHalfFP, sepDir2D);
+			}
+		}
 
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius)};
 
-		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collideeAxisStretch > 0.1f)));
+		const int collisionFunc = (allowSAT && (forceSAT || collideeElongated));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 
 		// Separation zone also uses projected radii (+ MoveDef base for push forces)
@@ -3002,7 +3072,7 @@ void CGroundMoveType::HandleUnitCollisions(
 			// const bool ignoreCollidee = (collideeYields && alliedCollision);
 
 			crushCollidee |= (!alliedCollision || allowCAU);
-			crushCollidee &= ((colliderParams.x * collider->mass) > (collideeParams.x * collidee->mass));
+			crushCollidee &= ((colliderParams.speed * collider->mass) > (collideeParams.x * collidee->mass));
 
 			if (crushCollidee && !CMoveMath::CrushResistant(*colliderMD, collidee)) {
 				auto& events = Sim::registry.get<UnitCrushEvents>(owner->entityReference);
@@ -3043,7 +3113,7 @@ void CGroundMoveType::HandleUnitCollisions(
 			const bool allowNewPath = (!atEndOfPath && !atGoal);
 			const bool checkYardMap = ((pushCollider || pushCollidee) || collideeUD->IsFactoryUnit());
 
-			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.y, collideeParams.y,  separationVect, allowNewPath, checkYardMap, false, curThread)) {
+			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.moveDefRadius, collideeParams.y,  separationVect, allowNewPath, checkYardMap, false, curThread)) {
 				ReRequestPath(false);
 			}
 
@@ -3054,13 +3124,13 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (moveCollider) {
 			if (isCollision) {
 				// Use projected radii for push magnitude — correct for elongated footprints
-				const float4 colliderPushParams = {colliderParams.x, colliderCircleRadius, colliderParams.z, colliderCircleRadius};
+				const ColliderParams colliderPushParams = {colliderParams.speed, colliderCircleRadius, colliderParams.axisStretchFactor, colliderCircleRadius};
 				const float2 collideePushParams  = {collidee->speed.w, collideeCircleRadius};
 				const float4 pushSepVect = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
 				forceFromMovingCollidees += CalculatePushVector(colliderPushParams, collideePushParams, allowUCO, pushSepVect, collider, collidee);
 			} else {
 				// push units away from each other though they are not colliding.
-				const float4 colliderParams2 = {colliderParams.x, colliderCircleRadius + separationDist * 0.5f, colliderParams.z, colliderCircleRadius + separationDist * 0.5f};
+				const ColliderParams colliderParams2 = {colliderParams.speed, colliderCircleRadius + separationDist * 0.5f, colliderParams.axisStretchFactor, colliderCircleRadius + separationDist * 0.5f};
 				const float2 collideeParams2  = {collidee->speed.w, collideeCircleRadius + separationDist * 0.5f};
 				const float4 separationVect2  = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
 				forceFromMovingCollidees += CalculatePushVector(colliderParams2, collideeParams2, allowUCO, separationVect2, collider, collidee);
@@ -3069,11 +3139,11 @@ void CGroundMoveType::HandleUnitCollisions(
 	}
 }
 
-float3 CGroundMoveType::CalculatePushVector(const float4 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
+float3 CGroundMoveType::CalculatePushVector(const ColliderParams &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
 {
-    const float colliderRelRadius = colliderParams.y / (colliderParams.y + collideeParams.y);
-    const float collideeRelRadius = collideeParams.y / (colliderParams.y + collideeParams.y);
-    const float collisionRadiusSum = allowUCO ? (colliderParams.y * colliderRelRadius + collideeParams.y * collideeRelRadius) : (colliderParams.y + collideeParams.y);
+    const float colliderRelRadius = colliderParams.footprintRadius / (colliderParams.footprintRadius + collideeParams.y);
+    const float collideeRelRadius = collideeParams.y / (colliderParams.footprintRadius + collideeParams.y);
+    const float collisionRadiusSum = allowUCO ? (colliderParams.footprintRadius * colliderRelRadius + collideeParams.y * collideeRelRadius) : (colliderParams.footprintRadius + collideeParams.y);
 
     const float sepDistance = separationVect.Length() + 0.1f;
     const float penDistance = std::max(collisionRadiusSum - sepDistance, 1.0f);
@@ -3085,7 +3155,7 @@ float3 CGroundMoveType::CalculatePushVector(const float4 &colliderParams, const 
     const float
         m1 = collider->mass,
         m2 = collidee->mass,
-        v1 = std::max(1.0f, colliderParams.x),
+        v1 = std::max(1.0f, colliderParams.speed),
         v2 = std::max(1.0f, collideeParams.x),
         c1 = 1.0f + (1.0f - math::fabs(collider->frontdir.dot(-sepDirection))) * 5.0f,
         c2 = 1.0f + (1.0f - math::fabs(collidee->frontdir.dot(sepDirection))) * 5.0f,
@@ -3118,14 +3188,14 @@ float3 CGroundMoveType::CalculatePushVector(const float4 &colliderParams, const 
 
 void CGroundMoveType::HandleFeatureCollisions(
 	CUnit* collider,
-	const float4& colliderParams,
+	const ColliderParams& colliderParams,
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
-	const bool forceSAT = (colliderParams.z > 0.1f);
+	const bool forceSAT = (colliderParams.axisStretchFactor > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
 	MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -3133,14 +3203,14 @@ void CGroundMoveType::HandleFeatureCollisions(
 	// copy on purpose, since DoDamage below can call Lua
 	QuadFieldQuery qfQuery;
 	qfQuery.threadOwner = curThread;
-	quadField.GetFeaturesExact(qfQuery, collider->pos, colliderParams.x + (colliderParams.y * 2.0f));
+	quadField.GetFeaturesExact(qfQuery, collider->pos, colliderParams.speed + (colliderParams.footprintRadius * 2.0f));
 
 	for (CFeature* collidee: *qfQuery.features) {
 		// const FeatureDef* collideeFD = collidee->def;
 
 		// use the collidee's Feature (not FeatureDef) footprint as radius
 		const float2 collideeParams = {0.0f, collidee->CalcFootPrintMaxInteriorRadius()};
-		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
+		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.footprintRadius + collideeParams.y)};
 
 		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collidee->CalcFootPrintAxisStretchFactor() > 0.1f))](separationVect, collider, collidee, colliderMD, nullptr))
 			continue;
@@ -3164,7 +3234,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		}
 
 		if (!collidee->IsMoving()) {
-			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.y, collideeParams.y,  separationVect, (!atEndOfPath && !atGoal), true, false, curThread)) {
+			if (HandleStaticObjectCollision(collider, collidee, colliderMD,  colliderParams.moveDefRadius, collideeParams.y,  separationVect, (!atEndOfPath && !atGoal), true, false, curThread)) {
 				ReRequestPath(false);
 			}
 
@@ -3172,7 +3242,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		}
 
 		const float  sepDistance    = separationVect.Length() + 0.1f;
-		const float  penDistance    = std::max((colliderParams.y + collideeParams.y) - sepDistance, 1.0f);
+		const float  penDistance    = std::max((colliderParams.footprintRadius + collideeParams.y) - sepDistance, 1.0f);
 		const float  sepResponse    = std::min(SQUARE_SIZE * 2.0f, penDistance * 0.5f);
 
 		const float3 sepDirection   = separationVect / sepDistance;
@@ -3184,7 +3254,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		const float
 			m1 = collider->mass,
 			m2 = collidee->mass * 10000.0f,
-			v1 = std::max(1.0f, colliderParams.x),
+			v1 = std::max(1.0f, colliderParams.speed),
 			v2 = 1.0f,
 			c1 = (1.0f - math::fabs( collider->frontdir.dot(-sepDirection))) * 5.0f,
 			c2 = (1.0f - math::fabs(-collider->frontdir.dot( sepDirection))) * 5.0f,

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -237,8 +237,14 @@ namespace SAT {
 		const MoveDef* collideeMD,
 		const float3& separationVec
 	) {
-		const float2 colliderSize = collider->GetFootPrint(0.5f * SQUARE_SIZE);
-		const float2 collideeSize = collidee->GetFootPrint(0.5f * SQUARE_SIZE);
+		// collider is always a mobile unit whose xsize/zsize were overridden by MoveDef,
+		// so use footprint (original UnitDef values) for the collision shape
+		const float2 colliderSize = float2(collider->footprint) * (0.5f * SQUARE_SIZE);
+		// collidee may be a mobile unit (MoveDef override), immobile unit, or feature;
+		// mobile units need footprint, others have correct xsize/zsize already
+		const float2 collideeSize = (collideeMD != nullptr)
+			? float2(collidee->footprint) * (0.5f * SQUARE_SIZE)
+			: collidee->GetFootPrint(0.5f * SQUARE_SIZE);
 
 		// true if no overlap on at least one axis
 		bool haveAxis = false;
@@ -2527,8 +2533,10 @@ void CGroundMoveType::HandleObjectCollisions()
 	// NOTE:
 	//   use the collider's UnitDef footprint as radius for collision
 	//   detection (its MoveDef footprint may be smaller for pathfinding)
-	const float colliderFootPrintRadius = collider->CalcFootPrintMaxInteriorRadius();
-	const float colliderAxisStretchFact = collider->CalcFootPrintAxisStretchFactor();
+	//   must read from footprint directly since xsize/zsize are overridden
+	//   to match the MoveDef during GroundMoveType initialization
+	const float colliderFootPrintRadius = std::max(collider->footprint.x, collider->footprint.y) * 0.5f * SQUARE_SIZE;
+	const float colliderAxisStretchFact = std::abs(collider->footprint.x - collider->footprint.y) * 1.0f / (collider->footprint.x + collider->footprint.y);
 
 	HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
 	HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
@@ -2845,11 +2853,17 @@ void CGroundMoveType::HandleUnitCollisions(
 		if (collider->loadingTransportId == collidee->id) continue;
 		if (collidee->loadingTransportId == collider->id) continue;
 
-		const float collDist = collidee->CalcFootPrintMaxInteriorRadius();
+		// mobile collidees have xsize/zsize overridden by MoveDef, so use footprint (original UnitDef values)
+		const float collDist = (collideeMobile)
+			? std::max(collidee->footprint.x, collidee->footprint.y) * 0.5f * SQUARE_SIZE
+			: collidee->CalcFootPrintMaxInteriorRadius();
 		const float2 collideeParams = {collidee->speed.w, collDist};
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collidee->CalcFootPrintAxisStretchFactor() > 0.1f)));
+		const float collideeAxisStretch = (collideeMobile)
+			? std::abs(collidee->footprint.x - collidee->footprint.y) * 1.0f / (collidee->footprint.x + collidee->footprint.y)
+			: 0.0f;
+		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collideeAxisStretch > 0.1f)));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 
 		// check for separation

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2766,8 +2766,8 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 						hasOBBCollision = true;
 						// OBB nose/tail squares must also contribute to the push-out force
 						const float3 pushDir = (pos - squarePos).SafeNormalize2D();
-						const float intoWall = std::min(0.0f, vel.dot(pushDir)); // negative = moving toward square
-						forceFromStaticCollidees += pushDir * (intoWall * squarePenDistance / squareColRadiusSum);
+						const float vmag = std::abs(vel.dot(pushDir)); // negative = moving toward square
+						forceFromStaticCollidees += pushDir * (-vmag * 0.5f * squarePenDistance / squareColRadiusSum);
 					}
 
 				}

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -258,6 +258,16 @@ namespace SAT {
 };
 
 
+// Returns the radius of an oriented rectangle (halfX x halfZ) projected onto a separation
+// direction — an ellipse approximation of the OBB extents. Gives a direction-aware radius:
+// tight on the sides, long nose-to-nose, without requiring SAT.
+// Formula: sqrt( (halfX * |dir·right|)² + (halfZ * |dir·front|)² )
+static float CalcProjectedFootprintRadius(const CSolidObject* obj, const float2& halfExtents, const float3& dir) {
+	const float dx = math::fabs(dir.dot(obj->rightdir)) * halfExtents.x;
+	const float dz = math::fabs(dir.dot(obj->frontdir)) * halfExtents.y;
+	return math::sqrt(dx * dx + dz * dz);
+}
+
 static bool CheckCollisionExclSAT(
 	const float4& separationVec,
 	const CSolidObject* collider = nullptr,
@@ -2537,9 +2547,13 @@ void CGroundMoveType::HandleObjectCollisions()
 	//   to match the MoveDef during GroundMoveType initialization
 	const float colliderFootPrintRadius = std::max(collider->footprint.x, collider->footprint.y) * 0.5f * SQUARE_SIZE;
 	const float colliderAxisStretchFact = std::abs(collider->footprint.x - collider->footprint.y) * 1.0f / (collider->footprint.x + collider->footprint.y);
+	// Use the MoveDef (pathfinding) footprint radius for separation checks and push forces.
+	// This prevents elongated footprints (e.g. 3x10) from pushing units away in all directions
+	// like a 10x10 circle — collision detection (SAT) still uses the full oriented footprint.
+	const float colliderMoveDefRadius = colliderMD->CalcFootPrintMinExteriorRadius();
 
-	HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
-	HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD, curThread);
+	HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius}, colliderUD, colliderMD, curThread);
+	HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact, colliderMoveDefRadius}, colliderUD, colliderMD, curThread);
 
 	if (forceStaticObjectCheck) {
 		MoveTypes::CheckCollisionQuery colliderInfo(collider);
@@ -2787,7 +2801,7 @@ bool CGroundMoveType::HandleStaticObjectCollision(
 
 void CGroundMoveType::HandleUnitCollisions(
 	CUnit* collider,
-	const float3& colliderParams, // .x := speed, .y := radius, .z := fpstretch
+	const float4& colliderParams, // .x := speed, .y := footprintRadius, .z := fpstretch, .w := moveDefRadius
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
@@ -2858,21 +2872,42 @@ void CGroundMoveType::HandleUnitCollisions(
 			? std::max(collidee->footprint.x, collidee->footprint.y) * 0.5f * SQUARE_SIZE
 			: collidee->CalcFootPrintMaxInteriorRadius();
 		const float2 collideeParams = {collidee->speed.w, collDist};
-		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		const float collideeAxisStretch = (collideeMobile)
+		// Compute a direction-aware collision radius for each unit by projecting its oriented
+		// footprint rectangle onto the separation direction (ellipse approximation of the OBB).
+		// This makes a 3x10 ship collide like a 3x10 shape — tight on the sides, long nose-to-nose —
+		// without needing SAT. Falls back to isotropic max-radius for non-mobile/non-elongated units.
+		const float3 sepDir2D = (collider->pos - collidee->pos).SafeNormalize2D();
+
+		const float2 colliderHalfFP  = float2(collider->footprint) * (0.5f * SQUARE_SIZE);
+		const float2 collideeHalfFP  = (collideeMobile)
+			? float2(collidee->footprint) * (0.5f * SQUARE_SIZE)
+			: float2(collDist, collDist);
+
+		const float collideeAxisStretch   = (collideeMobile)
 			? std::abs(collidee->footprint.x - collidee->footprint.y) * 1.0f / (collidee->footprint.x + collidee->footprint.y)
 			: 0.0f;
+
+		// Use projected radius when the unit is elongated enough to matter
+		const float colliderCircleRadius = (colliderParams.z > 0.1f)
+			? CalcProjectedFootprintRadius(collider, colliderHalfFP, sepDir2D)
+			: colliderParams.y;
+		const float collideeCircleRadius = (collideeAxisStretch > 0.1f)
+			? CalcProjectedFootprintRadius(collidee, collideeHalfFP, sepDir2D)
+			: collDist;
+
+		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderCircleRadius + collideeCircleRadius)};
+
 		const int collisionFunc = (allowSAT && (forceSAT || (collideeMobile && collideeAxisStretch > 0.1f)));
 		const bool isCollision = (checkCollisionFuncs[collisionFunc](separationVect, collider, collidee, colliderMD, collideeMD));
 
-		// check for separation
+		// Separation zone also uses projected radii (+ MoveDef base for push forces)
 		float separationDist = 0.f;
 		if (!isCollision && collideeMobile) {
 			const bool useCollideeSeparationDistance = !( collidee->moveType->IsPushResistant() && collidee->moveType->IsPushResitanceBlockActive() );
 			const float collideeSeparationDist = (useCollideeSeparationDistance) ? colliderUD->separationDistance : 0.f;
 			separationDist = std::max(colliderSeparationDist, collideeUD->separationDistance);
-			const float separation = colliderParams.y + collideeParams.y + separationDist; 
+			const float separation = colliderCircleRadius + collideeCircleRadius + separationDist;
 			const bool isSeparation = static_cast<float3>(separationVect).SqLength2D() <= Square(separation);
 			if (!isSeparation)
 				continue;
@@ -2954,20 +2989,24 @@ void CGroundMoveType::HandleUnitCollisions(
 
 		const bool moveCollider = ((pushCollider || !pushCollidee) && colliderMobile);
 		if (moveCollider) {
-			if (isCollision)
-				forceFromMovingCollidees += CalculatePushVector(colliderParams, collideeParams, allowUCO, separationVect, collider, collidee);
-			else {
+			if (isCollision) {
+				// Use projected radii for push magnitude — correct for elongated footprints
+				const float4 colliderPushParams = {colliderParams.x, colliderCircleRadius, colliderParams.z, colliderCircleRadius};
+				const float2 collideePushParams  = {collidee->speed.w, collideeCircleRadius};
+				const float4 pushSepVect = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
+				forceFromMovingCollidees += CalculatePushVector(colliderPushParams, collideePushParams, allowUCO, pushSepVect, collider, collidee);
+			} else {
 				// push units away from each other though they are not colliding.
-				const float3 colliderParams2 = {colliderParams.x, colliderParams.y + separationDist * 0.5f, colliderParams.z};
-				const float2 collideeParams2 = {collidee->speed.w, collDist + separationDist * 0.5f};
-				const float4 separationVect2 = {static_cast<float3>(separationVect), Square(colliderParams.y + collideeParams.y)};
+				const float4 colliderParams2 = {colliderParams.x, colliderCircleRadius + separationDist * 0.5f, colliderParams.z, colliderCircleRadius + separationDist * 0.5f};
+				const float2 collideeParams2  = {collidee->speed.w, collideeCircleRadius + separationDist * 0.5f};
+				const float4 separationVect2  = {static_cast<float3>(separationVect), Square(colliderCircleRadius + collideeCircleRadius)};
 				forceFromMovingCollidees += CalculatePushVector(colliderParams2, collideeParams2, allowUCO, separationVect2, collider, collidee);
 			}
 		}
 	}
 }
 
-float3 CGroundMoveType::CalculatePushVector(const float3 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
+float3 CGroundMoveType::CalculatePushVector(const float4 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee)
 {
     const float colliderRelRadius = colliderParams.y / (colliderParams.y + collideeParams.y);
     const float collideeRelRadius = collideeParams.y / (colliderParams.y + collideeParams.y);
@@ -3016,7 +3055,7 @@ float3 CGroundMoveType::CalculatePushVector(const float3 &colliderParams, const 
 
 void CGroundMoveType::HandleFeatureCollisions(
 	CUnit* collider,
-	const float3& colliderParams,
+	const float4& colliderParams,
 	const UnitDef* colliderUD,
 	const MoveDef* colliderMD,
 	int curThread
@@ -3741,4 +3780,3 @@ bool CGroundMoveType::SetMemberValue(unsigned int memberHash, void* memberValue)
 
 	return false;
 }
-

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -273,7 +273,7 @@ private:
 
 	float3 forceFromMovingCollidees;
 	float3 forceFromStaticCollidees;
-	float3 forceFromOBBCollidees;
+	bool hasOBBCollision = false;       /// true if elongated-footprint nose/tail overlaps a blocked square
 	float3 resultantForces;
 
 	unsigned int pathID = 0;

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -33,12 +33,12 @@ public:
 		std::array<std::pair<unsigned int, float*>, 9> floats;
 	};
 
-	struct ColliderParams {
-		float speed;              /// owner speed magnitude
-		float footprintRadius;    /// max half-extent of the UnitDef footprint (collision shape)
-		float axisStretchFactor;  /// 0 for square units, >0.1 triggers elongated-footprint logic
-		float moveDefRadius;      /// MoveDef-based radius for separation/push forces
-	};
+	//struct ColliderParams {
+	//	float speed;              /// owner speed magnitude
+	//	float footprintRadius;    /// max half-extent of the UnitDef footprint (collision shape)
+	//	float axisStretchFactor;  /// 0 for square units, >0.1 triggers elongated-footprint logic
+	//	float moveDefRadius;      /// MoveDef-based radius for separation/push forces
+	//};
 
 	void PostLoad();
 	void* GetPreallocContainer() { return owner; }  // creg
@@ -194,14 +194,14 @@ private:
 
     void HandleUnitCollisions(
         CUnit *collider,
-        const ColliderParams &colliderParams,
+        const float3 &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);
-    float3 CalculatePushVector(const ColliderParams &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
+    float3 CalculatePushVector(const float3 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
     void HandleFeatureCollisions(
         CUnit *collider,
-        const ColliderParams &colliderParams,
+        const float3 &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -33,13 +33,6 @@ public:
 		std::array<std::pair<unsigned int, float*>, 9> floats;
 	};
 
-	//struct ColliderParams {
-	//	float speed;              /// owner speed magnitude
-	//	float footprintRadius;    /// max half-extent of the UnitDef footprint (collision shape)
-	//	float axisStretchFactor;  /// 0 for square units, >0.1 triggers elongated-footprint logic
-	//	float moveDefRadius;      /// MoveDef-based radius for separation/push forces
-	//};
-
 	void PostLoad();
 	void* GetPreallocContainer() { return owner; }  // creg
 

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -187,14 +187,14 @@ private:
 
     void HandleUnitCollisions(
         CUnit *collider,
-        const float3 &colliderParams,
+        const float4 &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);
-    float3 CalculatePushVector(const float3 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
+    float3 CalculatePushVector(const float4 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
     void HandleFeatureCollisions(
         CUnit *collider,
-        const float3 &colliderParams,
+        const float4 &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);
@@ -309,4 +309,3 @@ private:
 };
 
 #endif // GROUNDMOVETYPE_H
-

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -33,6 +33,13 @@ public:
 		std::array<std::pair<unsigned int, float*>, 9> floats;
 	};
 
+	struct ColliderParams {
+		float speed;              /// owner speed magnitude
+		float footprintRadius;    /// max half-extent of the UnitDef footprint (collision shape)
+		float axisStretchFactor;  /// 0 for square units, >0.1 triggers elongated-footprint logic
+		float moveDefRadius;      /// MoveDef-based radius for separation/push forces
+	};
+
 	void PostLoad();
 	void* GetPreallocContainer() { return owner; }  // creg
 
@@ -187,14 +194,14 @@ private:
 
     void HandleUnitCollisions(
         CUnit *collider,
-        const float4 &colliderParams,
+        const ColliderParams &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);
-    float3 CalculatePushVector(const float4 &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
+    float3 CalculatePushVector(const ColliderParams &colliderParams, const float2 &collideeParams, const bool allowUCO, const float4 &separationVect, CUnit *collider, CUnit *collidee);
     void HandleFeatureCollisions(
         CUnit *collider,
-        const float4 &colliderParams,
+        const ColliderParams &colliderParams,
         const UnitDef *colliderUD,
         const MoveDef *colliderMD,
         int curThread);
@@ -266,6 +273,7 @@ private:
 
 	float3 forceFromMovingCollidees;
 	float3 forceFromStaticCollidees;
+	float3 forceFromOBBCollidees;
 	float3 resultantForces;
 
 	unsigned int pathID = 0;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -261,7 +261,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	ASSERT_SYNCED(pos);
 
 	footprint = int2(unitDef->xsize, unitDef->zsize);
-	hasElongatedFootprint = (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
+	hasElongatedFootprint = modInfo.allowSepAxisCollisionTest && (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
 	footprintHalfExtents = float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
 	footprintMaxRadius = (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
 
@@ -402,7 +402,7 @@ void CUnit::PostLoad()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// Recompute derived footprint geometry (not serialized, derived from footprint int2).
-	hasElongatedFootprint = (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
+	hasElongatedFootprint = modInfo.allowSepAxisCollisionTest && (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
 	footprintHalfExtents = float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
 	footprintMaxRadius = (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -3047,7 +3047,6 @@ CR_REG_METADATA(CUnit, (
 
 	CR_MEMBER(definedIconName),
 	CR_MEMBER_UN(currentIconIndex),
-	CR_MEMBER(customIconIndex),
 	CR_MEMBER_UN(drawIcon),
 
 	CR_MEMBER(transportedUnits),

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -261,6 +261,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	ASSERT_SYNCED(pos);
 
 	footprint = int2(unitDef->xsize, unitDef->zsize);
+	hasElongatedFootprint = (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
 
 	beingBuilt = params.beingBuilt;
 	mass = (beingBuilt)? mass: unitDef->mass;
@@ -3039,6 +3040,7 @@ CR_REG_METADATA(CUnit, (
 
 	CR_MEMBER(definedIconName),
 	CR_MEMBER_UN(currentIconIndex),
+	CR_MEMBER(customIconIndex),
 	CR_MEMBER_UN(drawIcon),
 
 	CR_MEMBER(transportedUnits),

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -262,6 +262,8 @@ void CUnit::PreInit(const UnitLoadParams& params)
 
 	footprint = int2(unitDef->xsize, unitDef->zsize);
 	hasElongatedFootprint = (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
+	footprintHalfExtents = float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
+	footprintMaxRadius = (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
 
 	beingBuilt = params.beingBuilt;
 	mass = (beingBuilt)? mass: unitDef->mass;
@@ -399,6 +401,11 @@ void CUnit::PostInit(const CUnit* builder)
 void CUnit::PostLoad()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// Recompute derived footprint geometry (not serialized, derived from footprint int2).
+	hasElongatedFootprint = (static_cast<float>(std::abs(footprint.x - footprint.y)) / (footprint.x + footprint.y)) > 0.1f;
+	footprintHalfExtents = float2(footprint.x - 1, footprint.y - 1) * (0.5f * SQUARE_SIZE);
+	footprintMaxRadius = (std::max(footprint.x, footprint.y) - 1) * 0.5f * SQUARE_SIZE;
+
 	UpdateRenderParams();
 	eventHandler.RenderUnitPreCreated(this);
 	eventHandler.RenderUnitCreated(this, isCloaked);

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -527,6 +527,9 @@ public:
 	bool isCloaked = false;
 	// true if the unit currently wants to be cloaked
 	bool wantCloak = false;
+	// true if the unit's UnitDef footprint is significantly non-square (stretch factor > 0.1);
+	// gates elongated-footprint collision logic (OBB scan expansion, projected radii, etc.)
+	bool hasElongatedFootprint = false;
 	// true if the unit leaves static ghosts
 	bool leavesGhost = false;
 
@@ -542,6 +545,7 @@ public:
 
 	mutable std::string definedIconName;
 	mutable size_t currentIconIndex = size_t(-1); // icon::INVALID_ICON_INDEX;
+	mutable size_t customIconIndex = size_t(-1); // icon::INVALID_ICON_INDEX;
 
 	bool drawIcon = true;
 private:

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -553,7 +553,6 @@ public:
 
 	mutable std::string definedIconName;
 	mutable size_t currentIconIndex = size_t(-1); // icon::INVALID_ICON_INDEX;
-	mutable size_t customIconIndex = size_t(-1); // icon::INVALID_ICON_INDEX;
 
 	bool drawIcon = true;
 private:

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -530,6 +530,14 @@ public:
 	// true if the unit's UnitDef footprint is significantly non-square (stretch factor > 0.1);
 	// gates elongated-footprint collision logic (OBB scan expansion, projected radii, etc.)
 	bool hasElongatedFootprint = false;
+
+	// Pre-computed collision geometry derived from the UnitDef footprint (int2).
+	// Mobile units have xsize/zsize overridden by MoveDef, so these cache the true
+	// physical shape for use in collision detection / OBB tests.
+	// Half-extents in world units: ((footprint - 1) * 0.5 * SQUARE_SIZE) per axis.
+	float2 footprintHalfExtents;
+	// Max half-extent (bounding circle radius): max(footprint.x, footprint.y) - 1) * 0.5 * SQUARE_SIZE.
+	float footprintMaxRadius = 0.0f;
 	// true if the unit leaves static ghosts
 	bool leavesGhost = false;
 


### PR DESCRIPTION
Executive Summary:

PR to allow mobile units with a non-square `footprint` to collide and separate like a rectangle, and not as a square dependent on `movedef`. This new feature is explicitly gated behind `modInfo.allowSepAxisCollisionTest = true`. And collision and separation logic for standard square movedef units should be untouched. 

This PR was inspired by:
1. Some drama on the BAR discord, where naval ship design is unnecessarily constrained by the square movedef requirement. 
2. Stress testing Claude Opus 4.6. Vibe coded up to a working state, then a manual review to cut out the cruft and fix edge cases. 

See videos for tests on 3x10 long units (using a 3x3 movedef), and 9x3 wide units (using a 9x9 movedef):

https://github.com/user-attachments/assets/e1e1800f-87b6-4120-a807-1c2733b55712

https://github.com/user-attachments/assets/c6ec3691-7888-4758-bf90-606df6149a5b

One note, the grey model sphere must be large enough to allow units (elongated or not) to push other units out of the way. Related to `CGroundMoveType::CheckCollisionSkid()` I think. 
This is a separate bug? that should be addressed in another PR. 