### PR TITLE
feat: add new NETMSG_DEDIMSG for private comms to game server

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2,6 +2,8 @@
 
 #include "LuaUnsyncedCtrl.h"
 
+#include <cstdint>
+
 #include "Game/Camera/DollyController.h"
 #include "LuaConfig.h"
 #include "LuaInclude.h"
@@ -255,6 +257,8 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SendLuaGaiaMsg);
 	REGISTER_LUA_CFUNC(SendLuaRulesMsg);
 	REGISTER_LUA_CFUNC(SendLuaMenuMsg);
+
+	REGISTER_LUA_CFUNC(SendDediMsg);
 
 	REGISTER_LUA_CFUNC(LoadCmdColorsConfig);
 	REGISTER_LUA_CFUNC(LoadCtrlPanelConfig);
@@ -3870,6 +3874,65 @@ int LuaUnsyncedCtrl::SendLuaMenuMsg(lua_State* L)
 	if (luaMenu != nullptr)
 		luaMenu->RecvLuaMsg(luaL_checksstring(L, 1), gu->myPlayerNum);
 
+	return 0;
+}
+
+
+/******************************************************************************
+ * Spring.SendDediMsg — opaque server-bound channel.
+ *
+ * Payloads cross the wire as NETMSG_DEDIMSG and terminate in the dedicated
+ * server. They are never broadcast to peers, never written to the demo stream.
+ *
+ * Every message carries a uint16 record-type header (engine-encoded
+ * little-endian) followed by an opaque payload. Headers 0x0001..0x0FFF are
+ * reserved for future engine use. Game code must use 0x1000..0xFFFF.
+******************************************************************************/
+
+namespace {
+
+// On-wire frame: u8 cmd, u16 size, u8 playerNum, u16 header, u8[] payload.
+constexpr size_t   kDediMsgWireOverhead     = sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint8_t);
+constexpr size_t   kDediMsgHeaderSize       = sizeof(uint16_t);
+constexpr size_t   kDediMsgMaxPayload       = (size_t(1) << 16) - 1 - kDediMsgWireOverhead - kDediMsgHeaderSize;
+constexpr uint16_t kDediMsgGameRangeMin   = 0x1000;
+
+} // namespace
+
+
+/***
+ *
+ * @function Spring.SendDediMsg
+ *
+ * Send an opaque payload to the dedicated server, tagged with a uint16
+ * record-type header. The header is engine-encoded little-endian and must be
+ * in the game-private range 0x1000..0xFFFF; values below 0x1000 are reserved
+ * for engine use.
+ *
+ * @param header  integer  record-type tag in [0x1000, 0xFFFF]
+ * @param payload string   raw bytes, up to 65529 bytes
+ * @return nil
+ */
+int LuaUnsyncedCtrl::SendDediMsg(lua_State* L)
+{
+	const lua_Integer headerArg = luaL_checkinteger(L, 1);
+	if (headerArg < kDediMsgGameRangeMin || headerArg > 0xFFFF)
+		luaL_error(L, "SendDediMsg() header 0x%x must be in the game-private range 0x%04x..0xFFFF", (unsigned)headerArg, (unsigned)kDediMsgGameRangeMin);
+
+	size_t payloadLen = 0;
+	const char* payload = luaL_optlstring(L, 2, "", &payloadLen);
+
+	if (payloadLen > kDediMsgMaxPayload)
+		luaL_error(L, "SendDediMsg() payload too large: %d > %d", (int)payloadLen, (int)kDediMsgMaxPayload);
+
+	const auto* bytes = reinterpret_cast<const uint8_t*>(payload);
+	std::vector<uint8_t> payloadBytes(bytes, bytes + payloadLen);
+
+	try {
+		clientNet->Send(CBaseNetProtocol::Get().SendDediMsg(gu->myPlayerNum, static_cast<uint16_t>(headerArg), payloadBytes));
+	} catch (const netcode::PackPacketException& ex) {
+		luaL_error(L, "SendDediMsg() packet error: %s", ex.what());
+	}
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -183,6 +183,8 @@ class LuaUnsyncedCtrl {
 		static int SendLuaRulesMsg(lua_State* L);
 		static int SendLuaMenuMsg(lua_State* L);
 
+		static int SendDediMsg(lua_State* L);
+
 		static int SetLastMessagePosition(lua_State* L);
 
 		static int MarkerAddPoint(lua_State* L);

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -49,6 +49,7 @@
 #include "System/FileSystem/SimpleParser.h"
 #include "System/Net/Connection.h"
 #include "System/Net/LocalConnection.h"
+#include "System/Net/PackPacket.h"
 #include "System/Net/UnpackPacket.h"
 #include "System/LoadSave/DemoRecorder.h"
 #include "System/LoadSave/DemoReader.h"
@@ -191,6 +192,7 @@ void CGameServer::Initialize()
 	{
 		netPingTimings.fill(spring_notime);
 		mapDrawTimings.fill({spring_notime, 0});
+		dediMsgTimings.fill({spring_notime, 0});
 		chatMutedFlags.fill({false, false});
 		aiControlFlags.fill(true);
 
@@ -1347,6 +1349,56 @@ void CGameServer::ProcessPacket(const unsigned playerNum, std::shared_ptr<const 
 
 			} catch (const netcode::UnpackPacketException& ex) {
 				Message(spring::format("[GameServer::%s][NETMSG_LUAMSG] exception \"%s\" from player \"%s\"", ex.what(), players[a].name.c_str()));
+			}
+		} break;
+
+		case NETMSG_DEDIMSG: {
+			// Private channel for clients to talk to the server/autohost without
+			// leaving a replay trace. Never broadcast, never demoed.
+			try {
+				// wire: <u8 cmd><u16 size><u8 playerNum><u16 header><u8[] payload>
+				netcode::UnpackPacket pckt(packet, sizeof(uint8_t) + sizeof(uint16_t));
+				uint8_t  playerNum;
+				uint16_t header;
+
+				pckt >> playerNum;
+				pckt >> header;
+
+				if (playerNum != a) {
+					Message(spring::format(WrongPlayer, msgCode, a, (unsigned)playerNum));
+					break;
+				}
+
+				// these packets shouldn't even exist in a demo
+				// but lets skip parsing them anyways if so
+				if (demoReader != nullptr)
+					break;
+
+				// per-player rate limit: 64 KiB/sec window.
+				constexpr uint32_t kBytesPerSecond = 64 * 1024;
+				constexpr int      kWindowMs       = 1000;
+
+				constexpr size_t kFrameOverhead =
+					sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint8_t);
+				const size_t payloadLen = packet->length - kFrameOverhead;
+
+				const spring_time now = spring_gettime();
+				auto& [windowStart, bytesInWindow] = dediMsgTimings[a];
+
+				if (!windowStart.isTime() || spring_diffmsecs(now, windowStart) >= kWindowMs) {
+					windowStart = now;
+					bytesInWindow = 0;
+				}
+
+				if (bytesInWindow + payloadLen > kBytesPerSecond) {
+					LOG_L(L_WARNING, "[GameServer::NETMSG_DEDIMSG] dropped payload from player %u (rate limit)", (unsigned)playerNum);
+					break;
+				}
+				bytesInWindow += static_cast<uint32_t>(payloadLen);
+
+				// DO SOMETHING in future PR
+			} catch (const netcode::UnpackPacketException& ex) {
+				Message(spring::format("[GameServer::%s][NETMSG_DEDIMSG] exception \"%s\" from player \"%s\"", __func__, ex.what(), players[a].name.c_str()));
 			}
 		} break;
 

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -213,6 +213,7 @@ private:
 
 	std::array<           spring_time           , MAX_PLAYERS> netPingTimings; // throttles NETMSG_PING
 	std::array< std::pair<spring_time, uint32_t>, MAX_PLAYERS> mapDrawTimings; // throttles NETMSG_MAPDRAW
+	std::array< std::pair<spring_time, uint32_t>, MAX_PLAYERS> dediMsgTimings; // throttles NETMSG_DEDIMSG
 	std::array< std::pair<       bool,     bool>, MAX_PLAYERS> chatMutedFlags; // blocks NETMSG_{CHAT,DRAW}
 	std::array<                            bool , MAX_PLAYERS> aiControlFlags; // blocks NETMSG_AI_CREATED (aicontrol)
 

--- a/rts/Net/Protocol/BaseNetProtocol.cpp
+++ b/rts/Net/Protocol/BaseNetProtocol.cpp
@@ -449,6 +449,20 @@ PacketType CBaseNetProtocol::SendLuaMsg(uint8_t playerNum, uint16_t script, uint
 	return PacketType(packet);
 }
 
+PacketType CBaseNetProtocol::SendDediMsg(uint8_t playerNum, uint16_t header, const std::vector<uint8_t>& payload)
+{
+	const uint32_t payloadSize = sizeof(playerNum) + sizeof(header) + payload.size();
+	const uint32_t frameSize   = sizeof(uint8_t) + sizeof(uint16_t);
+	const uint32_t packetSize  = frameSize + payloadSize;
+
+	if (packetSize >= (1 << (sizeof(uint16_t) * 8)))
+		throw netcode::PackPacketException("[BaseNetProto::SendDediMsg] maximum packet-size exceeded");
+
+	PackPacket* packet = new PackPacket(packetSize, NETMSG_DEDIMSG);
+	*packet << static_cast<uint16_t>(packetSize) << playerNum << header << payload;
+	return PacketType(packet);
+}
+
 
 PacketType CBaseNetProtocol::SendGiveAwayEverything(uint8_t playerNum, uint8_t giveToTeam, uint8_t takeFromTeam)
 {
@@ -672,6 +686,7 @@ CBaseNetProtocol::CBaseNetProtocol()
 	proto->AddType(NETMSG_AI_STATE_CHANGED, 4);
 	proto->AddType(NETMSG_GAME_FRAME_PROGRESS, 5);
 	proto->AddType(NETMSG_PING, 1 + (1 + 1 + 4));
+	proto->AddType(NETMSG_DEDIMSG, -2);
 
 #ifdef SYNCDEBUG
 	proto->AddType(NETMSG_SD_CHKREQUEST, 5);

--- a/rts/Net/Protocol/BaseNetProtocol.h
+++ b/rts/Net/Protocol/BaseNetProtocol.h
@@ -80,6 +80,7 @@ public:
 	PacketType SendPlayerLeft(uint8_t playerNum, uint8_t bIntended);
 	PacketType SendLogMsg(uint8_t playerNum, uint8_t logMsgLvl, const std::string& strData);
 	PacketType SendLuaMsg(uint8_t playerNum, uint16_t script, uint8_t mode, const std::vector<uint8_t>& rawData);
+	PacketType SendDediMsg(uint8_t playerNum, uint16_t header, const std::vector<uint8_t>& payload);
 	PacketType SendCurrentFrameProgress(int32_t frameNum);
 	PacketType SendPing(uint8_t playerNum, uint8_t pingTag, float localTime);
 

--- a/rts/Net/Protocol/NetMessageTypes.h
+++ b/rts/Net/Protocol/NetMessageTypes.h
@@ -96,6 +96,8 @@ enum NETMSG {
 
 	NETMSG_PING = 78, // uint8_t playerNum, uint8_t pingTag, float localTime
 
+	NETMSG_DEDIMSG = 79, // /* uint16_t messageSize */, uint8_t playerNum, uint16_t header, std::vector<uint8_t> payload
+
 	NETMSG_LAST //max types of netmessages, internal only
 };
 


### PR DESCRIPTION
First PR: game packet https://github.com/beyond-all-reason/RecoilEngine/issues/2040
Second PR: hook up to autohost https://github.com/beyond-all-reason/RecoilEngine/issues/2040
Third PR: usage of game packets with a small engine stats api, local file https://github.com/beyond-all-reason/RecoilEngine/issues/2041
 Fourth PR: send default engine stats through this API
