### PR TITLE
fix: compiler warnings with potential side effects

### DIFF
--- a/rts/Lua/LuaOpenGLUtils.cpp
+++ b/rts/Lua/LuaOpenGLUtils.cpp
@@ -1114,6 +1114,8 @@ void LuaMatTexture::Print(const string& indent) const
 		STRING_CASE(typeName, LUATEX_ICONS_ATLAS0);
 		STRING_CASE(typeName, LUATEX_ICONS_ATLAS1);
 
+		STRING_CASE(typeName, LUATEX_LUATEXTUREATLAS);
+
 		#undef STRING_CASE
 	}
 

--- a/rts/Map/SMF/SMFGroundTextures.cpp
+++ b/rts/Map/SMF/SMFGroundTextures.cpp
@@ -114,8 +114,7 @@ void CSMFGroundTextures::LoadTiles(CSMFMapFile& file)
 
 	tileMap.clear();
 	tileMap.resize(smfMap->tileCount);
-	tiles.clear();
-	tiles.resize(tileHeader.numTiles * SMALL_TILE_SIZE);
+	tiles.assign(static_cast<size_t>(tileHeader.numTiles) * SMALL_TILE_SIZE, 0);
 	squares.clear();
 	squares.resize(smfMap->numBigTexX * smfMap->numBigTexY);
 

--- a/rts/Rendering/DepthBufferCopy.cpp
+++ b/rts/Rendering/DepthBufferCopy.cpp
@@ -149,6 +149,6 @@ void DepthBufferCopy::CreateTextureAndFBO(bool ms)
 	depthFBO->Bind();
 	depthFBO->AttachTexture(depthTexture, target, GL_DEPTH_ATTACHMENT);
 	glDrawBuffer(GL_NONE);
-	depthFBO->CheckStatus("DEPTH-BUFFER-COPY-FBO" + ms ? "-MULTISAMPLED" : "");
+	depthFBO->CheckStatus(ms ? "DEPTH-BUFFER-COPY-FBO-MULTISAMPLED" : "DEPTH-BUFFER-COPY-FBO");
 	depthFBO->Unbind();
 }

--- a/rts/Rendering/GL/glHelpers.h
+++ b/rts/Rendering/GL/glHelpers.h
@@ -107,7 +107,7 @@ inline GLuint FetchActiveTextureSlot() {
 template<auto DedicatedGLFuncPtrPtr, GLenum... GLParamName, class AttribValuesTupleType>
 inline void glSetAny(AttribValuesTupleType&& newValues)
 {
-	if constexpr(DedicatedGLFuncPtrPtr)
+	if constexpr(DedicatedGLFuncPtrPtr != nullptr)
 	{
 		static auto HelperFunc = [](auto&& ... p) {
 			(*DedicatedGLFuncPtrPtr)(std::forward<decltype(p)>(p)...);

--- a/rts/Rendering/Textures/Bitmap.cpp
+++ b/rts/Rendering/Textures/Bitmap.cpp
@@ -356,11 +356,11 @@ void ITexMemPool::Init(size_t size)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (size == 0) {
-		if (texMemPool == nullptr || typeid(*texMemPool.get()) != typeid(TexNoMemPool))
+		if (dynamic_cast<TexNoMemPool*>(texMemPool.get()) == nullptr)
 			texMemPool = std::make_unique<TexNoMemPool>();
 	}
 	else {
-		if (texMemPool == nullptr || typeid(*texMemPool.get()) != typeid(  TexMemPool))
+		if (dynamic_cast<  TexMemPool*>(texMemPool.get()) == nullptr)
 			texMemPool = std::make_unique<  TexMemPool>();
 	}
 	texMemPool->Resize(size);
@@ -405,6 +405,7 @@ public:
 	BitmapAction(CBitmap* bmp_)
 		: bmp{ bmp_ }
 	{}
+	virtual ~BitmapAction() = default;
 
 	BitmapAction(const BitmapAction& ba) = delete;
 	BitmapAction(BitmapAction&& ba) noexcept = delete;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -367,8 +367,10 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcon(TypedRenderBuffer<VA_TYPE_2DTC3>& rb, 
 
 			std::swap(posX, posY);
 			break;
+		case CMiniMap::ROTATION_0:
+			break;
 	}
-	
+
 	float x0 = posX - iconSizeX;
 	float x1 = posX + iconSizeX;
 	float y0 = posY - iconSizeY;

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -336,7 +336,7 @@ MoveDef::MoveDef(const LuaTable& moveDefTable): MoveDef() {
 		waterline = std::abs(moveDefTable.GetInt("waterline", defaultWaterline));
 		overrideUnitWaterline = moveDefTable.GetBool("overrideUnitWaterline", overrideUnitWaterline);
 	} else {
-		waterline = std::numeric_limits<int>::max();
+		waterline = std::numeric_limits<float>::max();
 	}
 
 	height = std::max(1, moveDefTable.GetInt("height", defaultHeight));

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -336,6 +336,9 @@ MoveDef::MoveDef(const LuaTable& moveDefTable): MoveDef() {
 		waterline = std::abs(moveDefTable.GetInt("waterline", defaultWaterline));
 		overrideUnitWaterline = moveDefTable.GetBool("overrideUnitWaterline", overrideUnitWaterline);
 	} else {
+		// we read as int from configuration but used as float...
+		// this should probably be changed to float everywhere
+		// github issue: https://github.com/beyond-all-reason/RecoilEngine/issues/2996
 		waterline = static_cast<float>(std::numeric_limits<int>::max());
 	}
 

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -336,7 +336,7 @@ MoveDef::MoveDef(const LuaTable& moveDefTable): MoveDef() {
 		waterline = std::abs(moveDefTable.GetInt("waterline", defaultWaterline));
 		overrideUnitWaterline = moveDefTable.GetBool("overrideUnitWaterline", overrideUnitWaterline);
 	} else {
-		waterline = std::numeric_limits<float>::max();
+		waterline = static_cast<float>(std::numeric_limits<int>::max());
 	}
 
 	height = std::max(1, moveDefTable.GetInt("height", defaultHeight));

--- a/rts/Sim/Path/HAPFS/PathingState.cpp
+++ b/rts/Sim/Path/HAPFS/PathingState.cpp
@@ -395,7 +395,7 @@ void PathingState::CalcVertexPathCosts(const MoveDef& moveDef, int2 block, unsig
 	// other four directions are stored at the adjacent vertices)
 	auto idx = BlockPosToIdx(block);
 	const uint8_t nodeLinksObsoleteFlags = blockStates.nodeLinksObsoleteFlags[idx]
-								  		 & (moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK;
+								  		 & ((moveDef.allowDirectionalPathing) ? PATH_DIRECTIONS_MASK : PATH_DIRECTIONS_HALF_MASK);
 
 	int pathdir = 0;
 	for (int checkBit = 1; checkBit <= PATHDIR_LEFT_DOWN_MASK; checkBit <<= 1, ++pathdir) {

--- a/rts/Sim/Units/Scripts/CobDeferredCallin.cpp
+++ b/rts/Sim/Units/Scripts/CobDeferredCallin.cpp
@@ -12,10 +12,9 @@
 
 
 CCobDeferredCallin::CCobDeferredCallin(const CUnit* unit, const LuaHashString& hs, const std::vector<int>& dataStack, const int stackStart)
-	: argCount(argCount), unit(unit), funcName(hs.GetString()), funcHash(hs.GetHash())
+	: unit(unit), argCount(std::min(stackStart, MAX_LUA_COB_ARGS)), funcName(hs.GetString()), funcHash(hs.GetHash())
 {
 	const int size = static_cast<int>(dataStack.size());
-	argCount = std::min(stackStart, MAX_LUA_COB_ARGS);
 
 	const int start = std::max(0, size - stackStart);
 	const int end = std::min(size, start + argCount);


### PR DESCRIPTION
## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). This PR focuses on the more "potenitally breaking" fixes. Some of these are false positives (as in the underlying code has no bug) but changing the code avoids the warning. There are a few legit bugs that have slight behaviour changes.

I've gone through and successfully compiled every non-trivial fix, pulling the actual warning from the compiler into a review comment. I've added some explanations on sections where I wasn't sure whether the change was safe or why the change was made, to try and add detail for other reviewers.

# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.