### PR TITLE
fix: compiler warnings with no side effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,10 +414,6 @@ if(NOT MSVC)
 		## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
 		## it's been quite annoying since we switched to C++23
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
-		## libstdc++13 <functional> still uses std::result_of (deprecated in C++23),
-		## which trips through any ThreadPool::Enqueue callsite — suppress globally
-		## rather than sprinkle pragmas across every file that enqueues work.
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 	endif()
 
 	### CompileTime Warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,10 +409,16 @@ if(NOT MSVC)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsignaling-nans")
 	endif()
 
-	## warning: space between quotes and suffix is deprecated in C++23
-	## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
-	## it's been quite annoying since we switched to C++23
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
+	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		## warning: space between quotes and suffix is deprecated in C++23
+		## [[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept
+		## it's been quite annoying since we switched to C++23
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-literal-operator")
+		## libstdc++13 <functional> still uses std::result_of (deprecated in C++23),
+		## which trips through any ThreadPool::Enqueue callsite — suppress globally
+		## rather than sprinkle pragmas across every file that enqueues work.
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+	endif()
 
 	### CompileTime Warnings
 	set(COMMON_WARNINGS "${COMMON_WARNINGS} -Wformat -Wformat-security")

--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -19,7 +19,7 @@
 
 bool LuaConstGL::PushEntries(lua_State* L)
 {
-#define PUSH_GL(cmd) LuaPushNamedNumber(L, #cmd, GL_ ## cmd)
+#define PUSH_GL(cmd) LuaPushNamedNumber(L, #cmd, static_cast<lua_Number>(GL_ ## cmd))
 
 	/***
 	 * Drawing Primitives

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5767,7 +5767,7 @@ int LuaOpenGL::GetMatrixData(lua_State* L)
 int LuaOpenGL::PushAttrib(lua_State* L)
 {
 	CheckDrawingEnabled(L, __func__);
-	int mask = luaL_optnumber(L, 1, GL_ALL_ATTRIB_BITS);
+	int mask = luaL_optnumber(L, 1, static_cast<lua_Number>(GL_ALL_ATTRIB_BITS));
 	if (mask < 0) {
 		mask = -mask;
 		mask |= GL_ALL_ATTRIB_BITS;

--- a/rts/Lua/LuaParser.h
+++ b/rts/Lua/LuaParser.h
@@ -124,7 +124,6 @@ private:
 	struct boolean { bool b; };
 
 public:
-	LuaParser() = default;
 	LuaParser(const std::string& fileName, const std::string& fileModes, const std::string& accessModes, const boolean& synced = {false}, const boolean& setup = {true});
 	LuaParser(const std::string& textChunk, const std::string& accessModes, int = 0, const boolean& synced = {false}, const boolean& setup = {true});
 	~LuaParser();

--- a/rts/Lua/LuaParser.h
+++ b/rts/Lua/LuaParser.h
@@ -124,6 +124,7 @@ private:
 	struct boolean { bool b; };
 
 public:
+	LuaParser() = delete;
 	LuaParser(const std::string& fileName, const std::string& fileModes, const std::string& accessModes, const boolean& synced = {false}, const boolean& setup = {true});
 	LuaParser(const std::string& textChunk, const std::string& accessModes, int = 0, const boolean& synced = {false}, const boolean& setup = {true});
 	~LuaParser();

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -687,8 +687,8 @@ int LuaUnsyncedRead::GetLuaMemUsage(lua_State* L)
 
 	// sum up the individual (unsynced and synced) state footprints
 	for (bool synced: {false, true}) {
-		lgs.allocedBytes = {0};
-		lgs.numLuaAllocs = {0};
+		lgs.allocedBytes = 0;
+		lgs.numLuaAllocs = 0;
 
 		for (const luaContextData* lcd: *LUAHANDLE_CONTEXTS[synced]) {
 			lhs = &lcd->allocState;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -682,8 +682,8 @@ int LuaUnsyncedRead::GetLuaMemUsage(lua_State* L)
 
 	// sum up the individual (unsynced and synced) state footprints
 	for (bool synced: {false, true}) {
-		lgs.allocedBytes = {0};
-		lgs.numLuaAllocs = {0};
+		lgs.allocedBytes = 0;
+		lgs.numLuaAllocs = 0;
 
 		for (const luaContextData* lcd: *LUAHANDLE_CONTEXTS[synced]) {
 			lhs = &lcd->allocState;

--- a/rts/Rendering/GL/glDebugGroup.hpp
+++ b/rts/Rendering/GL/glDebugGroup.hpp
@@ -15,7 +15,7 @@ namespace GL {
 	public:
 		DebugGroupNoop(uint32_t id, const char* messsage) {}
 	};
-	class DebugGroupImpl : public DebugGroup {
+	class DebugGroupImpl final : public DebugGroup {
 	public:
 		DebugGroupImpl(uint32_t id, const char* messsage);
 		~DebugGroupImpl() override final;

--- a/rts/Sim/Path/HAPFS/PathEstimator.cpp
+++ b/rts/Sim/Path/HAPFS/PathEstimator.cpp
@@ -35,8 +35,8 @@ void CPathEstimator::Init(IPathFinder* pf, unsigned int BLOCK_SIZE, PathingState
 		pathChecksum = 0;
 		fileHashCode = CalcHash(__func__);
 
-		offsetBlockNum = {nbrOfBlocks.x * nbrOfBlocks.y};
-		costBlockNum = {nbrOfBlocks.x * nbrOfBlocks.y};
+		offsetBlockNum = nbrOfBlocks.x * nbrOfBlocks.y;
+		costBlockNum = nbrOfBlocks.x * nbrOfBlocks.y;
 
 		parentPathFinder = pf;
 		//nextPathEstimator = nullptr;

--- a/rts/Sim/Path/HAPFS/PathingState.cpp
+++ b/rts/Sim/Path/HAPFS/PathingState.cpp
@@ -106,8 +106,8 @@ void PathingState::Init(std::vector<IPathFinder*> pathFinderlist, PathingState* 
 	 	pathChecksum = 0;
 	 	fileHashCode = CalcHash(__func__);
 
-		offsetBlockNum = {mapDimensionsInBlocks.x * mapDimensionsInBlocks.y};
-		costBlockNum = {mapDimensionsInBlocks.x * mapDimensionsInBlocks.y};
+		offsetBlockNum = mapDimensionsInBlocks.x * mapDimensionsInBlocks.y;
+		costBlockNum = mapDimensionsInBlocks.x * mapDimensionsInBlocks.y;
 
 		vertexCosts.clear();
 		vertexCosts.resize(moveDefHandler.GetNumMoveDefs() * blockStates.GetSize() * PATH_DIRECTION_VERTICES, PATHCOST_INFINITY);
@@ -395,7 +395,7 @@ void PathingState::CalcVertexPathCosts(const MoveDef& moveDef, int2 block, unsig
 	// other four directions are stored at the adjacent vertices)
 	auto idx = BlockPosToIdx(block);
 	const uint8_t nodeLinksObsoleteFlags = blockStates.nodeLinksObsoleteFlags[idx]
-								  		 & (moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK;
+								  		 & ((moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK);
 
 	int pathdir = 0;
 	for (int checkBit = 1; checkBit <= PATHDIR_LEFT_DOWN_MASK; checkBit <<= 1, ++pathdir) {

--- a/rts/Sim/Path/HAPFS/PathingState.cpp
+++ b/rts/Sim/Path/HAPFS/PathingState.cpp
@@ -395,7 +395,7 @@ void PathingState::CalcVertexPathCosts(const MoveDef& moveDef, int2 block, unsig
 	// other four directions are stored at the adjacent vertices)
 	auto idx = BlockPosToIdx(block);
 	const uint8_t nodeLinksObsoleteFlags = blockStates.nodeLinksObsoleteFlags[idx]
-								  		 & ((moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK);
+								  		 & (moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK;
 
 	int pathdir = 0;
 	for (int checkBit = 1; checkBit <= PATHDIR_LEFT_DOWN_MASK; checkBit <<= 1, ++pathdir) {

--- a/rts/Sim/Path/HAPFS/Registry.h
+++ b/rts/Sim/Path/HAPFS/Registry.h
@@ -1,4 +1,4 @@
-#ifndef HAFS_REGISTRY_H__
+#ifndef HAPFS_REGISTRY_H__
 #define HAPFS_REGISTRY_H__
 
 #include "System/Ecs/EcsMain.h"

--- a/rts/Sim/Projectiles/FlareProjectile.cpp
+++ b/rts/Sim/Projectiles/FlareProjectile.cpp
@@ -37,7 +37,7 @@ CFlareProjectile::CFlareProjectile(const float3& pos, const float3& speed, CUnit
 	deathFrame(activateFrame + ((owner != nullptr)? owner->unitDef->flareTime: 1)),
 
 	numSubProjs(0),
-	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(subProjPos.size()))),
+	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(decltype(subProjPos)().size()))),
 	lastSubProj(0)
 {
 	alphaFalloff = (owner != nullptr)? 1.0f / owner->unitDef->flareTime: 1.0f;

--- a/rts/Sim/Projectiles/FlareProjectile.cpp
+++ b/rts/Sim/Projectiles/FlareProjectile.cpp
@@ -37,7 +37,7 @@ CFlareProjectile::CFlareProjectile(const float3& pos, const float3& speed, CUnit
 	deathFrame(activateFrame + ((owner != nullptr)? owner->unitDef->flareTime: 1)),
 
 	numSubProjs(0),
-	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(decltype(subProjPos)().size()))),
+	maxSubProjs(std::min((owner != nullptr)? owner->unitDef->flareSalvoSize: 0, int(std::tuple_size_v<decltype(subProjPos)>))),
 	lastSubProj(0)
 {
 	alphaFalloff = (owner != nullptr)? 1.0f / owner->unitDef->flareTime: 1.0f;

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -216,7 +216,7 @@ void CUnitScript::TickAllAnims(int deltaTime)
 	for (auto& ai : anims) {
 		LocalModelPiece& lmp = *pieces[ai.piece];
 		const auto& currFunc = TICK_ANIM_FUNCS[ai.animType];
-		if (ai.done |= std::invoke(currFunc, this, tickRate, lmp, ai)) {
+		if ((ai.done |= std::invoke(currFunc, this, tickRate, lmp, ai))) {
 			if (ai.hasWaiting)
 				doneAnims.emplace_back(ai);
 		}

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -470,7 +470,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 			// in params[0] was coming from and traced it back to this WTF hack,
 			// increment the number of wasted hours below:
 			//   number_of_hours_wasted = 3;
-			c.SetParam(0, INT_MAX / 2);
+			c.SetParam(0, static_cast<float>(INT_MAX / 2));
 		}
 
 		// this takes one simframe to do the deletion

--- a/rts/System/Ecs/EcsMain.h
+++ b/rts/System/Ecs/EcsMain.h
@@ -5,7 +5,17 @@
 
 #define ENTT_USE_ATOMIC
 
+#if defined(__GNUC__)
+// entt 3.10.3 uses std::aligned_storage_t, deprecated in C++23; bump entt to drop this
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "lib/entt/src/entt/entt.hpp"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 // class EcsMain {
 // public:

--- a/rts/System/Platform/Linux/Futex.cpp
+++ b/rts/System/Platform/Linux/Futex.cpp
@@ -126,7 +126,7 @@ linux_signal::linux_signal() noexcept
 
 linux_signal::~linux_signal()
 {
-	gen = {0};
+	gen = 0;
 	mtx = 0;
 }
 

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -201,10 +201,11 @@ namespace Threading {
 			, [affinityMask](const auto& gc) -> bool { return !!(affinityMask & gc.groupMask); });
 		
 		std::call_once(preferredMaskDetailsLogFlag, [&](){
-			if (preferredCache != pc.groupCaches.end())
+			if (preferredCache != pc.groupCaches.end()) {
 				LOG("[Threading] Preferred performance cache mask is: 0x%08x (L3 sized: %dKB)", preferredCache->groupMask, preferredCache->cacheSizes[2]/1024);
-			else
+			} else {
 				LOG_L(L_WARNING, "[Threading] Failed to find a preferred performance cache mask");
+			}
 		});
 
 		const uint32_t policy = affinityMask
@@ -241,10 +242,11 @@ namespace Threading {
 		const uint32_t fallbackThreadCount = GetPerformanceCpuCores();
 		
 		std::call_once(optimalThreadCountLogFlag, [&](){
-			if (optimalThreadCount > 0)
+			if (optimalThreadCount > 0) {
 				LOG("[Threading] Optimal thread count is %d", optimalThreadCount);
-			else
+			} else {
 				LOG_L(L_WARNING, "[Threading] Failed to determine optimal thread count. Falling back to %d", fallbackThreadCount);
+			}
 		});
 
 		return (optimalThreadCount > 0) ? optimalThreadCount : fallbackThreadCount;

--- a/rts/System/creg/creg.h
+++ b/rts/System/creg/creg.h
@@ -317,6 +317,13 @@ public: \
 	void TCls::_DestructInstance(void* d) { ((MyType*)d)->~MyType(); } \
 	creg::Class TCls::creg_class(#TCls, creg::CF_None, &TBase::creg_class, &TCls::_CregRegisterMembers, sizeof(TCls), alignof(TCls), std::is_polymorphic<TCls>::value, TCls::creg_isStruct, TCls::_ConstructInstance, TCls::_DestructInstance, TCls::_Alloc, TCls::_Free);
 
+/** @def CR_BIND_TEMPLATE_DECLARE
+ * Declares that TCls::creg_class is defined elsewhere (via CR_BIND_TEMPLATE),
+ * so using-only TUs don't warn about an undefined static template member.
+ */
+#define CR_BIND_TEMPLATE_DECLARE(TCls) \
+	template<> creg::Class TCls::creg_class;
+
 /** @def CR_BIND_TEMPLATE
  *  @see CR_BIND
  */

--- a/rts/System/creg/creg_cond.h
+++ b/rts/System/creg/creg_cond.h
@@ -25,6 +25,7 @@
 #define CR_DECLARE_DERIVED(TCls)
 #define CR_DECLARE_STRUCT(TStr)
 #define CR_DECLARE_SUB(cl)
+#define CR_BIND_TEMPLATE_DECLARE(TCls)
 #define CR_BIND_DERIVED(TCls, TBase, ctor_args)
 #define CR_BIND(TCls, ctor_args)
 #define CR_BIND_DERIVED_INTERFACE(TCls, TBase)

--- a/rts/System/type2.h
+++ b/rts/System/type2.h
@@ -107,3 +107,11 @@ using uint2 = type2<uint32_t>;
 using float2 = type2<float>;
 using short2 = type2<int16_t>;
 using ushort2 = type2<uint16_t>;
+
+#ifdef USING_CREG
+// creg_class specializations are defined in type2.cpp via CR_BIND_TEMPLATE
+template<> creg::Class type2<int32_t>::creg_class;
+template<> creg::Class type2<float>::creg_class;
+template<> creg::Class type2<int16_t>::creg_class;
+template<> creg::Class type2<uint16_t>::creg_class;
+#endif

--- a/rts/System/type2.h
+++ b/rts/System/type2.h
@@ -108,10 +108,8 @@ using float2 = type2<float>;
 using short2 = type2<int16_t>;
 using ushort2 = type2<uint16_t>;
 
-#ifdef USING_CREG
 // creg_class specializations are defined in type2.cpp via CR_BIND_TEMPLATE
-template<> creg::Class type2<int32_t>::creg_class;
-template<> creg::Class type2<float>::creg_class;
-template<> creg::Class type2<int16_t>::creg_class;
-template<> creg::Class type2<uint16_t>::creg_class;
-#endif
+CR_BIND_TEMPLATE_DECLARE(int2)
+CR_BIND_TEMPLATE_DECLARE(float2)
+CR_BIND_TEMPLATE_DECLARE(short2)
+CR_BIND_TEMPLATE_DECLARE(ushort2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,12 @@ else  (UNIX AND (NOT APPLE) AND (NOT MINGW))
 endif (UNIX AND (NOT APPLE) AND (NOT MINGW))
 
 ADD_SUBDIRECTORY(lib/catch2)
+# Engine-wide -fsingle-precision-constant (gcc) makes `0.` a float, which
+# triggers an ISO ambiguity error against Catch2's float/double overloads.
+# Build the vendored Catch2 without that flag.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	target_compile_options(Catch2 PRIVATE -fno-single-precision-constant)
+endif()
 
 include_directories(${CMAKE_BINARY_DIR}/src-generated/engine)
 


### PR DESCRIPTION
## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). This PR focuses on the non-behaviour changing fixes to code, mostly formatting changes or implicit casts.

# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.