### PR TITLE
Add "mainBuilder" member to allow resuming own task of canAssist = false builders

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -387,6 +387,11 @@ void CUnit::PostInit(const CUnit* builder)
 	eventHandler.UnitCreated(this, builder);
 	eoh->UnitCreated(*this, builder);
 
+	if (builder != nullptr)
+	{
+		mainBuilder = builder;
+	}
+
 	// skip past the gradual build-progression
 	if (!preBeingBuilt && !beingBuilt)
 		FinishedBuilding(true);
@@ -2915,6 +2920,7 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(lastNanoAdd),
 
 	CR_MEMBER(soloBuilder),
+	CR_MEMBER(mainBuilder),
 	CR_MEMBER(lastAttacker),
 	CR_MEMBER(transporter),
 

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -282,6 +282,7 @@ public:
 	const DynDamageArray* deathExpDamages = nullptr;
 
 	CUnit* soloBuilder = nullptr;
+	CUnit* mainBuilder = nullptr;
 	CUnit* lastAttacker = nullptr;
 	// transport that the unit is currently in
 	CUnit* transporter = nullptr;

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -120,9 +120,10 @@ void CBuilder::PreInit(const UnitLoadParams& params)
 bool CBuilder::CanAssistUnit(const CUnit* u, const UnitDef* def) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!unitDef->canAssist)
-		return false;
-
+	if (!unitDef->canAssist && u->mainBuilder != this) /* needs review please: is "this" inherently != from mainBuilder because mainBuilder is CUnit* while this is CBuilder* ? */ 
+	{
+	return false;	
+	}
 	return ((def == nullptr || u->unitDef == def) && u->beingBuilt && (u->buildProgress < 1.0f) && (u->soloBuilder == nullptr || u->soloBuilder == this));
 }
 


### PR DESCRIPTION
Add CUnit* mainBuilder member = original builder (the one that initiated the nano frame) as an immutable value.
Then compare this against builder on builder ->CanAssistUnit(unit) to allow resuming an inprogress construction.

Goal is to allow resuming own tasks for canAssist = false units.

Draft because haven't built nor tested yet.

Related to https://github.com/beyond-all-reason/RecoilEngine/issues/2893