### PR TITLE
docs: add ENGINE_PERFORMANCE.md with some notes on engine internals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,10 @@ The engine uses custom thread pools. See `THREADPOOL` define and related code.
 4. Follow the workflow in `contributing.md`
 5. Disclose any AI assistance used
 
+### Additional docs
+Please see @coding-agents/ for additional documentation:
+- coding-agents/ENGINE_PERFORMANCE.md — notes on scale targets and engine performance internals. Useful for performance related changes.
+
 ## Additional Resources
 
 - Official website: https://recoilengine.org

--- a/coding-agents/ENGINE_PERFORMANCE.md
+++ b/coding-agents/ENGINE_PERFORMANCE.md
@@ -1,0 +1,35 @@
+# Engine performance
+
+Recoil is an RTS engine built for large-scale games — designed to handle thousands of units at once.
+
+## Scale target
+
+- **Target:** ~10k concurrent units, *including buildings*.
+- Mobile units tend to be ~40% of that late-game total.
+- Largest seen in a real game: ~17.7k units. That's a data point, not a design target.
+
+## Sim, draw, and update frames
+
+A main-loop iteration contains any pending **sim frames** followed by exactly one **draw frame**. `CGame::Update` runs first (synced) and dispatches `SimFrame()`s as network packets arrive; then `CGame::Draw` produces the iteration's draw frame — an **update phase** (`CGame::UpdateUnsynced` — timings, interpolation, camera, GUI, sound, world-drawer prep), then rendering the world and screen. It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
+
+```
+main-loop iteration
+├── CGame::Update       (synced plumbing)
+│   └── SimFrame × 0..N  ← 0..N "sim frames" (30 Hz, deterministic)
+└── CGame::Draw         ← one "draw frame" (unsynced)
+    ├── UpdateUnsynced  (update phase)
+    └── render world + screen
+```
+
+| Frame | Rate | Synced? | Responsibility |
+|---|---|---|---|
+| **Sim frame** — `CGame::SimFrame` | fixed 30 Hz (`GAME_SPEED`) | yes | advance deterministic state: units, pathing, projectiles, line-of-sight, scripts, Lua `GameFrame` |
+| **Draw frame** — `CGame::Draw` | variable | no | update phase + render world/screen |
+
+### Scheduling and CPU budget
+
+- Sim is fixed-rate; draw is as fast as sim + rendering allow. No hard CPU split in normal builds.
+- **Zero, one, or many** sim frames per draw frame — if the client falls behind, pending sim frames burst in the next iteration to catch up.
+- Visuals interpolate between sim frames, so draw rate can exceed sim rate without stutter.
+- **Sim has priority.** If sim work can't fit in ~33.3 ms per tick, `simspeed` drops below 1.0 and the game runs in slow motion — sim frames are never skipped, just stretched across more wall time.
+  - Draw FPS may also drop as a side effect: the main thread is busy on sim, so fewer draw frames land per wall-clock second.

--- a/coding-agents/ENGINE_PERFORMANCE.md
+++ b/coding-agents/ENGINE_PERFORMANCE.md
@@ -10,21 +10,24 @@ Recoil is an RTS engine built for large-scale games — designed to handle thous
 
 ## Sim, draw, and update frames
 
-A main-loop iteration contains any pending **sim frames** followed by exactly one **draw frame**. `CGame::Update` runs first (synced) and dispatches `SimFrame()`s as network packets arrive; then `CGame::Draw` produces the iteration's draw frame — an **update phase** (`CGame::UpdateUnsynced` — timings, interpolation, camera, GUI, sound, world-drawer prep), then rendering the world and screen. It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
+A main-loop iteration contains any pending **sim frames** followed by exactly one **draw frame**. `CGame::Update` runs first (synced) and dispatches `SimFrame()`s as network packets arrive; then `CGame::Draw` produces the iteration's draw frame — first an **update phase** (`CGame::UpdateUnsynced`: timings, interpolation, camera, GUI, sound, world-drawer prep), then **rendering** the world and screen (`DrawGenesis` → `DrawScreenPost`). It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
 
 ```
 main-loop iteration
 ├── CGame::Update       (synced plumbing)
 │   └── SimFrame × 0..N  ← 0..N "sim frames" (30 Hz, deterministic)
 └── CGame::Draw         ← one "draw frame" (unsynced)
-    ├── UpdateUnsynced  (update phase)
-    └── render world + screen
+    ├── UpdateUnsynced         (update phase; ends at DrawGenesis)
+    └── render world + screen  (DrawGenesis → DrawScreenPost)
 ```
 
-| Frame | Rate | Synced? | Responsibility |
+| Phase | Rate | Synced? | Responsibility |
 |---|---|---|---|
 | **Sim frame** — `CGame::SimFrame` | fixed 30 Hz (`GAME_SPEED`) | yes | advance deterministic state: units, pathing, projectiles, line-of-sight, scripts, Lua `GameFrame` |
-| **Draw frame** — `CGame::Draw` | variable | no | update phase + render world/screen |
+| **Draw frame** — `CGame::Draw` | variable | no | update phase (see below) + render world/screen |
+| **Update phase** — `CGame::UpdateUnsynced` *(inside draw frame)* | per draw frame | no | timings, interpolation, camera, GUI, sound, world-drawer prep |
+
+**Benchmark names.** `fightertest` reports these phases as three peer buckets **Sim / Update / Render** — Sim ≈ `CGame::SimFrame`, Update ≈ `CGame::UpdateUnsynced`, Render ≈ `DrawGenesis` → `DrawScreenPost`.
 
 ### Scheduling and CPU budget
 

--- a/coding-agents/ENGINE_PERFORMANCE.md
+++ b/coding-agents/ENGINE_PERFORMANCE.md
@@ -10,15 +10,18 @@ Recoil is an RTS engine built for large-scale games — designed to handle thous
 
 ## Sim, draw, and update frames
 
-A main-loop iteration contains any pending **sim frames** followed by exactly one **draw frame**. `CGame::Update` runs first (synced) and dispatches `SimFrame()`s as network packets arrive; then `CGame::Draw` produces the iteration's draw frame — first an **update phase** (`CGame::UpdateUnsynced`: timings, interpolation, camera, GUI, sound, world-drawer prep), then **rendering** the world and screen (`DrawGenesis` → `DrawScreenPost`). It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
+The main loop is `Update → Draw`, repeating. Each iteration produces one draw frame and drains any queued sim frame packets first (0..N sim frames per iteration). `CGame::Update` (synced) dispatches `SimFrame()` calls as `NETMSG_NEWFRAME` packets arrive; `CGame::Draw` then does an **unsynced update phase** (`CGame::UpdateUnsynced`: timings, interpolation, camera, GUI, sound, world-drawer prep) followed by **rendering** (`DrawGenesis` → `DrawScreenPost`). The sim burst is capped at ~500 ms (`minDrawFPS`) so draw always gets to run. It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
+
+Conversely, if no sim frames are in the queue the main loop runs `Draw`/`UpdateUnsynced` as fast as possible — many draw iterations can pass between successive sim frames, with visuals interpolating smoothly in between via `globalRendering->timeOffset`.
 
 ```
-main-loop iteration
-├── CGame::Update       (synced plumbing)
-│   └── SimFrame × 0..N  ← 0..N "sim frames" (30 Hz, deterministic)
-└── CGame::Draw         ← one "draw frame" (unsynced)
-    ├── UpdateUnsynced         (update phase; ends at DrawGenesis)
-    └── render world + screen  (DrawGenesis → DrawScreenPost)
+main-loop iteration  (repeats as fast as possible)
+├── CGame::Update            (synced)
+│   └── SimFrame × 0..N      ← processes queued sim frames capped at
+|                              ~500ms per iteration
+└── CGame::Draw              (unsynced)
+    ├── UpdateUnsynced       ← unsynced update phase
+    └── DrawGenesis → DrawScreenPost  ← render world + screen
 ```
 
 | Phase | Rate | Synced? | Responsibility |
@@ -31,8 +34,20 @@ main-loop iteration
 
 ### Scheduling and CPU budget
 
-- Sim is fixed-rate; draw is as fast as sim + rendering allow. No hard CPU split in normal builds.
+- Sim has a target rate set by the server; draw is as fast as the hardware allows. The sim target is `30 Hz × speedFactor`; at a speed factor of 1x, in-game time tracks real-world time 1:1, and at 2x speed the server fires twice as many sim frames per real-world second so the world evolves twice as fast. 
 - **Zero, one, or many** sim frames per draw frame — if the client falls behind, pending sim frames burst in the next iteration to catch up.
 - Visuals interpolate between sim frames, so draw rate can exceed sim rate without stutter.
-- **Sim has priority.** If sim work can't fit in ~33.3 ms per tick, `simspeed` drops below 1.0 and the game runs in slow motion — sim frames are never skipped, just stretched across more wall time.
+- **Sim has priority, but with headroom.** Sim targets only **~60% of wall-clock time** — the rest is reserved so rendering can run afterwards. If the **median of all players' recent sim CPU%** exceeds 60%, the server drops the delivered speed below the requested speed; re-evaluated every 2 s.
+  - At 1× speed, that works out to ~20 ms of sim per ~33 ms tick. Higher speedFactor means more, shorter ticks per wall-second — the 60% wall-clock rule is unchanged.
+  - One-off slow frames don't throttle; sustained overrun does.
   - Draw FPS may also drop as a side effect: the main thread is busy on sim, so fewer draw frames land per wall-clock second.
+
+## Multi-threading
+
+The engine runs one **main thread** plus a pool of **worker threads**, all pinned to distinct cores. The main thread drives the sim/draw loop; workers pick up parallel work dispatched from the main thread (via `for_mt` and friends in `rts/System/Threading/ThreadPool.h`). The main thread also participates in draining the task queue while it waits.
+
+Worker count is chosen by inspecting CPU topology: cache groups are sorted by L3 size (largest first), and the pool fills from the best cache group, pulling in further groups until it has **at least** a target of ~6 threads on x86 (~4 on ARM). The target is a floor, not a ceiling — once a cache group is pulled, all its cores are pulled as well. This means the pool can be larger than the target. On a machine with fewer usable perf cores than the target, it shrinks to what's available. Pinning is done via `sched_setaffinity` on Linux and `SetThreadAffinityMask` on Windows. Efficiency cores are excluded on hybrid CPUs.
+
+Most parallel work in the engine is **homogeneous** — the same operation applied over many items (unit updates, projectile steps, etc.) via `for_mt`. Keeping parallel work homogeneous is a deliberate discipline: it makes determinism easier to reason about and keeps sim output independent of how work happens to land across threads.
+
+**QTPFS is the one heterogeneous exception.** The quad-tree pathfinder maintains its own per-worker search state (`SearchThreadData`, `SparseData`) independent of engine sim state, which lets it safely run path searches on the worker pool *in the background* via `for_mt_background`. Background tasks yield to higher-priority work by rescheduling themselves when other jobs arrive, so QTPFS soaks up idle worker capacity without preempting foreground parallelism.

--- a/coding-agents/ENGINE_PERFORMANCE.md
+++ b/coding-agents/ENGINE_PERFORMANCE.md
@@ -10,43 +10,45 @@ Recoil is an RTS engine built for large-scale games — designed to handle thous
 
 ## Sim, draw, and update frames
 
-The main loop is `Update → Draw`, repeating. Each iteration produces one draw frame and drains any queued sim frame packets first (0..N sim frames per iteration). `CGame::Update` (synced) dispatches `SimFrame()` calls as `NETMSG_NEWFRAME` packets arrive; `CGame::Draw` then does an **unsynced update phase** (`CGame::UpdateUnsynced`: timings, interpolation, camera, GUI, sound, world-drawer prep) followed by **rendering** (`DrawGenesis` → `DrawScreenPost`). The sim burst is capped at ~500 ms (`minDrawFPS`) so draw always gets to run. It's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
+The main loop is `Update → Draw`, repeating — see the diagram and table below for the per-phase breakdown. Each iteration first drains any queued sim-frame packets (0..N per iteration), then renders one draw frame. `CGame::Update` dispatches `SimFrame()` calls as `NETMSG_NEWFRAME` packets arrive; `CGame::Draw` runs the unsynced update phase and then renders. The sim burst is capped at ~500 ms (`minDrawFPS`) so draw always gets to run, and it's all one thread — sim and rendering are **not concurrent**; parallelism only happens *inside* a phase.
 
 Conversely, if no sim frames are in the queue the main loop runs `Draw`/`UpdateUnsynced` as fast as possible — many draw iterations can pass between successive sim frames, with visuals interpolating smoothly in between via `globalRendering->timeOffset`.
 
 ```
 main-loop iteration  (repeats as fast as possible)
-├── CGame::Update            (synced)
+├── CGame::Update            (mostly synced)
 │   └── SimFrame × 0..N      ← processes queued sim frames capped at
 |                              ~500ms per iteration
 └── CGame::Draw              (unsynced)
     ├── UpdateUnsynced       ← unsynced update phase
-    └── DrawGenesis → DrawScreenPost  ← render world + screen
+    └── render world + screen   ← Draw::World + Draw::Screen
 ```
 
 | Phase | Rate | Synced? | Responsibility |
 |---|---|---|---|
-| **Sim frame** — `CGame::SimFrame` | fixed 30 Hz (`GAME_SPEED`) | yes | advance deterministic state: units, pathing, projectiles, line-of-sight, scripts, Lua `GameFrame` |
+| **Sim frame** — `CGame::SimFrame` | fixed 30 Hz (`GAME_SPEED`) | mostly yes | advance deterministic state: units, pathing, projectiles, line-of-sight, scripts, Lua `GameFrame` |
 | **Draw frame** — `CGame::Draw` | variable | no | update phase (see below) + render world/screen |
 | **Update phase** — `CGame::UpdateUnsynced` *(inside draw frame)* | per draw frame | no | timings, interpolation, camera, GUI, sound, world-drawer prep |
 
-**Benchmark names.** `fightertest` reports these phases as three peer buckets **Sim / Update / Render** — Sim ≈ `CGame::SimFrame`, Update ≈ `CGame::UpdateUnsynced`, Render ≈ `DrawGenesis` → `DrawScreenPost`.
+### Profiler buckets
+
+The engine `CTimeProfiler` (and the `benchmark` tool) report three peer buckets: `Sim` (the whole synced step), `Update` (`CGame::UpdateUnsynced`), and `Draw` (rendering only, *excluding* the Update that runs first).
+
+`Sim` is **"mostly" synced**: it also bills unsynced work that runs inline during `SimFrame`.
+- **Explicit Lua callins** — `GameFrame`/`GameFramePost` run near the start of each sim frame.
+- **Event-driven Lua callins** — unsynced widgets can subscribe to synced game events, so their handlers run inline as those events fire during the frame.
+- **C++-only unsynced sections** — e.g. the MT projectile visual pass (`Sim::Projectiles::UpdateUnsyncedMT`) and ghosted-building updates (`CUnitDrawer::UpdateGhostedBuildings`).
 
 ### Scheduling and CPU budget
 
-- Sim has a target rate set by the server; draw is as fast as the hardware allows. The sim target is `30 Hz × speedFactor`; at a speed factor of 1x, in-game time tracks real-world time 1:1, and at 2x speed the server fires twice as many sim frames per real-world second so the world evolves twice as fast. 
+- Sim has a target rate set by the server; draw is as fast as the hardware allows. The sim target is `30 Hz × speedFactor`; at a speed factor of 1x, in-game time tracks real-world time 1:1, and at 2x speed the server fires twice as many sim frames per real-world second so the world evolves twice as fast.
 - **Zero, one, or many** sim frames per draw frame — if the client falls behind, pending sim frames burst in the next iteration to catch up.
 - Visuals interpolate between sim frames, so draw rate can exceed sim rate without stutter.
-- **Sim has priority, but with headroom.** Sim targets only **~60% of wall-clock time** — the rest is reserved so rendering can run afterwards. If the **median of all players' recent sim CPU%** exceeds 60%, the server drops the delivered speed below the requested speed; re-evaluated every 2 s.
-  - At 1× speed, that works out to ~20 ms of sim per ~33 ms tick. Higher speedFactor means more, shorter ticks per wall-second — the 60% wall-clock rule is unchanged.
-  - One-off slow frames don't throttle; sustained overrun does.
-  - Draw FPS may also drop as a side effect: the main thread is busy on sim, so fewer draw frames land per wall-clock second.
+- Sim time is carefully budgeted and scheduled against draw frames (because they run serially) so there's always a minimum fps for the player
 
 ## Multi-threading
 
-The engine runs one **main thread** plus a pool of **worker threads**, all pinned to distinct cores. The main thread drives the sim/draw loop; workers pick up parallel work dispatched from the main thread (via `for_mt` and friends in `rts/System/Threading/ThreadPool.h`). The main thread also participates in draining the task queue while it waits.
-
-Worker count is chosen by inspecting CPU topology: cache groups are sorted by L3 size (largest first), and the pool fills from the best cache group, pulling in further groups until it has **at least** a target of ~6 threads on x86 (~4 on ARM). The target is a floor, not a ceiling — once a cache group is pulled, all its cores are pulled as well. This means the pool can be larger than the target. On a machine with fewer usable perf cores than the target, it shrinks to what's available. Pinning is done via `sched_setaffinity` on Linux and `SetThreadAffinityMask` on Windows. Efficiency cores are excluded on hybrid CPUs.
+The engine runs one **main thread** plus a pool of **worker threads**, all pinned to distinct cores. We typically aim for 6-8 worker threads. The main thread drives the sim/draw loop; workers pick up parallel work dispatched from the main thread (via `for_mt` and friends in `rts/System/Threading/ThreadPool.h`). The main thread also participates in draining the task queue while it waits.
 
 Most parallel work in the engine is **homogeneous** — the same operation applied over many items (unit updates, projectile steps, etc.) via `for_mt`. Keeping parallel work homogeneous is a deliberate discipline: it makes determinism easier to reason about and keeps sim output independent of how work happens to land across threads.
 


### PR DESCRIPTION
# Purpose
A few separate discussions got some good answers worth putting in docs for coding agents as context.

Meant to be simple/vague, as coding agents can dig deeper for specifics when they need to.

NOTE: LLM generated by heavily reviewed/cut by me.