### PR TITLE
Enable Build Power while moving

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -224,6 +224,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetUnitBuildSpeed);
 	REGISTER_LUA_CFUNC(SetUnitBuildParams);
 	REGISTER_LUA_CFUNC(SetUnitNanoPieces);
+	REGISTER_LUA_CFUNC(SetUnitBuilderTarget);
 
 	REGISTER_LUA_CFUNC(SetUnitBlocking);
 	REGISTER_LUA_CFUNC(SetUnitCrashing);
@@ -3317,6 +3318,75 @@ int LuaSyncedCtrl::SetUnitNanoPieces(lua_State* L)
 	}
 
 	return 0;
+}
+
+/***
+ * @function Spring.SetUnitBuilderTarget
+ * @param builderID  integer   unit ID of the builder
+ * @param targetType string    "repair" | "reclaim" | "resurrect" | "capture"
+ * @param targetID   integer   unit ID (repair/reclaim-unit/capture) or
+ *                             feature ID (reclaim-feature/resurrect)
+ * @return boolean success
+ */
+int LuaSyncedCtrl::SetUnitBuilderTarget(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+	if (unit == nullptr)
+		return 0;
+
+	CBuilder* builder = dynamic_cast<CBuilder*>(unit);
+	if (builder == nullptr)
+		return 0;
+
+	const std::string targetType = luaL_checkstring(L, 2);
+	const int targetID = luaL_checkint(L, 3);
+
+	if (targetType == "repair") {
+		CUnit* target = unitHandler.GetUnit(targetID);
+		if (target == nullptr)
+			return 0;
+		builder->SetRepairTarget(target);
+
+	}
+	else if (targetType == "capture") {
+		CUnit* target = unitHandler.GetUnit(targetID);
+		if (target == nullptr)
+			return 0;
+		builder->SetCaptureTarget(target);
+
+	}
+	else if (targetType == "reclaim") {
+		// targetID may be a unit or a feature
+		// Feature IDs in Lua are offset by unitHandler.MaxUnits()
+		const int maxUnits = unitHandler.MaxUnits();
+		if (targetID >= maxUnits) {
+			CFeature* feature = featureHandler.GetFeature(targetID - maxUnits);
+			if (feature == nullptr)
+				return 0;
+			builder->SetReclaimTarget(feature);
+		}
+		else {
+			CUnit* target = unitHandler.GetUnit(targetID);
+			if (target == nullptr)
+				return 0;
+			builder->SetReclaimTarget(target);
+		}
+
+	}
+	else if (targetType == "resurrect") {
+		CFeature* feature = featureHandler.GetFeature(targetID - unitHandler.MaxUnits());
+		if (feature == nullptr)
+			return 0;
+		builder->SetResurrectTarget(feature);
+
+	}
+	else {
+		luaL_error(L, "SetUnitBuilderTarget: unknown targetType '%s'", targetType.c_str());
+		return 0;
+	}
+
+	lua_pushboolean(L, true);
+	return 1;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -112,6 +112,7 @@ class LuaSyncedCtrl
 		static int SetUnitBuildSpeed(lua_State* L);
 		static int SetUnitBuildParams(lua_State* L);
 		static int SetUnitNanoPieces(lua_State* L);
+		static int SetUnitBuilderTarget(lua_State* L);
 		static int SetUnitBlocking(lua_State* L);
 		static int SetUnitCrashing(lua_State* L);
 		static int SetUnitShieldState(lua_State* L);

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -764,6 +764,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_FLOAT("resurrectSpeed", ud.resurrectSpeed);
 	ADD_FLOAT("captureSpeed",   ud.captureSpeed);
 	ADD_FLOAT("terraformSpeed", ud.terraformSpeed);
+	ADD_FLOAT("nanoAimRate",    ud.nanoAimRate);
 
 	ADD_FLOAT("upDirSmoothing", ud.upDirSmoothing);
 
@@ -793,6 +794,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_BOOL("canRepeat",             ud.canRepeat);
 	ADD_BOOL("canCapture",            ud.canCapture);
 	ADD_BOOL("canResurrect",          ud.canResurrect);
+	ADD_BOOL("canBuildWhileMoving",	  ud.canBuildWhileMoving);
 	ADD_BOOL("canLoopbackAttack",     ud.canLoopbackAttack);
 	ADD_BOOL("canFireControl",        ud.canFireControl);
 	ADD_INT( "fireState",             ud.fireState);

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -450,8 +450,36 @@ void CBuilderCAI::GiveCommandReal(const Command& c, bool fromSynced)
 	// FIXME should happen just before CMobileCAI::GiveCommandReal? (the new cmd can still be skipped!)
 	if ((c.GetID() != CMD_WAIT) && !(c.GetOpts() & SHIFT_KEY)) {
 		if (nonQueingCommands.find(c.GetID()) == nonQueingCommands.end()) {
-			building = false;
-			static_cast<CBuilder*>(owner)->StopBuild();
+			// [MOBILE BUILD] Pure movement commands (MOVE, FIGHT, PATROL) directed
+			// at a canBuildWhileMoving unit should not interrupt ongoing work as
+			// long as the builder remains in range of its current target.
+			// The movement goal is updated by CMobileCAI::GiveCommandReal below,
+			// and Builder::Update() will keep applying build power each frame that
+			// IsInBuildRange() is satisfied.  If the new waypoint takes the unit
+			// out of range, Builder::Update() simply stops producing build power
+			// until range is re-established (or a new build command is issued).
+			const bool isMoveCmd =
+				(c.GetID() == CMD_MOVE   ||
+				 c.GetID() == CMD_FIGHT  ||
+				 c.GetID() == CMD_PATROL);
+
+			const CBuilder* b = static_cast<CBuilder*>(owner);
+			const bool hasActiveTarget =
+				(b->curBuild     != nullptr) ||
+				(b->curReclaim   != nullptr) ||
+				(b->curResurrect != nullptr) ||
+				(b->curCapture   != nullptr) ||
+				 b->terraforming;
+
+			const bool suppressStop =
+				isMoveCmd &&
+				owner->unitDef->canBuildWhileMoving &&
+				hasActiveTarget;
+
+			if (!suppressStop) {
+				building = false;
+				static_cast<CBuilder*>(owner)->StopBuild();
+			} 
 		}
 	}
 
@@ -1741,4 +1769,3 @@ void CBuilderCAI::BuggerOff(const float3& pos, float radius) {
 
 	CMobileCAI::BuggerOff(pos, radius);
 }
-

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -362,7 +362,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	resurrectSpeed = udTable.GetFloat("resurrectSpeed", buildSpeed);
 	captureSpeed   = udTable.GetFloat("captureSpeed",   buildSpeed);
 	terraformSpeed = udTable.GetFloat("terraformSpeed", buildSpeed);
-	nanoAimRate    = udTable.GetFloat("nanoAimRate",   nanoAimRate);
+	nanoAimRate    = udTable.GetFloat("nanoAimRate",		  0.5f);
 
 	upDirSmoothing = std::clamp(udTable.GetFloat("upDirSmoothing", 0.0f), 0.0f, 0.95f);
 	separationDistance = std::max(udTable.GetInt("separationDistance", 0), 0);

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -184,6 +184,8 @@ UnitDef::UnitDef()
 	, canBeAssisted(false)
 	, canSelfRepair(false)
 
+	, canBuildWhileMoving(false)
+
 	, canFireControl(false)
 	, canManualFire(false)
 
@@ -399,6 +401,8 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 
 	canBeAssisted = udTable.GetBool("canBeAssisted", true);
 	canSelfRepair = udTable.GetBool("canSelfRepair", false);
+
+	canBuildWhileMoving = udTable.GetBool("canBuildWhileMoving", false);
 
 	canFireControl = !udTable.GetBool("noAutoFire", false);
 	canManualFire = udTable.GetBool("canManualFire", udTable.GetBool("canDGun", false));

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -122,6 +122,7 @@ UnitDef::UnitDef()
 	, resurrectSpeed(0.0f)
 	, captureSpeed(0.0f)
 	, terraformSpeed(0.0f)
+	, nanoAimRate(0.0f)
 
 	, canSubmerge(false)
 	, canfly(false)
@@ -361,6 +362,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	resurrectSpeed = udTable.GetFloat("resurrectSpeed", buildSpeed);
 	captureSpeed   = udTable.GetFloat("captureSpeed",   buildSpeed);
 	terraformSpeed = udTable.GetFloat("terraformSpeed", buildSpeed);
+	nanoAimRate    = udTable.GetFloat("nanoAimRate",   nanoAimRate);
 
 	upDirSmoothing = std::clamp(udTable.GetFloat("upDirSmoothing", 0.0f), 0.0f, 0.95f);
 	separationDistance = std::max(udTable.GetInt("separationDistance", 0), 0);

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -180,6 +180,7 @@ public:
 	float resurrectSpeed;
 	float captureSpeed;
 	float terraformSpeed;
+	float nanoAimRate;
 
 	bool canSubmerge;
 	bool canfly;

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -171,6 +171,7 @@ public:
 	bool leavesGhost;
 
 	bool  buildRange3D;
+	bool  canBuildWhileMoving;
 	float buildDistance;
 	float buildSpeed;
 	float reclaimSpeed;

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -569,6 +569,21 @@ void CBuilder::SlowUpdate()
 		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
 	}
 
+	// [MOBILE BUILD] Re-orient the nano-piece toward the current work target
+	// while this unit is moving.  SlowUpdate cadence (~16 frames) is sufficient
+	// since script animation is not frame-perfect and the visual difference vs.
+	// a per-frame update is imperceptible.
+	if (unitDef->canBuildWhileMoving && IsMoving()) {
+
+		const bool CalledScriptStartBuilding =
+			(curBuild      != nullptr) ? ScriptStartBuilding(curBuild->pos, /*silent=*/true)     :
+			(curReclaim    != nullptr) ? ScriptStartBuilding(curReclaim->pos, /*silent=*/true)   :
+			(curResurrect  != nullptr) ? ScriptStartBuilding(curResurrect->pos, /*silent=*/true) :
+			(curCapture    != nullptr) ? ScriptStartBuilding(curCapture->pos, /*silent=*/true)   :
+			(helpTerraform != nullptr) ? ScriptStartBuilding(helpTerraform->terraformCenter, /*silent=*/true) : false;
+
+	}
+
 	CUnit::SlowUpdate();
 }
 

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -59,7 +59,8 @@ CR_REG_METADATA(CBuilder, (
 	CR_MEMBER(terraformCenter),
 	CR_MEMBER(terraformRadius),
 	CR_MEMBER(terraformType),
-	CR_MEMBER(nanoPieceCache)
+	CR_MEMBER(nanoPieceCache),
+	CR_MEMBER(lastNanoPieceOrientationUpdate)
 ))
 
 
@@ -93,7 +94,8 @@ CBuilder::CBuilder():
 	tz1(0),
 	tz2(0),
 	terraformCenter(ZeroVector),
-	terraformRadius(0)
+	terraformRadius(0),
+	lastNanoPieceOrientationUpdate(0.5)
 {
 }
 
@@ -548,6 +550,19 @@ void CBuilder::Update()
 
 	nanoPieceCache.Update();
 
+	// [MOBILE BUILD] Re-orient the nano-piece toward the current work target
+	if (unitDef->canBuildWhileMoving && (gs->frameNum >= lastNanoPieceOrientationUpdate)) {
+		lastNanoPieceOrientationUpdate = gs->frameNum + (unitDef->nanoAimRate * GAME_SPEED);
+
+		const bool CalledScriptStartBuilding =
+			(curBuild != nullptr) ? ScriptStartBuilding(curBuild->pos, /*silent=*/true) :
+			(curReclaim != nullptr) ? ScriptStartBuilding(curReclaim->pos, /*silent=*/true) :
+			(curResurrect != nullptr) ? ScriptStartBuilding(curResurrect->pos, /*silent=*/true) :
+			(curCapture != nullptr) ? ScriptStartBuilding(curCapture->pos, /*silent=*/true) :
+			(helpTerraform != nullptr) ? ScriptStartBuilding(helpTerraform->terraformCenter, /*silent=*/true) : false;
+
+	}
+
 	if (!beingBuilt && !IsStunned()) {
 		updated = updated || UpdateTerraform(fCommand);
 		updated = updated || AssistTerraform(fCommand);
@@ -567,21 +582,6 @@ void CBuilder::SlowUpdate()
 	if (terraforming) {
 		constexpr int tsr = TERRA_SMOOTHING_RADIUS;
 		mapDamage->RecalcArea(tx1 - tsr, tx2 + tsr, tz1 - tsr, tz2 + tsr);
-	}
-
-	// [MOBILE BUILD] Re-orient the nano-piece toward the current work target
-	// while this unit is moving.  SlowUpdate cadence (~16 frames) is sufficient
-	// since script animation is not frame-perfect and the visual difference vs.
-	// a per-frame update is imperceptible.
-	if (unitDef->canBuildWhileMoving && IsMoving()) {
-
-		const bool CalledScriptStartBuilding =
-			(curBuild      != nullptr) ? ScriptStartBuilding(curBuild->pos, /*silent=*/true)     :
-			(curReclaim    != nullptr) ? ScriptStartBuilding(curReclaim->pos, /*silent=*/true)   :
-			(curResurrect  != nullptr) ? ScriptStartBuilding(curResurrect->pos, /*silent=*/true) :
-			(curCapture    != nullptr) ? ScriptStartBuilding(curCapture->pos, /*silent=*/true)   :
-			(helpTerraform != nullptr) ? ScriptStartBuilding(helpTerraform->terraformCenter, /*silent=*/true) : false;
-
 	}
 
 	CUnit::SlowUpdate();

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -95,7 +95,7 @@ CBuilder::CBuilder():
 	tz2(0),
 	terraformCenter(ZeroVector),
 	terraformRadius(0),
-	lastNanoPieceOrientationUpdate(0.5)
+	lastNanoPieceOrientationUpdate(0)
 {
 }
 

--- a/rts/Sim/Units/UnitTypes/Builder.h
+++ b/rts/Sim/Units/UnitTypes/Builder.h
@@ -92,6 +92,7 @@ public:
 	int tx1,tx2,tz1,tz2;
 	float3 terraformCenter;
 	float terraformRadius;
+	float lastNanoPieceOrientationUpdate;
 
 private:
 	NanoPieceCache nanoPieceCache;


### PR DESCRIPTION
Feature request over on BAR-side. There is a desire for a "mobile builder", a unit that can repair and reclaim while moving. (corprinter). 

To our knowledge, the only way to do this is either raw movegoal manipulation, or attaching the "builder" on a mobile unit. 

This PR adds a unit `canBuildWhileMoving` to skip the automatic `building = false; static_cast<CBuilder*>(owner)->StopBuild();` whenever a move command is issued to the builder unit. 

In addition, `LuaSyncedCtrl::SetUnitBuilderTarget` is added so game-side lua can assign build targets directly, without needing to issue direct commands that could interrupt movement. 

And normally the heading to aim the nanopiece is only sent once. However, that heading could change as the builder and target move relative to each other, so ScriptStartBuilding is called repeatedly for `canBuildWhileMoving` units, at a rate controlled by the unitdef value `nanoAimRate` (in seconds). [Please note, most unitscripts break if this is called too often, and would need to be modified to use a low `nanoAimRate`]

Example game-side gadget:
```
function gadget:GameFrame(nn)
	if nn%1 == 0 then
		for _, unitID in ipairs(Spring.GetAllUnits()) do
			if (UnitDefs[Spring.GetUnitDefID(unitID)].canBuildWhileMoving) then
				local nearenemy = Spring.GetUnitNearestEnemy(unitID,UnitDefs[Spring.GetUnitDefID(unitID)].buildDistance)
				if (nearenemy ~= nil) then
					Spring.SetUnitBuilderTarget(unitID,"reclaim",nearenemy)
				end
				--local featuresNear = Spring.GetFeaturesInSphere(pos[1], pos[2], pos[3], UnitDefs[Spring.GetUnitDefID(unitID)].buildDistance)
				--table.sort(featuresNear)
				--for ii, ID in ipairs(featuresNear) do
				--	if (ID ~= unitID) then
				--		Spring.SetUnitBuilderTarget(unitID,"reclaim",ID+Game.maxUnits)
				--		break
				--	end
				--end
			end
		end
	end
end
```

Example videos:

https://github.com/user-attachments/assets/5aa96496-b4dd-4c99-b9c0-a31d1368052c

https://github.com/user-attachments/assets/b4a8c545-1ce8-4d99-bb79-c8f2fe8bd67e

