### PR TITLE
fix: address compiler warnings warnings in engine and vendored libs

### DIFF
--- a/AI/Skirmish/CMakeLists.txt
+++ b/AI/Skirmish/CMakeLists.txt
@@ -19,10 +19,31 @@ endmacro (skirmish_ai_message typemsg)
 # Add all Skirmish AI submodules
 get_list_of_submodules(SKIRMISH_AI_DIRS)
 set(DEPS_AI_SKIRMISH "")
+set(_skirmish_ai_clang_warns
+	-Wno-implicit-const-int-float-conversion
+	-Wno-parentheses-equality
+	-Wno-deprecated-declarations
+	-Wno-inconsistent-missing-override
+	-Wno-unused-lambda-capture
+	-Wno-pessimizing-move
+	-Wno-unneeded-internal-declaration
+	-Wno-unused-local-typedef
+	-Wno-unused-private-field
+	-Wno-unused-but-set-variable
+	-Wno-mismatched-tags
+	-Wno-vla-cxx-extension
+	-Wno-unused-variable
+)
 foreach    (skirmishAIDir ${SKIRMISH_AI_DIRS})
 	add_subdirectory(${skirmishAIDir})
 	if (TARGET ${skirmishAIDir})
 		list(APPEND DEPS_AI_SKIRMISH ${skirmishAIDir})
+		# Vendored Skirmish AI submodules (e.g. BARb, CircuitAI) don't compile
+		# cleanly under clang-19; suppress the warnings here rather than patching
+		# the submodule CMakeLists.
+		if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+			target_compile_options(${skirmishAIDir} PRIVATE ${_skirmish_ai_clang_warns})
+		endif()
 	endif()
 endforeach (skirmishAIDir)
 make_global(DEPS_AI_SKIRMISH)

--- a/AI/Skirmish/CMakeLists.txt
+++ b/AI/Skirmish/CMakeLists.txt
@@ -34,15 +34,21 @@ set(_skirmish_ai_clang_warns
 	-Wno-vla-cxx-extension
 	-Wno-unused-variable
 )
+set(_skirmish_ai_gcc_warns
+	-Wno-maybe-uninitialized
+	-Wno-deprecated-declarations
+)
 foreach    (skirmishAIDir ${SKIRMISH_AI_DIRS})
 	add_subdirectory(${skirmishAIDir})
 	if (TARGET ${skirmishAIDir})
 		list(APPEND DEPS_AI_SKIRMISH ${skirmishAIDir})
 		# Vendored Skirmish AI submodules (e.g. BARb, CircuitAI) don't compile
-		# cleanly under clang-19; suppress the warnings here rather than patching
-		# the submodule CMakeLists.
+		# cleanly under modern compilers; suppress the warnings here rather
+		# than patching the submodule CMakeLists.
 		if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 			target_compile_options(${skirmishAIDir} PRIVATE ${_skirmish_ai_clang_warns})
+		elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+			target_compile_options(${skirmishAIDir} PRIVATE ${_skirmish_ai_gcc_warns})
 		endif()
 	endif()
 endforeach (skirmishAIDir)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,13 +414,10 @@ if(NOT MSVC)
 		## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
 		## it's been quite annoying since we switched to C++23
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
-		## std::aligned_storage_t is deprecated in C++23 and used by vendored entt headers
+		## libstdc++13 <functional> still uses std::result_of (deprecated in C++23),
+		## which trips through any ThreadPool::Enqueue callsite — suppress globally
+		## rather than sprinkle pragmas across every file that enqueues work.
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-		## CR_DECLARE_STRUCT in templates triggers this; the static is defined by a
-		## matching CR_BIND_TEMPLATE in the TU that needs it
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
-		## vendored assimp public headers use #pragma pack in ways clang dislikes
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pragma-pack")
 	endif()
 
 	### CompileTime Warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,11 +409,21 @@ if(NOT MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsignaling-nans")
 	endif()
 
-	if (CLANG)
+	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 		## warning: space between quotes and suffix is deprecated in C++23
 		## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
 		## it's been quite annoying since we switched to C++23
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
+		## std::aligned_storage_t is deprecated in C++23 and used by vendored entt headers
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+		## many engine base classes use CR_DECLARE macros that inject virtuals, so
+		## marking every override consistently is impractical
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
+		## CR_DECLARE_STRUCT in templates triggers this; the static is defined by a
+		## matching CR_BIND_TEMPLATE in the TU that needs it
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
+		## vendored assimp public headers use #pragma pack in ways clang dislikes
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pragma-pack")
 	endif()
 
 	### CompileTime Warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,9 +416,6 @@ if(NOT MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
 		## std::aligned_storage_t is deprecated in C++23 and used by vendored entt headers
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-		## many engine base classes use CR_DECLARE macros that inject virtuals, so
-		## marking every override consistently is impractical
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 		## CR_DECLARE_STRUCT in templates triggers this; the static is defined by a
 		## matching CR_BIND_TEMPLATE in the TU that needs it
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,10 +409,12 @@ if(NOT MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsignaling-nans")
 	endif()
 
-	## warning: space between quotes and suffix is deprecated in C++23
-	## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
-	## it's been quite annoying since we switched to C++23
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
+	if (CLANG)
+		## warning: space between quotes and suffix is deprecated in C++23
+		## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
+		## it's been quite annoying since we switched to C++23
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
+	endif()
 
 	### CompileTime Warnings
 	set(COMMON_WARNINGS "${COMMON_WARNINGS} -Wformat -Wformat-security")

--- a/rts/Game/Camera/OverviewController.h
+++ b/rts/Game/Camera/OverviewController.h
@@ -11,7 +11,7 @@ public:
 	COverviewController();
 	~COverviewController();
 
-	const std::string GetName() const { return "ov"; }
+	const std::string GetName() const override { return "ov"; }
 
 	void KeyMove(float3 move) override {}
 	void MouseMove(float3 move) override {}
@@ -25,11 +25,11 @@ public:
 	void SetDir(const float3& newDir) override {}
 	void SetRot(const float3& newDir) override {camRotY = newDir.y;}
 
-	float3 SwitchFrom() const;
-	void SwitchTo(const CCameraController* oldCam, const bool showText);
+	float3 SwitchFrom() const override;
+	void SwitchTo(const CCameraController* oldCam, const bool showText) override;
 
-	void GetState(StateMap& sm) const;
-	bool SetState(const StateMap& sm);
+	void GetState(StateMap& sm) const override;
+	bool SetState(const StateMap& sm) override;
 
 	void ConfigNotify(const std::string& key, const std::string& value);
 	void ConfigUpdate();

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -25,14 +25,14 @@ public:
 	CMiniMap();
 	~CMiniMap() override;
 
-	bool MousePress(int x, int y, int button);
-	void MouseMove(int x, int y, int dx, int dy, int button);
-	void MouseRelease(int x, int y, int button);
+	bool MousePress(int x, int y, int button) override;
+	void MouseMove(int x, int y, int dx, int dy, int button) override;
+	void MouseRelease(int x, int y, int button) override;
 	void MouseWheel(bool up, float delta);
 	void MoveView(int x, int y) { MoveView(GetMapPosition(x, y)); }
-	bool IsAbove(int x, int y);
+	bool IsAbove(int x, int y) override;
 	bool IsInside(int x, int y);
-	std::string GetTooltip(int x, int y);
+	std::string GetTooltip(int x, int y) override;
 	void Draw() override;
 	void DrawForReal(bool useNormalizedCoors = true, bool updateTex = false, bool luaCall = false);
 	void Update();

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -19,7 +19,7 @@
 
 bool LuaConstGL::PushEntries(lua_State* L)
 {
-#define PUSH_GL(cmd) LuaPushNamedNumber(L, #cmd, GL_ ## cmd)
+#define PUSH_GL(cmd) LuaPushNamedNumber(L, #cmd, static_cast<lua_Number>(GL_ ## cmd))
 
 	/***
 	 * Drawing Primitives

--- a/rts/Lua/LuaGaia.h
+++ b/rts/Lua/LuaGaia.h
@@ -22,10 +22,10 @@ protected:
 	bool AddSyncedCode(lua_State* L) override { return true; }
 	bool AddUnsyncedCode(lua_State* L) override { return true; }
 
-	std::string GetUnsyncedFileName() const;
-	std::string GetSyncedFileName() const;
-	std::string GetInitFileModes() const;
-	int GetInitSelectTeam() const;
+	std::string GetUnsyncedFileName() const override;
+	std::string GetSyncedFileName() const override;
+	std::string GetInitFileModes() const override;
+	int GetInitSelectTeam() const override;
 
 private:
 	CLuaGaia(bool dryRun);

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5767,7 +5767,7 @@ int LuaOpenGL::GetMatrixData(lua_State* L)
 int LuaOpenGL::PushAttrib(lua_State* L)
 {
 	CheckDrawingEnabled(L, __func__);
-	int mask = luaL_optnumber(L, 1, GL_ALL_ATTRIB_BITS);
+	int mask = luaL_optnumber(L, 1, static_cast<lua_Number>(GL_ALL_ATTRIB_BITS));
 	if (mask < 0) {
 		mask = -mask;
 		mask |= GL_ALL_ATTRIB_BITS;

--- a/rts/Lua/LuaOpenGLUtils.cpp
+++ b/rts/Lua/LuaOpenGLUtils.cpp
@@ -1114,6 +1114,8 @@ void LuaMatTexture::Print(const string& indent) const
 		STRING_CASE(typeName, LUATEX_ICONS_ATLAS0);
 		STRING_CASE(typeName, LUATEX_ICONS_ATLAS1);
 
+		STRING_CASE(typeName, LUATEX_LUATEXTUREATLAS);
+
 		#undef STRING_CASE
 	}
 

--- a/rts/Lua/LuaParser.h
+++ b/rts/Lua/LuaParser.h
@@ -124,7 +124,6 @@ private:
 	struct boolean { bool b; };
 
 public:
-	LuaParser() = default;
 	LuaParser(const std::string& fileName, const std::string& fileModes, const std::string& accessModes, const boolean& synced = {false}, const boolean& setup = {true});
 	LuaParser(const std::string& textChunk, const std::string& accessModes, int = 0, const boolean& synced = {false}, const boolean& setup = {true});
 	~LuaParser();

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4480,8 +4480,6 @@ int LuaSyncedCtrl::AddUnitResource(lua_State* L)
 	return 0;
 }
 
-/*
-
 /***
  * @function Spring.UseUnitResource
  * @param unitID integer

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -627,8 +627,8 @@ int LuaUnsyncedRead::GetLuaMemUsage(lua_State* L)
 
 	// sum up the individual (unsynced and synced) state footprints
 	for (bool synced: {false, true}) {
-		lgs.allocedBytes = {0};
-		lgs.numLuaAllocs = {0};
+		lgs.allocedBytes = 0;
+		lgs.numLuaAllocs = 0;
 
 		for (const luaContextData* lcd: *LUAHANDLE_CONTEXTS[synced]) {
 			lhs = &lcd->allocState;

--- a/rts/Map/SMF/SMFGroundTextures.cpp
+++ b/rts/Map/SMF/SMFGroundTextures.cpp
@@ -111,11 +111,23 @@ void CSMFGroundTextures::LoadTiles(CSMFMapFile& file)
 		std::string err = fmt::sprintf("[SMFGroundTextures::%s] smfMap->tileCount=%d <= 0", __func__, smfMap->tileCount);
 		throw content_error(err);
 	}
+	if (tileHeader.numTiles <= 0) {
+		std::string err = fmt::sprintf("[SMFGroundTextures::%s] tileHeader.numTiles=%d <= 0", __func__, tileHeader.numTiles);
+		throw content_error(err);
+	}
 
 	tileMap.clear();
 	tileMap.resize(smfMap->tileCount);
 	tiles.clear();
-	tiles.resize(tileHeader.numTiles * SMALL_TILE_SIZE);
+	// GCC 13 emits a spurious -Wstringop-overflow on this resize.
+#if defined(__GNUC__) && !defined(__clang__)
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+	tiles.resize(static_cast<size_t>(tileHeader.numTiles) * SMALL_TILE_SIZE);
+#if defined(__GNUC__) && !defined(__clang__)
+	#pragma GCC diagnostic pop
+#endif
 	squares.clear();
 	squares.resize(smfMap->numBigTexX * smfMap->numBigTexY);
 

--- a/rts/Map/SMF/SMFGroundTextures.cpp
+++ b/rts/Map/SMF/SMFGroundTextures.cpp
@@ -111,23 +111,10 @@ void CSMFGroundTextures::LoadTiles(CSMFMapFile& file)
 		std::string err = fmt::sprintf("[SMFGroundTextures::%s] smfMap->tileCount=%d <= 0", __func__, smfMap->tileCount);
 		throw content_error(err);
 	}
-	if (tileHeader.numTiles <= 0) {
-		std::string err = fmt::sprintf("[SMFGroundTextures::%s] tileHeader.numTiles=%d <= 0", __func__, tileHeader.numTiles);
-		throw content_error(err);
-	}
 
 	tileMap.clear();
 	tileMap.resize(smfMap->tileCount);
-	tiles.clear();
-	// GCC 13 emits a spurious -Wstringop-overflow on this resize.
-#if defined(__GNUC__) && !defined(__clang__)
-	#pragma GCC diagnostic push
-	#pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif
-	tiles.resize(static_cast<size_t>(tileHeader.numTiles) * SMALL_TILE_SIZE);
-#if defined(__GNUC__) && !defined(__clang__)
-	#pragma GCC diagnostic pop
-#endif
+	tiles.assign(static_cast<size_t>(tileHeader.numTiles) * SMALL_TILE_SIZE, 0);
 	squares.clear();
 	squares.resize(smfMap->numBigTexX * smfMap->numBigTexY);
 

--- a/rts/Map/SMF/SMFGroundTextures.h
+++ b/rts/Map/SMF/SMFGroundTextures.h
@@ -17,10 +17,10 @@ public:
 	CSMFGroundTextures(CSMFReadMap* rm);
 	~CSMFGroundTextures() override;
 
-	void DrawUpdate();
-	bool SetSquareLuaTexture(int texSquareX, int texSquareY, int texID);
-	bool GetSquareLuaTexture(int texSquareX, int texSquareY, int texID, int texSizeX, int texSizeY, int lodMin, int lodMax);
-	void BindSquareTexture(int texSquareX, int texSquareY);
+	void DrawUpdate() override;
+	bool SetSquareLuaTexture(int texSquareX, int texSquareY, int texID) override;
+	bool GetSquareLuaTexture(int texSquareX, int texSquareY, int texID, int texSizeX, int texSizeY, int lodMin, int lodMax) override;
+	void BindSquareTexture(int texSquareX, int texSquareY) override;
 
 protected:
 	void LoadTiles(CSMFMapFile& file);

--- a/rts/Menu/SelectMenu.h
+++ b/rts/Menu/SelectMenu.h
@@ -39,7 +39,7 @@ private:
 	void ShowConnectWindow(bool show);
 	void DirectConnect(const std::string& addr);
 
-	bool HandleEventSelf(const SDL_Event& ev);
+	bool HandleEventSelf(const SDL_Event& ev) override;
 
 	void SelectScript(const std::string& s);
 	void SelectMap(const std::string& s);

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -49,7 +49,7 @@ public:
 	CModelDrawerDataBase(const std::string& ecName, int ecOrder, bool& mtModelDrawer_);
 	virtual ~CModelDrawerDataBase() override;
 public:
-	virtual void Update() = 0;
+	void Update() override = 0;
 protected:
 	virtual bool IsAlpha(const T* co) const = 0;
 private:

--- a/rts/Rendering/DepthBufferCopy.cpp
+++ b/rts/Rendering/DepthBufferCopy.cpp
@@ -149,6 +149,6 @@ void DepthBufferCopy::CreateTextureAndFBO(bool ms)
 	depthFBO->Bind();
 	depthFBO->AttachTexture(depthTexture, target, GL_DEPTH_ATTACHMENT);
 	glDrawBuffer(GL_NONE);
-	depthFBO->CheckStatus("DEPTH-BUFFER-COPY-FBO" + ms ? "-MULTISAMPLED" : "");
+	depthFBO->CheckStatus(ms ? "DEPTH-BUFFER-COPY-FBO-MULTISAMPLED" : "DEPTH-BUFFER-COPY-FBO");
 	depthFBO->Unbind();
 }

--- a/rts/Rendering/Env/BumpWater.h
+++ b/rts/Rendering/Env/BumpWater.h
@@ -20,11 +20,11 @@ class CBumpWater : public IWater, public CEventClient
 {
 public:
 	//! CEventClient interface
-	bool WantsEvent(const std::string& eventName) {
+	bool WantsEvent(const std::string& eventName) override {
 		return shoreWaves && (eventName == "UnsyncedHeightMapUpdate");
 	}
-	bool GetFullRead() const { return true; }
-	int GetReadAllyTeam() const { return AllAccessTeam; }
+	bool GetFullRead() const override { return true; }
+	int GetReadAllyTeam() const override { return AllAccessTeam; }
 
 public:
 	CBumpWater();
@@ -64,7 +64,7 @@ private:
 
 	int atlasX,atlasY;
 
-	void UnsyncedHeightMapUpdate(const SRectangle& rect);
+	void UnsyncedHeightMapUpdate(const SRectangle& rect) override;
 
 private:
 	//! user options

--- a/rts/Rendering/Env/DynWater.h
+++ b/rts/Rendering/Env/DynWater.h
@@ -20,7 +20,7 @@ public:
 	void Draw() override;
 	void UpdateWater(const CGame* game) override;
 	void Update() override;
-	void AddExplosion(const float3& pos, float strength, float size);
+	void AddExplosion(const float3& pos, float strength, float size) override;
 	WATER_RENDERER GetID() const override { return WATER_RENDERER_DYNAMIC; }
 
 	bool CanDrawReflectionPass() const override { return true; }

--- a/rts/Rendering/Env/Particles/Classes/GeoThermSmokeProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/GeoThermSmokeProjectile.h
@@ -9,7 +9,7 @@ class CFeature;
 
 class CGeoThermSmokeProjectile : public CSmokeProjectile
 {
-	CR_DECLARE(CGeoThermSmokeProjectile)
+	CR_DECLARE_DERIVED(CGeoThermSmokeProjectile)
 public:
 	CGeoThermSmokeProjectile() { }
 	CGeoThermSmokeProjectile(
@@ -19,7 +19,7 @@ public:
 		const CFeature* geo
 	);
 
-	void Update();
+	void Update() override;
 	void UpdateDir();
 
 	void DrawOnMinimap() const override {}

--- a/rts/Rendering/Env/SkyBox.h
+++ b/rts/Rendering/Env/SkyBox.h
@@ -25,7 +25,7 @@ public:
 	void UpdateSunDir() override {}
 	void UpdateSkyTexture() override {}
 
-	void Draw();
+	void Draw() override;
 
 	bool IsValid() const override { return valid; }
 

--- a/rts/Rendering/Features/FeatureDrawerData.h
+++ b/rts/Rendering/Features/FeatureDrawerData.h
@@ -9,7 +9,7 @@ class CCamera;
 class CFeatureDrawerData : public CFeatureDrawerDataBase {
 public:
 	// CEventClient interface
-	bool WantsEvent(const std::string & eventName) {
+	bool WantsEvent(const std::string & eventName) override {
 		return
 			eventName == "RenderFeaturePreCreated" ||
 			eventName == "RenderFeatureCreated"    ||

--- a/rts/Rendering/GL/glDebugGroup.hpp
+++ b/rts/Rendering/GL/glDebugGroup.hpp
@@ -15,7 +15,7 @@ namespace GL {
 	public:
 		DebugGroupNoop(uint32_t id, const char* messsage) {}
 	};
-	class DebugGroupImpl : public DebugGroup {
+	class DebugGroupImpl final : public DebugGroup {
 	public:
 		DebugGroupImpl(uint32_t id, const char* messsage);
 		~DebugGroupImpl() override final;

--- a/rts/Rendering/GL/glHelpers.h
+++ b/rts/Rendering/GL/glHelpers.h
@@ -107,7 +107,7 @@ inline GLuint FetchActiveTextureSlot() {
 template<auto DedicatedGLFuncPtrPtr, GLenum... GLParamName, class AttribValuesTupleType>
 inline void glSetAny(AttribValuesTupleType&& newValues)
 {
-	if constexpr(DedicatedGLFuncPtrPtr)
+	if constexpr(DedicatedGLFuncPtrPtr != nullptr)
 	{
 		static auto HelperFunc = [](auto&& ... p) {
 			(*DedicatedGLFuncPtrPtr)(std::forward<decltype(p)>(p)...);

--- a/rts/Rendering/GroundFlash.h
+++ b/rts/Rendering/GroundFlash.h
@@ -15,7 +15,7 @@ class CVertexArray;
 class CGroundFlash : public CExpGenSpawnable
 {
 public:
-	CR_DECLARE(CGroundFlash)
+	CR_DECLARE_DERIVED(CGroundFlash)
 
 	CGroundFlash(const float3& _pos);
 	CGroundFlash();
@@ -26,7 +26,7 @@ public:
 	virtual void Draw() {}
 	/// @return false when it should be deleted
 	virtual bool Update() { return false; }
-	virtual void Init(const CUnit* owner, const float3& offset) {}
+	void Init(const CUnit* owner, const float3& offset) override {}
 
 	float3 CalcNormal(const float3 midPos, const float3 camDir, float quadSize) const;
 

--- a/rts/Rendering/Models/AssIO.h
+++ b/rts/Rendering/Models/AssIO.h
@@ -3,8 +3,12 @@
 #ifndef ASS_IO_H
 #define ASS_IO_H
 
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/IOStream.hpp"
 #include "lib/assimp/include/assimp/IOSystem.hpp"
+#pragma clang diagnostic pop
 class CFileHandler;
 
 // Custom implementation of Assimp IOStream to support Spring's VFS

--- a/rts/Rendering/Models/AssParser.cpp
+++ b/rts/Rendering/Models/AssParser.cpp
@@ -25,6 +25,9 @@
 #include "System/FileSystem/FileHandler.h"
 #include "System/FileSystem/FileSystem.h"
 
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/config.h"
 #include "lib/assimp/include/assimp/defs.h"
 #include "lib/assimp/include/assimp/types.h"
@@ -32,6 +35,7 @@
 #include "lib/assimp/include/assimp/postprocess.h"
 #include "lib/assimp/include/assimp/Importer.hpp"
 #include "lib/assimp/include/assimp/DefaultLogger.hpp"
+#pragma clang diagnostic pop
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/Rendering/Models/AssParser.cpp
+++ b/rts/Rendering/Models/AssParser.cpp
@@ -626,10 +626,11 @@ void CAssParser::Load(S3DModel& model, const std::string& modelFilePath)
 				/* Try to salvage the model since such "invalid" ones can actually be
 				 * produced by industry standard tools (in particular, Blender). */
 				meshNode = Impl::FindFallbackNode(scene);
-				if (meshNode && meshNode->mParent)
+				if (meshNode && meshNode->mParent) {
 					LOG_SL(LOG_SECTION_MODEL, L_WARNING, "Found a likely replacement candidate for mesh \"%s\" - node \"%s\". It might be incorrect!", meshName.c_str(), meshNode->mName.data);
-				else
+				} else {
 					throw content_error("An assimp model has invalid pieces hierarchy. Failed to find suitable replacement.");
+				}
 			}
 
 			std::string const parentName(meshNode->mParent->mName.C_Str());

--- a/rts/Rendering/Models/IModelParser.cpp
+++ b/rts/Rendering/Models/IModelParser.cpp
@@ -25,7 +25,11 @@
 #include "System/Threading/ThreadPool.h"
 #include "System/ContainerUtil.h"
 #include "System/LoadLock.h"
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/Importer.hpp"
+#pragma clang diagnostic pop
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/Rendering/QTPFSPathDrawer.h
+++ b/rts/Rendering/QTPFSPathDrawer.h
@@ -29,7 +29,7 @@ public:
 
 	void DrawAll() const override;
 	void UpdateExtraTexture(int, int, int, int, unsigned char*) const override;
-	void DrawInMiniMap();
+	void DrawInMiniMap() override;
 
 private:
 	void DrawNodes(const MoveDef* md, TypedRenderBuffer<VA_TYPE_C>& rb, const std::vector<const QTPFS::QTNode*>& nodes, const QTPFS::NodeLayer& nodeLayer) const;

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -356,11 +356,11 @@ void ITexMemPool::Init(size_t size)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (size == 0) {
-		if (texMemPool == nullptr || typeid(*texMemPool.get()) != typeid(TexNoMemPool))
+		if (dynamic_cast<TexNoMemPool*>(texMemPool.get()) == nullptr)
 			texMemPool = std::make_unique<TexNoMemPool>();
 	}
 	else {
-		if (texMemPool == nullptr || typeid(*texMemPool.get()) != typeid(  TexMemPool))
+		if (dynamic_cast<  TexMemPool*>(texMemPool.get()) == nullptr)
 			texMemPool = std::make_unique<  TexMemPool>();
 	}
 	texMemPool->Resize(size);
@@ -405,6 +405,7 @@ public:
 	BitmapAction(CBitmap* bmp_)
 		: bmp{ bmp_ }
 	{}
+	virtual ~BitmapAction() = default;
 
 	BitmapAction(const BitmapAction& ba) = delete;
 	BitmapAction(BitmapAction&& ba) noexcept = delete;

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -168,7 +168,7 @@ public:
 		return mem;
 	}
 
-	void FreeRaw(uint8_t* mem, size_t size) {
+	void FreeRaw(uint8_t* mem, size_t size) override {
 		RECOIL_DETAILED_TRACY_ZONE;
 		if (mem == nullptr)
 			return;
@@ -207,7 +207,7 @@ public:
 			DefragRaw();
 	}
 
-	void Resize(size_t size) {
+	void Resize(size_t size) override {
 		RECOIL_DETAILED_TRACY_ZONE;
 		size = AlignUp(size, sizeof(uint64_t));
 

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -367,8 +367,10 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcon(TypedRenderBuffer<VA_TYPE_2DTC3>& rb, 
 
 			std::swap(posX, posY);
 			break;
+		case CMiniMap::ROTATION_0:
+			break;
 	}
-	
+
 	float x0 = posX - iconSizeX;
 	float x1 = posX + iconSizeX;
 	float y0 = posY - iconSizeY;

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -153,7 +153,7 @@ public:
 	void DrawUnitIconsScreen() const override;
 protected:
 	void DrawObjectsShadow(int modelType) const override;
-	void DrawOpaqueObjects(int modelType, bool drawReflection, bool drawRefraction) const;
+	void DrawOpaqueObjects(int modelType, bool drawReflection, bool drawRefraction) const override;
 	void DrawOpaqueObjectsAux(int modelType) const override; //AI units
 
 	void DrawAlphaObjects(int modelType, bool drawReflection, bool drawRefraction) const override;

--- a/rts/Sim/Features/Feature.h
+++ b/rts/Sim/Features/Feature.h
@@ -22,7 +22,7 @@ class DamageArray;
 
 class CFeature: public CSolidObject, public spring::noncopyable
 {
-	CR_DECLARE(CFeature)
+	CR_DECLARE_DERIVED(CFeature)
 
 public:
 	CFeature();

--- a/rts/Sim/Features/Feature.h
+++ b/rts/Sim/Features/Feature.h
@@ -63,17 +63,17 @@ public:
 	 */
 	void Initialize(const FeatureLoadParams& params);
 
-	const SolidObjectDef* GetDef() const { return ((const SolidObjectDef*) def); }
+	const SolidObjectDef* GetDef() const override { return ((const SolidObjectDef*) def); }
 
-	int GetBlockingMapID() const;
+	int GetBlockingMapID() const override;
 
 	/**
 	 * Negative amount = reclaim
 	 * @return true if reclaimed
 	 */
-	bool AddBuildPower(CUnit* builder, float amount);
-	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID);
-	void SetVelocity(const float3& v);
+	bool AddBuildPower(CUnit* builder, float amount) override;
+	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID) override;
+	void SetVelocity(const float3& v) override;
 	void ForcedMove(const float3& newPos) override;
 	void ForcedSpin(const float3& newDir) override;
 	void ForcedSpin(const float3& newFrontDir, const float3& newRightDir) override; 
@@ -90,7 +90,7 @@ public:
 	void StartFire();
 	void EmitGeoSmoke();
 
-	void DependentDied(CObject *o);
+	void DependentDied(CObject *o) override;
 	void ChangeTeam(int newTeam);
 
 	bool IsInLosForAllyTeam(int argAllyTeam) const;

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -127,7 +127,7 @@ public:
 	const float3& GetGroundNormal(const float3&) const;
 	float GetGroundHeight(const float3&) const;
 
-	void SyncWaypoints() {
+	void SyncWaypoints() override {
 		// Synced vars trigger a checksum update on change, which is expensive so we should check
 		// that there has been a change before triggering an update to the checksum.
 		if (!currWayPoint.bitExactEquals(earlyCurrWayPoint))

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -135,7 +135,7 @@ public:
 		if (!nextWayPoint.bitExactEquals(earlyNextWayPoint))
 			nextWayPoint = earlyNextWayPoint;
 	}
-	unsigned int GetPathId() { return pathID; }
+	unsigned int GetPathId() override { return pathID; }
 
 	float GetTurnRadius() {
 		const float absTurnSpeed = std::max(0.0001f, math::fabs(turnRate));

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -336,7 +336,7 @@ MoveDef::MoveDef(const LuaTable& moveDefTable): MoveDef() {
 		waterline = std::abs(moveDefTable.GetInt("waterline", defaultWaterline));
 		overrideUnitWaterline = moveDefTable.GetBool("overrideUnitWaterline", overrideUnitWaterline);
 	} else {
-		waterline = std::numeric_limits<int>::max();
+		waterline = std::numeric_limits<float>::max();
 	}
 
 	height = std::max(1, moveDefTable.GetInt("height", defaultHeight));

--- a/rts/Sim/Path/HAPFS/PathEstimator.cpp
+++ b/rts/Sim/Path/HAPFS/PathEstimator.cpp
@@ -35,8 +35,8 @@ void CPathEstimator::Init(IPathFinder* pf, unsigned int BLOCK_SIZE, PathingState
 		pathChecksum = 0;
 		fileHashCode = CalcHash(__func__);
 
-		offsetBlockNum = {nbrOfBlocks.x * nbrOfBlocks.y};
-		costBlockNum = {nbrOfBlocks.x * nbrOfBlocks.y};
+		offsetBlockNum = nbrOfBlocks.x * nbrOfBlocks.y;
+		costBlockNum = nbrOfBlocks.x * nbrOfBlocks.y;
 
 		parentPathFinder = pf;
 		//nextPathEstimator = nullptr;

--- a/rts/Sim/Path/HAPFS/PathingState.cpp
+++ b/rts/Sim/Path/HAPFS/PathingState.cpp
@@ -106,8 +106,8 @@ void PathingState::Init(std::vector<IPathFinder*> pathFinderlist, PathingState* 
 	 	pathChecksum = 0;
 	 	fileHashCode = CalcHash(__func__);
 
-		offsetBlockNum = {mapDimensionsInBlocks.x * mapDimensionsInBlocks.y};
-		costBlockNum = {mapDimensionsInBlocks.x * mapDimensionsInBlocks.y};
+		offsetBlockNum = mapDimensionsInBlocks.x * mapDimensionsInBlocks.y;
+		costBlockNum = mapDimensionsInBlocks.x * mapDimensionsInBlocks.y;
 
 		vertexCosts.clear();
 		vertexCosts.resize(moveDefHandler.GetNumMoveDefs() * blockStates.GetSize() * PATH_DIRECTION_VERTICES, PATHCOST_INFINITY);
@@ -395,7 +395,7 @@ void PathingState::CalcVertexPathCosts(const MoveDef& moveDef, int2 block, unsig
 	// other four directions are stored at the adjacent vertices)
 	auto idx = BlockPosToIdx(block);
 	const uint8_t nodeLinksObsoleteFlags = blockStates.nodeLinksObsoleteFlags[idx]
-								  		 & (moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK;
+								  		 & ((moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK);
 
 	int pathdir = 0;
 	for (int checkBit = 1; checkBit <= PATHDIR_LEFT_DOWN_MASK; checkBit <<= 1, ++pathdir) {

--- a/rts/Sim/Path/HAPFS/Registry.h
+++ b/rts/Sim/Path/HAPFS/Registry.h
@@ -1,4 +1,4 @@
-#ifndef HAFS_REGISTRY_H__
+#ifndef HAPFS_REGISTRY_H__
 #define HAPFS_REGISTRY_H__
 
 #include "System/Ecs/EcsMain.h"

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -16,7 +16,7 @@ class CUnit;
 
 class CExpGenSpawnable : public CWorldObject
 {
-	CR_DECLARE(CExpGenSpawnable)
+	CR_DECLARE_DERIVED(CExpGenSpawnable)
 public:
 	using AllocFunc = CExpGenSpawnable*(*)();
 	using GetMemberInfoFunc = bool(*)(SExpGenSpawnableMemberInfo&);

--- a/rts/Sim/Projectiles/FlareProjectile.cpp
+++ b/rts/Sim/Projectiles/FlareProjectile.cpp
@@ -37,7 +37,7 @@ CFlareProjectile::CFlareProjectile(const float3& pos, const float3& speed, CUnit
 	deathFrame(activateFrame + ((owner != nullptr)? owner->unitDef->flareTime: 1)),
 
 	numSubProjs(0),
-	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(subProjPos.size()))),
+	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(decltype(subProjPos)().size()))),
 	lastSubProj(0)
 {
 	alphaFalloff = (owner != nullptr)? 1.0f / owner->unitDef->flareTime: 1.0f;

--- a/rts/Sim/Units/CommandAI/AirCAI.h
+++ b/rts/Sim/Units/CommandAI/AirCAI.h
@@ -14,29 +14,29 @@ class AAirMoveType;
 class CAirCAI : public CMobileCAI
 {
 public:
-	CR_DECLARE(CAirCAI)
+	CR_DECLARE_DERIVED(CAirCAI)
 	CAirCAI(CUnit* owner);
 	CAirCAI();
 
-	int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
-	void SlowUpdate();
-	void GiveCommandReal(const Command& c, bool fromSynced = true);
+	int GetDefaultCmd(const CUnit* pointed, const CFeature* feature) override;
+	void SlowUpdate() override;
+	void GiveCommandReal(const Command& c, bool fromSynced = true) override;
 	void AddUnit(CUnit* unit);
-	void FinishCommand();
-	void BuggerOff(const float3& pos, float radius);
+	void FinishCommand() override;
+	void BuggerOff(const float3& pos, float radius) override;
 //	void StopMove();
 
-	void ExecuteGuard(Command& c);
+	void ExecuteGuard(Command& c) override;
 	void ExecuteAreaAttack(Command& c);
-	void ExecuteAttack(Command& c);
-	void ExecuteFight(Command& c);
-	void ExecuteMove(Command& c);
+	void ExecuteAttack(Command& c) override;
+	void ExecuteFight(Command& c) override;
+	void ExecuteMove(Command& c) override;
 
 	bool IsValidTarget(const CUnit* enemy, CWeapon* weapon) const override;
 
 private:
 	bool AirAutoGenerateTarget(AAirMoveType*);
-	bool SelectNewAreaAttackTargetOrPos(const Command& ac);
+	bool SelectNewAreaAttackTargetOrPos(const Command& ac) override;
 	void PushOrUpdateReturnFight() {
 		CCommandAI::PushOrUpdateReturnFight(commandPos1, commandPos2);
 	}

--- a/rts/Sim/Units/Scripts/CobDeferredCallin.cpp
+++ b/rts/Sim/Units/Scripts/CobDeferredCallin.cpp
@@ -12,10 +12,9 @@
 
 
 CCobDeferredCallin::CCobDeferredCallin(const CUnit* unit, const LuaHashString& hs, const std::vector<int>& dataStack, const int stackStart)
-	: argCount(argCount), unit(unit), funcName(hs.GetString()), funcHash(hs.GetHash())
+	: unit(unit), argCount(std::min(stackStart, MAX_LUA_COB_ARGS)), funcName(hs.GetString()), funcHash(hs.GetHash())
 {
 	const int size = static_cast<int>(dataStack.size());
-	argCount = std::min(stackStart, MAX_LUA_COB_ARGS);
 
 	const int start = std::max(0, size - stackStart);
 	const int end = std::min(size, start + argCount);

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -216,7 +216,7 @@ void CUnitScript::TickAllAnims(int deltaTime)
 	for (auto& ai : anims) {
 		LocalModelPiece& lmp = *pieces[ai.piece];
 		const auto& currFunc = TICK_ANIM_FUNCS[ai.animType];
-		if (ai.done |= std::invoke(currFunc, this, tickRate, lmp, ai)) {
+		if ((ai.done |= std::invoke(currFunc, this, tickRate, lmp, ai))) {
 			if (ai.hasWaiting)
 				doneAnims.emplace_back(ai);
 		}

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -64,7 +64,7 @@ static constexpr uint8_t LOS_ALL_MASK_BITS = \
 class CUnit : public CSolidObject
 {
 public:
-	CR_DECLARE(CUnit)
+	CR_DECLARE_DERIVED(CUnit)
 
 	CUnit();
 	virtual ~CUnit();
@@ -79,27 +79,27 @@ public:
 	virtual void Update();
 	virtual void SlowUpdate();
 
-	const SolidObjectDef* GetDef() const { return ((const SolidObjectDef*) unitDef); }
+	const SolidObjectDef* GetDef() const override { return ((const SolidObjectDef*) unitDef); }
 
-	virtual void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID);
+	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID) override;
 	virtual void DoWaterDamage();
 	virtual void FinishedBuilding(bool postInit);
 
 	void ApplyDamage(CUnit* attacker, const DamageArray& damages, float& baseDamage, float& experienceMod);
-	void ApplyImpulse(const float3& impulse);
+	void ApplyImpulse(const float3& impulse) override;
 
 	bool AttackUnit(CUnit* unit, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
 	bool AttackGround(const float3& pos, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
 	void DropCurrentAttackTarget();
 
-	int GetBlockingMapID() const { return id; }
+	int GetBlockingMapID() const override { return id; }
 
 	void ChangeLos(int losRad, int airRad);
 
 	void TurnIntoNanoframe();
 
 	// negative amount=reclaim, return= true -> build power was successfully applied
-	bool AddBuildPower(CUnit* builder, float amount);
+	bool AddBuildPower(CUnit* builder, float amount) override;
 
 	virtual void Activate();
 	virtual void Deactivate();
@@ -112,7 +112,7 @@ public:
 
 	CMatrix44f GetTransformMatrix(bool synced = false, bool fullread = false) const override final;
 
-	void DependentDied(CObject* o);
+	void DependentDied(CObject* o) override;
 
 	bool AllowedReclaim(CUnit* builder) const;
 
@@ -137,13 +137,13 @@ public:
 
 	void AddExperience(float exp);
 
-	void SetMass(float newMass);
+	void SetMass(float newMass) override;
 
 	void DoSeismicPing(float pingSize);
 
 	void CalculateTerrainType();
 	void UpdateTerrainType();
-	void UpdatePhysicalState(float eps);
+	void UpdatePhysicalState(float eps) override;
 
 	float3 GetErrorVector(int allyteam) const;
 	float3 GetErrorPos(int allyteam, bool aiming = false) const { return (aiming? aimPos: midPos) + GetErrorVector(allyteam); }

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -470,7 +470,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 			// in params[0] was coming from and traced it back to this WTF hack,
 			// increment the number of wasted hours below:
 			//   number_of_hours_wasted = 3;
-			c.SetParam(0, INT_MAX / 2);
+			c.SetParam(0, static_cast<float>(INT_MAX / 2));
 		}
 
 		// this takes one simframe to do the deletion

--- a/rts/Sim/Units/UnitTypes/Building.h
+++ b/rts/Sim/Units/UnitTypes/Building.h
@@ -9,7 +9,7 @@
 class CBuilding : public CUnit
 {
 public:
-	CR_DECLARE(CBuilding)
+	CR_DECLARE_DERIVED(CBuilding)
 
 	CBuilding(): CUnit() { immobile = true; }
 

--- a/rts/System/Platform/Linux/Futex.cpp
+++ b/rts/System/Platform/Linux/Futex.cpp
@@ -126,7 +126,7 @@ linux_signal::linux_signal() noexcept
 
 linux_signal::~linux_signal()
 {
-	gen = {0};
+	gen = 0;
 	mtx = 0;
 }
 

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -201,10 +201,11 @@ namespace Threading {
 			, [affinityMask](const auto& gc) -> bool { return !!(affinityMask & gc.groupMask); });
 		
 		std::call_once(preferredMaskDetailsLogFlag, [&](){
-			if (preferredCache != pc.groupCaches.end())
+			if (preferredCache != pc.groupCaches.end()) {
 				LOG("[Threading] Preferred performance cache mask is: 0x%08x (L3 sized: %dKB)", preferredCache->groupMask, preferredCache->cacheSizes[2]/1024);
-			else
+			} else {
 				LOG_L(L_WARNING, "[Threading] Failed to find a preferred performance cache mask");
+			}
 		});
 
 		const uint32_t policy = affinityMask
@@ -241,10 +242,11 @@ namespace Threading {
 		const uint32_t fallbackThreadCount = GetPerformanceCpuCores();
 		
 		std::call_once(optimalThreadCountLogFlag, [&](){
-			if (optimalThreadCount > 0)
+			if (optimalThreadCount > 0) {
 				LOG("[Threading] Optimal thread count is %d", optimalThreadCount);
-			else
+			} else {
 				LOG_L(L_WARNING, "[Threading] Failed to determine optimal thread count. Falling back to %d", fallbackThreadCount);
+			}
 		});
 
 		return (optimalThreadCount > 0) ? optimalThreadCount : fallbackThreadCount;

--- a/rts/System/SafeUtil.h
+++ b/rts/System/SafeUtil.h
@@ -52,6 +52,10 @@ namespace spring {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-const-int-float-conversion"
+#endif
     template<typename TOut, typename TIn>
     inline TOut SafeCast(TIn value)
     {
@@ -96,6 +100,9 @@ namespace spring {
         // limits have been checked, therefore safe to cast
         return static_cast<TOut>(value);
     }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif

--- a/rts/System/Sound/Null/NullAudioChannel.h
+++ b/rts/System/Sound/Null/NullAudioChannel.h
@@ -10,24 +10,24 @@ class NullAudioChannel : public IAudioChannel {
 public:
 	~NullAudioChannel() {}
 
-	void Enable(bool newState) {}
-	void SetVolume(float newVolume) {}
+	void Enable(bool newState) override {}
+	void SetVolume(float newVolume) override {}
 
-	void PlaySample(size_t id, float volume = 1.0f) {}
-	void PlaySample(size_t id, const float3& p, float volume = 1.0f) {}
-	void PlaySample(size_t id, const float3& p, const float3& velocity, float volume = 1.0f) {}
+	void PlaySample(size_t id, float volume = 1.0f) override {}
+	void PlaySample(size_t id, const float3& p, float volume = 1.0f) override {}
+	void PlaySample(size_t id, const float3& p, const float3& velocity, float volume = 1.0f) override {}
 
-	void PlaySample(size_t id, const CWorldObject* p, float volume = 1.0f) {}
+	void PlaySample(size_t id, const CWorldObject* p, float volume = 1.0f) override {}
 
-	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) {}
-	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) {}
+	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) override {}
+	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) override {}
 
-	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) {}
+	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) override {}
 
-	void StreamStop() {}
-	void StreamPause() {}
-	float StreamGetTime() { return 0.f; }
-	float StreamGetPlayTime() { return 0.f; }
+	void StreamStop() override {}
+	void StreamPause() override {}
+	float StreamGetTime() override { return 0.f; }
+	float StreamGetPlayTime() override { return 0.f; }
 
 protected:
 	void FindSourceAndPlay(size_t id, const float3& p, const float3& velocity, float volume, bool relative) override {}

--- a/rts/System/Sound/Null/NullSound.h
+++ b/rts/System/Sound/Null/NullSound.h
@@ -42,7 +42,7 @@ public:
 	void PrintDebugInfo() override;
 	bool SoundThreadQuit() const override { return false; }
 	bool CanLoadSoundDefs() const override { return true; }
-	bool LoadSoundDefsImpl(LuaParser* defsParser) { return false; }
+	bool LoadSoundDefsImpl(LuaParser* defsParser) override { return false; }
 
 	const float3& GetListenerPos() const override { return ZeroVector; }
 

--- a/rts/System/Sound/OpenAL/AudioChannel.h
+++ b/rts/System/Sound/OpenAL/AudioChannel.h
@@ -24,30 +24,30 @@ private:
 	typedef std::pair<std::string, float> StreamQueueItem;
 
 public:
-	void Enable(bool newState);
-	void SetVolume(float newVolume);
+	void Enable(bool newState) override;
+	void SetVolume(float newVolume) override;
 
-	void PlaySample(size_t id, float volume = 1.0f);
-	void PlaySample(size_t id, const float3& pos, float volume = 1.0f);
-	void PlaySample(size_t id, const float3& pos, const float3& velocity, float volume = 1.0f);
+	void PlaySample(size_t id, float volume = 1.0f) override;
+	void PlaySample(size_t id, const float3& pos, float volume = 1.0f) override;
+	void PlaySample(size_t id, const float3& pos, const float3& velocity, float volume = 1.0f) override;
 
-	void PlaySample(size_t id, const CWorldObject* obj, float volume = 1.0f);
+	void PlaySample(size_t id, const CWorldObject* obj, float volume = 1.0f) override;
 
-	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj);
-	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector);
+	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) override;
+	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) override;
 
 	void StreamPlay(const StreamQueueItem& item, bool enqueue) { StreamPlay(item.first, item.second, enqueue); }
-	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false);
+	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) override;
 
 	/**
 	 * @brief Stop playback
 	 *
 	 * Do not call this if you just want to play another file (for performance).
 	 */
-	void StreamStop();
-	void StreamPause();
-	float StreamGetTime();
-	float StreamGetPlayTime();
+	void StreamStop() override;
+	void StreamPause() override;
+	float StreamGetTime() override;
+	float StreamGetPlayTime() override;
 
 protected:
 	void FindSourceAndPlay(size_t id, const float3& pos, const float3& velocity, float volume, bool relative) override;

--- a/rts/System/Sound/OpenAL/Sound.h
+++ b/rts/System/Sound/OpenAL/Sound.h
@@ -37,7 +37,7 @@ public:
 	size_t GetDefSoundId(const std::string& name) override;
 	size_t GetSoundId(const std::string& name) override;
 
-	SoundItem* GetSoundItem(size_t id);
+	SoundItem* GetSoundItem(size_t id) override;
 	CSoundSource* GetNextBestSource(bool lock = true) override;
 
 	void NewFrame() override;
@@ -66,7 +66,7 @@ public:
 	bool SoundThreadQuit() const override { return soundThreadQuit; }
 	bool CanLoadSoundDefs() const override { return canLoadDefs; }
 
-	bool LoadSoundDefsImpl(LuaParser* defsParser);
+	bool LoadSoundDefsImpl(LuaParser* defsParser) override;
 	const float3& GetListenerPos() const override { return myPos; }
 
 	ALCdevice* GetCurrentDevice() { return curDevice; }

--- a/rts/System/type2.h
+++ b/rts/System/type2.h
@@ -107,3 +107,11 @@ using uint2 = type2<uint32_t>;
 using float2 = type2<float>;
 using short2 = type2<int16_t>;
 using ushort2 = type2<uint16_t>;
+
+#ifdef USING_CREG
+// creg_class specializations are defined in type2.cpp via CR_BIND_TEMPLATE
+template<> creg::Class type2<int32_t>::creg_class;
+template<> creg::Class type2<float>::creg_class;
+template<> creg::Class type2<int16_t>::creg_class;
+template<> creg::Class type2<uint16_t>::creg_class;
+#endif

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -111,19 +111,27 @@ endforeach()
 ADD_SUBDIRECTORY(assimp)
 target_compile_definitions(assimp PRIVATE -DASSIMP_BUILD_NO_OWN_ZLIB)
 
-# Suppress clang warnings-as-errors in vendored assimp (ASSIMP_WERROR=ON).
+# Suppress warnings-as-errors in vendored assimp (ASSIMP_WERROR=ON).
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	set(_assimp_clang_warns
+	set(_assimp_warns
 		-Wno-pragma-pack
 		-Wno-ordered-compare-function-pointers
 		-Wno-deprecated-declarations
 		-Wno-tautological-bitwise-compare
 		-Wno-unused-but-set-variable
 	)
-	target_compile_options(assimp PRIVATE ${_assimp_clang_warns})
+	target_compile_options(assimp PRIVATE ${_assimp_warns})
 	if (TARGET IrrXML)
 		target_compile_options(IrrXML PRIVATE -Wno-pragma-pack)
 	endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+	set(_assimp_warns
+		-Wno-class-memaccess
+		-Wno-deprecated-declarations
+		-Wno-tautological-compare
+		-Wno-maybe-uninitialized
+	)
+	target_compile_options(assimp PRIVATE ${_assimp_warns})
 endif()
 
 # simdjson, a fastgltf dependency (manually added to submodules to work around the build system limitations)
@@ -190,3 +198,6 @@ add_subdirectory(lunasvg)
 set(CMAKE_CXX_FLAGS ${SAVED_CMAKE_FLAGS})
 
 add_subdirectory(RmlUi)
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND TARGET rmlui_core)
+	target_compile_options(rmlui_core PRIVATE -Wno-array-bounds)
+endif()

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -111,6 +111,21 @@ endforeach()
 ADD_SUBDIRECTORY(assimp)
 target_compile_definitions(assimp PRIVATE -DASSIMP_BUILD_NO_OWN_ZLIB)
 
+# Suppress clang warnings-as-errors in vendored assimp (ASSIMP_WERROR=ON).
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	set(_assimp_clang_warns
+		-Wno-pragma-pack
+		-Wno-ordered-compare-function-pointers
+		-Wno-deprecated-declarations
+		-Wno-tautological-bitwise-compare
+		-Wno-unused-but-set-variable
+	)
+	target_compile_options(assimp PRIVATE ${_assimp_clang_warns})
+	if (TARGET IrrXML)
+		target_compile_options(IrrXML PRIVATE -Wno-pragma-pack)
+	endif()
+endif()
+
 # simdjson, a fastgltf dependency (manually added to submodules to work around the build system limitations)
 set(SIMDJSON_AVX512_ALLOWED OFF CACHE BOOL "forced by Recoil build env" FORCE)
 set(SIMDJSON_BASH OFF CACHE BOOL "forced by Recoil build env" FORCE)
@@ -135,6 +150,9 @@ ADD_SUBDIRECTORY(fastgltf)
 
 ADD_SUBDIRECTORY(squish)
 ADD_SUBDIRECTORY(rg-etc1)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	target_compile_options(rgetc1 PRIVATE -Wno-absolute-value -Wno-unused-value)
+endif()
 
 option(TRACY_ENABLE "Enable tracy profiling" OFF)
 

--- a/rts/lib/lua/CMakeLists.txt
+++ b/rts/lib/lua/CMakeLists.txt
@@ -55,3 +55,11 @@ if (UNIX)
 else (UNIX)
 	SET_TARGET_PROPERTIES(lua PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")
 endif (UNIX)
+
+# Suppress clang -Werror warnings in vendored lua sources.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	target_compile_options(lua PRIVATE
+		-Wno-empty-body
+		-Wno-implicit-int-float-conversion
+	)
+endif()

--- a/rts/lib/lua/include/LuaUser.cpp
+++ b/rts/lib/lua/include/LuaUser.cpp
@@ -381,7 +381,7 @@ static const inline int FastLog10(const float f)
 {
 	assert(f != 0.0f); // log10(0) = -inf
 
-	if (f < 1.0f || f >= (SPRING_INT64_MAX >> 1))
+	if (f < 1.0f || f >= static_cast<float>(SPRING_INT64_MAX >> 1))
 		return std::floor(std::log10(f));
 
 	const std::int64_t i = f;

--- a/rts/lib/lua/include/LuaUser.cpp
+++ b/rts/lib/lua/include/LuaUser.cpp
@@ -381,7 +381,7 @@ static const inline int FastLog10(const float f)
 {
 	assert(f != 0.0f); // log10(0) = -inf
 
-	if (f < 1.0f || f >= static_cast<float>(SPRING_INT64_MAX >> 1))
+	if (f < 1.0f || f >= (SPRING_INT64_MAX >> 1))
 		return std::floor(std::log10(f));
 
 	const std::int64_t i = f;

--- a/rts/lib/lua/src/lauxlib.cpp
+++ b/rts/lib/lua/src/lauxlib.cpp
@@ -596,8 +596,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0])
-     ;
+   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
     lf.extraline = 0;
   }
   ungetc(c, lf.f);

--- a/rts/lib/lua/src/lauxlib.cpp
+++ b/rts/lib/lua/src/lauxlib.cpp
@@ -596,7 +596,8 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
+   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0])
+     ;
     lf.extraline = 0;
   }
   ungetc(c, lf.f);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ ADD_SUBDIRECTORY(lib/catch2)
 # Engine-wide -fsingle-precision-constant (gcc) makes `0.` a float, which
 # triggers an ISO ambiguity error against Catch2's float/double overloads.
 # Build the vendored Catch2 without that flag.
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	target_compile_options(Catch2 PRIVATE -fno-single-precision-constant)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,12 @@ else  (UNIX AND (NOT APPLE) AND (NOT MINGW))
 endif (UNIX AND (NOT APPLE) AND (NOT MINGW))
 
 ADD_SUBDIRECTORY(lib/catch2)
+# Engine-wide -fsingle-precision-constant (gcc) makes `0.` a float, which
+# triggers an ISO ambiguity error against Catch2's float/double overloads.
+# Build the vendored Catch2 without that flag.
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+	target_compile_options(Catch2 PRIVATE -fno-single-precision-constant)
+endif()
 
 include_directories(${CMAKE_BINARY_DIR}/src-generated/engine)
 


### PR DESCRIPTION

## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). Some of these are false positives, some are just a formatting change, but there are a few legit bugs that have slight behaviour changes.

I've gone through and tested every non-trivial fix, pulling the actual warning from the compiler into a review comment. I've added some explanations on sections where I wasn't sure whether the change was safe or why the change was made, to try and add detail for other reviewers.

# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.