### PR TITLE
fix: compiler warnings for missing overrides

### DIFF
--- a/rts/Game/Camera/OverviewController.h
+++ b/rts/Game/Camera/OverviewController.h
@@ -11,7 +11,7 @@ public:
 	COverviewController();
 	~COverviewController();
 
-	const std::string GetName() const { return "ov"; }
+	const std::string GetName() const override { return "ov"; }
 
 	void KeyMove(float3 move) override {}
 	void MouseMove(float3 move) override {}
@@ -25,11 +25,11 @@ public:
 	void SetDir(const float3& newDir) override {}
 	void SetRot(const float3& newDir) override {camRotY = newDir.y;}
 
-	float3 SwitchFrom() const;
-	void SwitchTo(const CCameraController* oldCam, const bool showText);
+	float3 SwitchFrom() const override;
+	void SwitchTo(const CCameraController* oldCam, const bool showText) override;
 
-	void GetState(StateMap& sm) const;
-	bool SetState(const StateMap& sm);
+	void GetState(StateMap& sm) const override;
+	bool SetState(const StateMap& sm) override;
 
 	void ConfigNotify(const std::string& key, const std::string& value);
 	void ConfigUpdate();

--- a/rts/Game/UI/MiniMap.h
+++ b/rts/Game/UI/MiniMap.h
@@ -25,14 +25,14 @@ public:
 	CMiniMap();
 	~CMiniMap() override;
 
-	bool MousePress(int x, int y, int button);
-	void MouseMove(int x, int y, int dx, int dy, int button);
-	void MouseRelease(int x, int y, int button);
+	bool MousePress(int x, int y, int button) override;
+	void MouseMove(int x, int y, int dx, int dy, int button) override;
+	void MouseRelease(int x, int y, int button) override;
 	void MouseWheel(bool up, float delta);
 	void MoveView(int x, int y) { MoveView(GetMapPosition(x, y)); }
-	bool IsAbove(int x, int y);
+	bool IsAbove(int x, int y) override;
 	bool IsInside(int x, int y);
-	std::string GetTooltip(int x, int y);
+	std::string GetTooltip(int x, int y) override;
 	void Draw() override;
 	void DrawForReal(bool useNormalizedCoors = true, bool updateTex = false, bool luaCall = false);
 	void Update();

--- a/rts/Lua/LuaGaia.h
+++ b/rts/Lua/LuaGaia.h
@@ -22,10 +22,10 @@ protected:
 	bool AddSyncedCode(lua_State* L) override { return true; }
 	bool AddUnsyncedCode(lua_State* L) override { return true; }
 
-	std::string GetUnsyncedFileName() const;
-	std::string GetSyncedFileName() const;
-	std::string GetInitFileModes() const;
-	int GetInitSelectTeam() const;
+	std::string GetUnsyncedFileName() const override;
+	std::string GetSyncedFileName() const override;
+	std::string GetInitFileModes() const override;
+	int GetInitSelectTeam() const override;
 
 private:
 	CLuaGaia(bool dryRun);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4480,8 +4480,6 @@ int LuaSyncedCtrl::AddUnitResource(lua_State* L)
 	return 0;
 }
 
-/*
-
 /***
  * @function Spring.UseUnitResource
  * @param unitID integer

--- a/rts/Map/SMF/SMFGroundTextures.h
+++ b/rts/Map/SMF/SMFGroundTextures.h
@@ -17,10 +17,10 @@ public:
 	CSMFGroundTextures(CSMFReadMap* rm);
 	~CSMFGroundTextures() override;
 
-	void DrawUpdate();
-	bool SetSquareLuaTexture(int texSquareX, int texSquareY, int texID);
-	bool GetSquareLuaTexture(int texSquareX, int texSquareY, int texID, int texSizeX, int texSizeY, int lodMin, int lodMax);
-	void BindSquareTexture(int texSquareX, int texSquareY);
+	void DrawUpdate() override;
+	bool SetSquareLuaTexture(int texSquareX, int texSquareY, int texID) override;
+	bool GetSquareLuaTexture(int texSquareX, int texSquareY, int texID, int texSizeX, int texSizeY, int lodMin, int lodMax) override;
+	void BindSquareTexture(int texSquareX, int texSquareY) override;
 
 protected:
 	void LoadTiles(CSMFMapFile& file);

--- a/rts/Menu/SelectMenu.h
+++ b/rts/Menu/SelectMenu.h
@@ -39,7 +39,7 @@ private:
 	void ShowConnectWindow(bool show);
 	void DirectConnect(const std::string& addr);
 
-	bool HandleEventSelf(const SDL_Event& ev);
+	bool HandleEventSelf(const SDL_Event& ev) override;
 
 	void SelectScript(const std::string& s);
 	void SelectMap(const std::string& s);

--- a/rts/Rendering/Common/ModelDrawerData.h
+++ b/rts/Rendering/Common/ModelDrawerData.h
@@ -49,7 +49,7 @@ public:
 	CModelDrawerDataBase(const std::string& ecName, int ecOrder, bool& mtModelDrawer_);
 	virtual ~CModelDrawerDataBase() override;
 public:
-	virtual void Update() = 0;
+	void Update() override = 0;
 protected:
 	virtual bool IsAlpha(const T* co) const = 0;
 private:

--- a/rts/Rendering/Env/BumpWater.h
+++ b/rts/Rendering/Env/BumpWater.h
@@ -20,11 +20,11 @@ class CBumpWater : public IWater, public CEventClient
 {
 public:
 	//! CEventClient interface
-	bool WantsEvent(const std::string& eventName) {
+	bool WantsEvent(const std::string& eventName) override {
 		return shoreWaves && (eventName == "UnsyncedHeightMapUpdate");
 	}
-	bool GetFullRead() const { return true; }
-	int GetReadAllyTeam() const { return AllAccessTeam; }
+	bool GetFullRead() const override { return true; }
+	int GetReadAllyTeam() const override { return AllAccessTeam; }
 
 public:
 	CBumpWater();
@@ -64,7 +64,7 @@ private:
 
 	int atlasX,atlasY;
 
-	void UnsyncedHeightMapUpdate(const SRectangle& rect);
+	void UnsyncedHeightMapUpdate(const SRectangle& rect) override;
 
 private:
 	//! user options

--- a/rts/Rendering/Env/DynWater.h
+++ b/rts/Rendering/Env/DynWater.h
@@ -20,7 +20,7 @@ public:
 	void Draw() override;
 	void UpdateWater(const CGame* game) override;
 	void Update() override;
-	void AddExplosion(const float3& pos, float strength, float size);
+	void AddExplosion(const float3& pos, float strength, float size) override;
 	WATER_RENDERER GetID() const override { return WATER_RENDERER_DYNAMIC; }
 
 	bool CanDrawReflectionPass() const override { return true; }

--- a/rts/Rendering/Env/Particles/Classes/GeoThermSmokeProjectile.h
+++ b/rts/Rendering/Env/Particles/Classes/GeoThermSmokeProjectile.h
@@ -9,7 +9,7 @@ class CFeature;
 
 class CGeoThermSmokeProjectile : public CSmokeProjectile
 {
-	CR_DECLARE(CGeoThermSmokeProjectile)
+	CR_DECLARE_DERIVED(CGeoThermSmokeProjectile)
 public:
 	CGeoThermSmokeProjectile() { }
 	CGeoThermSmokeProjectile(
@@ -19,7 +19,7 @@ public:
 		const CFeature* geo
 	);
 
-	void Update();
+	void Update() override;
 	void UpdateDir();
 
 	void DrawOnMinimap() const override {}

--- a/rts/Rendering/Env/SkyBox.h
+++ b/rts/Rendering/Env/SkyBox.h
@@ -25,7 +25,7 @@ public:
 	void UpdateSunDir() override {}
 	void UpdateSkyTexture() override {}
 
-	void Draw();
+	void Draw() override;
 
 	bool IsValid() const override { return valid; }
 

--- a/rts/Rendering/Features/FeatureDrawerData.h
+++ b/rts/Rendering/Features/FeatureDrawerData.h
@@ -9,7 +9,7 @@ class CCamera;
 class CFeatureDrawerData : public CFeatureDrawerDataBase {
 public:
 	// CEventClient interface
-	bool WantsEvent(const std::string & eventName) {
+	bool WantsEvent(const std::string & eventName) override {
 		return
 			eventName == "RenderFeaturePreCreated" ||
 			eventName == "RenderFeatureCreated"    ||

--- a/rts/Rendering/GroundFlash.h
+++ b/rts/Rendering/GroundFlash.h
@@ -15,7 +15,7 @@ class CVertexArray;
 class CGroundFlash : public CExpGenSpawnable
 {
 public:
-	CR_DECLARE(CGroundFlash)
+	CR_DECLARE_DERIVED(CGroundFlash)
 
 	CGroundFlash(const float3& _pos);
 	CGroundFlash();
@@ -26,7 +26,7 @@ public:
 	virtual void Draw() {}
 	/// @return false when it should be deleted
 	virtual bool Update() { return false; }
-	virtual void Init(const CUnit* owner, const float3& offset) {}
+	void Init(const CUnit* owner, const float3& offset) override {}
 
 	float3 CalcNormal(const float3 midPos, const float3 camDir, float quadSize) const;
 

--- a/rts/Rendering/QTPFSPathDrawer.h
+++ b/rts/Rendering/QTPFSPathDrawer.h
@@ -29,7 +29,7 @@ public:
 
 	void DrawAll() const override;
 	void UpdateExtraTexture(int, int, int, int, unsigned char*) const override;
-	void DrawInMiniMap();
+	void DrawInMiniMap() override;
 
 private:
 	void DrawNodes(const MoveDef* md, TypedRenderBuffer<VA_TYPE_C>& rb, const std::vector<const QTPFS::QTNode*>& nodes, const QTPFS::NodeLayer& nodeLayer) const;

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -168,7 +168,7 @@ public:
 		return mem;
 	}
 
-	void FreeRaw(uint8_t* mem, size_t size) {
+	void FreeRaw(uint8_t* mem, size_t size) override {
 		RECOIL_DETAILED_TRACY_ZONE;
 		if (mem == nullptr)
 			return;
@@ -207,7 +207,7 @@ public:
 			DefragRaw();
 	}
 
-	void Resize(size_t size) {
+	void Resize(size_t size) override {
 		RECOIL_DETAILED_TRACY_ZONE;
 		size = AlignUp(size, sizeof(uint64_t));
 

--- a/rts/Rendering/Units/UnitDrawer.h
+++ b/rts/Rendering/Units/UnitDrawer.h
@@ -153,7 +153,7 @@ public:
 	void DrawUnitIconsScreen() const override;
 protected:
 	void DrawObjectsShadow(int modelType) const override;
-	void DrawOpaqueObjects(int modelType, bool drawReflection, bool drawRefraction) const;
+	void DrawOpaqueObjects(int modelType, bool drawReflection, bool drawRefraction) const override;
 	void DrawOpaqueObjectsAux(int modelType) const override; //AI units
 
 	void DrawAlphaObjects(int modelType, bool drawReflection, bool drawRefraction) const override;

--- a/rts/Sim/Features/Feature.h
+++ b/rts/Sim/Features/Feature.h
@@ -22,7 +22,7 @@ class DamageArray;
 
 class CFeature: public CSolidObject, public spring::noncopyable
 {
-	CR_DECLARE(CFeature)
+	CR_DECLARE_DERIVED(CFeature)
 
 public:
 	CFeature();
@@ -63,17 +63,17 @@ public:
 	 */
 	void Initialize(const FeatureLoadParams& params);
 
-	const SolidObjectDef* GetDef() const { return ((const SolidObjectDef*) def); }
+	const SolidObjectDef* GetDef() const override { return ((const SolidObjectDef*) def); }
 
-	int GetBlockingMapID() const;
+	int GetBlockingMapID() const override;
 
 	/**
 	 * Negative amount = reclaim
 	 * @return true if reclaimed
 	 */
-	bool AddBuildPower(CUnit* builder, float amount);
-	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID);
-	void SetVelocity(const float3& v);
+	bool AddBuildPower(CUnit* builder, float amount) override;
+	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID) override;
+	void SetVelocity(const float3& v) override;
 	void ForcedMove(const float3& newPos) override;
 	void ForcedSpin(const float3& newDir) override;
 	void ForcedSpin(const float3& newFrontDir, const float3& newRightDir) override; 
@@ -90,7 +90,7 @@ public:
 	void StartFire();
 	void EmitGeoSmoke();
 
-	void DependentDied(CObject *o);
+	void DependentDied(CObject *o) override;
 	void ChangeTeam(int newTeam);
 
 	bool IsInLosForAllyTeam(int argAllyTeam) const;

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -127,7 +127,7 @@ public:
 	const float3& GetGroundNormal(const float3&) const;
 	float GetGroundHeight(const float3&) const;
 
-	void SyncWaypoints() {
+	void SyncWaypoints() override {
 		// Synced vars trigger a checksum update on change, which is expensive so we should check
 		// that there has been a change before triggering an update to the checksum.
 		if (!currWayPoint.bitExactEquals(earlyCurrWayPoint))
@@ -135,7 +135,7 @@ public:
 		if (!nextWayPoint.bitExactEquals(earlyNextWayPoint))
 			nextWayPoint = earlyNextWayPoint;
 	}
-	unsigned int GetPathId() { return pathID; }
+	unsigned int GetPathId() override { return pathID; }
 
 	float GetTurnRadius() {
 		const float absTurnSpeed = std::max(0.0001f, math::fabs(turnRate));

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -16,7 +16,7 @@ class CUnit;
 
 class CExpGenSpawnable : public CWorldObject
 {
-	CR_DECLARE(CExpGenSpawnable)
+	CR_DECLARE_DERIVED(CExpGenSpawnable)
 public:
 	using AllocFunc = CExpGenSpawnable*(*)();
 	using GetMemberInfoFunc = bool(*)(SExpGenSpawnableMemberInfo&);

--- a/rts/Sim/Units/CommandAI/AirCAI.h
+++ b/rts/Sim/Units/CommandAI/AirCAI.h
@@ -14,29 +14,29 @@ class AAirMoveType;
 class CAirCAI : public CMobileCAI
 {
 public:
-	CR_DECLARE(CAirCAI)
+	CR_DECLARE_DERIVED(CAirCAI)
 	CAirCAI(CUnit* owner);
 	CAirCAI();
 
-	int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
-	void SlowUpdate();
-	void GiveCommandReal(const Command& c, bool fromSynced = true);
+	int GetDefaultCmd(const CUnit* pointed, const CFeature* feature) override;
+	void SlowUpdate() override;
+	void GiveCommandReal(const Command& c, bool fromSynced = true) override;
 	void AddUnit(CUnit* unit);
-	void FinishCommand();
-	void BuggerOff(const float3& pos, float radius);
+	void FinishCommand() override;
+	void BuggerOff(const float3& pos, float radius) override;
 //	void StopMove();
 
-	void ExecuteGuard(Command& c);
+	void ExecuteGuard(Command& c) override;
 	void ExecuteAreaAttack(Command& c);
-	void ExecuteAttack(Command& c);
-	void ExecuteFight(Command& c);
-	void ExecuteMove(Command& c);
+	void ExecuteAttack(Command& c) override;
+	void ExecuteFight(Command& c) override;
+	void ExecuteMove(Command& c) override;
 
 	bool IsValidTarget(const CUnit* enemy, CWeapon* weapon) const override;
 
 private:
 	bool AirAutoGenerateTarget(AAirMoveType*);
-	bool SelectNewAreaAttackTargetOrPos(const Command& ac);
+	bool SelectNewAreaAttackTargetOrPos(const Command& ac) override;
 	void PushOrUpdateReturnFight() {
 		CCommandAI::PushOrUpdateReturnFight(commandPos1, commandPos2);
 	}

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -64,7 +64,7 @@ static constexpr uint8_t LOS_ALL_MASK_BITS = \
 class CUnit : public CSolidObject
 {
 public:
-	CR_DECLARE(CUnit)
+	CR_DECLARE_DERIVED(CUnit)
 
 	CUnit();
 	virtual ~CUnit();
@@ -79,27 +79,27 @@ public:
 	virtual void Update();
 	virtual void SlowUpdate();
 
-	const SolidObjectDef* GetDef() const { return ((const SolidObjectDef*) unitDef); }
+	const SolidObjectDef* GetDef() const override { return ((const SolidObjectDef*) unitDef); }
 
-	virtual void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID);
+	void DoDamage(const DamageArray& damages, const float3& impulse, CUnit* attacker, int weaponDefID, int projectileID) override;
 	virtual void DoWaterDamage();
 	virtual void FinishedBuilding(bool postInit);
 
 	void ApplyDamage(CUnit* attacker, const DamageArray& damages, float& baseDamage, float& experienceMod);
-	void ApplyImpulse(const float3& impulse);
+	void ApplyImpulse(const float3& impulse) override;
 
 	bool AttackUnit(CUnit* unit, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
 	bool AttackGround(const float3& pos, bool isUserTarget, bool wantManualFire, bool fpsMode = false);
 	void DropCurrentAttackTarget();
 
-	int GetBlockingMapID() const { return id; }
+	int GetBlockingMapID() const override { return id; }
 
 	void ChangeLos(int losRad, int airRad);
 
 	void TurnIntoNanoframe();
 
 	// negative amount=reclaim, return= true -> build power was successfully applied
-	bool AddBuildPower(CUnit* builder, float amount);
+	bool AddBuildPower(CUnit* builder, float amount) override;
 
 	virtual void Activate();
 	virtual void Deactivate();
@@ -112,7 +112,7 @@ public:
 
 	CMatrix44f GetTransformMatrix(bool synced = false, bool fullread = false) const override final;
 
-	void DependentDied(CObject* o);
+	void DependentDied(CObject* o) override;
 
 	bool AllowedReclaim(CUnit* builder) const;
 
@@ -137,13 +137,13 @@ public:
 
 	void AddExperience(float exp);
 
-	void SetMass(float newMass);
+	void SetMass(float newMass) override;
 
 	void DoSeismicPing(float pingSize);
 
 	void CalculateTerrainType();
 	void UpdateTerrainType();
-	void UpdatePhysicalState(float eps);
+	void UpdatePhysicalState(float eps) override;
 
 	float3 GetErrorVector(int allyteam) const;
 	float3 GetErrorPos(int allyteam, bool aiming = false) const { return (aiming? aimPos: midPos) + GetErrorVector(allyteam); }

--- a/rts/Sim/Units/UnitTypes/Building.h
+++ b/rts/Sim/Units/UnitTypes/Building.h
@@ -9,7 +9,7 @@
 class CBuilding : public CUnit
 {
 public:
-	CR_DECLARE(CBuilding)
+	CR_DECLARE_DERIVED(CBuilding)
 
 	CBuilding(): CUnit() { immobile = true; }
 

--- a/rts/System/Sound/Null/NullAudioChannel.h
+++ b/rts/System/Sound/Null/NullAudioChannel.h
@@ -10,24 +10,24 @@ class NullAudioChannel : public IAudioChannel {
 public:
 	~NullAudioChannel() {}
 
-	void Enable(bool newState) {}
-	void SetVolume(float newVolume) {}
+	void Enable(bool newState) override {}
+	void SetVolume(float newVolume) override {}
 
-	void PlaySample(size_t id, float volume = 1.0f) {}
-	void PlaySample(size_t id, const float3& p, float volume = 1.0f) {}
-	void PlaySample(size_t id, const float3& p, const float3& velocity, float volume = 1.0f) {}
+	void PlaySample(size_t id, float volume = 1.0f) override {}
+	void PlaySample(size_t id, const float3& p, float volume = 1.0f) override {}
+	void PlaySample(size_t id, const float3& p, const float3& velocity, float volume = 1.0f) override {}
 
-	void PlaySample(size_t id, const CWorldObject* p, float volume = 1.0f) {}
+	void PlaySample(size_t id, const CWorldObject* p, float volume = 1.0f) override {}
 
-	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) {}
-	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) {}
+	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) override {}
+	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) override {}
 
-	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) {}
+	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) override {}
 
-	void StreamStop() {}
-	void StreamPause() {}
-	float StreamGetTime() { return 0.f; }
-	float StreamGetPlayTime() { return 0.f; }
+	void StreamStop() override {}
+	void StreamPause() override {}
+	float StreamGetTime() override { return 0.f; }
+	float StreamGetPlayTime() override { return 0.f; }
 
 protected:
 	void FindSourceAndPlay(size_t id, const float3& p, const float3& velocity, float volume, bool relative) override {}

--- a/rts/System/Sound/Null/NullSound.h
+++ b/rts/System/Sound/Null/NullSound.h
@@ -42,7 +42,7 @@ public:
 	void PrintDebugInfo() override;
 	bool SoundThreadQuit() const override { return false; }
 	bool CanLoadSoundDefs() const override { return true; }
-	bool LoadSoundDefsImpl(LuaParser* defsParser) { return false; }
+	bool LoadSoundDefsImpl(LuaParser* defsParser) override { return false; }
 
 	const float3& GetListenerPos() const override { return ZeroVector; }
 

--- a/rts/System/Sound/OpenAL/AudioChannel.h
+++ b/rts/System/Sound/OpenAL/AudioChannel.h
@@ -24,30 +24,30 @@ private:
 	typedef std::pair<std::string, float> StreamQueueItem;
 
 public:
-	void Enable(bool newState);
-	void SetVolume(float newVolume);
+	void Enable(bool newState) override;
+	void SetVolume(float newVolume) override;
 
-	void PlaySample(size_t id, float volume = 1.0f);
-	void PlaySample(size_t id, const float3& pos, float volume = 1.0f);
-	void PlaySample(size_t id, const float3& pos, const float3& velocity, float volume = 1.0f);
+	void PlaySample(size_t id, float volume = 1.0f) override;
+	void PlaySample(size_t id, const float3& pos, float volume = 1.0f) override;
+	void PlaySample(size_t id, const float3& pos, const float3& velocity, float volume = 1.0f) override;
 
-	void PlaySample(size_t id, const CWorldObject* obj, float volume = 1.0f);
+	void PlaySample(size_t id, const CWorldObject* obj, float volume = 1.0f) override;
 
-	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj);
-	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector);
+	void PlayRandomSample(const GuiSoundSet& soundSet, const CWorldObject* obj) override;
+	void PlayRandomSample(const GuiSoundSet& soundSet, const float3& pos, const float3& vel = ZeroVector) override;
 
 	void StreamPlay(const StreamQueueItem& item, bool enqueue) { StreamPlay(item.first, item.second, enqueue); }
-	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false);
+	void StreamPlay(const std::string& path, float volume = 1.0f, bool enqueue = false) override;
 
 	/**
 	 * @brief Stop playback
 	 *
 	 * Do not call this if you just want to play another file (for performance).
 	 */
-	void StreamStop();
-	void StreamPause();
-	float StreamGetTime();
-	float StreamGetPlayTime();
+	void StreamStop() override;
+	void StreamPause() override;
+	float StreamGetTime() override;
+	float StreamGetPlayTime() override;
 
 protected:
 	void FindSourceAndPlay(size_t id, const float3& pos, const float3& velocity, float volume, bool relative) override;

--- a/rts/System/Sound/OpenAL/Sound.h
+++ b/rts/System/Sound/OpenAL/Sound.h
@@ -37,7 +37,7 @@ public:
 	size_t GetDefSoundId(const std::string& name) override;
 	size_t GetSoundId(const std::string& name) override;
 
-	SoundItem* GetSoundItem(size_t id);
+	SoundItem* GetSoundItem(size_t id) override;
 	CSoundSource* GetNextBestSource(bool lock = true) override;
 
 	void NewFrame() override;
@@ -66,7 +66,7 @@ public:
 	bool SoundThreadQuit() const override { return soundThreadQuit; }
 	bool CanLoadSoundDefs() const override { return canLoadDefs; }
 
-	bool LoadSoundDefsImpl(LuaParser* defsParser);
+	bool LoadSoundDefsImpl(LuaParser* defsParser) override;
 	const float3& GetListenerPos() const override { return myPos; }
 
 	ALCdevice* GetCurrentDevice() { return curDevice; }


### PR DESCRIPTION
## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). This PR focuses just on adding the many missing overrides.

# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.