### PR TITLE
feat: add DEDIMSG <-> autohost bidirectional channel

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2362,6 +2362,37 @@ bool CLuaHandle::RecvLuaMsg(const string& msg, int playerID)
 }
 
 
+/*** Receives messages from the dedicated server / autohost over the private
+ * NETMSG_DEDIMSG channel. The local Lua side sends these via
+ * `Spring.SendDediMsg`; the autohost replies via the `/dedimsgbynum` PushAction.
+ * Always unsynced -- never fires on synced handles.
+ *
+ * @function Callins:RecvDediMsg
+ * @param msg string  raw bytes from the server (may contain embedded 0's)
+ * @param header integer  record-type tag in [1, 65535]; 1..0xFFF is engine-reserved
+ */
+bool CLuaHandle::RecvDediMsg(const string& msg, int header)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	LUA_CALL_IN_CHECK(L, false);
+	luaL_checkstack(L, 8, __func__);
+
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return false;
+
+	lua_pushsstring(L, msg); // allows embedded 0's
+	lua_pushnumber(L, header);
+
+	if (!RunCallIn(L, cmdStr, 2, 1))
+		return false;
+
+	const bool retval = luaL_optboolean(L, -1, false);
+	lua_pop(L, 1);
+	return retval;
+}
+
+
 /******************************************************************************/
 
 void CLuaHandle::SetDevMode(bool value)
@@ -2466,6 +2497,25 @@ void CLuaHandle::HandleLuaMsg(int playerID, int script, int mode, const std::vec
 				luaRules->RecvLuaMsg(msg, playerID);
 		} break;
 	}
+}
+
+
+void CLuaHandle::HandleDediMsg(int header, const std::vector<std::uint8_t>& data)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	std::string msg;
+	msg.resize(data.size());
+	std::copy(data.begin(), data.end(), msg.begin());
+
+	// Unsynced fan-out only. luaUI is unsynced; luaGaia/luaRules dispatch via
+	// CSplitLuaHandle::RecvDediMsg which forwards to unsyncedLuaHandle (see
+	// LuaHandleSynced.h) -- this is where the unsynced-only invariant lives.
+	if (luaUI != nullptr)
+		luaUI->RecvDediMsg(msg, header);
+	if (luaGaia != nullptr)
+		luaGaia->RecvDediMsg(msg, header);
+	if (luaRules != nullptr)
+		luaRules->RecvDediMsg(msg, header);
 }
 
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -303,6 +303,7 @@ class CLuaHandle : public CEventClient
 		void Shutdown();
 		bool GotChatMsg(const std::string& msg, int playerID);
 		bool RecvLuaMsg(const std::string& msg, int playerID);
+		bool RecvDediMsg(const std::string& msg, int header);
 
 	public:
 		// custom call-in  (inter-script calls)
@@ -409,6 +410,7 @@ class CLuaHandle : public CEventClient
 		static bool GetDevMode() { return devMode; }
 
 		static void HandleLuaMsg(int playerID, int script, int mode, const std::vector<std::uint8_t>& msg);
+		static void HandleDediMsg(int header, const std::vector<std::uint8_t>& msg);
 
 	protected: // static
 		static bool devMode; // allows real file access

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -188,6 +188,10 @@ class CSplitLuaHandle
 			return syncedLuaHandle.RecvLuaMsg(msg, playerID);
 		}
 
+		bool RecvDediMsg(const std::string& msg, int header) {
+			return unsyncedLuaHandle.RecvDediMsg(msg, header);
+		}
+
 	public:
 		void CheckStack() {
 			syncedLuaHandle.CheckStack();

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -3909,6 +3909,12 @@ constexpr uint16_t kDediMsgGameRangeMin   = 0x1000;
  * in the game-private range 0x1000..0xFFFF; values below 0x1000 are reserved
  * for engine use.
  *
+ * The dedi forwards each frame to the autohost as EVENT GAME_DEDIMSG (see
+ * AutohostInterface.cpp). The autohost can reply by injecting the PushAction
+ * `/dedimsgbynum <playerNum-decimal> <header-decimal> <text-payload>`, which
+ * arrives at the originating client as a `Callins:RecvDediMsg(msg, header)`
+ * callin on unsynced handles only.
+ *
  * @param header  integer  record-type tag in [0x1000, 0xFFFF]
  * @param payload string   raw bytes, up to 65529 bytes
  * @return nil

--- a/rts/Net/AutohostInterface.cpp
+++ b/rts/Net/AutohostInterface.cpp
@@ -149,6 +149,30 @@ enum EVENT
 	GAME_LUAMSG = 20,
 
 	/**
+	 * Private message from a player to the dedicated server / autohost.
+	 *
+	 *   (uint8 magic = 79, uint16 msgsize, uint8 playernumber, uint16 header, uint8[msgsize - 6] payload)
+	 *
+	 * The message data is a straight copy of the whole NETMSG_DEDIMSG packet
+	 * including the magic 79 byte. See CBaseNetProtocol::SendDediMsg.
+	 *
+	 * Unlike GAME_LUAMSG, these packets are never broadcast to other players
+	 * and never written to demos -- they exist specifically as a private
+	 * channel for game-side widgets/gadgets to talk to the autohost without
+	 * leaving a replay trace (e.g. moderation reports, bulk stats).
+	 *
+	 * The autohost can reply to a player by injecting the PushAction command
+	 *   /dedimsgbynum <playerNum-decimal> <header-decimal> <text-payload>
+	 * over the existing chat-message UDP channel (see GetChatMessage). The
+	 * text-payload must not contain NUL bytes, the substring "//" (treated as
+	 * a comment marker by Action parsing), or trailing whitespace (rtrim'd).
+	 *
+	 * Headers in the range 0x0001..0x0FFF are reserved for the engine; game
+	 * code must use 0x1000..0xFFFF.
+	 */
+	GAME_DEDIMSG = 21,
+
+	/**
 	 * Team statistics
 	 *
 	 *   (uint8 teamnumber, TeamStatistics stats)
@@ -368,6 +392,17 @@ void AutohostInterface::SendLuaMsg(const std::uint8_t* msg, size_t msgSize)
 	if (autohost.is_open()) {
 		std::vector<std::uint8_t> buffer(msgSize+1);
 		buffer[0] = GAME_LUAMSG;
+		std::copy(msg, msg + msgSize, buffer.begin() + 1);
+
+		Send(asio::buffer(buffer));
+	}
+}
+
+void AutohostInterface::SendDediMsg(const std::uint8_t* msg, size_t msgSize)
+{
+	if (autohost.is_open()) {
+		std::vector<std::uint8_t> buffer(msgSize+1);
+		buffer[0] = GAME_DEDIMSG;
 		std::copy(msg, msg + msgSize, buffer.begin() + 1);
 
 		Send(asio::buffer(buffer));

--- a/rts/Net/AutohostInterface.h
+++ b/rts/Net/AutohostInterface.h
@@ -47,6 +47,7 @@ public:
 	void Warning(const std::string& message);
 
 	void SendLuaMsg(const std::uint8_t* msg, size_t msgSize);
+	void SendDediMsg(const std::uint8_t* msg, size_t msgSize);
 	void Send(const std::uint8_t* msg, size_t msgSize);
 
 	/**

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -1396,7 +1396,8 @@ void CGameServer::ProcessPacket(const unsigned playerNum, std::shared_ptr<const 
 				}
 				bytesInWindow += static_cast<uint32_t>(payloadLen);
 
-				// DO SOMETHING in future PR
+				if (hostif != nullptr)
+					hostif->SendDediMsg(packet->data, packet->length);
 			} catch (const netcode::UnpackPacketException& ex) {
 				Message(spring::format("[GameServer::%s][NETMSG_DEDIMSG] exception \"%s\" from player \"%s\"", __func__, ex.what(), players[a].name.c_str()));
 			}
@@ -2456,6 +2457,52 @@ void CGameServer::PushAction(const Action& action, bool fromAutoHost)
 
 			if (iter != players.end())
 				SpecPlayer(iter->id);
+		} break;
+
+
+		case hashString("dedimsgbynum"): {
+			// Autohost-originated reply over the private NETMSG_DEDIMSG channel.
+			// Format: <player-id-decimal> <header-decimal> <text-payload>
+			// Constraints on the text-payload (imposed by Action parsing and the
+			// chat-message UDP recv at AutohostInterface.cpp:GetChatMessage):
+			//   - no NUL bytes (UDP recv treats the datagram as a C-string)
+			//   - no "//" substring (Action.cpp strips it as a comment marker)
+			//   - no trailing whitespace (Action.cpp rtrim's it)
+			if (!fromAutoHost) {
+				LOG_L(L_WARNING, "[%s] /%s only allowed from autohost", __func__, action.command.c_str());
+				return;
+			}
+
+			// Tokenize(.., 2) returns at most 3 entries: player, header, then
+			// everything else as one string (with internal whitespace preserved).
+			const std::vector<std::string> tokens = CSimpleParser::Tokenize(action.extra, 2);
+			if (tokens.size() < 2) {
+				LOG_L(L_WARNING, "[%s] usage: /%s <player-id> <header> <payload>", __func__, action.command.c_str());
+				return;
+			}
+
+			const int playerNum = atoi(tokens[0].c_str());
+			const int header    = atoi(tokens[1].c_str());
+
+			if (playerNum < 0 || (size_t)playerNum >= players.size()) {
+				LOG_L(L_WARNING, "[%s] /%s invalid player-id '%s'", __func__, action.command.c_str(), tokens[0].c_str());
+				return;
+			}
+			if (header < 1 || header > 0xFFFF) {
+				LOG_L(L_WARNING, "[%s] /%s invalid header '%s' (must be decimal 1..65535)", __func__, action.command.c_str(), tokens[1].c_str());
+				return;
+			}
+
+			const std::string& payload = (tokens.size() >= 3) ? tokens[2] : std::string();
+			const std::vector<std::uint8_t> payloadBytes(payload.begin(), payload.end());
+
+			try {
+				players[playerNum].SendData(
+					CBaseNetProtocol::Get().SendDediMsg(
+						SERVER_PLAYER, static_cast<std::uint16_t>(header), payloadBytes));
+			} catch (const netcode::PackPacketException& ex) {
+				LOG_L(L_ERROR, "[%s] /%s pack error: %s", __func__, action.command.c_str(), ex.what());
+			}
 		} break;
 
 

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -1031,6 +1031,47 @@ void CGame::ClientReadNet()
 				}
 			} break;
 
+			case NETMSG_DEDIMSG: {
+				ZoneScopedN("Net::DediMsg");
+				try {
+					netcode::UnpackPacket unpack(packet, sizeof(uint8_t));
+
+					std::uint16_t packetSize;
+					std::uint8_t  playerNum;
+					std::uint16_t header;
+					std::vector<std::uint8_t> data;
+
+					unpack >> packetSize;
+					if (packetSize != packet->length)
+						throw netcode::UnpackPacketException("invalid packet-size");
+
+					// Min legal size = cmd + size + playerNum + header (6).
+					// Validate before computing data.resize() to avoid an
+					// attacker-controlled size underflow.
+					constexpr std::uint16_t kMinPacketSize =
+						sizeof(std::uint8_t) + sizeof(std::uint16_t)
+						+ sizeof(std::uint8_t) + sizeof(std::uint16_t);
+					if (packetSize < kMinPacketSize)
+						throw netcode::UnpackPacketException("packet too short");
+
+					unpack >> playerNum;
+					// DEDIMSG arriving at a client must be server-originated by
+					// convention (see GameServer.cpp PushAction "dedimsgbynum").
+					if (playerNum != SERVER_PLAYER)
+						throw netcode::UnpackPacketException("non-server source");
+
+					unpack >> header;
+
+					data.resize(packetSize - kMinPacketSize);
+					unpack >> data;
+
+					CLuaHandle::HandleDediMsg(header, data);
+					AddTraffic(playerNum, packetCode, dataLength);
+				} catch (const netcode::UnpackPacketException& ex) {
+					LOG_L(L_ERROR, "[Game::%s][NETMSG_DEDIMSG] exception \"%s\"", __func__, ex.what());
+				}
+			} break;
+
 
 			case NETMSG_SHARE: {
 				ZoneScopedN("Net::Share");


### PR DESCRIPTION
First PR: game packet https://github.com/beyond-all-reason/RecoilEngine/issues/2040
Second PR: hook up to autohost https://github.com/beyond-all-reason/RecoilEngine/issues/2040
Third PR: usage of game packets with a small engine stats api, local file https://github.com/beyond-all-reason/RecoilEngine/issues/2041
Fourth PR: send default engine stats through this API
