### PR TITLE
Document why `wupget:UnitResurrected` is missing

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1100,6 +1100,11 @@ void CLuaHandle::UnitFinished(const CUnit* unit)
 	UnitCallIn(cmdStr, unit);
 }
 
+void CLuaHandle::UnitResurrected([[maybe_unused]] const CUnit* unit)
+{
+	/* This implementation is intentionally left blank for educational purposes,
+	 * since a gameside implementation is an excellent example of a custom call-in. */
+}
 
 /*** Called when a factory finishes construction of a unit.
  *

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -127,6 +127,7 @@ class CLuaHandle : public CEventClient
 
 		void UnitCreated(const CUnit* unit, const CUnit* builder) override;
 		void UnitFinished(const CUnit* unit) override;
+		void UnitResurrected(const CUnit* unit); // fake call-in, doesn't exist in CEventClient
 		void UnitFromFactory(const CUnit* unit, const CUnit* factory, bool userOrders) override;
 		void UnitReverseBuilt(const CUnit* unit) override;
 		void UnitConstructionDecayed(const CUnit* unit, float timeSinceLastBuild, float iterationPeriod, float part) override;


### PR DESCRIPTION
Via a dummy function so that people trying to add it in the future are likely to actually stumble upon it.