### PR TITLE
fix: ignore compiler warnings for libs/submodules

### DIFF
--- a/AI/Skirmish/CMakeLists.txt
+++ b/AI/Skirmish/CMakeLists.txt
@@ -19,10 +19,37 @@ endmacro (skirmish_ai_message typemsg)
 # Add all Skirmish AI submodules
 get_list_of_submodules(SKIRMISH_AI_DIRS)
 set(DEPS_AI_SKIRMISH "")
+set(_skirmish_ai_clang_warns
+	-Wno-implicit-const-int-float-conversion
+	-Wno-parentheses-equality
+	-Wno-deprecated-declarations
+	-Wno-inconsistent-missing-override
+	-Wno-unused-lambda-capture
+	-Wno-pessimizing-move
+	-Wno-unneeded-internal-declaration
+	-Wno-unused-local-typedef
+	-Wno-unused-private-field
+	-Wno-unused-but-set-variable
+	-Wno-mismatched-tags
+	-Wno-vla-cxx-extension
+	-Wno-unused-variable
+)
+set(_skirmish_ai_gcc_warns
+	-Wno-maybe-uninitialized
+	-Wno-deprecated-declarations
+)
 foreach    (skirmishAIDir ${SKIRMISH_AI_DIRS})
 	add_subdirectory(${skirmishAIDir})
 	if (TARGET ${skirmishAIDir})
 		list(APPEND DEPS_AI_SKIRMISH ${skirmishAIDir})
+		# Vendored Skirmish AI submodules (e.g. BARb, CircuitAI) don't compile
+		# cleanly under modern compilers; suppress the warnings here rather
+		# than patching the submodule CMakeLists.
+		if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+			target_compile_options(${skirmishAIDir} PRIVATE ${_skirmish_ai_clang_warns})
+		elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+			target_compile_options(${skirmishAIDir} PRIVATE ${_skirmish_ai_gcc_warns})
+		endif()
 	endif()
 endforeach (skirmishAIDir)
 make_global(DEPS_AI_SKIRMISH)

--- a/rts/Rendering/Models/AssIO.h
+++ b/rts/Rendering/Models/AssIO.h
@@ -3,8 +3,12 @@
 #ifndef ASS_IO_H
 #define ASS_IO_H
 
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/IOStream.hpp"
 #include "lib/assimp/include/assimp/IOSystem.hpp"
+#pragma clang diagnostic pop
 class CFileHandler;
 
 // Custom implementation of Assimp IOStream to support Spring's VFS

--- a/rts/Rendering/Models/AssIO.h
+++ b/rts/Rendering/Models/AssIO.h
@@ -4,11 +4,15 @@
 #define ASS_IO_H
 
 // assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpragma-pack"
+#endif
 #include "lib/assimp/include/assimp/IOStream.hpp"
 #include "lib/assimp/include/assimp/IOSystem.hpp"
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 class CFileHandler;
 
 // Custom implementation of Assimp IOStream to support Spring's VFS

--- a/rts/Rendering/Models/AssParser.cpp
+++ b/rts/Rendering/Models/AssParser.cpp
@@ -25,6 +25,9 @@
 #include "System/FileSystem/FileHandler.h"
 #include "System/FileSystem/FileSystem.h"
 
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/config.h"
 #include "lib/assimp/include/assimp/defs.h"
 #include "lib/assimp/include/assimp/types.h"
@@ -32,6 +35,7 @@
 #include "lib/assimp/include/assimp/postprocess.h"
 #include "lib/assimp/include/assimp/Importer.hpp"
 #include "lib/assimp/include/assimp/DefaultLogger.hpp"
+#pragma clang diagnostic pop
 
 #include "System/Misc/TracyDefs.h"
 
@@ -626,10 +630,11 @@ void CAssParser::Load(S3DModel& model, const std::string& modelFilePath)
 				/* Try to salvage the model since such "invalid" ones can actually be
 				 * produced by industry standard tools (in particular, Blender). */
 				meshNode = Impl::FindFallbackNode(scene);
-				if (meshNode && meshNode->mParent)
+				if (meshNode && meshNode->mParent) {
 					LOG_SL(LOG_SECTION_MODEL, L_WARNING, "Found a likely replacement candidate for mesh \"%s\" - node \"%s\". It might be incorrect!", meshName.c_str(), meshNode->mName.data);
-				else
+				} else {
 					throw content_error("An assimp model has invalid pieces hierarchy. Failed to find suitable replacement.");
+				}
 			}
 
 			std::string const parentName(meshNode->mParent->mName.C_Str());

--- a/rts/Rendering/Models/AssParser.cpp
+++ b/rts/Rendering/Models/AssParser.cpp
@@ -26,8 +26,10 @@
 #include "System/FileSystem/FileSystem.h"
 
 // assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpragma-pack"
+#endif
 #include "lib/assimp/include/assimp/config.h"
 #include "lib/assimp/include/assimp/defs.h"
 #include "lib/assimp/include/assimp/types.h"
@@ -35,7 +37,9 @@
 #include "lib/assimp/include/assimp/postprocess.h"
 #include "lib/assimp/include/assimp/Importer.hpp"
 #include "lib/assimp/include/assimp/DefaultLogger.hpp"
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/Rendering/Models/IModelParser.cpp
+++ b/rts/Rendering/Models/IModelParser.cpp
@@ -25,7 +25,11 @@
 #include "System/Threading/ThreadPool.h"
 #include "System/ContainerUtil.h"
 #include "System/LoadLock.h"
+// assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpragma-pack"
 #include "lib/assimp/include/assimp/Importer.hpp"
+#pragma clang diagnostic pop
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/Rendering/Models/IModelParser.cpp
+++ b/rts/Rendering/Models/IModelParser.cpp
@@ -26,10 +26,14 @@
 #include "System/ContainerUtil.h"
 #include "System/LoadLock.h"
 // assimp public headers modify #pragma pack across includes (clang -Wpragma-pack)
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpragma-pack"
+#endif
 #include "lib/assimp/include/assimp/Importer.hpp"
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #include "System/Misc/TracyDefs.h"
 

--- a/rts/System/SafeUtil.h
+++ b/rts/System/SafeUtil.h
@@ -52,6 +52,10 @@ namespace spring {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-const-int-float-conversion"
+#endif
     template<typename TOut, typename TIn>
     inline TOut SafeCast(TIn value)
     {
@@ -96,6 +100,9 @@ namespace spring {
         // limits have been checked, therefore safe to cast
         return static_cast<TOut>(value);
     }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -111,7 +111,9 @@ endforeach()
 ADD_SUBDIRECTORY(assimp)
 target_compile_definitions(assimp PRIVATE -DASSIMP_BUILD_NO_OWN_ZLIB)
 
-# Suppress warnings-as-errors in vendored assimp (ASSIMP_WERROR=ON).
+# Suppress warnings in vendored assimp (we're not going to modify the library code)
+# Vendored assimp 4.0.1 trips these warnings in its own code.
+# Recheck this list if assimp is upgraded; later releases fixed some of these.
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(_assimp_warns
 		-Wno-pragma-pack
@@ -159,6 +161,9 @@ ADD_SUBDIRECTORY(fastgltf)
 ADD_SUBDIRECTORY(squish)
 ADD_SUBDIRECTORY(rg-etc1)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# Benign clang-only warnings in vendored rg_etc1.cpp (no-op labs() on unsigned +
+	# bare mark-as-used statements).
+	# We're not going to touch the decades old impl, so suppress the warnings.
 	target_compile_options(rgetc1 PRIVATE -Wno-absolute-value -Wno-unused-value)
 endif()
 
@@ -199,5 +204,7 @@ set(CMAKE_CXX_FLAGS ${SAVED_CMAKE_FLAGS})
 
 add_subdirectory(RmlUi)
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND TARGET rmlui_core)
+	# Known GCC-only -Warray-bounds false positive in vendored RmlUi at -O2+.
+	# Fixed in GCC 14 -- retest dropping this once CI is off GCC 13.
 	target_compile_options(rmlui_core PRIVATE -Wno-array-bounds)
 endif()

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -111,6 +111,29 @@ endforeach()
 ADD_SUBDIRECTORY(assimp)
 target_compile_definitions(assimp PRIVATE -DASSIMP_BUILD_NO_OWN_ZLIB)
 
+# Suppress warnings-as-errors in vendored assimp (ASSIMP_WERROR=ON).
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	set(_assimp_warns
+		-Wno-pragma-pack
+		-Wno-ordered-compare-function-pointers
+		-Wno-deprecated-declarations
+		-Wno-tautological-bitwise-compare
+		-Wno-unused-but-set-variable
+	)
+	target_compile_options(assimp PRIVATE ${_assimp_warns})
+	if (TARGET IrrXML)
+		target_compile_options(IrrXML PRIVATE -Wno-pragma-pack)
+	endif()
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+	set(_assimp_warns
+		-Wno-class-memaccess
+		-Wno-deprecated-declarations
+		-Wno-tautological-compare
+		-Wno-maybe-uninitialized
+	)
+	target_compile_options(assimp PRIVATE ${_assimp_warns})
+endif()
+
 # simdjson, a fastgltf dependency (manually added to submodules to work around the build system limitations)
 set(SIMDJSON_AVX512_ALLOWED OFF CACHE BOOL "forced by Recoil build env" FORCE)
 set(SIMDJSON_BASH OFF CACHE BOOL "forced by Recoil build env" FORCE)
@@ -135,6 +158,9 @@ ADD_SUBDIRECTORY(fastgltf)
 
 ADD_SUBDIRECTORY(squish)
 ADD_SUBDIRECTORY(rg-etc1)
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	target_compile_options(rgetc1 PRIVATE -Wno-absolute-value -Wno-unused-value)
+endif()
 
 option(TRACY_ENABLE "Enable tracy profiling" OFF)
 
@@ -172,3 +198,6 @@ add_subdirectory(lunasvg)
 set(CMAKE_CXX_FLAGS ${SAVED_CMAKE_FLAGS})
 
 add_subdirectory(RmlUi)
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND TARGET rmlui_core)
+	target_compile_options(rmlui_core PRIVATE -Wno-array-bounds)
+endif()

--- a/rts/lib/lua/CMakeLists.txt
+++ b/rts/lib/lua/CMakeLists.txt
@@ -55,3 +55,11 @@ if (UNIX)
 else (UNIX)
 	SET_TARGET_PROPERTIES(lua PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")
 endif (UNIX)
+
+# Suppress clang -Werror warnings in vendored lua sources.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	target_compile_options(lua PRIVATE
+		-Wno-empty-body
+		-Wno-implicit-int-float-conversion
+	)
+endif()

--- a/rts/lib/lua/CMakeLists.txt
+++ b/rts/lib/lua/CMakeLists.txt
@@ -56,10 +56,9 @@ else (UNIX)
 	SET_TARGET_PROPERTIES(lua PROPERTIES COMPILE_FLAGS "${PIC_FLAG}")
 endif (UNIX)
 
-# Suppress clang -Werror warnings in vendored lua sources.
+# Vendored lua has an intentional empty-body loop (lauxlib.cpp shebang skip).
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	target_compile_options(lua PRIVATE
 		-Wno-empty-body
-		-Wno-implicit-int-float-conversion
 	)
 endif()


### PR DESCRIPTION
## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). This PR focuses on getting rid of the warnings from our submodules, which we are unlikely to fix. I assume most come from new c++23 warnings or something similar.


# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.