### PR TITLE
fix: legit bugs found by compiler warnings

### DIFF
--- a/AI/Wrappers/CUtils/SimpleLog.c
+++ b/AI/Wrappers/CUtils/SimpleLog.c
@@ -95,7 +95,8 @@ void simpleLog_log(const char* fmt, ...) {
 
 void simpleLog_initcallback(int id, const char* section, logfunction func, int _logLevel)
 {
-	strncpy(logSection, section, 32);
+	strncpy(logSection, section, sizeof(logSection) - 1);
+	logSection[sizeof(logSection) - 1] = '\0';
 	logFunction = func;
 	interfaceid = id;
 	logLevel = _logLevel;

--- a/rts/Game/InMapDrawModel.cpp
+++ b/rts/Game/InMapDrawModel.cpp
@@ -145,7 +145,7 @@ void CInMapDrawModel::EraseNear(const float3& constPos, int playerID, const bool
 	if (!playerHandler.IsValidPlayer(playerID))
 		return;
 
-	const CPlayer* sender;
+	const CPlayer* sender = nullptr;
 
 	if (!alwaysErase) // we don't need to check sender if we always erase regardless of sender
 		sender = playerHandler.Player(playerID);

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -270,7 +270,7 @@ public:
 		}
 
 		auto args = CSimpleParser::Tokenize(action.GetArgs());
-		bool parseFailure;
+		bool parseFailure = false;
 
 		int smfMeshDrawerArg = (!args.empty()) ? StringToInt(args[0], &parseFailure) : -1.0;
 		if (parseFailure) smfMeshDrawerArg = -1.0;

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -200,9 +200,7 @@ int LuaFonts::LoadFont(lua_State* L)
 		return 0;
 
 	auto shPtrFontPtr = static_cast<decltype(f)*>(lua_newuserdata(L, sizeof(decltype(f))));
-	memset(shPtrFontPtr, 0, sizeof(decltype(f)));
-
-	*shPtrFontPtr = std::move(f);
+	new (shPtrFontPtr) decltype(f)(std::move(f));
 
 	luaL_getmetatable(L, "Font");
 	lua_setmetatable(L, -2);

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -2922,10 +2922,10 @@ int LuaOpenGL::DispatchCompute(lua_State* L)
 
 	static std::array<GLint, 3> maxNumGroups = maxCompWGFunc();
 
-	if (numGroupX < 0 || numGroupX > maxNumGroups[0] ||
-		numGroupY < 0 || numGroupY > maxNumGroups[1] ||
-		numGroupZ < 0 || numGroupZ > maxNumGroups[2])
-		luaL_error(L, "%s Incorrect number of work groups specified x: 0 > %d < %d; y: 0 > %d < %d; z: 0 > %d < %d", __func__, numGroupX, maxNumGroups[0], numGroupY, maxNumGroups[1], numGroupZ, maxNumGroups[2]);
+	if (numGroupX > maxNumGroups[0] ||
+		numGroupY > maxNumGroups[1] ||
+		numGroupZ > maxNumGroups[2])
+		luaL_error(L, "%s: work groups count exceeds GL_MAX_COMPUTE_WORK_GROUP_COUNT. (x=%u > %d, y=%u > %d, z=%u > %d)", __func__, numGroupX, maxNumGroups[0], numGroupY, maxNumGroups[1], numGroupZ, maxNumGroups[2]);
 
 	glDispatchCompute(numGroupX, numGroupY, numGroupZ);
 

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -2922,9 +2922,9 @@ int LuaOpenGL::DispatchCompute(lua_State* L)
 
 	static std::array<GLint, 3> maxNumGroups = maxCompWGFunc();
 
-	if (numGroupX < 0 && numGroupX > maxNumGroups[0] ||
-		numGroupY < 0 && numGroupY > maxNumGroups[1] ||
-		numGroupZ < 0 && numGroupZ > maxNumGroups[2])
+	if (numGroupX < 0 || numGroupX > maxNumGroups[0] ||
+		numGroupY < 0 || numGroupY > maxNumGroups[1] ||
+		numGroupZ < 0 || numGroupZ > maxNumGroups[2])
 		luaL_error(L, "%s Incorrect number of work groups specified x: 0 > %d < %d; y: 0 > %d < %d; z: 0 > %d < %d", __func__, numGroupX, maxNumGroups[0], numGroupY, maxNumGroups[1], numGroupZ, maxNumGroups[2]);
 
 	glDispatchCompute(numGroupX, numGroupY, numGroupZ);

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -924,7 +924,7 @@ void CFontTexture::PinFont(std::shared_ptr<FontFace>& face, const std::string& f
 		cached->second.timestamp = time;
 	} else {
 		if (pinnedRecentFonts.size() >= maxPinnedFonts) {
-			SizedFontKey* oldest;
+			SizedFontKey* oldest = nullptr;
 			float oldestTime = time;
 			for(auto &[key, timestampedFont]: pinnedRecentFonts) {
 				if (timestampedFont.timestamp <= oldestTime) {

--- a/rts/Rendering/Fonts/CFontTexture.cpp
+++ b/rts/Rendering/Fonts/CFontTexture.cpp
@@ -932,7 +932,9 @@ void CFontTexture::PinFont(std::shared_ptr<FontFace>& face, const std::string& f
 					oldestTime = timestampedFont.timestamp;
 				}
 			}
-			pinnedRecentFonts.erase(*oldest);
+			if (oldest != nullptr) {
+				pinnedRecentFonts.erase(*oldest);
+			}
 		}
 		pinnedRecentFonts[fontKey] = { face, time };
 	}

--- a/rts/Rendering/GL/FBO.h
+++ b/rts/Rendering/GL/FBO.h
@@ -188,9 +188,9 @@ private:
 		}
 
 	public:
-		GLuint id;
-		GLsizei xsize, ysize, zsize;
-		GLenum target, format, type;
+		GLuint id = 0;
+		GLsizei xsize = 0, ysize = 0, zsize = 0;
+		GLenum target = 0, format = 0, type = 0;
 		std::vector<unsigned char> pixels;
 	};
 

--- a/rts/Rendering/Models/3DModelPiece.hpp
+++ b/rts/Rendering/Models/3DModelPiece.hpp
@@ -15,6 +15,7 @@
 struct S3DModel;
 struct S3DModelPiece {
 	S3DModelPiece() = default;
+	virtual ~S3DModelPiece() = default;
 
 	virtual void Clear() {
 		name.clear();

--- a/rts/Rml/SolLua/RmlSolLua.cpp
+++ b/rts/Rml/SolLua/RmlSolLua.cpp
@@ -41,7 +41,7 @@ namespace Rml::SolLua
 {
 	SolLuaPlugin* Initialise(sol::state_view* state, const Rml::String& lua_environment_identifier)
 	{
-		SolLuaPlugin* slp;
+		SolLuaPlugin* slp = nullptr;
 		if (state != nullptr)
 		{
 			slp = new SolLuaPlugin(*state, lua_environment_identifier);

--- a/rts/System/Platform/Linux/CpuTopology.cpp
+++ b/rts/System/Platform/Linux/CpuTopology.cpp
@@ -142,7 +142,7 @@ enum Vendor { VENDOR_INTEL, VENDOR_AMD, VENDOR_UNKNOWN };
 
 // Detect CPU vendor (Intel or VENDOR_AMD)
 Vendor detect_cpu_vendor() {
-	unsigned int eax, ebx, ecx, edx;
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
 	__get_cpuid(0, &eax, &ebx, &ecx, &edx);
 	if (ebx == 0x756E6547) return VENDOR_INTEL; // "GenuineIntel"
 	if (ebx == 0x68747541) return VENDOR_AMD;   // "AuthenticAMD"
@@ -152,7 +152,7 @@ Vendor detect_cpu_vendor() {
 // Detect Intel core type using CPUID 0x1A
 CoreType get_intel_core_type(int cpu) {
 	set_cpu_affinity(cpu);
-	unsigned int eax, ebx, ecx, edx;
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
 	if (__get_cpuid(0x1A, &eax, &ebx, &ecx, &edx)) {
 		uint8_t coreType = ( eax & 0xFF000000 ) >> 24;  // Extract core type
 

--- a/rts/System/Platform/Watchdog.cpp
+++ b/rts/System/Platform/Watchdog.cpp
@@ -66,6 +66,12 @@ namespace Watchdog
 	};
 
 	struct WatchDogThreadSlot {
+		void Reset() {
+			primary  = false;
+			active   = false;
+			regorder = 0;
+		}
+
 		std::atomic<bool> primary = {false};
 		std::atomic<bool> active = {false};
 		std::atomic<unsigned int> regorder = {0};
@@ -374,11 +380,8 @@ namespace Watchdog
 			registeredThreads[i] = &registeredThreadsData[WDT_COUNT];
 			threadNumTable[hashString(threadNames[i])] = i;
 		}
-		for (auto& slot : threadSlots) {
-			slot.primary   = false;
-			slot.active    = false;
-			slot.regorder  = 0;
-		}
+		for (auto& slot : threadSlots)
+			slot.Reset();
 
 		// disable if gdb is running
 		if (Platform::IsRunningInDebugger()) {
@@ -429,11 +432,8 @@ namespace Watchdog
 		}
 		for (unsigned int i = 0; i < WDT_COUNT; ++i)
 			registeredThreads[i] = &registeredThreadsData[WDT_COUNT];
-		for (auto& slot : threadSlots) {
-			slot.primary   = false;
-			slot.active    = false;
-			slot.regorder  = 0;
-		}
+		for (auto& slot : threadSlots)
+			slot.Reset();
 		threadNumTable.clear();
 	}
 }

--- a/rts/System/Platform/Watchdog.cpp
+++ b/rts/System/Platform/Watchdog.cpp
@@ -366,12 +366,19 @@ namespace Watchdog
 	{
 		std::lock_guard<spring::mutex> lock(wdmutex);
 
-		memset(registeredThreadsData, 0, sizeof(registeredThreadsData));
+		for (auto& info : registeredThreadsData) {
+			info.ResetThreadInfo();
+			info.ResetThreadControls();
+		}
 		for (unsigned int i = 0; i < WDT_COUNT; ++i) {
 			registeredThreads[i] = &registeredThreadsData[WDT_COUNT];
 			threadNumTable[hashString(threadNames[i])] = i;
 		}
-		memset(threadSlots, 0, sizeof(threadSlots));
+		for (auto& slot : threadSlots) {
+			slot.primary   = false;
+			slot.active    = false;
+			slot.regorder  = 0;
+		}
 
 		// disable if gdb is running
 		if (Platform::IsRunningInDebugger()) {
@@ -416,10 +423,17 @@ namespace Watchdog
 		hangDetectorThread.join();
 		LOG_L(L_INFO, "[WatchDog::%s][3]", __func__);
 
-		memset(registeredThreadsData, 0, sizeof(registeredThreadsData));
+		for (auto& info : registeredThreadsData) {
+			info.ResetThreadInfo();
+			info.ResetThreadControls();
+		}
 		for (unsigned int i = 0; i < WDT_COUNT; ++i)
 			registeredThreads[i] = &registeredThreadsData[WDT_COUNT];
-		memset(threadSlots, 0, sizeof(threadSlots));
+		for (auto& slot : threadSlots) {
+			slot.primary   = false;
+			slot.active    = false;
+			slot.regorder  = 0;
+		}
 		threadNumTable.clear();
 	}
 }


### PR DESCRIPTION
## Purpose
Fix the warning spam when compiling with clang, gcc, or msvc (mostly clang). This PR focuses on the "legit" bugs found when compiling with -Wall (which has a lot of nits/false positives). Wall is only used in debug builds so I'm not worried about fixing all of them.

I went through and successfully compiled every fix, and pulled the actual warning from the compiler into a review comment. And explained the associated bug.

# AI Disclosure
This PR was generated through running claude code in a loop to fix every warning. However, every non-trivial change was inspected and several "fixes" were dropped in favor of different solutions to try and keep backwards compatibility in mind. I've called out the couple places where I don't understand the fix or the implication of the fix to other reviewers.