### PR TITLE
refactor: move cob thread tracking to a slot pool for performance

### DIFF
--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobInstance.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobScriptNames.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobThread.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/CobThreadID.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/LuaScriptNames.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/LuaUnitScript.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/Scripts/NullUnitScript.cpp"

--- a/rts/Sim/Units/Scripts/CobEngine.cpp
+++ b/rts/Sim/Units/Scripts/CobEngine.cpp
@@ -7,14 +7,28 @@
 #include "CobThread.h"
 #include "CobFile.h"
 
+#include <cstddef>
 #include <cstdint>
 #include "System/Misc/TracyDefs.h"
 #include "Lua/LuaUI.h"
 
+// For slot pool generation handling.
+// We're using 13 generation bits / 18 slot bits so that:
+// * at 32k MAX_UNITS, every unit could have 8 cob scripts
+// * there's room for 8,192 generations
+// both of which are WELL beyond the supported use case of the engine.
+static constexpr uint32_t THREAD_ID_GEN_BITS  = 13;
+static constexpr uint32_t THREAD_ID_SLOT_BITS = 18;
+constexpr static uint32_t GENERATION_MAX = (1 << THREAD_ID_GEN_BITS) - 1;
+constexpr static uint32_t SLOT_MAX = (1 << THREAD_ID_SLOT_BITS) - 1;
+static_assert(THREAD_ID_GEN_BITS + THREAD_ID_SLOT_BITS <= 31,                                  
+			"thread id must fit in non-negative int");
+
 CR_BIND(CCobEngine, )
 
 CR_REG_METADATA(CCobEngine, (
-	CR_MEMBER(threadInstances),
+	CR_MEMBER(threadSlots),
+	CR_MEMBER(recycledThreadSlots),
 	CR_MEMBER(tickAddedThreads),
 	CR_MEMBER(tickRemovedThreads),
 	CR_MEMBER(runningThreadIDs),
@@ -25,8 +39,7 @@ CR_REG_METADATA(CCobEngine, (
 	CR_IGNORED(curThread),
 	CR_IGNORED(deferredCallins),
 
-	CR_MEMBER(currentTime),
-	CR_MEMBER(threadCounter)
+	CR_MEMBER(currentTime)
 ))
 
 CR_BIND(CCobEngine::SleepingThread, )
@@ -34,38 +47,75 @@ CR_REG_METADATA(CCobEngine::SleepingThread, (
 	CR_MEMBER(id),
 	CR_MEMBER(wt)
 ))
+CR_BIND(CCobEngine::Slot, )
+CR_REG_METADATA(CCobEngine::Slot, (
+	CR_MEMBER(generation),
+	CR_MEMBER(isOccupied),
+	CR_MEMBER(thread)
+))
 
 static const char* const numCobThreadsPlot = "CobThreads";
+
+int CCobEngine::AllocateThreadID()
+{
+	size_t slotIndex;
+    
+	if (recycledThreadSlots.empty()) {
+		slotIndex = threadSlots.size();
+		threadSlots.emplace_back();
+	} else {
+		slotIndex = recycledThreadSlots.back();
+		recycledThreadSlots.pop_back();
+	}
+	
+	Slot* slot = &threadSlots[slotIndex];
+	slot->generation = (slot->generation + 1) & GENERATION_MAX;
+	slot->isOccupied = true;
+	return PackThreadID(slot->generation, slotIndex);
+}
 
 int CCobEngine::AddThread(CCobThread&& thread)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (thread.GetID() == -1)
-		thread.SetID(GenThreadID());
+	if (thread.GetID() == -1) {
+		thread.SetID(AllocateThreadID());
+	}
+	
+	uint32_t generation;
+    size_t slotIndex;
+    UnpackThreadID(thread.GetID(), generation, slotIndex);
+	
+	Slot* slot = &threadSlots[slotIndex];
+	slot->thread = std::move(thread);
+	slot->thread.cobInst->AddThreadID(slot->thread.GetID());
 
-	CCobInstance* o = thread.cobInst;
-	CCobThread& t = threadInstances[thread.GetID()];
-
-	// move thread into registry, hand its ID to owner
-	t = std::move(thread);
-	o->AddThreadID(t.GetID());
-
-	TracyPlot(numCobThreadsPlot, static_cast<int64_t>(threadInstances.size()));
-
-	return (t.GetID());
+	TracyPlot(numCobThreadsPlot, static_cast<int64_t>(threadSlots.size() - recycledThreadSlots.size()));
+	return slot->thread.GetID();
 }
 
 bool CCobEngine::RemoveThread(int threadID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const auto it = threadInstances.find(threadID);
 
-	if (it != threadInstances.end()) {
-		threadInstances.erase(it);
-		TracyPlot(numCobThreadsPlot, static_cast<int64_t>(threadInstances.size()));
-		return true;
+    size_t slotIndex;
+	uint32_t generation;
+	UnpackThreadID(threadID,  generation, slotIndex);
+	if unlikely(slotIndex >= threadSlots.size()) {
+    	return false;
 	}
 
-	return false;
+	Slot* matchingSlot = &threadSlots[slotIndex];
+	if (!matchingSlot->isOccupied || matchingSlot->generation != generation) {
+		return false;
+	}
+
+	std::destroy_at(&matchingSlot->thread);
+	std::construct_at(&matchingSlot->thread); // avoids double destruct when the deque tears down at engine shutdown
+
+	matchingSlot->isOccupied = false;
+	recycledThreadSlots.push_back(slotIndex);
+
+	TracyPlot(numCobThreadsPlot, static_cast<int64_t>(threadSlots.size() - recycledThreadSlots.size()));
+	return true;
 }
 
 void CCobEngine::ProcessQueuedThreads() {
@@ -78,7 +128,7 @@ void CCobEngine::ProcessQueuedThreads() {
 	}
 	tickRemovedThreads.clear();
 
-	// move new threads spawned by START into threadInstances;
+	// move new threads spawned by START into threadSlots;
 	// their ID's will already have been scheduled into either
 	// waitingThreadIDs or sleepingThreadIDs
 	for (CCobThread& t: tickAddedThreads) {
@@ -110,8 +160,8 @@ void CCobEngine::SanityCheckThreads(const CCobInstance* owner)
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (false) {
 		// no threads belonging to owner should be left
-		for (const auto& p: threadInstances) {
-			assert(p.second.cobInst != owner);
+		for (const auto& p: threadSlots) {
+			assert(p.thread.cobInst != owner || p.isOccupied == false);
 		}
 		for (const CCobThread& t: tickAddedThreads) {
 			assert(t.cobInst != owner);
@@ -237,4 +287,19 @@ void CCobEngine::RunDeferredCallins()
 		if (luaUI)
 			luaUI->Cob2LuaBatch(cmdStr, callins);
 	}
+}
+
+int CCobEngine::PackThreadID(const uint32_t generation, const size_t slotIndex) {
+	assert(slotIndex <= SLOT_MAX);
+	assert(generation <= GENERATION_MAX);
+	if unlikely (slotIndex > SLOT_MAX || generation > GENERATION_MAX) {
+		return -1;
+	}
+	return static_cast<int>((generation << THREAD_ID_SLOT_BITS) | slotIndex);
+}
+
+void CCobEngine::UnpackThreadID(const int threadID, uint32_t& generation, size_t& slotIndex) {
+	const uint32_t bits = static_cast<uint32_t>(threadID);
+	generation = (bits >> THREAD_ID_SLOT_BITS) & GENERATION_MAX;
+	slotIndex = bits & SLOT_MAX;
 }

--- a/rts/Sim/Units/Scripts/CobEngine.cpp
+++ b/rts/Sim/Units/Scripts/CobEngine.cpp
@@ -80,7 +80,8 @@ int CCobEngine::AddThread(CCobThread&& thread)
 	if (thread.GetID() == -1) {
 		thread.SetID(AllocateThreadID());
 	}
-	
+	assert(thread.GetID() >= 0);
+
 	uint32_t generation;
     size_t slotIndex;
     UnpackThreadID(thread.GetID(), generation, slotIndex);
@@ -95,6 +96,7 @@ int CCobEngine::AddThread(CCobThread&& thread)
 
 bool CCobEngine::RemoveThread(int threadID) {
 	RECOIL_DETAILED_TRACY_ZONE;
+	assert(threadID >= 0);
 
     size_t slotIndex;
 	uint32_t generation;
@@ -293,6 +295,8 @@ int CCobEngine::PackThreadID(const uint32_t generation, const size_t slotIndex) 
 	assert(slotIndex <= SLOT_MAX);
 	assert(generation <= GENERATION_MAX);
 	if unlikely (slotIndex > SLOT_MAX || generation > GENERATION_MAX) {
+		LOG_L(L_ERROR, "[CCobEngine::%s] cannot pack id (generation=%u, slotIndex=%zu) — exceeds GENERATION_MAX=%u or SLOT_MAX=%u",
+			__func__, generation, slotIndex, GENERATION_MAX, SLOT_MAX);
 		return -1;
 	}
 	return static_cast<int>((generation << THREAD_ID_SLOT_BITS) | slotIndex);

--- a/rts/Sim/Units/Scripts/CobEngine.cpp
+++ b/rts/Sim/Units/Scripts/CobEngine.cpp
@@ -12,18 +12,6 @@
 #include "System/Misc/TracyDefs.h"
 #include "Lua/LuaUI.h"
 
-// For slot pool generation handling.
-// We're using 13 generation bits / 18 slot bits so that:
-// * at 32k MAX_UNITS, every unit could have 8 cob scripts
-// * there's room for 8,192 generations
-// both of which are WELL beyond the supported use case of the engine.
-static constexpr uint32_t THREAD_ID_GEN_BITS  = 13;
-static constexpr uint32_t THREAD_ID_SLOT_BITS = 18;
-constexpr static uint32_t GENERATION_MAX = (1 << THREAD_ID_GEN_BITS) - 1;
-constexpr static uint32_t SLOT_MAX = (1 << THREAD_ID_SLOT_BITS) - 1;
-static_assert(THREAD_ID_GEN_BITS + THREAD_ID_SLOT_BITS <= 31,                                  
-			"thread id must fit in non-negative int");
-
 CR_BIND(CCobEngine, )
 
 CR_REG_METADATA(CCobEngine, (
@@ -56,7 +44,7 @@ CR_REG_METADATA(CCobEngine::Slot, (
 
 static const char* const numCobThreadsPlot = "CobThreads";
 
-int CCobEngine::AllocateThreadID()
+CobThreadID CCobEngine::AllocateThreadID()
 {
 	size_t slotIndex;
     
@@ -69,23 +57,23 @@ int CCobEngine::AllocateThreadID()
 	}
 	
 	Slot* slot = &threadSlots[slotIndex];
-	slot->generation = (slot->generation + 1) & GENERATION_MAX;
+	slot->generation = (slot->generation + 1) & CobThreadID::GEN_MAX;
 	slot->isOccupied = true;
-	return PackThreadID(slot->generation, slotIndex);
+	return CobThreadID::Pack(slot->generation, slotIndex);
 }
 
-int CCobEngine::AddThread(CCobThread&& thread)
+CobThreadID CCobEngine::AddThread(CCobThread&& thread)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (thread.GetID() == -1) {
+	if (!thread.GetID().IsValid()) {
 		thread.SetID(AllocateThreadID());
 	}
-	assert(thread.GetID() >= 0);
+	assert(thread.GetID().IsValid());
 
 	uint32_t generation;
     size_t slotIndex;
-    UnpackThreadID(thread.GetID(), generation, slotIndex);
-	
+    thread.GetID().Unpack(generation, slotIndex);
+
 	Slot* slot = &threadSlots[slotIndex];
 	slot->thread = std::move(thread);
 	slot->thread.cobInst->AddThreadID(slot->thread.GetID());
@@ -94,13 +82,13 @@ int CCobEngine::AddThread(CCobThread&& thread)
 	return slot->thread.GetID();
 }
 
-bool CCobEngine::RemoveThread(int threadID) {
+bool CCobEngine::RemoveThread(CobThreadID threadID) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	assert(threadID >= 0);
+	assert(threadID.IsValid());
 
     size_t slotIndex;
 	uint32_t generation;
-	UnpackThreadID(threadID,  generation, slotIndex);
+	threadID.Unpack(generation, slotIndex);
 	if unlikely(slotIndex >= threadSlots.size()) {
     	return false;
 	}
@@ -125,7 +113,7 @@ void CCobEngine::ProcessQueuedThreads() {
 
 	// Remove threads killed during Tick by other thread (SIGNAL), we do it
 	// here as nothing is actively referencing any thread's memory here.
-	for (int threadID: tickRemovedThreads) {
+	for (CobThreadID threadID: tickRemovedThreads) {
 		RemoveThread(threadID);
 	}
 	tickRemovedThreads.clear();
@@ -152,7 +140,7 @@ void CCobEngine::ScheduleThread(const CCobThread* thread)
 			sleepingThreadIDs.push(SleepingThread{thread->GetID(), thread->GetWakeTime()});
 		} break;
 		default: {
-			LOG_L(L_ERROR, "[COBEngine::%s] unknown state %d for thread %d", __func__, thread->GetState(), thread->GetID());
+			LOG_L(L_ERROR, "[COBEngine::%s] unknown state %d for thread %d", __func__, thread->GetState(), thread->GetID().Raw());
 		} break;
 	}
 }
@@ -216,7 +204,7 @@ void CCobEngine::WakeSleepingThreads()
 				RemoveThread(zzzThread->GetID());
 			} break;
 			default: {
-				LOG_L(L_ERROR, "[COBEngine::%s] unknown state %d for thread %d", __func__, zzzThread->GetState(), zzzThread->GetID());
+				LOG_L(L_ERROR, "[COBEngine::%s] unknown state %d for thread %d", __func__, zzzThread->GetState(), zzzThread->GetID().Raw());
 			} break;
 		}
 	}
@@ -226,7 +214,7 @@ void CCobEngine::TickRunningThreads()
 {
 	ZoneScoped;
 	// advance all currently running threads
-	for (const int threadID: runningThreadIDs) {
+	for (const CobThreadID threadID: runningThreadIDs) {
 		TickThread(GetThread(threadID));
 	}
 
@@ -291,19 +279,3 @@ void CCobEngine::RunDeferredCallins()
 	}
 }
 
-int CCobEngine::PackThreadID(const uint32_t generation, const size_t slotIndex) {
-	assert(slotIndex <= SLOT_MAX);
-	assert(generation <= GENERATION_MAX);
-	if unlikely (slotIndex > SLOT_MAX || generation > GENERATION_MAX) {
-		LOG_L(L_ERROR, "[CCobEngine::%s] cannot pack id (generation=%u, slotIndex=%zu) — exceeds GENERATION_MAX=%u or SLOT_MAX=%u",
-			__func__, generation, slotIndex, GENERATION_MAX, SLOT_MAX);
-		return -1;
-	}
-	return static_cast<int>((generation << THREAD_ID_SLOT_BITS) | slotIndex);
-}
-
-void CCobEngine::UnpackThreadID(const int threadID, uint32_t& generation, size_t& slotIndex) {
-	const uint32_t bits = static_cast<uint32_t>(threadID);
-	generation = (bits >> THREAD_ID_SLOT_BITS) & GENERATION_MAX;
-	slotIndex = bits & SLOT_MAX;
-}

--- a/rts/Sim/Units/Scripts/CobEngine.h
+++ b/rts/Sim/Units/Scripts/CobEngine.h
@@ -9,12 +9,13 @@
  */
 
 #include <vector>
+#include <deque>
 
 #include "CobThread.h"
 #include "CobDeferredCallin.h"
 #include "System/creg/creg_cond.h"
 #include "System/creg/STL_Queue.h"
-#include "System/creg/STL_Map.h"
+#include "System/creg/STL_Deque.h"
 #include "System/Cpp11Compat.hpp"
 
 class CCobThread;
@@ -34,6 +35,15 @@ public:
 		int wt;
 	};
 
+	struct Slot {
+		CR_DECLARE_STRUCT(Slot)
+
+		uint32_t generation = 0;
+		bool isOccupied = false;
+
+		CCobThread thread;
+	};
+
 	struct CCobThreadComp {
 	public:
 		bool operator() (const SleepingThread& a, const SleepingThread& b) const {
@@ -43,7 +53,6 @@ public:
 
 public:
 	void Init() {
-		threadInstances.reserve(2048);
 		tickAddedThreads.reserve(128);
 
 		runningThreadIDs.reserve(512);
@@ -54,12 +63,12 @@ public:
 		curThread = nullptr;
 
 		currentTime = 0;
-		threadCounter = 0;
 	}
 	void Kill() {
-		// threadInstances is never explicitly iterated in the actual code,
-		// but iterated during sync dumps, so clean it with clear_unordered_map
-		spring::clear_unordered_map(threadInstances);
+		// threadSlots is never explicitly iterated in the actual code,
+		// but iterated during sync dumps, so clear it
+		threadSlots.clear();
+		recycledThreadSlots.clear();
 		spring::clear_unordered_map(deferredCallins);
 		tickAddedThreads.clear();
 
@@ -76,17 +85,23 @@ public:
 
 
 	CCobThread* GetThread(int threadID) {
-		const auto it = threadInstances.find(threadID);
-
-		if (it == threadInstances.end())
+		uint32_t generation;
+		size_t slotIndex;
+		UnpackThreadID(threadID, generation, slotIndex);
+		if (slotIndex >= threadSlots.size()) {
 			return nullptr;
+		}
 
-		return &(it->second);
+		Slot* matchingSlot = &threadSlots[slotIndex];
+		if (!matchingSlot->isOccupied || matchingSlot->generation != generation) {
+			return nullptr;
+		}
+
+		return &matchingSlot->thread;
 	}
 
 	bool RemoveThread(int threadID);
 	int AddThread(CCobThread&& thread);
-	int GenThreadID() { return (threadCounter++); }
 
 	void QueueAddThread(CCobThread&& thread) { tickAddedThreads.emplace_back(std::move(thread)); }
 	void QueueRemoveThread(int threadID) { tickRemovedThreads.emplace_back(threadID); }
@@ -95,15 +110,19 @@ public:
 	void ScheduleThread(const CCobThread* thread);
 	void SanityCheckThreads(const CCobInstance* owner);
 
-	const auto& GetThreadInstances() const { return threadInstances; }
+	// HACK: cob threads currently need their id ahead of being stored. A refactor
+	//       that relies on the new stability guarantees of the deque/slots means we 
+	//       could AddThread instead of separating thread ids from storage.
+	// this MUST be followed by an AddThread or a QueueAddThread or slots will leak.
+	int AllocateThreadID();
+
+	const auto& GetThreadSlots() const { return threadSlots; }
 //	const auto& GetTickAddedThreads() const { return tickAddedThreads; }
 //	const auto& GetTickRemovedThreads() const { return tickRemovedThreads; }
 //	const auto& GetRunningThreadIDs() const { return runningThreadIDs; }
 	const auto& GetWaitingThreadIDs() const { return waitingThreadIDs; }
 	const auto& GetSleepingThreadIDs() const { return sleepingThreadIDs; }
 	const auto  GetCurrTime() const { return currentTime; }
-	const auto  GetThreadCounter() const { return threadCounter; }
-	const auto  GetCurrCounter() const { return threadCounter; }
 
 	void AddDeferredCallin(CCobDeferredCallin&& deferredCallin);
 	void RunDeferredCallins();
@@ -113,9 +132,14 @@ private:
 	void WakeSleepingThreads();
 	void TickRunningThreads();
 
+	static int PackThreadID(uint32_t generation, size_t slotIndex);
+	static void UnpackThreadID(int threadID, uint32_t& generation, size_t& slotIndex);
+
 private:
-	// registry of every thread across all script instances
-	spring::unordered_map<int, CCobThread> threadInstances;
+	// slot pool of live threads across all script instances, indexed by id
+	// (this is a perf optimization to reuse instances since theres so much churn)
+	std::deque<Slot> threadSlots;
+	std::vector<size_t> recycledThreadSlots;
 	// threads that are spawned during Tick
 	std::vector<CCobThread> tickAddedThreads;
 	// threads that are killed during Tick
@@ -133,7 +157,6 @@ private:
 	CCobThread* curThread = nullptr;
 
 	int currentTime = 0;
-	int threadCounter = 0;
 };
 
 

--- a/rts/Sim/Units/Scripts/CobEngine.h
+++ b/rts/Sim/Units/Scripts/CobEngine.h
@@ -12,6 +12,7 @@
 #include <deque>
 
 #include "CobThread.h"
+#include "CobThreadID.h"
 #include "CobDeferredCallin.h"
 #include "System/creg/creg_cond.h"
 #include "System/creg/STL_Queue.h"
@@ -31,7 +32,7 @@ public:
 	struct SleepingThread {
 		CR_DECLARE_STRUCT(SleepingThread)
 
-		int id;
+		CobThreadID id;
 		int wt;
 	};
 
@@ -84,10 +85,10 @@ public:
 	void ShowScriptError(const std::string& msg);
 
 
-	CCobThread* GetThread(int threadID) {
+	CCobThread* GetThread(CobThreadID threadID) {
 		uint32_t generation;
 		size_t slotIndex;
-		UnpackThreadID(threadID, generation, slotIndex);
+		threadID.Unpack(generation, slotIndex);
 		if (slotIndex >= threadSlots.size()) {
 			return nullptr;
 		}
@@ -100,11 +101,11 @@ public:
 		return &matchingSlot->thread;
 	}
 
-	bool RemoveThread(int threadID);
-	int AddThread(CCobThread&& thread);
+	bool RemoveThread(CobThreadID threadID);
+	CobThreadID AddThread(CCobThread&& thread);
 
 	void QueueAddThread(CCobThread&& thread) { tickAddedThreads.emplace_back(std::move(thread)); }
-	void QueueRemoveThread(int threadID) { tickRemovedThreads.emplace_back(threadID); }
+	void QueueRemoveThread(CobThreadID threadID) { tickRemovedThreads.emplace_back(threadID); }
 	void ProcessQueuedThreads();
 
 	void ScheduleThread(const CCobThread* thread);
@@ -114,7 +115,7 @@ public:
 	//       that relies on the new stability guarantees of the deque/slots means we 
 	//       could AddThread instead of separating thread ids from storage.
 	// this MUST be followed by an AddThread or a QueueAddThread or slots will leak.
-	int AllocateThreadID();
+	CobThreadID AllocateThreadID();
 
 	const auto& GetThreadSlots() const { return threadSlots; }
 //	const auto& GetTickAddedThreads() const { return tickAddedThreads; }
@@ -132,9 +133,6 @@ private:
 	void WakeSleepingThreads();
 	void TickRunningThreads();
 
-	static int PackThreadID(uint32_t generation, size_t slotIndex);
-	static void UnpackThreadID(int threadID, uint32_t& generation, size_t& slotIndex);
-
 private:
 	// slot pool of live threads across all script instances, indexed by id
 	// (this is a perf optimization to reuse instances since theres so much churn)
@@ -143,10 +141,10 @@ private:
 	// threads that are spawned during Tick
 	std::vector<CCobThread> tickAddedThreads;
 	// threads that are killed during Tick
-	std::vector<int> tickRemovedThreads;
+	std::vector<CobThreadID> tickRemovedThreads;
 
-	std::vector<int> runningThreadIDs;
-	std::vector<int> waitingThreadIDs;
+	std::vector<CobThreadID> runningThreadIDs;
+	std::vector<CobThreadID> waitingThreadIDs;
 
 	spring::unordered_map<int, std::vector<CCobDeferredCallin> > deferredCallins;
 

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -568,7 +568,7 @@ int CCobInstance::RealCall(int functionId, std::array<int, 1 + MAX_COB_ARGS>& ar
 
 	// tick the thread locally in case we're recursively running this function and then the threads may reallocate
 	CCobThread newThread(this);
-	newThread.SetID(cobEngine->GenThreadID());
+	newThread.SetID(cobEngine->AllocateThreadID());
 
 	// make sure this is run even if the call terminates instantly
 	if (cb != CBNone)

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -83,6 +83,7 @@ void CCobInstance::PostLoad()
 
 	for (int threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
+		assert(t != nullptr);
 
 		t->cobInst = this;
 		t->cobFile = cobFile;
@@ -101,18 +102,12 @@ CCobInstance::~CCobInstance()
 	// delete our threads, make sure callbacks do not run.
 	// MakeGarbage() neuters Stop()'s self-removal, so we own the pop_back here.
 	while (!threadIDs.empty()) {
-		const int threadID = threadIDs.back();
-		threadIDs.pop_back();
-
-		CCobThread* t = cobEngine->GetThread(threadID);
-		if (t == nullptr) {
-			LOG_L(L_ERROR, "[CCobInstance::%s] stale thread id %d in threadIDs (instance=%p, unit=%d)",
-				__func__, threadID, static_cast<void*>(this), (unit != nullptr ? unit->id : -1));
-			continue;
-		}
+		CCobThread* t = cobEngine->GetThread(threadIDs.back());
+		assert(t != nullptr);
 
 		t->MakeGarbage();
-		cobEngine->RemoveThread(threadID);
+		cobEngine->RemoveThread(t->GetID());
+		threadIDs.pop_back();
 	}
 
 	cobEngine->SanityCheckThreads(this);
@@ -521,6 +516,7 @@ void CCobInstance::AnimFinished(AnimType type, int piece, int axis)
 	ZoneScoped;
 	for (int threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
+		assert(t != nullptr);
 		t->AnimFinished(type, piece, axis);
 	}
 }
@@ -741,6 +737,7 @@ void CCobInstance::Signal(int signal)
 	RECOIL_DETAILED_TRACY_ZONE;
 	for (int threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
+		assert(t != nullptr);
 
 		if ((signal & t->GetSignalMask()) == 0)
 			continue;

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -98,14 +98,21 @@ CCobInstance::~CCobInstance()
 	// this may be dangerous, is it really desired?
 	// Destroy();
 
-	// delete our threads, make sure callbacks do not run
+	// delete our threads, make sure callbacks do not run.
+	// MakeGarbage() neuters Stop()'s self-removal, so we own the pop_back here.
 	while (!threadIDs.empty()) {
-		CCobThread* t = cobEngine->GetThread(threadIDs.back());
+		const int threadID = threadIDs.back();
+		threadIDs.pop_back();
+
+		CCobThread* t = cobEngine->GetThread(threadID);
+		if (t == nullptr) {
+			LOG_L(L_ERROR, "[CCobInstance::%s] stale thread id %d in threadIDs (instance=%p, unit=%d)",
+				__func__, threadID, static_cast<void*>(this), (unit != nullptr ? unit->id : -1));
+			continue;
+		}
 
 		t->MakeGarbage();
-		cobEngine->RemoveThread(t->GetID());
-
-		threadIDs.pop_back();
+		cobEngine->RemoveThread(threadID);
 	}
 
 	cobEngine->SanityCheckThreads(this);
@@ -603,6 +610,8 @@ int CCobInstance::RealCall(int functionId, std::array<int, 1 + MAX_COB_ARGS>& ar
 		// dtor runs the callback
 		if (retCode != nullptr)
 			*retCode = newThread.GetRetCode();
+
+		cobEngine->RemoveThread(newThread.GetID());
 	} else {
 		cobEngine->AddThread(std::move(newThread));
 	}

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -81,7 +81,7 @@ void CCobInstance::PostLoad()
 
 	cobFile = cobFileHandler->GetCobFile(unit->unitDef->scriptName);
 
-	for (int threadID: threadIDs) {
+	for (CobThreadID threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
 		assert(t != nullptr);
 
@@ -514,7 +514,7 @@ float CCobInstance::TargetWeight(int weaponNum, const CUnit* targetUnit)
 void CCobInstance::AnimFinished(AnimType type, int piece, int axis)
 {
 	ZoneScoped;
-	for (int threadID: threadIDs) {
+	for (CobThreadID threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
 		assert(t != nullptr);
 		t->AnimFinished(type, piece, axis);
@@ -611,6 +611,7 @@ int CCobInstance::RealCall(int functionId, std::array<int, 1 + MAX_COB_ARGS>& ar
 	} else {
 		cobEngine->AddThread(std::move(newThread));
 	}
+
 
 	// handle any spawned threads
 	cobEngine->ProcessQueuedThreads();
@@ -735,7 +736,7 @@ void CCobInstance::ThreadCallback(ThreadCallbackType type, int retCode, int cbPa
 void CCobInstance::Signal(int signal)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	for (int threadID: threadIDs) {
+	for (CobThreadID threadID: threadIDs) {
 		CCobThread* t = cobEngine->GetThread(threadID);
 		assert(t != nullptr);
 

--- a/rts/Sim/Units/Scripts/CobInstance.h
+++ b/rts/Sim/Units/Scripts/CobInstance.h
@@ -3,6 +3,7 @@
 #ifndef COB_INSTANCE_H
 #define COB_INSTANCE_H
 
+#include "CobThreadID.h"
 #include "UnitScript.h"
 #include "Sim/Units/Unit.h"
 
@@ -48,7 +49,7 @@ public:
 	CCobFile* cobFile;
 
 	std::vector<int> staticVars;
-	std::vector<int> threadIDs;
+	std::vector<CobThreadID> threadIDs;
 
 public:
 	// creg only
@@ -59,8 +60,8 @@ public:
 	void Init();
 	void PostLoad();
 
-	void AddThreadID(int threadID) { threadIDs.push_back(threadID); }
-	bool RemoveThreadID(int threadID)
+	void AddThreadID(CobThreadID threadID) { threadIDs.push_back(threadID); }
+	bool RemoveThreadID(CobThreadID threadID)
 	{
 		const auto it = std::find(threadIDs.begin(), threadIDs.end(), threadID);
 

--- a/rts/Sim/Units/Scripts/CobThread.cpp
+++ b/rts/Sim/Units/Scripts/CobThread.cpp
@@ -379,7 +379,7 @@ bool CCobThread::Tick()
 
 				CCobThread t(cobInst);
 
-				t.SetID(cobEngine->GenThreadID());
+				t.SetID(cobEngine->AllocateThreadID());
 				t.InitStack(r2, this);
 				t.Start(r1, signalMask, {{0}}, true);
 

--- a/rts/Sim/Units/Scripts/CobThread.h
+++ b/rts/Sim/Units/Scripts/CobThread.h
@@ -7,6 +7,7 @@
 #include <array>
 
 #include "CobInstance.h"
+#include "CobThreadID.h"
 #include "Lua/LuaRules.h"
 
 class CCobFile;
@@ -67,7 +68,7 @@ public:
 	void Start(int functionId, int sigMask, const std::array<int, 1 + MAX_COB_ARGS>& args, bool schedule);
 	void Stop();
 
-	void SetID(int threadID) { id = threadID; }
+	void SetID(CobThreadID threadID) { id = threadID; }
 	void SetState(State s) { state = s; }
 
 	/**
@@ -100,7 +101,7 @@ public:
 
 	const std::string& GetName();
 
-	int GetID() const { return id; }
+	CobThreadID GetID() const { return id; }
 	int GetStackVal(int pos) const { return dataStack[pos]; }
 	int GetWakeTime() const { return wakeTime; }
 	int GetRetCode() const { return retCode; }
@@ -148,7 +149,7 @@ protected:
 	}
 
 protected:
-	int id = -1;
+	CobThreadID id;
 	int pc = 0;
 
 	int wakeTime = 0;

--- a/rts/Sim/Units/Scripts/CobThreadID.cpp
+++ b/rts/Sim/Units/Scripts/CobThreadID.cpp
@@ -1,0 +1,24 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "CobThreadID.h"
+
+#include <cassert>
+
+#include "System/BranchPrediction.h"
+#include "System/Log/ILog.h"
+
+CR_BIND(CobThreadID, )
+CR_REG_METADATA(CobThreadID, (
+	CR_MEMBER(raw)
+))
+
+CobThreadID CobThreadID::Pack(const uint32_t generation, const size_t slotIndex) {
+	assert(slotIndex <= SLOT_MAX);
+	assert(generation <= GEN_MAX);
+	if unlikely (slotIndex > SLOT_MAX || generation > GEN_MAX) {
+		LOG_L(L_ERROR, "[CobThreadID::%s] cannot pack id (generation=%u, slotIndex=%zu) — exceeds GEN_MAX=%u or SLOT_MAX=%u",
+			__func__, generation, slotIndex, GEN_MAX, SLOT_MAX);
+		return CobThreadID::Invalid();
+	}
+	return CobThreadID(static_cast<int>((generation << SLOT_BITS) | slotIndex));
+}

--- a/rts/Sim/Units/Scripts/CobThreadID.h
+++ b/rts/Sim/Units/Scripts/CobThreadID.h
@@ -1,0 +1,58 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef COB_THREAD_ID_H
+#define COB_THREAD_ID_H
+
+#include <compare>
+#include <cstdint>
+#include <ostream>
+
+#include "System/creg/creg_cond.h"
+
+#include <cstddef>
+
+// Opaque handle for a thread inside CCobEngine's slot pool. The payload
+// packs a generation and a slot index.
+class CobThreadID
+{
+	CR_DECLARE_STRUCT(CobThreadID)
+
+public:
+	// We're using 13 generation bits / 18 slot bits so that:
+	// * at 32k MAX_UNITS, every unit could have 8 cob scripts
+	// * there's room for 8,192 generations
+	// both of which are WELL beyond the supported use case of the engine.
+	static constexpr uint32_t GEN_BITS  = 13;
+	static constexpr uint32_t SLOT_BITS = 18;
+	static constexpr uint32_t GEN_MAX   = (1u << GEN_BITS)  - 1;
+	static constexpr uint32_t SLOT_MAX  = (1u << SLOT_BITS) - 1;
+	static_assert(GEN_BITS + SLOT_BITS <= 31, "thread id must fit in non-negative int");
+
+	constexpr CobThreadID() = default;
+	constexpr explicit CobThreadID(int rawValue) : raw(rawValue) {}
+
+	static constexpr CobThreadID Invalid() { return CobThreadID(-1); }
+	static CobThreadID Pack(uint32_t generation, size_t slotIndex);
+
+	constexpr bool IsValid() const { return raw >= 0; }
+	constexpr int  Raw()     const { return raw; }
+
+	// inlining because unpack gets called at least once per cob thread per sim frame
+	void Unpack(uint32_t& generation, size_t& slotIndex) const {
+		const uint32_t bits = static_cast<uint32_t>(raw);
+		generation = (bits >> SLOT_BITS) & GEN_MAX;
+		slotIndex  = bits & SLOT_MAX;
+	}
+
+	friend constexpr bool operator==(CobThreadID, CobThreadID) = default;
+	friend constexpr auto operator<=>(CobThreadID, CobThreadID) = default;
+
+	friend std::ostream& operator<<(std::ostream& os, CobThreadID id) {
+		return os << id.raw;
+	}
+
+private:
+	int32_t raw = -1;
+};
+
+#endif // COB_THREAD_ID_H

--- a/rts/System/Sync/DumpState.cpp
+++ b/rts/System/Sync/DumpState.cpp
@@ -560,13 +560,20 @@ void DumpState(int newMinFrameNum, int newMaxFrameNum, int newFramePeriod, std::
 	#endif
 	#ifdef DUMP_UNIT_SCRIPT_COB_DATA
 	{
+		const auto& slots = cobEngine->GetThreadSlots();
+		size_t liveThreads = 0;
+		for (const auto& s : slots) {
+			if (s.isOccupied) ++liveThreads;
+		}
+
 		file << "\tCobEngine:\n";
 		file << "\t\tcurrentTime: " << cobEngine->GetCurrTime();
-		file << "\t\tCobThreads: " << cobEngine->GetThreadInstances().size() << "\n";
-		for (const auto& [tid, thread] : cobEngine->GetThreadInstances()) {
+		file << "\t\tCobThreads: " << liveThreads << "\n";
+		for (const auto& [generation, isOccupied, thread] : slots) {
+			if (!isOccupied) continue;
 			auto ownerID = thread.cobInst->GetUnit() ? thread.cobInst->GetUnit()->id : -1;
 			file
-				<< "\t\t\tid: " << tid << " t.id " << thread.GetID() << " t.wt " << thread.GetWakeTime()
+				<< "\t\t\tgeneration: " << generation << " t.id " << thread.GetID() << " t.wt " << thread.GetWakeTime()
 				<< " owner " << ownerID
 				<< " fn " << thread.cobFile->name
 				<< " code cs " << CheckSum(thread.cobFile->code)


### PR DESCRIPTION
## Change

Moves cob engine's internal storage/tracking of threads to a slot pool backed by a std::deque instead of a spring::unordered_map, to eek out some extra performance.

There's a hack due to ordering requirements of the existing code but I figure a second PR can clean that up - let's keep this PR focused.

## Context

Some instrumentation of our hash maps found that cob was one of the worst users of our spring::unordered_map, because of how many tombstones it would leave behind in the map (cob has constant thread churn).

`spring::unordered_map<int, CCobThread> threadInstances` performance over 5000 late game sim frames was:
```
[HashContainerStats] Top 20 containers by total time (ns/op):
  type                         |  total-ms  |  find-hit |  find-miss |  insert | erase |   rehash
  synced map<int, CCobThread>  |  3031.91ms |     130ns |     1360ns |  1292ns |   0ns | 219100ns
```
Changing it to a chained hashmap fixed the find-miss() ns per op (since it didnt have to search the entire array of tombstones) but made the find() worse because it had to chase bucket pointers.

So, taking a step back and realizing that nothing really iterates on this and the amount of churn it sees, an object pool is probably a better data structure. So let's try it!

## Performance

Tracy:
<img width="1800" height="1075" alt="Screenshot 2026-04-25 at 11 53 28 PM" src="https://github.com/user-attachments/assets/58d49bf7-6d90-41fb-836c-f226ff1a5fff" />
<img width="1796" height="1066" alt="Screenshot 2026-04-25 at 11 54 13 PM" src="https://github.com/user-attachments/assets/05b6036b-2571-4799-97da-771a7e49e2bd" />

Overall:
<img width="802" height="385" alt="Screenshot 2026-04-26 at 12 32 03 AM" src="https://github.com/user-attachments/assets/69f93e02-3107-41c3-b547-8280fb3f30a5" />
<img width="824" height="199" alt="image" src="https://github.com/user-attachments/assets/dd062ec9-0a36-4cb9-93a2-16a6c5d3dd19" />



## AI Disclosure
All hand-written (!) with claude as a guide/reviewer.