### PR TITLE
feat: add historical hash comparison and desync detection to collect-hashes

### DIFF
--- a/.github/workflows/fightertest.yml
+++ b/.github/workflows/fightertest.yml
@@ -168,33 +168,177 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-  # Collects sync hashes from all fightertest runs into one place.
-  # TODO: compare hashes against known-good values from prior runs to detect
-  # desync regressions automatically.
+  # Collects sync hashes from all fightertest runs, prints a history table,
+  # and fails if hashes diverge from the merge-base commit (desync detection).
   collect-hashes:
     if: always()
     needs: [setup, fightertest]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TESTED_SHA: ${{ needs.setup.outputs.sha }}
     steps:
-      - name: Download all fightertest artifacts
+      - name: Download current run artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: fightertest-*-${{ needs.setup.outputs.sha }}
           path: artifacts
 
-      - name: Print sync hashes
+      - name: Build combined hash manifest
         run: |
           set -euo pipefail
-          echo "## Sync hashes for ${{ needs.setup.outputs.sha }}"
-          echo ""
           for dir in artifacts/fightertest-*; do
-            test_name=$(basename "$dir" | sed "s/^fightertest-//; s/-${{ needs.setup.outputs.sha }}$//")
+            test_name=$(basename "$dir" | sed "s/^fightertest-//; s/-${TESTED_SHA}$//")
             hash_file="$dir/fightertest_synchash.txt"
             if [ -f "$hash_file" ]; then
-              hash=$(head -n 1 "$hash_file")
-              echo "$test_name: $hash"
+              echo "$test_name $(head -n 1 "$hash_file")"
             else
-              echo "$test_name: MISSING"
+              echo "$test_name MISSING"
             fi
+          done | sort > synchashes.txt
+          echo "Current hashes:"
+          cat synchashes.txt
+
+      - name: Upload combined hash manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: fightertest-synchashes-${{ needs.setup.outputs.sha }}
+          path: synchashes.txt
+          retention-days: 90
+
+      - name: Determine commits to look up
+        id: history
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          base_branch="master"
+
+          # Compare tested commit against base branch
+          compare=$(gh api "repos/${repo}/compare/${base_branch}...${TESTED_SHA}" \
+            --jq '{ahead: .ahead_by, merge_base: .merge_base_commit.sha, commits: [.commits[].sha]}')
+          ahead=$(echo "$compare" | jq -r '.ahead')
+          merge_base=$(echo "$compare" | jq -r '.merge_base')
+
+          if [ "$ahead" -eq 0 ]; then
+            echo "on_base=true" >> "$GITHUB_OUTPUT"
+            # On master — collect last 10 commits (excluding current)
+            gh api "repos/${repo}/commits?sha=${base_branch}&per_page=11" \
+              --jq '.[].sha' | grep -v "^${TESTED_SHA}$" | head -10 > commits_to_check.txt
+          else
+            echo "on_base=false" >> "$GITHUB_OUTPUT"
+            echo "merge_base=${merge_base}" >> "$GITHUB_OUTPUT"
+
+            # 5 commits at and before the merge base (where the branch diverged)
+            gh api "repos/${repo}/commits?sha=${merge_base}&per_page=5" \
+              --jq '.[].sha' > commits_to_check.txt
+
+            # Up to 10 branch commits (newest first, excluding current)
+            echo "$compare" | jq -r '.commits | reverse | .[].sha' \
+              | grep -v "^${TESTED_SHA}$" | head -10 >> commits_to_check.txt
+          fi
+
+          # Deduplicate while preserving order
+          awk '!seen[$0]++' commits_to_check.txt > tmp && mv tmp commits_to_check.txt
+          echo "Commits to look up ($(wc -l < commits_to_check.txt)):"
+          cat commits_to_check.txt
+
+      - name: Fetch historical hashes
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          mkdir -p history
+
+          while read -r sha; do
+            artifact_name="fightertest-synchashes-${sha}"
+            artifact_id=$(gh api "repos/${repo}/actions/artifacts?name=${artifact_name}" \
+              --jq '.artifacts[0].id // empty' 2>/dev/null || true)
+
+            if [ -n "$artifact_id" ]; then
+              if gh api "repos/${repo}/actions/artifacts/${artifact_id}/zip" \
+                   > "history/${sha}.zip" 2>/dev/null; then
+                unzip -qo "history/${sha}.zip" -d "history/${sha}" 2>/dev/null || true
+                rm -f "history/${sha}.zip"
+              fi
+            fi
+          done < commits_to_check.txt
+
+          found=$(find history -name synchashes.txt | wc -l)
+          echo "Found hashes for ${found} prior commit(s)"
+
+      - name: Print hash history
+        run: |
+          set -euo pipefail
+          tests=$(awk '{print $1}' synchashes.txt | tr '\n' ' ')
+
+          # Build header
+          header="| Commit |"
+          separator="|--------|"
+          for t in $tests; do
+            header="$header $t |"
+            separator="$separator------|"
           done
+
+          {
+            echo "## Fightertest sync hashes"
+            echo ""
+            echo "$header"
+            echo "$separator"
+
+            # Current commit row
+            row="| ${TESTED_SHA:0:12} (current) |"
+            for t in $tests; do
+              h=$(awk -v t="$t" '$1==t {print $2}' synchashes.txt)
+              row="$row \`${h:-MISSING}\` |"
+            done
+            echo "$row"
+
+            # Historical rows
+            while read -r sha; do
+              manifest="history/${sha}/synchashes.txt"
+              [ -f "$manifest" ] || continue
+              row="| ${sha:0:12} |"
+              for t in $tests; do
+                h=$(awk -v t="$t" '$1==t {print $2}' "$manifest")
+                row="$row \`${h:-?}\` |"
+              done
+              echo "$row"
+            done < commits_to_check.txt
+
+            echo ""
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Compare against merge base
+        if: steps.history.outputs.on_base == 'false'
+        run: |
+          set -euo pipefail
+          merge_base="${{ steps.history.outputs.merge_base }}"
+          base_manifest="history/${merge_base}/synchashes.txt"
+
+          if [ ! -f "$base_manifest" ]; then
+            echo "::warning::No fightertest hashes found for merge base ${merge_base:0:12} — cannot verify sync stability"
+            exit 0
+          fi
+
+          echo "Comparing against merge base ${merge_base:0:12}..."
+          diff_found=0
+          while read -r test_name hash; do
+            base_hash=$(awk -v t="$test_name" '$1==t {print $2}' "$base_manifest")
+            if [ -z "$base_hash" ]; then
+              echo "::warning::${test_name}: no base hash to compare"
+            elif [ "$hash" = "MISSING" ]; then
+              echo "::error::${test_name}: hash MISSING in current run"
+              diff_found=1
+            elif [ "$hash" != "$base_hash" ]; then
+              echo "::error::${test_name}: DESYNC — current ${hash} != base ${base_hash}"
+              diff_found=1
+            else
+              echo "${test_name}: OK (${hash})"
+            fi
+          done < synchashes.txt
+
+          if [ "$diff_found" -ne 0 ]; then
+            echo "::error::Sync hash mismatch detected — this commit changes deterministic behavior relative to merge base ${merge_base:0:12}"
+            exit 1
+          fi
+          echo "All hashes match merge base."


### PR DESCRIPTION
The collect-hashes job now uploads a combined synchashes manifest per
tested commit, fetches historical manifests via the GitHub API, renders
a markdown summary table, and fails on branch builds when hashes diverge
from the merge-base commit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Part 4 (final part?) of #2910