### PR TITLE
Fix #1820, `CModInfo` → `CModRules`

### DIFF
--- a/doc/site/content/articles/modrules-and-others.markdown
+++ b/doc/site/content/articles/modrules-and-others.markdown
@@ -13,13 +13,12 @@ This article will briefly describe all of them in a way that hopefully prevents 
 * lives in `./modinfo.lua`, hence the name.
 * many mature games put `"$VERSION"` as the version. This is a magic value replaced by the Rapid distribution system with the actual version string. Check out Rapid's documentation for specifics.
 * this file is both necessary and sufficient for a Recoil game, and its contents can consist of just the `name` entry as well.
-* for engine devs: note that in engine internals, modinfo is **not** represented by the `CModInfo` class, that one is actually _mod rules_! Modinfo is a "class 1 meta file" only really referred to in the archive scanner.
 
 ### Mod rules
 * a hardcoded set of knobs for tweaking engine behaviour.
 * some technical (like the choice of pathfinding system or allocation limits) and some gameplay related (like the resource cost scaling for repairing).
 * everything is a single constant global value. No per-unit rules, no changing at runtime, no rules outside the limited set exposed by the engine.
-* read from `./gamedata/modrules.lua`, hence the name. Internal engine C++ code stores them in the `CModInfo` class.
+* read from `./gamedata/modrules.lua`, hence the name.
 * can depend on modoptions.
 
 ### Mod options

--- a/rts/ExternalAI/AICallback.cpp
+++ b/rts/ExternalAI/AICallback.cpp
@@ -30,7 +30,7 @@
 #include "Sim/Misc/GeometricObjects.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/QuadField.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/Wind.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
@@ -982,7 +982,7 @@ const unsigned short* CAICallback::GetRadarMap()
 
 const unsigned short* CAICallback::GetJammerMap()
 {
-	const int jammerAllyTeam = modInfo.separateJammers ? teamHandler.AllyTeam(team) : 0;
+	const int jammerAllyTeam = modRules.separateJammers ? teamHandler.AllyTeam(team) : 0;
 	return &losHandler->jammer.losMaps[jammerAllyTeam].front();
 }
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -41,7 +41,7 @@
 #include "Sim/Misc/ResourceMapAnalyzer.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h" // for quadField.GetFeaturesExact(pos, radius)
 #include "System/SafeCStrings.h"
 #include "System/SpringMath.h"
@@ -1626,134 +1626,134 @@ EXPORT(const char*) skirmishAiCallback_Game_getRulesParamString(int skirmishAIId
 //########### BEGIN Mod
 
 EXPORT(const char*) skirmishAiCallback_Mod_getFileName(int skirmishAIId) {
-	return modInfo.filename.c_str();
+	return modRules.filename.c_str();
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getHash(int skirmishAIId) {
-	return archiveScanner->GetArchiveCompleteChecksum(modInfo.humanNameVersioned);
+	return archiveScanner->GetArchiveCompleteChecksum(modRules.humanNameVersioned);
 }
 EXPORT(const char*) skirmishAiCallback_Mod_getHumanName(int skirmishAIId) {
-	return modInfo.humanNameVersioned.c_str();
+	return modRules.humanNameVersioned.c_str();
 }
 
 EXPORT(const char*) skirmishAiCallback_Mod_getShortName(int skirmishAIId) {
-	return modInfo.shortName.c_str();
+	return modRules.shortName.c_str();
 }
 
 EXPORT(const char*) skirmishAiCallback_Mod_getVersion(int skirmishAIId) {
-	return modInfo.version.c_str();
+	return modRules.version.c_str();
 }
 
 EXPORT(const char*) skirmishAiCallback_Mod_getMutator(int skirmishAIId) {
-	return modInfo.mutator.c_str();
+	return modRules.mutator.c_str();
 }
 
 EXPORT(const char*) skirmishAiCallback_Mod_getDescription(int skirmishAIId) {
-	return modInfo.description.c_str();
+	return modRules.description.c_str();
 }
 
 EXPORT(bool) skirmishAiCallback_Mod_getConstructionDecay(int skirmishAIId) {
-	return modInfo.constructionDecay;
+	return modRules.constructionDecay;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getConstructionDecayTime(int skirmishAIId) {
-	return modInfo.constructionDecayTime;
+	return modRules.constructionDecayTime;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getConstructionDecaySpeed(int skirmishAIId) {
-	return modInfo.constructionDecaySpeed;
+	return modRules.constructionDecaySpeed;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getMultiReclaim(int skirmishAIId) {
-	return modInfo.multiReclaim;
+	return modRules.multiReclaim;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getReclaimMethod(int skirmishAIId) {
-	return modInfo.reclaimMethod;
+	return modRules.reclaimMethod;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getReclaimUnitMethod(int skirmishAIId) {
-	return modInfo.reclaimUnitMethod;
+	return modRules.reclaimUnitMethod;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getReclaimUnitEnergyCostFactor(int skirmishAIId) {
-	return modInfo.reclaimUnitCostFactor.energy;
+	return modRules.reclaimUnitCostFactor.energy;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getReclaimUnitEfficiency(int skirmishAIId) {
-	return modInfo.reclaimUnitEfficiency.metal;
+	return modRules.reclaimUnitEfficiency.metal;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getReclaimFeatureEnergyCostFactor(int skirmishAIId) {
-	return modInfo.reclaimFeatureCostFactor.energy;
+	return modRules.reclaimFeatureCostFactor.energy;
 }
 
 EXPORT(bool) skirmishAiCallback_Mod_getReclaimUnitDrainHealth(int skirmishAIId) {
-	return modInfo.reclaimUnitDrainHealth;
+	return modRules.reclaimUnitDrainHealth;
 }
 
 EXPORT(bool) skirmishAiCallback_Mod_getReclaimAllowEnemies(int skirmishAIId) {
-	return modInfo.reclaimAllowEnemies;
+	return modRules.reclaimAllowEnemies;
 }
 
 EXPORT(bool) skirmishAiCallback_Mod_getReclaimAllowAllies(int skirmishAIId) {
-	return modInfo.reclaimAllowAllies;
+	return modRules.reclaimAllowAllies;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getRepairEnergyCostFactor(int skirmishAIId) {
-	return modInfo.repairCostFactor.energy;
+	return modRules.repairCostFactor.energy;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getResurrectEnergyCostFactor(int skirmishAIId) {
-	return modInfo.resurrectCostFactor.energy;
+	return modRules.resurrectCostFactor.energy;
 }
 
 EXPORT(float) skirmishAiCallback_Mod_getCaptureEnergyCostFactor(int skirmishAIId) {
-	return modInfo.captureCostFactor.energy;
+	return modRules.captureCostFactor.energy;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getTransportGround(int skirmishAIId) {
-	return modInfo.transportGround;
+	return modRules.transportGround;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getTransportHover(int skirmishAIId) {
-	return modInfo.transportHover;
+	return modRules.transportHover;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getTransportShip(int skirmishAIId) {
-	return modInfo.transportShip;
+	return modRules.transportShip;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getTransportAir(int skirmishAIId) {
-	return modInfo.transportAir;
+	return modRules.transportAir;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getFireAtKilled(int skirmishAIId) {
-	return modInfo.fireAtKilled;
+	return modRules.fireAtKilled;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getFireAtCrashing(int skirmishAIId) {
-	return modInfo.fireAtCrashing;
+	return modRules.fireAtCrashing;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getFlankingBonusModeDefault(int skirmishAIId) {
-	return modInfo.flankingBonusModeDefault;
+	return modRules.flankingBonusModeDefault;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getLosMipLevel(int skirmishAIId) {
-	return modInfo.losMipLevel;
+	return modRules.losMipLevel;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getAirMipLevel(int skirmishAIId) {
-	return modInfo.airMipLevel;
+	return modRules.airMipLevel;
 }
 
 EXPORT(int) skirmishAiCallback_Mod_getRadarMipLevel(int skirmishAIId) {
-	return modInfo.radarMipLevel;
+	return modRules.radarMipLevel;
 }
 
 EXPORT(bool) skirmishAiCallback_Mod_getRequireSonarUnderWater(int skirmishAIId) {
-	return modInfo.requireSonarUnderWater;
+	return modRules.requireSonarUnderWater;
 }
 
 //########### END Mod

--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -16,7 +16,7 @@
 #include "System/SpringMath.h"
 #include "System/Input/KeyInput.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -76,7 +76,7 @@ void CSpringController::ConfigUpdate()
 	lockCardinalDirections = configHandler->GetBool("CamSpringLockCardinalDirections");
 	trackMapHeight = configHandler->GetInt("CamSpringTrackMapHeightMode");
 
-	if (trackMapHeight == HeightTracking::Smooth && !modInfo.enableSmoothMesh) {
+	if (trackMapHeight == HeightTracking::Smooth && !modRules.enableSmoothMesh) {
 		LOG_L(L_ERROR, "Smooth mesh disabled");
 		trackMapHeight = HeightTracking::Terrain;
 	}

--- a/rts/Game/Camera/SpringController.cpp
+++ b/rts/Game/Camera/SpringController.cpp
@@ -16,7 +16,7 @@
 #include "System/SpringMath.h"
 #include "System/Input/KeyInput.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -80,7 +80,7 @@ void CSpringController::ConfigUpdate()
 	meshBlendMinDist = configHandler->GetFloat("CamSpringSmoothMeshBlendMinDist");
 	meshBlendMaxDist = std::max(configHandler->GetFloat("CamSpringSmoothMeshBlendMaxDist"), meshBlendMinDist + 1.0f);
 
-	if (trackMapHeight == HeightTracking::Smooth && !modInfo.enableSmoothMesh) {
+	if (trackMapHeight == HeightTracking::Smooth && !modRules.enableSmoothMesh) {
 		LOG_L(L_WARNING, "[CSpringController] smoothmesh height tracking (mode 2) requested but the game disabled the smooth mesh, falling back to terrain tracking");
 		trackMapHeight = HeightTracking::Terrain;
 	}

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -77,7 +77,7 @@
 #include "Sim/Misc/GroundBlockingObjectMap.h"
 #include "Sim/Misc/BuildingMaskMap.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/InterceptHandler.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/SideParser.h"
@@ -261,7 +261,7 @@ CGame::CGame(const std::string& mapFileName, const std::string& modFileName, ILo
 
 	envResHandler.ResetState();
 
-	modInfo.Init(modFileName);
+	modRules.Init(modFileName);
 
 	// needed for LuaIntro (pushes LuaConstGame)
 	assert(mapInfo == nullptr);
@@ -645,11 +645,11 @@ void CGame::PreLoadSimulation(LuaParser* defsParser)
 	ENTER_SYNCED_CODE();
 
 	loadscreen->SetLoadMessage("Creating Smooth Height Mesh");
-	smoothGround.Init(int2(mapDims.mapx, mapDims.mapy), modInfo.smoothMeshResDivider, modInfo.smoothMeshSmoothRadius);
+	smoothGround.Init(int2(mapDims.mapx, mapDims.mapy), modRules.smoothMeshResDivider, modRules.smoothMeshSmoothRadius);
 
 	loadscreen->SetLoadMessage("Creating QuadField & CEGs");
 	moveDefHandler.Init(defsParser);
-	quadField.Init(int2(mapDims.mapx, mapDims.mapy), modInfo.quadFieldQuadSizeInElmos);
+	quadField.Init(int2(mapDims.mapx, mapDims.mapy), modRules.quadFieldQuadSizeInElmos);
 	damageArrayHandler.Init(defsParser);
 	explGenHandler.Init();
 }
@@ -707,7 +707,7 @@ void CGame::PostLoadSimulation(LuaParser* defsParser)
 	//   --> need a way to let Lua flush it or re-calculate map
 	//   checksum (over heightmap + blockmap, not raw archive)
 	mapDamage = IMapDamage::InitMapDamage();
-	pathManager = IPathManager::GetInstance(modInfo.pathFinderSystem);
+	pathManager = IPathManager::GetInstance(modRules.pathFinderSystem);
 	moveDefHandler.PostSimInit();
 
 	// load map-specific features

--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -78,7 +78,7 @@
 #include "Sim/Misc/GroundBlockingObjectMap.h"
 #include "Sim/Misc/BuildingMaskMap.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/InterceptHandler.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/SideParser.h"
@@ -262,7 +262,7 @@ CGame::CGame(const std::string& mapFileName, const std::string& modFileName, ILo
 
 	envResHandler.ResetState();
 
-	modInfo.Init(modFileName);
+	modRules.Init(modFileName);
 
 	// needed for LuaIntro (pushes LuaConstGame)
 	assert(mapInfo == nullptr);
@@ -646,11 +646,11 @@ void CGame::PreLoadSimulation(LuaParser* defsParser)
 	ENTER_SYNCED_CODE();
 
 	loadscreen->SetLoadMessage("Creating Smooth Height Mesh");
-	smoothGround.Init(int2(mapDims.mapx, mapDims.mapy), modInfo.smoothMeshResDivider, modInfo.smoothMeshSmoothRadius);
+	smoothGround.Init(int2(mapDims.mapx, mapDims.mapy), modRules.smoothMeshResDivider, modRules.smoothMeshSmoothRadius);
 
 	loadscreen->SetLoadMessage("Creating QuadField & CEGs");
 	moveDefHandler.Init(defsParser);
-	quadField.Init(int2(mapDims.mapx, mapDims.mapy), modInfo.quadFieldQuadSizeInElmos);
+	quadField.Init(int2(mapDims.mapx, mapDims.mapy), modRules.quadFieldQuadSizeInElmos);
 	damageArrayHandler.Init(defsParser);
 	explGenHandler.Init();
 }
@@ -708,7 +708,7 @@ void CGame::PostLoadSimulation(LuaParser* defsParser)
 	//   --> need a way to let Lua flush it or re-calculate map
 	//   checksum (over heightmap + blockmap, not raw archive)
 	mapDamage = IMapDamage::InitMapDamage();
-	pathManager = IPathManager::GetInstance(modInfo.pathFinderSystem);
+	pathManager = IPathManager::GetInstance(modRules.pathFinderSystem);
 	moveDefHandler.PostSimInit();
 
 	// load map-specific features

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -21,7 +21,7 @@
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/MoveType.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"
@@ -751,7 +751,7 @@ size_t CGameHelper::GenerateWeaponTargets(const CWeapon* weapon, const CUnit* av
 				if (targetLOSState & LOS_INLOS) {
 					targetPriority *= (secDamage + targetUnit->health);
 
-					if (paralyzer && targetUnit->paralyzeDamage > (modInfo.paralyzeOnMaxHealth? targetUnit->maxHealth: targetUnit->health))
+					if (paralyzer && targetUnit->paralyzeDamage > (modRules.paralyzeOnMaxHealth? targetUnit->maxHealth: targetUnit->health))
 						targetPriority *= tgtPriorityMults[5];
 
 					if (weapon->hasTargetWeight)
@@ -1331,11 +1331,11 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 		assert(!ThreadPool::IsInMultiThreadedSection());
 
 		// buffer should be the maximum distance given by the movetype using the formula:
-		// maxspeed * modInfo.unitQuadPositionUpdateRate + half footStep + 1
+		// maxspeed * modRules.unitQuadPositionUpdateRate + half footStep + 1
 		// +1 on end is a safety buffer against rounding issues with square placement.
 		// placeholder values are given here for the moment.
 		const int largestMoveTypSizeH = moveDefHandler.GetLargestFootPrintSizeH() + 1;
-		const int bufferSize = SQUARE_SIZE * modInfo.unitQuadPositionUpdateRate * 2 + largestMoveTypSizeH + 1;
+		const int bufferSize = SQUARE_SIZE * modRules.unitQuadPositionUpdateRate * 2 + largestMoveTypSizeH + 1;
 		const float3 min((x1 - bufferSize) * SQUARE_SIZE, 0.f, (z1 - bufferSize) * SQUARE_SIZE);
 		const float3 max((x2 + bufferSize) * SQUARE_SIZE, 0.f, (z2 + bufferSize) * SQUARE_SIZE);
 

--- a/rts/Game/SyncedGameCommands.cpp
+++ b/rts/Game/SyncedGameCommands.cpp
@@ -20,7 +20,7 @@
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "Sim/Units/UnitDefHandler.h"
 #include "Sim/Units/UnitHandler.h"
@@ -595,7 +595,7 @@ void SyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<LuaGaiaActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DesyncActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<AtmActionExecutor>());
-	if (modInfo.allowTake)
+	if (modRules.allowTake)
 		AddActionExecutor(AllocActionExecutor<TakeActionExecutor>());
 
 	AddActionExecutor(AllocActionExecutor<SkipActionExecutor>());

--- a/rts/Game/UI/GameInfo.cpp
+++ b/rts/Game/UI/GameInfo.cpp
@@ -12,7 +12,7 @@
 #include "Rendering/Fonts/glFont.h"
 #include "Sim/Misc/Team.h"
 #include "Sim/Misc/Wind.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Path/IPathManager.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/StringUtil.h"

--- a/rts/Game/UI/PlayerRosterDrawer.cpp
+++ b/rts/Game/UI/PlayerRosterDrawer.cpp
@@ -12,7 +12,7 @@
 #include "Rendering/GlobalRendering.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "System/GlobalConfig.h"
 #include "System/Misc/SpringTime.h"
@@ -29,7 +29,7 @@ void CPlayerRosterDrawer::Draw()
 	if (playerRoster.GetSortType() == PlayerRoster::Disabled)
 		return;
 
-	if (!modInfo.allowEnginePlayerlist)
+	if (!modRules.allowEnginePlayerlist)
 		return;
 
 	const unsigned currentTime = spring_now().toSecsi();

--- a/rts/Game/UI/QuitBox.cpp
+++ b/rts/Game/UI/QuitBox.cpp
@@ -14,7 +14,7 @@
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GL/glExtra.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "System/Log/ILog.h"
 #include "Net/Protocol/NetProtocol.h"
@@ -333,7 +333,7 @@ void CQuitBox::MouseRelease(int x, int y, int button)
 		// save current game state
 		if (save) {
 			const std::string currTimeStr = CTimeUtil::GetCurrentTimeStr();
-			const std::string saveFileName = currTimeStr + "_" + modInfo.filename + "_" + gameSetup->mapName;
+			const std::string saveFileName = currTimeStr + "_" + modRules.filename + "_" + gameSetup->mapName;
 
 			game->Save("Saves/" + saveFileName + ".ssf", "");
 		}

--- a/rts/Game/UI/StartPosSelecter.cpp
+++ b/rts/Game/UI/StartPosSelecter.cpp
@@ -17,7 +17,7 @@
 #include "Rendering/Fonts/glFont.h"
 #include "Net/Protocol/NetProtocol.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 
 #include "System/Misc/TracyDefs.h"
 
@@ -89,7 +89,7 @@ bool CStartPosSelecter::MousePress(int x, int y, int button)
 	if (button != SDL_BUTTON_LEFT)
 		return false;
 
-	if (modInfo.useStartPositionSelecter == false) {
+	if (modRules.useStartPositionSelecter == false) {
 		return false;
 	}
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -91,7 +91,7 @@
 
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitDefHandler.h"
@@ -4236,7 +4236,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Desync"));
 #endif
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Resync"));
-	if (modInfo.allowTake)
+	if (modRules.allowTake)
 		AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Take"));
 
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaRules"));

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -92,7 +92,7 @@
 
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitDefHandler.h"
@@ -4254,7 +4254,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Desync"));
 #endif
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Resync"));
-	if (modInfo.allowTake)
+	if (modRules.allowTake)
 		AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Take"));
 
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaRules"));

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -261,7 +261,7 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	 *
 	 * ## Other modifiers
 	 *
-	 * - `modInfo.targetableTransportedUnits`: Controls whether transported units are targetable.
+	 * - `modRules.targetableTransportedUnits`: Controls whether transported units are targetable.
 	 *
 	 * ## Callins
 	 *

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -12,7 +12,7 @@
 #include "Map/MetalMap.h"
 #include "Map/ReadMap.h"
 #include "Rendering/Fonts/glFont.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/CategoryHandler.h"
 #include "Sim/Misc/DamageArrayHandler.h"
 #include "Sim/Misc/Wind.h"
@@ -31,7 +31,7 @@
 
 /* TODO:
  * - Inline these declarations (place each above the specific line they are pushed into the constant.
- * - There are many missing (for example modInfo related ones)
+ * - There are many missing (for example modRules related ones)
  */
 /*** Game specific information
  *
@@ -176,52 +176,52 @@ bool LuaConstGame::PushEntries(lua_State* L)
 		LuaPushNamedNumber(L, "gravity"        , -mapInfo->map.gravity * GAME_SPEED * GAME_SPEED);
 	}
 
-	if (!modInfo.filename.empty()) {
+	if (!modRules.filename.empty()) {
 		// mod-info; values are meaningless prior to Game::Load
-		LuaPushNamedString(L, "gameName"     , modInfo.humanName);
-		LuaPushNamedString(L, "gameShortName", modInfo.shortName);
-		LuaPushNamedString(L, "gameVersion"  , modInfo.version);
-		LuaPushNamedString(L, "gameMutator"  , modInfo.mutator);
-		LuaPushNamedString(L, "gameDesc"     , modInfo.description);
+		LuaPushNamedString(L, "gameName"     , modRules.humanName);
+		LuaPushNamedString(L, "gameShortName", modRules.shortName);
+		LuaPushNamedString(L, "gameVersion"  , modRules.version);
+		LuaPushNamedString(L, "gameMutator"  , modRules.mutator);
+		LuaPushNamedString(L, "gameDesc"     , modRules.description);
 
-		LuaPushNamedString(L, "modName"      , modInfo.humanNameVersioned);
-		LuaPushNamedString(L, "modShortName" , modInfo.shortName);
-		LuaPushNamedString(L, "modVersion"   , modInfo.version);
-		LuaPushNamedString(L, "modMutator"   , modInfo.mutator);
-		LuaPushNamedString(L, "modDesc"      , modInfo.description);
+		LuaPushNamedString(L, "modName"      , modRules.humanNameVersioned);
+		LuaPushNamedString(L, "modShortName" , modRules.shortName);
+		LuaPushNamedString(L, "modVersion"   , modRules.version);
+		LuaPushNamedString(L, "modMutator"   , modRules.mutator);
+		LuaPushNamedString(L, "modDesc"      , modRules.description);
 
-		LuaPushNamedBool  (L, "constructionDecay"     , modInfo.constructionDecay);
-		LuaPushNamedNumber(L, "constructionDecayTime" , modInfo.constructionDecayTime);
-		LuaPushNamedNumber(L, "constructionDecaySpeed", modInfo.constructionDecaySpeed);
+		LuaPushNamedBool  (L, "constructionDecay"     , modRules.constructionDecay);
+		LuaPushNamedNumber(L, "constructionDecayTime" , modRules.constructionDecayTime);
+		LuaPushNamedNumber(L, "constructionDecaySpeed", modRules.constructionDecaySpeed);
 
-		LuaPushNamedNumber(L, "multiReclaim"                  , modInfo.multiReclaim);
-		LuaPushNamedNumber(L, "reclaimMethod"                 , modInfo.reclaimMethod);
-		LuaPushNamedNumber(L, "reclaimUnitMethod"             , modInfo.reclaimUnitMethod);
-		LuaPushNamedNumber(L, "reclaimUnitEnergyCostFactor"   , modInfo.reclaimUnitCostFactor.energy);
-		LuaPushNamedNumber(L, "reclaimUnitEfficiency"         , modInfo.reclaimUnitEfficiency.metal);
-		LuaPushNamedNumber(L, "reclaimFeatureEnergyCostFactor", modInfo.reclaimFeatureCostFactor.energy);
-		LuaPushNamedBool  (L, "reclaimUnitDrainHealth"        , modInfo.reclaimUnitDrainHealth);
-		LuaPushNamedBool  (L, "reclaimAllowEnemies"           , modInfo.reclaimAllowEnemies);
-		LuaPushNamedBool  (L, "reclaimAllowAllies"            , modInfo.reclaimAllowAllies);
-		LuaPushNamedNumber(L, "repairEnergyCostFactor"        , modInfo.repairCostFactor.energy);
-		LuaPushNamedNumber(L, "resurrectEnergyCostFactor"     , modInfo.resurrectCostFactor.energy);
-		LuaPushNamedNumber(L, "captureEnergyCostFactor"       , modInfo.captureCostFactor.energy);
+		LuaPushNamedNumber(L, "multiReclaim"                  , modRules.multiReclaim);
+		LuaPushNamedNumber(L, "reclaimMethod"                 , modRules.reclaimMethod);
+		LuaPushNamedNumber(L, "reclaimUnitMethod"             , modRules.reclaimUnitMethod);
+		LuaPushNamedNumber(L, "reclaimUnitEnergyCostFactor"   , modRules.reclaimUnitCostFactor.energy);
+		LuaPushNamedNumber(L, "reclaimUnitEfficiency"         , modRules.reclaimUnitEfficiency.metal);
+		LuaPushNamedNumber(L, "reclaimFeatureEnergyCostFactor", modRules.reclaimFeatureCostFactor.energy);
+		LuaPushNamedBool  (L, "reclaimUnitDrainHealth"        , modRules.reclaimUnitDrainHealth);
+		LuaPushNamedBool  (L, "reclaimAllowEnemies"           , modRules.reclaimAllowEnemies);
+		LuaPushNamedBool  (L, "reclaimAllowAllies"            , modRules.reclaimAllowAllies);
+		LuaPushNamedNumber(L, "repairEnergyCostFactor"        , modRules.repairCostFactor.energy);
+		LuaPushNamedNumber(L, "resurrectEnergyCostFactor"     , modRules.resurrectCostFactor.energy);
+		LuaPushNamedNumber(L, "captureEnergyCostFactor"       , modRules.captureCostFactor.energy);
 
 		// Despite being bools, these are exposed to Lua as 0/1 for legacy reasons
-		LuaPushNamedNumber(L, "transportAir"   , modInfo.transportAir);
-		LuaPushNamedNumber(L, "transportShip"  , modInfo.transportShip);
-		LuaPushNamedNumber(L, "transportHover" , modInfo.transportHover);
-		LuaPushNamedNumber(L, "transportGround", modInfo.transportGround);
-		LuaPushNamedNumber(L, "fireAtKilled"   , modInfo.fireAtKilled);
-		LuaPushNamedNumber(L, "fireAtCrashing" , modInfo.fireAtCrashing);
-		LuaPushNamedNumber(L, "requireSonarUnderWater", modInfo.requireSonarUnderWater);
+		LuaPushNamedNumber(L, "transportAir"   , modRules.transportAir);
+		LuaPushNamedNumber(L, "transportShip"  , modRules.transportShip);
+		LuaPushNamedNumber(L, "transportHover" , modRules.transportHover);
+		LuaPushNamedNumber(L, "transportGround", modRules.transportGround);
+		LuaPushNamedNumber(L, "fireAtKilled"   , modRules.fireAtKilled);
+		LuaPushNamedNumber(L, "fireAtCrashing" , modRules.fireAtCrashing);
+		LuaPushNamedNumber(L, "requireSonarUnderWater", modRules.requireSonarUnderWater);
 
-		LuaPushNamedBool  (L, "paralyzeOnMaxHealth", modInfo.paralyzeOnMaxHealth);
-		LuaPushNamedNumber(L, "paralyzeDeclineRate", modInfo.paralyzeDeclineRate);
+		LuaPushNamedBool  (L, "paralyzeOnMaxHealth", modRules.paralyzeOnMaxHealth);
+		LuaPushNamedNumber(L, "paralyzeDeclineRate", modRules.paralyzeDeclineRate);
 
-		LuaPushNamedBool  (L, "allowEnginePlayerlist", modInfo.allowEnginePlayerlist);
+		LuaPushNamedBool  (L, "allowEnginePlayerlist", modRules.allowEnginePlayerlist);
 		/*** @field Game.nativeExcessSharing boolean whether the engine handles excess resources overflow */
-		LuaPushNamedBool  (L, "nativeExcessSharing", modInfo.nativeExcessSharing);
+		LuaPushNamedBool  (L, "nativeExcessSharing", modRules.nativeExcessSharing);
 	}
 
 	if (archiveScanner != nullptr && mapInfo != nullptr) {
@@ -229,7 +229,7 @@ bool LuaConstGame::PushEntries(lua_State* L)
 		sha512::hex_digest mapHexDigest;
 		sha512::hex_digest modHexDigest;
 		sha512::dump_digest(archiveScanner->GetArchiveCompleteChecksumBytes(mapInfo->map.name), mapHexDigest);
-		sha512::dump_digest(archiveScanner->GetArchiveCompleteChecksumBytes(modInfo.filename), modHexDigest);
+		sha512::dump_digest(archiveScanner->GetArchiveCompleteChecksumBytes(modRules.filename), modHexDigest);
 
 		LuaPushNamedString(L, "mapChecksum", mapHexDigest.data());
 		LuaPushNamedString(L, "modChecksum", modHexDigest.data());

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -39,7 +39,7 @@
 #include "Sim/Misc/DamageArray.h"
 #include "Sim/Misc/DamageArrayHandler.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
 #include "Sim/Misc/Team.h"
 #include "Sim/Misc/TeamHandler.h"
@@ -2334,7 +2334,7 @@ int LuaSyncedCtrl::SetUnitHealth(lua_State* L)
 				} break;
 				case hashString("paralyze"): {
 					const float argValue = lua_tofloat(L, LUA_TABLE_VALUE_INDEX);
-					const float refValue = modInfo.paralyzeOnMaxHealth? unit->maxHealth: unit->health;
+					const float refValue = modRules.paralyzeOnMaxHealth? unit->maxHealth: unit->health;
 
 					if ((unit->paralyzeDamage = std::max(0.0f, argValue)) > refValue) {
 						unit->SetStunned(true);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -39,7 +39,7 @@
 #include "Sim/Misc/DamageArray.h"
 #include "Sim/Misc/DamageArrayHandler.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/SmoothHeightMesh.h"
 #include "Sim/Misc/Team.h"
 #include "Sim/Misc/TeamHandler.h"
@@ -2382,7 +2382,7 @@ int LuaSyncedCtrl::SetUnitHealth(lua_State* L)
 				} break;
 				case hashString("paralyze"): {
 					const float argValue = lua_tofloat(L, LUA_TABLE_VALUE_INDEX);
-					const float refValue = modInfo.paralyzeOnMaxHealth? unit->maxHealth: unit->health;
+					const float refValue = modRules.paralyzeOnMaxHealth? unit->maxHealth: unit->health;
 
 					if ((unit->paralyzeDamage = std::max(0.0f, argValue)) > refValue) {
 						unit->SetStunned(true);

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -50,7 +50,7 @@
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/CustomColorPalette.h"
@@ -520,7 +520,7 @@ int LuaUnsyncedRead::GetReplayLength(lua_State* L)
  */
 int LuaUnsyncedRead::GetGameName(lua_State* L)
 {
-	lua_pushstring(L, modInfo.humanNameVersioned.c_str());
+	lua_pushstring(L, modRules.humanNameVersioned.c_str());
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -50,7 +50,7 @@
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/CustomColorPalette.h"
@@ -523,7 +523,7 @@ int LuaUnsyncedRead::GetReplayLength(lua_State* L)
  */
 int LuaUnsyncedRead::GetGameName(lua_State* L)
 {
-	lua_pushstring(L, modInfo.humanNameVersioned.c_str());
+	lua_pushstring(L, modRules.humanNameVersioned.c_str());
 	return 1;
 }
 

--- a/rts/Rendering/Map/InfoTexture/Modern/Radar.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Radar.cpp
@@ -8,7 +8,7 @@
 #include "Rendering/Shaders/Shader.h"
 #include "Rendering/GL/SubState.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
 
@@ -114,7 +114,7 @@ void CRadarTexture::Update()
 		return;
 	}
 
-	const int jammerAllyTeam = modInfo.separateJammers ? gu->myAllyTeam : 0;
+	const int jammerAllyTeam = modRules.separateJammers ? gu->myAllyTeam : 0;
 
 	const auto& myRadar  = losHandler->radar.losMaps[gu->myAllyTeam].GetLosMap();
 	const auto& myJammer = losHandler->jammer.losMaps[jammerAllyTeam].GetLosMap();

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/InterceptHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/LosHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/LosMap.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/ModInfo.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/ModRules.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/NanoPieceCache.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/QuadField.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Misc/Resource.cpp"

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -17,7 +17,7 @@
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/CollisionVolume.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/Utils/UnitTrapCheckUtils.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
@@ -133,18 +133,18 @@ bool CFeature::IsInLosForAllyTeam(int argAllyTeam) const
 
 	const bool isGaia = allyteam == std::max(0, teamHandler.GaiaAllyTeamID());
 
-	switch (modInfo.featureVisibility) {
-		case CModInfo::FEATURELOS_NONE:
+	switch (modRules.featureVisibility) {
+		case CModRules::FEATURELOS_NONE:
 		default:
 			return losHandler->InLos(pos, argAllyTeam);
 
 		// these next two only make sense when Gaia is enabled
-		case CModInfo::FEATURELOS_GAIAONLY:
+		case CModRules::FEATURELOS_GAIAONLY:
 			return (isGaia || losHandler->InLos(pos, argAllyTeam));
-		case CModInfo::FEATURELOS_GAIAALLIED:
+		case CModRules::FEATURELOS_GAIAALLIED:
 			return (isGaia || allyteam == argAllyTeam || losHandler->InLos(pos, argAllyTeam));
 
-		case CModInfo::FEATURELOS_ALL:
+		case CModRules::FEATURELOS_ALL:
 			return true;
 	}
 }
@@ -321,11 +321,11 @@ bool CFeature::AddBuildPower(CUnit* builder, float amount)
 		return false;
 
 	// don't let them exploit chunk reclaim
-	if (isRepairingBeforeResurrect && (modInfo.reclaimMethod > 1))
+	if (isRepairingBeforeResurrect && (modRules.reclaimMethod > 1))
 		return false;
 
 	// make sure several units cant reclaim at once on a single feature
-	if ((modInfo.multiReclaim == 0) && (lastReclaimFrame == gs->frameNum))
+	if ((modRules.multiReclaim == 0) && (lastReclaimFrame == gs->frameNum))
 		return true;
 
 	const float step = -amount / reclaimTime;
@@ -337,7 +337,7 @@ bool CFeature::AddBuildPower(CUnit* builder, float amount)
 	const float reclaimLeftTemp = std::max(0.0f, reclaimLeft - step);
 	const float fractionReclaimed = oldReclaimLeft - reclaimLeftTemp;
 	const auto resourceFraction = (defResources * fractionReclaimed).cap_at(resources);
-	const auto resourceCost = resourceFraction.metal * modInfo.reclaimFeatureCostFactor;
+	const auto resourceCost = resourceFraction.metal * modRules.reclaimFeatureCostFactor;
 
 	SResourceOrder order;
 	order.quantum    = false;
@@ -350,17 +350,17 @@ bool CFeature::AddBuildPower(CUnit* builder, float amount)
 		// always give remaining resources at the end
 		order.add = resources;
 	}
-	else if (modInfo.reclaimMethod == 0) {
+	else if (modRules.reclaimMethod == 0) {
 		// Gradual reclaim
 		order.add = resourceFraction;
 	}
-	else if (modInfo.reclaimMethod == 1) {
+	else if (modRules.reclaimMethod == 1) {
 		// All-at-end method
 		// see `reclaimLeftTemp == 0.0f` case
 	}
 	else {
 		// Chunky reclaiming, work out how many chunk boundaries we crossed
-		const float chunkSize = 1.0f / modInfo.reclaimMethod;
+		const float chunkSize = 1.0f / modRules.reclaimMethod;
 
 		const int oldChunk  = ChunkNumber(oldReclaimLeft);
 		const int newChunk  = ChunkNumber(reclaimLeft);
@@ -732,7 +732,7 @@ void CFeature::EmitGeoSmoke()
 }
 
 
-int CFeature::ChunkNumber(float f) { return int(math::ceil(f * modInfo.reclaimMethod)); }
+int CFeature::ChunkNumber(float f) { return int(math::ceil(f * modRules.reclaimMethod)); }
 
 // note: this is not actually used by GroundBlockingObjectMap anymore, just
 // to distinguish unit and feature ID's (values >= MaxUnits() correspond to

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -6,7 +6,7 @@
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Map/ReadMap.h"
 #include "System/Log/ILog.h"
 #include "System/SpringHash.h"
@@ -209,7 +209,7 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 
 	// jammers share all the same map independent of the allyTeam
 	if (type == LOS_TYPE_JAMMER || type == LOS_TYPE_SONAR_JAMMER)
-		allyteam *= modInfo.separateJammers;
+		allyteam *= modRules.separateJammers;
 
 	if (radius <= 0.0f) {
 		if (uli != nullptr) {
@@ -713,13 +713,13 @@ void CLosHandler::Init()
 	baseRadarErrorSize = defBaseRadarErrorSize;
 	baseRadarErrorMult = defBaseRadarErrorMult;
 
-	los.Init(modInfo.losMipLevel, ILosType::LOS_TYPE_LOS);
-	airLos.Init(modInfo.airMipLevel, ILosType::LOS_TYPE_AIRLOS);
-	radar.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_RADAR);
-	sonar.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SONAR);
-	seismic.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SEISMIC);
-	jammer.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_JAMMER);
-	sonarJammer.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SONAR_JAMMER);
+	        los.Init(modRules.  losMipLevel, ILosType::LOS_TYPE_LOS         );
+	     airLos.Init(modRules.  airMipLevel, ILosType::LOS_TYPE_AIRLOS      );
+	      radar.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_RADAR       );
+	      sonar.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SONAR       );
+	    seismic.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SEISMIC     );
+	     jammer.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_JAMMER      );
+	sonarJammer.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SONAR_JAMMER);
 
 	radarErrorSizes.clear();
 	radarErrorSizes.resize(teamHandler.ActiveAllyTeams(), defBaseRadarErrorSize);
@@ -873,7 +873,7 @@ bool CLosHandler::InLos(const CUnit* unit, int allyTeam) const
 	//      are also in radar ("sonar") coverage if requireSonarUnderWater
 	//      is enabled --> underwater units can NOT BE SEEN AT ALL without
 	//      active radar!
-	if (modInfo.alwaysVisibleOverridesCloaked) {
+	if (modRules.alwaysVisibleOverridesCloaked) {
 		if (unit->alwaysVisible)
 			return true;
 		if (unit->isCloaked && unit->allyteam != allyTeam)
@@ -892,7 +892,7 @@ bool CLosHandler::InLos(const CUnit* unit, int allyTeam) const
 	if (unit->useAirLos)
 		return (InAirLos(unit->pos, allyTeam) || InAirLos(unit->pos + unit->speed, allyTeam));
 
-	if (modInfo.requireSonarUnderWater) {
+	if (modRules.requireSonarUnderWater) {
 		if (unit->IsUnderWater() && !InRadar(unit, allyTeam)) {
 			return false;
 		}
@@ -911,7 +911,7 @@ bool CLosHandler::InAirLos(const CUnit* unit, int allyTeam) const
 	//      are also in radar ("sonar") coverage if requireSonarUnderWater
 	//      is enabled --> underwater units can NOT BE SEEN AT ALL without
 	//      active radar!
-	if (modInfo.alwaysVisibleOverridesCloaked) {
+	if (modRules.alwaysVisibleOverridesCloaked) {
 		if (unit->alwaysVisible)
 			return true;
 		if (unit->isCloaked && unit->allyteam != allyTeam)
@@ -927,7 +927,7 @@ bool CLosHandler::InAirLos(const CUnit* unit, int allyTeam) const
 	if (globalLOS[allyTeam])
 		return true;
 
-	if (modInfo.requireSonarUnderWater) {
+	if (modRules.requireSonarUnderWater) {
 		if (unit->IsUnderWater() && !InRadar(unit, allyTeam))
 			return false;
 	}
@@ -942,9 +942,9 @@ bool CLosHandler::InRadar(const float3 pos, int allyTeam) const
 	// position is underwater, only sonar can see it
 	// note: only check jammers when we have a common jammer map, else jammers only apply to objects!
 	if (pos.y < 0.0f)
-		return (sonar.InSight(pos, allyTeam) && !(!modInfo.separateJammers && sonarJammer.InSight(pos, 0)));
+		return (sonar.InSight(pos, allyTeam) && !(!modRules.separateJammers && sonarJammer.InSight(pos, 0)));
 
-	return (radar.InSight(pos, allyTeam) && !(!modInfo.separateJammers && jammer.InSight(pos, 0)));
+	return (radar.InSight(pos, allyTeam) && !(!modRules.separateJammers && jammer.InSight(pos, 0)));
 }
 
 
@@ -974,7 +974,7 @@ bool CLosHandler::InRadar(const CUnit* unit, int allyTeam) const
 bool CLosHandler::InJammer(const float3 pos, int allyTeam) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const int jammerAlly = modInfo.separateJammers ? allyTeam : 0;
+	const int jammerAlly = modRules.separateJammers ? allyTeam : 0;
 
 	if (pos.y < 0.0f)
 		return sonarJammer.InSight(pos, jammerAlly);
@@ -991,7 +991,7 @@ bool CLosHandler::InJammer(const CUnit* unit, int allyTeam) const
 
 	//TODO handle ingame alliances
 
-	const int jammerAlly = modInfo.separateJammers ? unit->allyteam : 0;
+	const int jammerAlly = modRules.separateJammers ? unit->allyteam : 0;
 
 	if (unit->IsUnderWater()) {
 		return sonarJammer.InSight(unit->pos, jammerAlly);

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -6,7 +6,7 @@
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
 #include "Sim/Misc/TeamHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Map/ReadMap.h"
 #include "System/Log/ILog.h"
 #include "System/SpringHash.h"
@@ -209,7 +209,7 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 
 	// jammers share all the same map independent of the allyTeam
 	if (type == LOS_TYPE_JAMMER || type == LOS_TYPE_SONAR_JAMMER)
-		allyteam *= modInfo.separateJammers;
+		allyteam *= modRules.separateJammers;
 
 	if (radius <= 0.0f) {
 		if (uli != nullptr) {
@@ -713,13 +713,13 @@ void CLosHandler::Init()
 	baseRadarErrorSize = defBaseRadarErrorSize;
 	baseRadarErrorMult = defBaseRadarErrorMult;
 
-	los.Init(modInfo.losMipLevel, ILosType::LOS_TYPE_LOS);
-	airLos.Init(modInfo.airMipLevel, ILosType::LOS_TYPE_AIRLOS);
-	radar.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_RADAR);
-	sonar.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SONAR);
-	seismic.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SEISMIC);
-	jammer.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_JAMMER);
-	sonarJammer.Init(modInfo.radarMipLevel, ILosType::LOS_TYPE_SONAR_JAMMER);
+	        los.Init(modRules.  losMipLevel, ILosType::LOS_TYPE_LOS         );
+	     airLos.Init(modRules.  airMipLevel, ILosType::LOS_TYPE_AIRLOS      );
+	      radar.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_RADAR       );
+	      sonar.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SONAR       );
+	    seismic.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SEISMIC     );
+	     jammer.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_JAMMER      );
+	sonarJammer.Init(modRules.radarMipLevel, ILosType::LOS_TYPE_SONAR_JAMMER);
 
 	radarErrorSizes.clear();
 	radarErrorSizes.resize(teamHandler.ActiveAllyTeams(), defBaseRadarErrorSize);
@@ -873,7 +873,7 @@ bool CLosHandler::InLos(const CUnit* unit, int allyTeam) const
 	//      are also in radar ("sonar") coverage if requireSonarUnderWater
 	//      is enabled --> underwater units can NOT BE SEEN AT ALL without
 	//      active radar!
-	if (modInfo.alwaysVisibleOverridesCloaked) {
+	if (modRules.alwaysVisibleOverridesCloaked) {
 		if (unit->alwaysVisible)
 			return true;
 		if (unit->isCloaked && unit->allyteam != allyTeam)
@@ -892,7 +892,7 @@ bool CLosHandler::InLos(const CUnit* unit, int allyTeam) const
 	if (unit->useAirLos)
 		return (InAirLos(unit->pos, allyTeam) || InAirLos(unit->pos + unit->speed, allyTeam));
 
-	if (modInfo.requireSonarUnderWater) {
+	if (modRules.requireSonarUnderWater) {
 		if (unit->IsUnderWater() && !InRadar(unit, allyTeam)) {
 			return false;
 		}
@@ -911,7 +911,7 @@ bool CLosHandler::InAirLos(const CUnit* unit, int allyTeam) const
 	//      are also in radar ("sonar") coverage if requireSonarUnderWater
 	//      is enabled --> underwater units can NOT BE SEEN AT ALL without
 	//      active radar!
-	if (modInfo.alwaysVisibleOverridesCloaked) {
+	if (modRules.alwaysVisibleOverridesCloaked) {
 		if (unit->alwaysVisible)
 			return true;
 		if (unit->isCloaked && unit->allyteam != allyTeam)
@@ -927,7 +927,7 @@ bool CLosHandler::InAirLos(const CUnit* unit, int allyTeam) const
 	if (globalLOS[allyTeam])
 		return true;
 
-	if (modInfo.requireSonarUnderWater) {
+	if (modRules.requireSonarUnderWater) {
 		if (unit->IsUnderWater() && !InRadar(unit, allyTeam))
 			return false;
 	}
@@ -942,9 +942,9 @@ bool CLosHandler::InRadar(const float3 pos, int allyTeam) const
 	// position is underwater, only sonar can see it
 	// note: only check jammers when we have a common jammer map, else jammers only apply to objects!
 	if (pos.y < 0.0f)
-		return (sonar.InSight(pos, allyTeam) && !(!modInfo.separateJammers && sonarJammer.InSight(pos, 0)));
+		return (sonar.InSight(pos, allyTeam) && !(!modRules.separateJammers && sonarJammer.InSight(pos, 0)));
 
-	return (radar.InSight(pos, allyTeam) && !(!modInfo.separateJammers && jammer.InSight(pos, 0)));
+	return (radar.InSight(pos, allyTeam) && !(!modRules.separateJammers && jammer.InSight(pos, 0)));
 }
 
 
@@ -976,7 +976,7 @@ bool CLosHandler::InRadar(const CUnit* unit, int allyTeam) const
 bool CLosHandler::InJammer(const float3 pos, int allyTeam) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const int jammerAlly = modInfo.separateJammers ? allyTeam : 0;
+	const int jammerAlly = modRules.separateJammers ? allyTeam : 0;
 
 	return jammer.InSight(pos, jammerAlly);
 }
@@ -988,15 +988,15 @@ bool CLosHandler::InJammer(const CUnit* unit, int allyTeam) const
 		return false;
 
 	//TODO handle ingame alliances
-	const int jammerAlly = modInfo.separateJammers ? unit->allyteam : 0;
-	
+	const int jammerAlly = modRules.separateJammers ? unit->allyteam : 0;
+
 	return jammer.InSight(unit->pos, jammerAlly);
 }
 
 bool CLosHandler::InSonarJammer(const float3 pos, int allyTeam) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const int jammerAlly = modInfo.separateJammers ? allyTeam : 0;
+	const int jammerAlly = modRules.separateJammers ? allyTeam : 0;
 
 	return sonarJammer.InSight(pos, jammerAlly);
 }
@@ -1008,7 +1008,7 @@ bool CLosHandler::InSonarJammer(const CUnit* unit, int allyTeam) const
 		return false;
 	
 	//TODO handle ingame alliances
-	const int jammerAlly = modInfo.separateJammers ? unit->allyteam : 0;
+	const int jammerAlly = modRules.separateJammers ? unit->allyteam : 0;
 
 	return sonarJammer.InSight(unit->pos, jammerAlly);
 }

--- a/rts/Sim/Misc/ModRules.cpp
+++ b/rts/Sim/Misc/ModRules.cpp
@@ -1,7 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 
-#include "ModInfo.h"
+#include "ModRules.h"
 
 #include "Lua/LuaParser.h"
 #include "Lua/LuaSyncedRead.h"
@@ -16,9 +16,9 @@
 
 #include <bit>
 
-CModInfo modInfo;
+CModRules modRules;
 
-void CModInfo::ResetState()
+void CModRules::ResetState()
 {
 	filename.clear();
 	humanName.clear();
@@ -157,7 +157,7 @@ void CModInfo::ResetState()
 	}
 }
 
-void CModInfo::Init(const std::string& modFileName)
+void CModRules::Init(const std::string& modFileName)
 {
 	{
 		filename = modFileName;

--- a/rts/Sim/Misc/ModRules.h
+++ b/rts/Sim/Misc/ModRules.h
@@ -7,10 +7,10 @@
 #include "Sim/Misc/Resource.h"
 #include "Sim/Path/PFSTypes.h"
 
-class CModInfo
+class CModRules
 {
 public:
-	CModInfo() { ResetState(); }
+	CModRules() { ResetState(); }
 
 	void ResetState();
 	void Init(const std::string& modFileName);
@@ -256,6 +256,6 @@ public:
 	bool useStartPositionSelecter;
 };
 
-extern CModInfo modInfo;
+extern CModRules modRules;
 
 #endif // MOD_INFO_H

--- a/rts/Sim/Misc/ModRules.h
+++ b/rts/Sim/Misc/ModRules.h
@@ -1,16 +1,15 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef MOD_INFO_H
-#define MOD_INFO_H
+#pragma once
 
 #include <string>
 #include "Sim/Misc/Resource.h"
 #include "Sim/Path/PFSTypes.h"
 
-class CModInfo
+class CModRules
 {
 public:
-	CModInfo() { ResetState(); }
+	CModRules() { ResetState(); }
 
 	void ResetState();
 	void Init(const std::string& modFileName);
@@ -256,6 +255,4 @@ public:
 	bool useStartPositionSelecter;
 };
 
-extern CModInfo modInfo;
-
-#endif // MOD_INFO_H
+extern CModRules modRules;

--- a/rts/Sim/Misc/SmoothHeightMesh.cpp
+++ b/rts/Sim/Misc/SmoothHeightMesh.cpp
@@ -8,7 +8,7 @@
 
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/float3.h"
 #include "System/Log/ILog.h"
 #include "System/SpringMath.h"
@@ -63,7 +63,7 @@ void SmoothHeightMesh::Init(int2 max, int res, int smoothRad)
 	RECOIL_DETAILED_TRACY_ZONE;
 	Kill();
 
-	enabled = modInfo.enableSmoothMesh;
+	enabled = modRules.enableSmoothMesh;
 
 	// we use SSE in performance sensitive code, don't let the window size be too small.
 	if (smoothRad < 4) smoothRad = 4;

--- a/rts/Sim/Misc/SmoothHeightMesh.cpp
+++ b/rts/Sim/Misc/SmoothHeightMesh.cpp
@@ -8,7 +8,7 @@
 
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/float3.h"
 #include "System/Log/ILog.h"
 #include "System/SpringMath.h"
@@ -86,7 +86,7 @@ void SmoothHeightMesh::Init(int2 max, int res, int smoothRad)
 	RECOIL_DETAILED_TRACY_ZONE;
 	Kill();
 
-	enabled = modInfo.enableSmoothMesh;
+	enabled = modRules.enableSmoothMesh;
 
 	// we use SSE in performance sensitive code, don't let the window size be too small.
 	if (smoothRad < 4) smoothRad = 4;

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -11,7 +11,7 @@
 #include "Game/GlobalUnsynced.h"
 #include "Map/ReadMap.h"
 #include "Net/Protocol/NetProtocol.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
@@ -369,7 +369,7 @@ void CTeam::SlowUpdate()
 	if (mShare > 0.0f) { dm = std::min(1.0f, mExcess / mShare); }
 
 	// now evenly distribute our excess resources among allied teams
-	if (modInfo.nativeExcessSharing) {
+	if (modRules.nativeExcessSharing) {
 		for (int a = 0; a < teamHandler.ActiveTeams(); ++a) {
 			if ((a != teamNum) && (teamHandler.AllyTeam(teamNum) == teamHandler.AllyTeam(a))) {
 				CTeam* team = teamHandler.Team(a);

--- a/rts/Sim/Misc/Team.cpp
+++ b/rts/Sim/Misc/Team.cpp
@@ -11,7 +11,7 @@
 #include "Game/GlobalUnsynced.h"
 #include "Map/ReadMap.h"
 #include "Net/Protocol/NetProtocol.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
@@ -370,7 +370,7 @@ void CTeam::SlowUpdate()
 	if (mShare > 0.0f) { dm = std::min(1.0f, mExcess / mShare); }
 
 	// now evenly distribute our excess resources among allied teams
-	if (modInfo.nativeExcessSharing) {
+	if (modRules.nativeExcessSharing) {
 		for (int a = 0; a < teamHandler.ActiveTeams(); ++a) {
 			if ((a != teamNum) && (teamHandler.AllyTeam(teamNum) == teamHandler.AllyTeam(a))) {
 				CTeam* team = teamHandler.Team(a);

--- a/rts/Sim/Misc/Wind.cpp
+++ b/rts/Sim/Misc/Wind.cpp
@@ -5,7 +5,7 @@
 #include "GlobalSynced.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/ContainerUtil.h"
 #include "System/SpringMath.h"
 
@@ -125,8 +125,8 @@ void EnvResourceHandler::Update()
 	curWindDir = curWindVec;
 	curWindVec = curWindDir * curWindStrength;
 
-	if (const auto& wcrp = modInfo.windChangeReportPeriod; wcrp > 0 && gs->frameNum % wcrp == 0) {
-		// update generators every modInfo.windChangeReportPeriod frames
+	if (const auto& wcrp = modRules.windChangeReportPeriod; wcrp > 0 && gs->frameNum % wcrp == 0) {
+		// update generators every modRules.windChangeReportPeriod frames
 		for (auto unitID : allGeneratorIDs) {
 			unitHandler.GetUnit(unitID)->UpdateWind(curWindDir.x, curWindDir.z, curWindStrength);
 		}

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -19,7 +19,7 @@
 #include "Sim/Features/Feature.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/GeometricObjects.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Path/IPathManager.h"
@@ -408,7 +408,7 @@ static float3 CalcSpeedVectorInclGravity(const CUnit* owner, const CGroundMoveTy
 	const float3 horSpeed = ownerSpd * XZVector * dirSign * revSign;
 	const float3 verSpeed = UpVector * ownerSpd.y;
 
-	if (!modInfo.allowHoverUnitStrafing || owner->moveDef->speedModClass != MoveDef::Hover) {
+	if (!modRules.allowHoverUnitStrafing || owner->moveDef->speedModClass != MoveDef::Hover) {
 		const float3 accelVec = (gndTangVec * hAcc) + (UpVector * vAcc);
 		const float3 speedVec = (horSpeed + verSpeed) + accelVec;
 
@@ -703,7 +703,7 @@ void CGroundMoveType::UpdateUnitPosition() {
  	if (owner->UnderFirstPersonControl())
  		UpdateDirectControl();
 
-	UpdateOwnerPos(owner->speed, calcSpeedVectorFuncs[modInfo.allowGroundUnitGravity](owner, this, deltaSpeed, myGravity));
+	UpdateOwnerPos(owner->speed, calcSpeedVectorFuncs[modRules.allowGroundUnitGravity](owner, this, deltaSpeed, myGravity));
 }
 
 void CGroundMoveType::UpdateCollisionDetections() {
@@ -855,8 +855,8 @@ void CGroundMoveType::SlowUpdate()
 				// in this case, don't wait around making the unit try to run into an obstacle for
 				// longer than absolutely necessary.
 				bool timeForRepath = fallenOutOfExitOnly
-				                   || (    gs->frameNum >= wantRepathFrame + modInfo.pfRepathDelayInFrames
-				                       && (gs->frameNum >= lastRepathFrame + modInfo.pfRepathMaxRateInFrames || lastWaypoint) );
+				                   || (    gs->frameNum >= wantRepathFrame + modRules.pfRepathDelayInFrames
+				                       && (gs->frameNum >= lastRepathFrame + modRules.pfRepathMaxRateInFrames || lastWaypoint) );
 
 				// can't request a new path while the unit is stuck in terrain/static objects
 				if (timeForRepath){
@@ -1538,7 +1538,7 @@ void CGroundMoveType::UpdateSkid()
 			// TODO:
 			//   bouncing behaves too much like a rubber-ball,
 			//   most impact energy needs to go into the ground
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > minCollSpeed && minCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > minCollSpeed && minCollSpeed >= 0.0f)
 				owner->DoDamage(DamageArray(impactDamageMul), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_GROUND, -1);
 
 			skidRotSpeed = 0.0f;
@@ -1715,11 +1715,11 @@ void CGroundMoveType::CheckCollisionSkid()
 				continue;
 
 			// damage the collider, no added impulse
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 				collider->DoDamage(DamageArray(impactDamageMul), ZeroVector, collidee, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			// damage the (static) collidee based on collider's mass, no added impulse
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
 				collidee->DoDamage(DamageArray(impactDamageMul), ZeroVector, collider, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			collider->Move(collSeparationDir * collImpactSpeed, true);
@@ -1745,11 +1745,11 @@ void CGroundMoveType::CheckCollisionSkid()
 				continue;
 
 			// damage the collider
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 				collider->DoDamage(DamageArray(colliderImpactDmgMult), collSeparationDir * colliderImpactDmgMult, collidee, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			// damage the collidee
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
 				collidee->DoDamage(DamageArray(collideeImpactDmgMult), collSeparationDir * -collideeImpactDmgMult, collider, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			collider->Move( colliderImpactImpulse, true);
@@ -1780,7 +1780,7 @@ void CGroundMoveType::CheckCollisionSkid()
 		// damage the collider, no added impulse (!)
 		// the collidee feature can not be passed along to the collider as attacker
 		// yet, keep symmetry and do not pass collider along to the collidee either
-		if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+		if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 			collider->DoDamage(DamageArray(impactDamageMul), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 		// damage the collidee feature based on collider's mass
@@ -1844,7 +1844,7 @@ float3 CGroundMoveType::GetObstacleAvoidanceDir(const float3& desiredDir) {
 		return lastAvoidanceDir = flatFrontDir;
 
 	// Speed-optimizer. Reduces the times this system is run.
-	if ((gs->frameNum + owner->id) % modInfo.groundUnitCollisionAvoidanceUpdateRate) {
+	if ((gs->frameNum + owner->id) % modRules.groundUnitCollisionAvoidanceUpdateRate) {
 		if (!avoidingUnits)
 			lastAvoidanceDir = desiredDir;
 
@@ -2554,7 +2554,7 @@ void CGroundMoveType::HandleObjectCollisions()
 	// then only apply forces from static objects/terrain. This prevent units from pushing each
 	// other into buildings far enough that the pathing systems can't get them out again.
 	float3 tryForce = forceFromStaticCollidees + forceFromMovingCollidees;
-	float maxPushForceSq = maxSpeed*maxSpeed*modInfo.maxCollisionPushMultiplier;
+	float maxPushForceSq = maxSpeed*maxSpeed*modRules.maxCollisionPushMultiplier;
 	if (tryForce.SqLength() > maxPushForceSq)
 		(tryForce.Normalize()) *= maxSpeed;
 
@@ -2789,10 +2789,10 @@ void CGroundMoveType::HandleUnitCollisions(
 	// NOTE: probably too large for most units (eg. causes tree falling animations to be skipped)
 	// const float3 crushImpulse = collider->speed * collider->mass * Sign(int(!reversing));
 
-	const bool allowUCO = modInfo.allowUnitCollisionOverlap;
-	const bool allowCAU = modInfo.allowCrushingAlliedUnits;
-	const bool allowPEU = modInfo.allowPushingEnemyUnits;
-	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
+	const bool allowUCO = modRules.allowUnitCollisionOverlap;
+	const bool allowCAU = modRules.allowCrushingAlliedUnits;
+	const bool allowPEU = modRules.allowPushingEnemyUnits;
+	const bool allowSAT = modRules.allowSepAxisCollisionTest;
 	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
@@ -3009,7 +3009,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 	int curThread
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
+	const bool allowSAT = modRules.allowSepAxisCollisionTest;
 	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
@@ -3284,7 +3284,7 @@ void CGroundMoveType::AdjustPosToWaterLine()
 	if (owner->IsFlying())
 		return;
 
-	if (modInfo.allowGroundUnitGravity) {
+	if (modRules.allowGroundUnitGravity) {
 		if (owner->FloatOnWater()) {
 			MoveDef *md = owner->moveDef;
 			owner->Move(UpVector * (std::max(CGround::GetHeightReal(owner->pos.x, owner->pos.z), -md->waterline) - owner->pos.y), true);

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -19,7 +19,7 @@
 #include "Sim/Features/Feature.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/GeometricObjects.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Path/IPathManager.h"
@@ -411,7 +411,7 @@ static float3 CalcSpeedVectorInclGravity(const CUnit* owner, const CGroundMoveTy
 	const float3 horSpeed = ownerSpd * XZVector * dirSign * revSign;
 	const float3 verSpeed = UpVector * ownerSpd.y;
 
-	if (!modInfo.allowHoverUnitStrafing || owner->moveDef->speedModClass != MoveDef::Hover) {
+	if (!modRules.allowHoverUnitStrafing || owner->moveDef->speedModClass != MoveDef::Hover) {
 		const float3 accelVec = (gndTangVec * hAcc) + (UpVector * vAcc);
 		const float3 speedVec = (horSpeed + verSpeed) + accelVec;
 
@@ -706,7 +706,7 @@ void CGroundMoveType::UpdateUnitPosition() {
  	if (owner->UnderFirstPersonControl())
  		UpdateDirectControl();
 
-	UpdateOwnerPos(owner->speed, calcSpeedVectorFuncs[modInfo.allowGroundUnitGravity](owner, this, deltaSpeed, myGravity));
+	UpdateOwnerPos(owner->speed, calcSpeedVectorFuncs[modRules.allowGroundUnitGravity](owner, this, deltaSpeed, myGravity));
 }
 
 void CGroundMoveType::UpdateCollisionDetections() {
@@ -858,8 +858,8 @@ void CGroundMoveType::SlowUpdate()
 				// in this case, don't wait around making the unit try to run into an obstacle for
 				// longer than absolutely necessary.
 				bool timeForRepath = fallenOutOfExitOnly
-				                   || (    gs->frameNum >= wantRepathFrame + modInfo.pfRepathDelayInFrames
-				                       && (gs->frameNum >= lastRepathFrame + modInfo.pfRepathMaxRateInFrames || lastWaypoint) );
+				                   || (    gs->frameNum >= wantRepathFrame + modRules.pfRepathDelayInFrames
+				                       && (gs->frameNum >= lastRepathFrame + modRules.pfRepathMaxRateInFrames || lastWaypoint) );
 
 				// can't request a new path while the unit is stuck in terrain/static objects
 				if (timeForRepath){
@@ -1541,7 +1541,7 @@ void CGroundMoveType::UpdateSkid()
 			// TODO:
 			//   bouncing behaves too much like a rubber-ball,
 			//   most impact energy needs to go into the ground
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > minCollSpeed && minCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > minCollSpeed && minCollSpeed >= 0.0f)
 				owner->DoDamage(DamageArray(impactDamageMul), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_GROUND, -1);
 
 			skidRotSpeed = 0.0f;
@@ -1718,11 +1718,11 @@ void CGroundMoveType::CheckCollisionSkid()
 				continue;
 
 			// damage the collider, no added impulse
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 				collider->DoDamage(DamageArray(impactDamageMul), ZeroVector, collidee, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			// damage the (static) collidee based on collider's mass, no added impulse
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
 				collidee->DoDamage(DamageArray(impactDamageMul), ZeroVector, collider, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			collider->Move(collSeparationDir * collImpactSpeed, true);
@@ -1748,11 +1748,11 @@ void CGroundMoveType::CheckCollisionSkid()
 				continue;
 
 			// damage the collider
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 				collider->DoDamage(DamageArray(colliderImpactDmgMult), collSeparationDir * colliderImpactDmgMult, collidee, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			// damage the collidee
-			if (modInfo.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
+			if (modRules.allowUnitCollisionDamage && collImpactSpeed > (collideeMinCollSpeed = collideeUD->minCollisionSpeed) && collideeMinCollSpeed >= 0.0f)
 				collidee->DoDamage(DamageArray(collideeImpactDmgMult), collSeparationDir * -collideeImpactDmgMult, collider, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 			collider->Move( colliderImpactImpulse, true);
@@ -1783,7 +1783,7 @@ void CGroundMoveType::CheckCollisionSkid()
 		// damage the collider, no added impulse (!)
 		// the collidee feature can not be passed along to the collider as attacker
 		// yet, keep symmetry and do not pass collider along to the collidee either
-		if (modInfo.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
+		if (modRules.allowUnitCollisionDamage && collImpactSpeed > colliderMinCollSpeed && colliderMinCollSpeed >= 0.0f)
 			collider->DoDamage(DamageArray(impactDamageMul), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 
 		// damage the collidee feature based on collider's mass
@@ -1847,7 +1847,7 @@ float3 CGroundMoveType::GetObstacleAvoidanceDir(const float3& desiredDir) {
 		return lastAvoidanceDir = flatFrontDir;
 
 	// Speed-optimizer. Reduces the times this system is run.
-	if ((gs->frameNum + owner->id) % modInfo.groundUnitCollisionAvoidanceUpdateRate) {
+	if ((gs->frameNum + owner->id) % modRules.groundUnitCollisionAvoidanceUpdateRate) {
 		if (!avoidingUnits)
 			lastAvoidanceDir = desiredDir;
 
@@ -2557,7 +2557,7 @@ void CGroundMoveType::HandleObjectCollisions()
 	// then only apply forces from static objects/terrain. This prevent units from pushing each
 	// other into buildings far enough that the pathing systems can't get them out again.
 	float3 tryForce = forceFromStaticCollidees + forceFromMovingCollidees;
-	float maxPushForceSq = maxSpeed*maxSpeed*modInfo.maxCollisionPushMultiplier;
+	float maxPushForceSq = maxSpeed*maxSpeed*modRules.maxCollisionPushMultiplier;
 	if (tryForce.SqLength() > maxPushForceSq)
 		(tryForce.Normalize()) *= maxSpeed;
 
@@ -2792,10 +2792,10 @@ void CGroundMoveType::HandleUnitCollisions(
 	// NOTE: probably too large for most units (eg. causes tree falling animations to be skipped)
 	// const float3 crushImpulse = collider->speed * collider->mass * Sign(int(!reversing));
 
-	const bool allowUCO = modInfo.allowUnitCollisionOverlap;
-	const bool allowCAU = modInfo.allowCrushingAlliedUnits;
-	const bool allowPEU = modInfo.allowPushingEnemyUnits;
-	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
+	const bool allowUCO = modRules.allowUnitCollisionOverlap;
+	const bool allowCAU = modRules.allowCrushingAlliedUnits;
+	const bool allowPEU = modRules.allowPushingEnemyUnits;
+	const bool allowSAT = modRules.allowSepAxisCollisionTest;
 	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
@@ -3012,7 +3012,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 	int curThread
 ) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const bool allowSAT = modInfo.allowSepAxisCollisionTest;
+	const bool allowSAT = modRules.allowSepAxisCollisionTest;
 	const bool forceSAT = (colliderParams.z > 0.1f);
 
 	const float3 crushImpulse = owner->speed * owner->mass * Sign(int(!reversing));
@@ -3287,7 +3287,7 @@ void CGroundMoveType::AdjustPosToWaterLine()
 	if (owner->IsFlying())
 		return;
 
-	if (modInfo.allowGroundUnitGravity) {
+	if (modRules.allowGroundUnitGravity) {
 		if (owner->FloatOnWater()) {
 			MoveDef *md = owner->moveDef;
 			owner->Move(UpVector * (std::max(CGround::GetHeightReal(owner->pos.x, owner->pos.z), -md->waterline) - owner->pos.y), true);

--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -9,7 +9,7 @@
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/GroundBlockingObjectMap.h"
 #include "Sim/Misc/QuadField.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Units/Scripts/UnitScript.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
@@ -828,7 +828,7 @@ bool CHoverAirMoveType::UpdateAirPhysics()
 	// note: unlike StrafeAirMoveType, UpdateTakeoff and UpdateLanding call
 	// UpdateAirPhysics() so we ignore terrain while we are in those states
 	bool crashed = false;
-	if (modInfo.allowAircraftToHitGround) {
+	if (modRules.allowAircraftToHitGround) {
 		const bool cpGroundContact = (cpGroundHeight > ownerMinHeight);
 		const bool bpGroundContact = (bpGroundHeight > ownerMinHeight);
 		const bool   handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
@@ -874,7 +874,7 @@ bool CHoverAirMoveType::UpdateAirPhysics()
 	//   VS on that
 	UpdateVerticalSpeed(spd, pos.y - std::max(cpGroundHeight, bpGroundHeight), verticalSpeed);
 
-	if (modInfo.allowAircraftToLeaveMap || (pos + spd).IsInBounds())
+	if (modRules.allowAircraftToLeaveMap || (pos + spd).IsInBounds())
 		owner->Move(spd, true);
 
 	return crashed;

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -7,7 +7,7 @@
 #include "Sim/Misc/YardmapStatusEffectsMap.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Path/IPathManager.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Units/Unit.h"
 #include "System/creg/STL_Map.h"
 #include "System/Exceptions.h"
@@ -377,7 +377,7 @@ bool MoveDef::DoRawSearch(
 		, std::clamp(int((endPos.z + upDir) / SQUARE_SIZE), 0, mapDims.mapym1)
 		);
 	const int2 diffBlk = {std::abs(endBlock.x - startBlock.x), std::abs(endBlock.y - startBlock.y)};
-	const float speedModThreshold = modInfo.pfRawMoveSpeedThreshold;
+	const float speedModThreshold = modRules.pfRawMoveSpeedThreshold;
 
 	const/*expr*/ auto StepFunc = [](const int2& dir, const int2& dif, int2& pos, int2& err) {
 		pos.x += (dir.x * (err.y >= 0));

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -7,7 +7,7 @@
 #include "Sim/Misc/YardmapStatusEffectsMap.h"
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Path/IPathManager.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Units/Unit.h"
 #include "System/creg/STL_Map.h"
 #include "System/Exceptions.h"
@@ -380,7 +380,7 @@ bool MoveDef::DoRawSearch(
 		, std::clamp(int((endPos.z + upDir) / SQUARE_SIZE), 0, mapDims.mapym1)
 		);
 	const int2 diffBlk = {std::abs(endBlock.x - startBlock.x), std::abs(endBlock.y - startBlock.y)};
-	const float speedModThreshold = modInfo.pfRawMoveSpeedThreshold;
+	const float speedModThreshold = modRules.pfRawMoveSpeedThreshold;
 
 	const/*expr*/ auto StepFunc = [](const int2& dir, const int2& dif, int2& pos, int2& err) {
 		pos.x += (dir.x * (err.y >= 0));

--- a/rts/Sim/MoveTypes/MoveMath/GroundMoveMath.cpp
+++ b/rts/Sim/MoveTypes/MoveMath/GroundMoveMath.cpp
@@ -1,7 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "MoveMath.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 
 #include "System/Misc/TracyDefs.h"

--- a/rts/Sim/MoveTypes/MoveMath/HoverMoveMath.cpp
+++ b/rts/Sim/MoveTypes/MoveMath/HoverMoveMath.cpp
@@ -1,7 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "MoveMath.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 
 #include "System/Misc/TracyDefs.h"

--- a/rts/Sim/MoveTypes/MoveType.cpp
+++ b/rts/Sim/MoveTypes/MoveType.cpp
@@ -8,7 +8,7 @@
 #include "Components/MoveTypesComponents.h"
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
@@ -87,7 +87,7 @@ void AMoveType::SlowUpdate()
 void AMoveType::UpdateCollisionMap(bool force)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!force && ((gs->frameNum + owner->id) % modInfo.unitQuadPositionUpdateRate))
+	if (!force && ((gs->frameNum + owner->id) % modRules.unitQuadPositionUpdateRate))
 		return;
 
 	if (owner->pos != oldCollisionUpdatePos){

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -8,7 +8,7 @@
 #include "Map/ReadMap.h"
 #include "Sim/Misc/GeometricObjects.h"
 #include "Sim/Misc/GroundBlockingObjectMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Units/Scripts/UnitScript.h"
 #include "Sim/Units/Unit.h"
@@ -619,7 +619,7 @@ bool CStrafeAirMoveType::HandleCollisions(bool checkCollisions) {
 					owner->Move(-dif * (dist - totRad), true);
 					owner->SetVelocity(owner->speed * 0.99f);
 
-					if (modInfo.allowUnitCollisionDamage) {
+					if (modRules.allowUnitCollisionDamage) {
 						owner->DoDamage(DamageArray(damage), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 						unit->DoDamage(DamageArray(damage), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 					}
@@ -635,7 +635,7 @@ bool CStrafeAirMoveType::HandleCollisions(bool checkCollisions) {
 					if (!unit->UsingScriptMoveType())
 						unit->Move(dif * (dist - totRad) * (part), true);
 
-					if (modInfo.allowUnitCollisionDamage) {
+					if (modRules.allowUnitCollisionDamage) {
 						owner->DoDamage(DamageArray(damage), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 						unit->DoDamage(DamageArray(damage), ZeroVector, nullptr, -CSolidObject::DAMAGE_COLLISION_OBJECT, -1);
 					}
@@ -1141,7 +1141,7 @@ bool CStrafeAirMoveType::UpdateAirPhysics(const float4& controlInputs, const flo
 	//   to start bouncing with ever-increasing amplitude while
 	//   stunned, so the same applies there
 	bool crashed = false;
-	if (modInfo.allowAircraftToHitGround) {
+	if (modRules.allowAircraftToHitGround) {
 		const bool groundContact = (groundHeight > (owner->midPos.y - owner->radius));
 		const bool handleContact = (aircraftState != AIRCRAFT_LANDED && aircraftState != AIRCRAFT_TAKEOFF);
 

--- a/rts/Sim/MoveTypes/Systems/UnitTrapCheckSystem.cpp
+++ b/rts/Sim/MoveTypes/Systems/UnitTrapCheckSystem.cpp
@@ -7,7 +7,7 @@
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Features/Feature.h"
 #include "Sim/Features/FeatureHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/MoveTypes/Components/MoveTypesComponents.h"
 #include "Sim/MoveTypes/GroundMoveType.h"
@@ -45,7 +45,7 @@ void UnitTrapCheckSystem::Init() {
 void TagUnitsThatMayBeStuck(std::vector<CUnit*> &curList, const CSolidObject* collidee, int curThread) {
     RECOIL_DETAILED_TRACY_ZONE;
     const int largestMoveTypSizeH = moveDefHandler.GetLargestFootPrintSizeH() + 1;
-    const int bufferSize = SQUARE_SIZE * modInfo.unitQuadPositionUpdateRate * 2 + largestMoveTypSizeH + 1;
+    const int bufferSize = SQUARE_SIZE * modRules.unitQuadPositionUpdateRate * 2 + largestMoveTypSizeH + 1;
 
     const int2& pos = collidee->mapPos;
     const int xmin = pos.x;

--- a/rts/Sim/Path/HAPFS/PathFinder.cpp
+++ b/rts/Sim/Path/HAPFS/PathFinder.cpp
@@ -12,7 +12,7 @@
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/GeometricObjects.h"
 #include "System/MathConstants.h"
 #include "System/TimeProfiler.h"

--- a/rts/Sim/Path/HAPFS/PathManager.cpp
+++ b/rts/Sim/Path/HAPFS/PathManager.cpp
@@ -14,7 +14,7 @@
 #include "PathSearch.h"
 #include "Registry.h"
 #include "Map/MapInfo.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Objects/SolidObject.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "System/Log/ILog.h"
@@ -315,7 +315,7 @@ IPath::SearchResult CPathManager::ArrangePath(
 
 	{
 		RECOIL_DETAILED_TRACY_ZONE;
-		if (heurGoalDist2D <= (MAXRES_SEARCH_DISTANCE * modInfo.pfRawDistMult)) {
+		if (heurGoalDist2D <= (MAXRES_SEARCH_DISTANCE * modRules.pfRawDistMult)) {
 			pfDef->AllowRawPathSearch( true);
 			pfDef->AllowDefPathSearch(false); // block default search
 

--- a/rts/Sim/Path/HAPFS/PathManager.h
+++ b/rts/Sim/Path/HAPFS/PathManager.h
@@ -5,7 +5,7 @@
 
 #include <cinttypes>
 
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Path/IPathManager.h"
 #include "IPath.h"
 #include "IPathFinder.h"

--- a/rts/Sim/Path/HAPFS/PathingState.cpp
+++ b/rts/Sim/Path/HAPFS/PathingState.cpp
@@ -9,7 +9,7 @@
 #include "Game/LoadScreen.h"
 #include "Net/Protocol/NetProtocol.h"
 
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"
 #include "PathFinder.h"
@@ -631,14 +631,14 @@ void PathingState::Update()
 	// determine how many blocks we should update
 	int blocksToUpdate = 0;
 	{
-		const int progressiveUpdates = std::ceil(updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<2)) * modInfo.pfUpdateRateScale);
+		const int progressiveUpdates = std::ceil(updatedBlocks.size() * (1.f / (BLOCKS_TO_UPDATE<<2)) * modRules.pfUpdateRateScale);
 		const int MIN_BLOCKS_TO_UPDATE = 1;
 		const int MAX_BLOCKS_TO_UPDATE = std::max<int>(BLOCKS_TO_UPDATE >> 1, MIN_BLOCKS_TO_UPDATE);
 
 		blocksToUpdate = std::clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE) * numMoveDefs;
 	
 		// LOG("[%d] blocksToUpdate=%d progressiveUpdates=%d [%f]"
-		// 		, BLOCK_SIZE, blocksToUpdate, progressiveUpdates, modInfo.pfUpdateRateScale);
+		// 		, BLOCK_SIZE, blocksToUpdate, progressiveUpdates, modRules.pfUpdateRateScale);
 	}
 
 	//LOG("PathingState::Update blocksToUpdate %d", blocksToUpdate);

--- a/rts/Sim/Path/QTPFS/NodeLayer.cpp
+++ b/rts/Sim/Path/QTPFS/NodeLayer.cpp
@@ -24,7 +24,7 @@ inline int __bsfd (int mask)
 #include "Node.h"
 
 #include "Map/MapInfo.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -23,7 +23,7 @@
 #include "Map/MapInfo.h"
 
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"
@@ -809,14 +809,14 @@ void QTPFS::PathManager::Update() {
 			int updatedBlocks = nodeLayersMapDamageTrack.mapChangeTrackers[layerNum].damageQueue.size();
 			{
 				constexpr int BLOCKS_TO_UPDATE = 16;
-				const int progressiveUpdates = std::ceil(updatedBlocks * (1.f / (BLOCKS_TO_UPDATE<<3)) * modInfo.pfUpdateRateScale);
+				const int progressiveUpdates = std::ceil(updatedBlocks * (1.f / (BLOCKS_TO_UPDATE<<3)) * modRules.pfUpdateRateScale);
 				constexpr int MIN_BLOCKS_TO_UPDATE = 0;
 				constexpr int MAX_BLOCKS_TO_UPDATE = std::max<int>(BLOCKS_TO_UPDATE, MIN_BLOCKS_TO_UPDATE);
 
 				blocksToUpdate = std::clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE);
 			
 				// LOG("[%d] blocksToUpdate=%d updatedBlocks=%d [%f]"
-				// 		, layerNum, blocksToUpdate, updatedBlocks, modInfo.pfUpdateRateScale);
+				// 		, layerNum, blocksToUpdate, updatedBlocks, modRules.pfUpdateRateScale);
 			}
 			return blocksToUpdate;
 		};

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -23,7 +23,7 @@
 #include "Map/MapInfo.h"
 
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"
@@ -816,14 +816,14 @@ void QTPFS::PathManager::Update() {
 			int updatedBlocks = nodeLayersMapDamageTrack.mapChangeTrackers[layerNum].damageQueue.size();
 			{
 				constexpr int BLOCKS_TO_UPDATE = 16;
-				const int progressiveUpdates = std::ceil(updatedBlocks * (1.f / (BLOCKS_TO_UPDATE<<3)) * modInfo.pfUpdateRateScale);
+				const int progressiveUpdates = std::ceil(updatedBlocks * (1.f / (BLOCKS_TO_UPDATE<<3)) * modRules.pfUpdateRateScale);
 				constexpr int MIN_BLOCKS_TO_UPDATE = 0;
 				constexpr int MAX_BLOCKS_TO_UPDATE = std::max<int>(BLOCKS_TO_UPDATE, MIN_BLOCKS_TO_UPDATE);
 
 				blocksToUpdate = std::clamp(progressiveUpdates, MIN_BLOCKS_TO_UPDATE, MAX_BLOCKS_TO_UPDATE);
 			
 				// LOG("[%d] blocksToUpdate=%d updatedBlocks=%d [%f]"
-				// 		, layerNum, blocksToUpdate, updatedBlocks, modInfo.pfUpdateRateScale);
+				// 		, layerNum, blocksToUpdate, updatedBlocks, modRules.pfUpdateRateScale);
 			}
 			return blocksToUpdate;
 		};

--- a/rts/Sim/Path/QTPFS/PathManager.h
+++ b/rts/Sim/Path/QTPFS/PathManager.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Path/IPathManager.h"
 #include "NodeLayer.h"
 #include "PathCache.h"

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -12,7 +12,7 @@
 #include "NodeLayer.h"
 #include "Sim/Misc/CollisionHandler.h"
 #include "Sim/Misc/GlobalConstants.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/Log/ILog.h"
 #include "Game/SelectedUnitsHandler.h"
 #include "Sim/Objects/SolidObject.h"
@@ -172,7 +172,7 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData) {
 		for (auto i = firstCleanPointId + 1; i < pointCount; ++i) {
 			const float3& nextPoint = pathToRepair->GetPoint(i);
 			pathLength += nextPoint.distance2D(prevPoint);
-			if (pathLength >= modInfo.qtRefreshPathMinDist)
+			if (pathLength >= modRules.qtRefreshPathMinDist)
 				return true;
 		}
 		return false;
@@ -561,9 +561,9 @@ void QTPFS::PathSearch::InitStartingSearchNodes() {
 
 	// max nodes is split between forward and reverse search.
 	if (pathOwner != nullptr){
-		float relativeModifier = std::max(MAP_RELATIVE_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearchedRelativeToMapOpenNodes);
+		float relativeModifier = std::max(MAP_RELATIVE_MAX_NODES_SEARCHED, modRules.qtMaxNodesSearchedRelativeToMapOpenNodes);
 		int relativeLimit = nodeLayer->GetNumOpenNodes() * relativeModifier;
-		int absoluteLimit = std::max(MAP_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearched);
+		int absoluteLimit = std::max(MAP_MAX_NODES_SEARCHED, modRules.qtMaxNodesSearched);
 
 		nodeSearchLimit = std::max(absoluteLimit, relativeLimit) >> 1;
 	} else {
@@ -675,16 +675,16 @@ void QTPFS::PathSearch::SetNodeSearchLimit() {
 
 	// Approximate the distance the pathing system can search out to. The calculation takes into account that we use
 	// bi-directional path finding.
-	const float maxDist = math::sqrt(modInfo.qtMaxNodesSearched>>1) * 2 * avgNodeLength;
+	const float maxDist = math::sqrt(modRules.qtMaxNodesSearched>>1) * 2 * avgNodeLength;
 
 	constexpr int minNodesSearched = 256;
-	const int limit = modInfo.qtMaxNodesSearched>>1;
+	const int limit = modRules.qtMaxNodesSearched>>1;
 
 	const float interp = std::clamp(dist / maxDist, 0.f, 1.f);
 	nodeSearchLimit = std::max(minNodesSearched, int(limit * CircularEaseOut(interp)));
 
 	// LOG("%s: Pathing ease out for layer %d is (srchMax: %d, sqrs: %d, nodes: %d, dist: %f, avg: %f, max: %f) %d", __func__, nodeLayer->GetNodelayer(),
-	// 	modInfo.qtMaxNodesSearched, mapDims.mapSquares, nodeLayer->GetNumLeafNodes(), dist, avgNodeLength, maxDist, nodeSearchLimit);
+	// 	modRules.qtMaxNodesSearched, mapDims.mapSquares, nodeLayer->GetNumLeafNodes(), dist, avgNodeLength, maxDist, nodeSearchLimit);
 }
 
 // #pragma GCC push_options
@@ -2148,7 +2148,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 	uint32_t repathIndex = 0;
 	// Unowned paths do not allow repaths - they always perform a full path search.
 	if (!haveFullPath && pathOwner != nullptr) {
-		const float minRepathLength = modInfo.qtRefreshPathMinDist;
+		const float minRepathLength = modRules.qtRefreshPathMinDist;
 		bool pathIsBigEnoughForRepath = (pathDist >= minRepathLength);
 
 		// This may result in a short path still not finding an index, but that's fine:

--- a/rts/Sim/Path/QTPFS/PathSearch.cpp
+++ b/rts/Sim/Path/QTPFS/PathSearch.cpp
@@ -12,7 +12,7 @@
 #include "NodeLayer.h"
 #include "Sim/Misc/CollisionHandler.h"
 #include "Sim/Misc/GlobalConstants.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "System/Log/ILog.h"
 #include "Game/SelectedUnitsHandler.h"
 #include "Sim/Objects/SolidObject.h"
@@ -172,7 +172,7 @@ void QTPFS::PathSearch::InitializeThread(SearchThreadData* threadData, IPath* pa
 		for (auto i = firstCleanPointId + 1; i < pointCount; ++i) {
 			const float3& nextPoint = pathToRepair->GetPoint(i);
 			pathLength += nextPoint.distance2D(prevPoint);
-			if (pathLength >= modInfo.qtRefreshPathMinDist)
+			if (pathLength >= modRules.qtRefreshPathMinDist)
 				return true;
 		}
 		return false;
@@ -561,9 +561,9 @@ void QTPFS::PathSearch::InitStartingSearchNodes() {
 
 	// max nodes is split between forward and reverse search.
 	if (pathOwner != nullptr){
-		float relativeModifier = std::max(MAP_RELATIVE_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearchedRelativeToMapOpenNodes);
+		float relativeModifier = std::max(MAP_RELATIVE_MAX_NODES_SEARCHED, modRules.qtMaxNodesSearchedRelativeToMapOpenNodes);
 		int relativeLimit = nodeLayer->GetNumOpenNodes() * relativeModifier;
-		int absoluteLimit = std::max(MAP_MAX_NODES_SEARCHED, modInfo.qtMaxNodesSearched);
+		int absoluteLimit = std::max(MAP_MAX_NODES_SEARCHED, modRules.qtMaxNodesSearched);
 
 		nodeSearchLimit = std::max(absoluteLimit, relativeLimit) >> 1;
 	} else {
@@ -675,16 +675,16 @@ void QTPFS::PathSearch::SetNodeSearchLimit() {
 
 	// Approximate the distance the pathing system can search out to. The calculation takes into account that we use
 	// bi-directional path finding.
-	const float maxDist = math::sqrt(modInfo.qtMaxNodesSearched>>1) * 2 * avgNodeLength;
+	const float maxDist = math::sqrt(modRules.qtMaxNodesSearched>>1) * 2 * avgNodeLength;
 
 	constexpr int minNodesSearched = 256;
-	const int limit = modInfo.qtMaxNodesSearched>>1;
+	const int limit = modRules.qtMaxNodesSearched>>1;
 
 	const float interp = std::clamp(dist / maxDist, 0.f, 1.f);
 	nodeSearchLimit = std::max(minNodesSearched, int(limit * CircularEaseOut(interp)));
 
 	// LOG("%s: Pathing ease out for layer %d is (srchMax: %d, sqrs: %d, nodes: %d, dist: %f, avg: %f, max: %f) %d", __func__, nodeLayer->GetNodelayer(),
-	// 	modInfo.qtMaxNodesSearched, mapDims.mapSquares, nodeLayer->GetNumLeafNodes(), dist, avgNodeLength, maxDist, nodeSearchLimit);
+	// 	modRules.qtMaxNodesSearched, mapDims.mapSquares, nodeLayer->GetNumLeafNodes(), dist, avgNodeLength, maxDist, nodeSearchLimit);
 }
 
 // #pragma GCC push_options
@@ -2152,7 +2152,7 @@ void QTPFS::PathSearch::TracePath(IPath* path) {
 	uint32_t repathIndex = 0;
 	// Unowned paths do not allow repaths - they always perform a full path search.
 	if (!haveFullPath && pathOwner != nullptr) {
-		const float minRepathLength = modInfo.qtRefreshPathMinDist;
+		const float minRepathLength = modRules.qtRefreshPathMinDist;
 		bool pathIsBigEnoughForRepath = (pathDist >= minRepathLength);
 
 		// This may result in a short path still not finding an index, but that's fine:

--- a/rts/Sim/Projectiles/PieceProjectile.cpp
+++ b/rts/Sim/Projectiles/PieceProjectile.cpp
@@ -13,7 +13,7 @@
 #include "Rendering/Env/Particles/Classes/SmokeTrailProjectile.h"
 #include "Rendering/Models/3DModelPiece.hpp"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Projectiles/ProjectileMemPool.h"
@@ -151,7 +151,7 @@ void CPieceProjectile::Collision(CUnit* unit, CFeature* feature)
 		return;
 
 	if ((explFlags & PF_Explode) && (unit || feature)) {
-		const DamageArray damageArray(modInfo.debrisDamage);
+		const DamageArray damageArray(modRules.debrisDamage);
 		const CExplosionParams params = {
 			.pos                  = pos,
 			.dir                  = ZeroVector,
@@ -159,8 +159,8 @@ void CPieceProjectile::Collision(CUnit* unit, CFeature* feature)
 			.weaponDef            = nullptr,
 			.owner                = owner(),
 			.hitObject            = ExplosionHitObject(unit, feature),
-			.craterAreaOfEffect   = modInfo.debrisDamage * 0.25f,
-			.damageAreaOfEffect   = modInfo.debrisDamage * 0.5f,
+			.craterAreaOfEffect   = modRules.debrisDamage * 0.25f,
+			.damageAreaOfEffect   = modRules.debrisDamage * 0.5f,
 			.edgeEffectiveness    = 0.0f,
 			.explosionSpeed       = 10.0f,
 			.gfxMod               = 1.0f,

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -7,7 +7,7 @@
 #include "Game/SelectedUnitsHandler.h"
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/StrafeAirMoveType.h"
 #include "Sim/Units/Unit.h"
@@ -427,7 +427,7 @@ void CAirCAI::ExecuteAttack(Command& c)
 				StopMoveAndFinishCommand();
 				return;
 			}
-			if (targetUnit->GetTransporter() != nullptr && !modInfo.targetableTransportedUnits) {
+			if (targetUnit->GetTransporter() != nullptr && !modRules.targetableTransportedUnits) {
 				StopMoveAndFinishCommand();
 				return;
 			}

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -16,7 +16,7 @@
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
 #include "Sim/Units/BuildInfo.h"
@@ -1512,7 +1512,7 @@ void CCommandAI::ExecuteAttack(Command& c)
 				FinishCommand();
 				return;
 			}
-			if (targetUnit->GetTransporter() != nullptr && !modInfo.targetableTransportedUnits) {
+			if (targetUnit->GetTransporter() != nullptr && !modRules.targetableTransportedUnits) {
 				FinishCommand();
 				return;
 			}

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -9,7 +9,7 @@
 #include "Map/Ground.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/LosHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/AAirMoveType.h"
@@ -639,12 +639,12 @@ void CMobileCAI::ExecuteGuard(Command& c)
 	}
 
 	constexpr float epsilonish = 1.0f * INV_GAME_SPEED;
-	const float sqrRecalculateThreshold = modInfo.guardRecalculateThreshold;
-	const float sqrStoppedProximityGoal = modInfo.guardStoppedProximityGoal;
-	const float stoppedExtraDistanceOffset = modInfo.guardStoppedExtraDistance;
-	const float sqrMovingProximityGoal = modInfo.guardMovingProximityGoal;
-	const float movingIntervalMultiplier = modInfo.guardMovingIntervalMultiplier;
-	const float maxTimeToIntercept = modInfo.guardInterceptionLimit;
+	const float sqrRecalculateThreshold    = modRules.guardRecalculateThreshold;
+	const float sqrStoppedProximityGoal    = modRules.guardStoppedProximityGoal;
+	const float stoppedExtraDistanceOffset = modRules.guardStoppedExtraDistance;
+	const float sqrMovingProximityGoal     = modRules.guardMovingProximityGoal;
+	const float movingIntervalMultiplier   = modRules.guardMovingIntervalMultiplier;
+	const float maxTimeToIntercept         = modRules.guardInterceptionLimit;
 
 	float3 goalPos = owner->pos;
 	float3 deltaPos = guardee->pos - owner->pos;
@@ -918,7 +918,7 @@ void CMobileCAI::ExecuteAttack(Command& c)
 					StopMoveAndFinishCommand();
 					return;
 				}
-				if (targetUnit->GetTransporter() != nullptr && !modInfo.targetableTransportedUnits) {
+				if (targetUnit->GetTransporter() != nullptr && !modRules.targetableTransportedUnits) {
 					StopMoveAndFinishCommand();
 					return;
 				}

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -46,7 +46,7 @@
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/Wind.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/GroundMoveType.h"
 #include "Sim/MoveTypes/HoverAirMoveType.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
@@ -157,12 +157,12 @@ CFeature* CUnit::CreateWreck(int wreckLevel, int smokeTime)
 void CUnit::InitStatic()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	globalUnitParams.empDeclineRate = 1.0f / modInfo.paralyzeDeclineRate;
-	globalUnitParams.expMultiplier = modInfo.unitExpMultiplier;
-	globalUnitParams.expPowerScale = modInfo.unitExpPowerScale;
-	globalUnitParams.expHealthScale = modInfo.unitExpHealthScale;
-	globalUnitParams.expReloadScale = modInfo.unitExpReloadScale;
-	globalUnitParams.expGrade = modInfo.unitExpGrade;
+	globalUnitParams.empDeclineRate = 1.0f / modRules.paralyzeDeclineRate;
+	globalUnitParams.expMultiplier  = modRules.unitExpMultiplier;
+	globalUnitParams.expPowerScale  = modRules.unitExpPowerScale;
+	globalUnitParams.expHealthScale = modRules.unitExpHealthScale;
+	globalUnitParams.expReloadScale = modRules.unitExpReloadScale;
+	globalUnitParams.expGrade       = modRules.unitExpGrade;
 
 	CBuilderCaches::InitStatic();
 	unitToolTipMap.Clear();
@@ -820,7 +820,7 @@ void CUnit::ReleaseTransportees(CUnit* attacker, bool selfDestruct, bool reclaim
 			if (unitDef->canfly && transportee->unitDef->canmove)
 				transportee->commandAI->GiveCommand(Command(CMD_MOVE, transportee->pos));
 
-			transportee->SetStunned(transportee->paralyzeDamage > (modInfo.paralyzeOnMaxHealth? transportee->maxHealth: transportee->health));
+			transportee->SetStunned(transportee->paralyzeDamage > (modRules.paralyzeOnMaxHealth? transportee->maxHealth: transportee->health));
 			transportee->SetVelocityAndSpeed(speed * (0.5f + 0.5f * gsRNG.NextFloat()));
 
 			eventHandler.UnitUnloaded(transportee, this);
@@ -995,7 +995,7 @@ void CUnit::SlowUpdate()
 		// DoDamage) we potentially start decaying from a lower damage
 		// level and would otherwise be de-paralyzed more quickly than
 		// specified by <paralyzeTime>
-		paralyzeDamage -= ((modInfo.paralyzeOnMaxHealth? maxHealth: health) * (UNIT_SLOWUPDATE_RATE * INV_GAME_SPEED) * globalUnitParams.empDeclineRate);
+		paralyzeDamage -= ((modRules.paralyzeOnMaxHealth? maxHealth: health) * (UNIT_SLOWUPDATE_RATE * INV_GAME_SPEED) * globalUnitParams.empDeclineRate);
 		paralyzeDamage = std::max(paralyzeDamage, 0.0f);
 	}
 
@@ -1006,7 +1006,7 @@ void CUnit::SlowUpdate()
 		// which would make us invulnerable to most non-/small-AOE weapon impacts
 		static_cast<AMoveType*>(moveType)->SlowUpdate();
 
-		const bool notStunned = (paralyzeDamage <= (modInfo.paralyzeOnMaxHealth? maxHealth: health));
+		const bool notStunned = (paralyzeDamage <= (modRules.paralyzeOnMaxHealth? maxHealth: health));
 		const bool inFireBase = (transporter == nullptr || !transporter->unitDef->IsTransportUnit() || transporter->unitDef->isFirePlatform);
 
 		// de-stun only if we are not (still) inside a non-firebase transport
@@ -1030,8 +1030,8 @@ void CUnit::SlowUpdate()
 
 	if (beingBuilt) {
 		const auto framesSinceLastNanoAdd = gs->frameNum - lastNanoAdd;
-		if (modInfo.constructionDecay && (modInfo.constructionDecayTime < framesSinceLastNanoAdd)) {
-			float buildDecay = buildTime * modInfo.constructionDecaySpeed;
+		if (modRules.constructionDecay && (modRules.constructionDecayTime < framesSinceLastNanoAdd)) {
+			float buildDecay = buildTime * modRules.constructionDecaySpeed;
 
 			buildDecay = 1.0f / std::max(0.001f, buildDecay);
 			buildDecay = std::min(buildProgress, buildDecay);
@@ -1259,7 +1259,7 @@ void CUnit::ApplyDamage(CUnit* attacker, const DamageArray& damages, float& base
 			health -= baseDamage;
 			health = std::min(health, maxHealth);
 
-			if (health > paralyzeDamage && !modInfo.paralyzeOnMaxHealth) {
+			if (health > paralyzeDamage && !modRules.paralyzeOnMaxHealth) {
 				SetStunned(false);
 			}
 		}
@@ -1273,7 +1273,7 @@ void CUnit::ApplyDamage(CUnit* attacker, const DamageArray& damages, float& base
 		//
 		// rate of paralysis-damage reduction is lower if the unit has less than
 		// maximum health to ensure stun-time is always equal to <paralyzeTime>
-		const float baseHealth = (modInfo.paralyzeOnMaxHealth? maxHealth: health);
+		const float baseHealth = (modRules.paralyzeOnMaxHealth? maxHealth: health);
 		const float paralysisDecayRate = baseHealth * globalUnitParams.empDeclineRate;
 		const float sumParalysisDamage = paralysisDecayRate * damages.paralyzeDamageTime;
 		const float maxParalysisDamage = std::max(baseHealth + sumParalysisDamage - paralyzeDamage, 0.0f);
@@ -2029,7 +2029,7 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		else if (health < maxHealth) {
 			// repair
 			const float step = std::min(amount / buildTime, 1.0f - (health / maxHealth));
-			const auto resourceUse = cost * step * modInfo.repairCostFactor;
+			const auto resourceUse = cost * step * modRules.repairCostFactor;
 
 			if (!builderTeam->HaveResources(resourceUse)) {
 				builderTeam->resPull += resourceUse;
@@ -2058,10 +2058,10 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 
 		const float step = std::max(amount / buildTime, -buildProgress);
 		const auto costFraction = cost * -step;
-		const auto refund  = costFraction * modInfo.reclaimUnitEfficiency;
-		const auto useCost = costFraction * modInfo.reclaimUnitCostFactor;
-		const float healthStep        = modInfo.reclaimUnitDrainHealth ? maxHealth * step : 0;
-		const float buildProgressStep = int(modInfo.reclaimUnitMethod == 0) * step;
+		const auto refund  = costFraction * modRules.reclaimUnitEfficiency;
+		const auto useCost = costFraction * modRules.reclaimUnitCostFactor;
+		const float healthStep        = modRules.reclaimUnitDrainHealth ? maxHealth * step : 0;
+		const float buildProgressStep = int(modRules.reclaimUnitMethod == 0) * step;
 		const float postHealth        = health + healthStep;
 		const float postBuildProgress = buildProgress + buildProgressStep;
 
@@ -2078,13 +2078,13 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		order.use = useCost;
 		order.useIncomeMultiplier = false; // Dont apply income bonus to reclaimed units
 		
-		if (modInfo.reclaimUnitMethod == 0) {
+		if (modRules.reclaimUnitMethod == 0) {
 			// gradual reclamation of invested resources
 			order.add = refund;
 		} else {
 			// lump reclamation of invested resources
 			if (postHealth <= 0.0f || postBuildProgress <= 0.0f) {
-				order.add = cost * buildProgress * modInfo.reclaimUnitEfficiency;
+				order.add = cost * buildProgress * modRules.reclaimUnitEfficiency;
 				killMe = true; // to make 100% sure the unit gets killed, and so no resources are reclaimed twice!
 			}
 		}
@@ -2094,7 +2094,7 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		}
 
 		// turn reclaimee into nanoframe (even living units)
-		if (modInfo.reclaimUnitMethod == 0)
+		if (modRules.reclaimUnitMethod == 0)
 			TurnIntoNanoframe();
 
 		// reduce health & resources
@@ -2125,9 +2125,9 @@ bool CUnit::AllowedReclaim(CUnit* builder) const
 	// Don't allow the reclaim if the unit is finished and we arent allowed to reclaim it
 	if (!beingBuilt) {
 		if (allyteam == builder->allyteam) {
-			if ((team != builder->team) && (!modInfo.reclaimAllowAllies)) return false;
+			if ((team != builder->team) && (!modRules.reclaimAllowAllies)) return false;
 		} else {
-			if (!modInfo.reclaimAllowEnemies) return false;
+			if (!modRules.reclaimAllowEnemies) return false;
 		}
 	}
 
@@ -2515,7 +2515,7 @@ bool CUnit::GetNewCloakState(bool stunCheck) {
 	const CUnit* closestEnemy = this;
 
 	if (!stunCheck)
-		closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(this, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, modInfo.decloakRequiresLineOfSight);
+		closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(this, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, modRules.decloakRequiresLineOfSight);
 
 	return (eventHandler.AllowUnitCloak(this, closestEnemy));
 }
@@ -2734,7 +2734,7 @@ bool CUnit::DetachUnitCore(CUnit* unit)
 			unit->moveType->UseHeading(true);
 
 		// de-stun detaching units in case we are not a fire-platform
-		unit->SetStunned(unit->paralyzeDamage > (modInfo.paralyzeOnMaxHealth? unit->maxHealth: unit->health));
+		unit->SetStunned(unit->paralyzeDamage > (modRules.paralyzeOnMaxHealth? unit->maxHealth: unit->health));
 
 		unit->moveType->SlowUpdate();
 		unit->moveType->LeaveTransport();

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -8,7 +8,7 @@
 #include "Sim/Misc/CategoryHandler.h"
 #include "Sim/Misc/CollisionVolume.h"
 #include "Sim/Misc/DamageArrayHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/Weapons/WeaponDefHandler.h"
 #include "Sim/Units/CommandAI/Command.h"
@@ -465,9 +465,9 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	moveState = udTable.GetInt("moveState", (canmove && speed > 0.0f)? MOVESTATE_NONE: MOVESTATE_MANEUVER);
 	moveState = std::min(moveState, int(MOVESTATE_ROAM));
 
-	flankingBonusMode = udTable.GetInt("flankingBonusMode", modInfo.flankingBonusModeDefault);
-	flankingBonusMax  = udTable.GetFloat("flankingBonusMax", modInfo.flankingBonusMaxDefault);
-	flankingBonusMin  = udTable.GetFloat("flankingBonusMin", modInfo.flankingBonusMinDefault);
+	flankingBonusMode = udTable.GetInt("flankingBonusMode", modRules.flankingBonusModeDefault);
+	flankingBonusMax  = udTable.GetFloat("flankingBonusMax", modRules.flankingBonusMaxDefault);
+	flankingBonusMin  = udTable.GetFloat("flankingBonusMin", modRules.flankingBonusMinDefault);
 	flankingBonusDir  = udTable.GetFloat3("flankingBonusDir", FwdVector);
 	flankingBonusMobilityAdd = udTable.GetFloat("flankingBonusMobilityAdd", 0.01f);
 
@@ -609,16 +609,16 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 			floatOnWater      |= udTable.GetBool("floater", udTable.KeyExists("WaterLine"));
 
 			// we have no MoveDef, so pathType == -1 and IsAirUnit() MIGHT be true
-			cantBeTransported |= (!modInfo.transportAir && canfly);
+			cantBeTransported |= (!modRules.transportAir && canfly);
 		} else {
 			//upright           |= (moveDef->speedModClass == MoveDef::Hover);
 			//upright           |= (moveDef->speedModClass == MoveDef::Ship );
 
 			// we have a MoveDef, so pathType != -1 and IsGroundUnit() MUST be true
-			cantBeTransported |= (!modInfo.transportGround && moveDef->speedModClass == MoveDef::Tank );
-			cantBeTransported |= (!modInfo.transportGround && moveDef->speedModClass == MoveDef::KBot );
-			cantBeTransported |= (!modInfo.transportShip   && moveDef->speedModClass == MoveDef::Ship );
-			cantBeTransported |= (!modInfo.transportHover  && moveDef->speedModClass == MoveDef::Hover);
+			cantBeTransported |= (!modRules.transportGround && moveDef->speedModClass == MoveDef::Tank );
+			cantBeTransported |= (!modRules.transportGround && moveDef->speedModClass == MoveDef::KBot );
+			cantBeTransported |= (!modRules.transportShip   && moveDef->speedModClass == MoveDef::Ship );
+			cantBeTransported |= (!modRules.transportHover  && moveDef->speedModClass == MoveDef::Hover);
 		}
 
 		if (seismicSignature == -1.0f) {

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -13,7 +13,7 @@
 #include "CommandAI/BuilderCAI.h"
 #include "Sim/Ecs/Registry.h"
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
 #include "Sim/MoveTypes/Systems/GeneralMoveSystem.h"

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -14,7 +14,7 @@
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Misc/GroundBlockingObjectMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
@@ -404,7 +404,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 		return true;
 	}
 
-	if ((modInfo.reclaimMethod != 1) && (curResurrectee->reclaimLeft < 1)) {
+	if ((modRules.reclaimMethod != 1) && (curResurrectee->reclaimLeft < 1)) {
 		// this corpse has been reclaimed a little, need to restore
 		// its resources before we can let the player resurrect it
 		curResurrectee->AddBuildPower(this, resurrectSpeed);
@@ -417,7 +417,7 @@ bool CBuilder::UpdateResurrect(const Command& fCommand)
 	const float step = resurrectSpeed / resurrecteeDef->buildTime;
 
 	const bool resurrectAllowed = eventHandler.AllowFeatureBuildStep(this, curResurrectee, step);
-	const bool canExecResurrect = (resurrectAllowed && UseResources(resurrecteeDef->cost * step * modInfo.resurrectCostFactor));
+	const bool canExecResurrect = (resurrectAllowed && UseResources(resurrecteeDef->cost * step * modRules.resurrectCostFactor));
 
 	if (canExecResurrect) {
 		curResurrectee->resurrectProgress += step;
@@ -504,7 +504,7 @@ bool CBuilder::UpdateCapture(const Command& fCommand)
 	const float captureProgressTemp = std::min(curCapturee->captureProgress + captureProgressStep, 1.0f);
 
 	const float captureFraction = captureProgressTemp - curCapturee->captureProgress;
-	const auto resourceUseScaled = curCapturee->cost * captureFraction * modInfo.captureCostFactor;
+	const auto resourceUseScaled = curCapturee->cost * captureFraction * modRules.captureCostFactor;
 
 	const bool buildStepAllowed = (eventHandler.AllowUnitBuildStep(this, curCapturee, captureProgressStep));
 	const bool captureStepAllowed = (eventHandler.AllowUnitCaptureStep(this, curCapturee, captureProgressStep));

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -7,7 +7,7 @@
 #include "Map/Ground.h"
 #include "Map/ReadMap.h"
 #include "Sim/Misc/GroundBlockingObjectMap.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
@@ -455,7 +455,7 @@ void CFactory::AssignBuildeeOrders(CUnit* unit) {
 
 	Command c(CMD_MOVE);
 
-	if (!unit->unitDef->canfly && modInfo.insertBuiltUnitMoveCommand) {
+	if (!unit->unitDef->canfly && modRules.insertBuiltUnitMoveCommand) {
 		// HACK: when a factory has a rallypoint set far enough away
 		// to trigger the non-admissible path estimators, we want to
 		// avoid units getting stuck inside by issuing them an extra
@@ -484,7 +484,7 @@ void CFactory::AssignBuildeeOrders(CUnit* unit) {
 	}
 
 	if (unitCmdQue.empty()) {
-		if (modInfo.insertBuiltUnitMoveCommand) {
+		if (modRules.insertBuiltUnitMoveCommand) {
 			unitCAI->GiveCommand(c);
 		}
 
@@ -508,7 +508,7 @@ void CFactory::AssignBuildeeOrders(CUnit* unit) {
 
 			unitCAI->GiveCommand(c);
 		}
-	} else if (modInfo.insertBuiltUnitMoveCommand) {
+	} else if (modRules.insertBuiltUnitMoveCommand) {
 		unitCmdQue.push_front(c);
 	}
 }

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -13,7 +13,7 @@
 #include "Sim/Misc/CollisionVolume.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/InterceptHandler.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Misc/QuadField.h"
 #include "Sim/MoveTypes/AAirMoveType.h"
@@ -1032,9 +1032,9 @@ bool CWeapon::TestTarget(const float3& tgtPos, const SWeaponTarget& trg) const
 				return false;
 			if ((trg.unit->category & onlyTargetCategory) == 0)
 				return false;
-			if (trg.unit->isDead && !modInfo.fireAtKilled)
+			if (trg.unit->isDead && !modRules.fireAtKilled)
 				return false;
-			if (trg.unit->IsCrashing() && !modInfo.fireAtCrashing)
+			if (trg.unit->IsCrashing() && !modRules.fireAtCrashing)
 				return false;
 			if ((trg.unit->losStatus[owner->allyteam] & (LOS_INLOS | LOS_INRADAR)) == 0)
 				return false;
@@ -1045,7 +1045,7 @@ bool CWeapon::TestTarget(const float3& tgtPos, const SWeaponTarget& trg) const
 				return false;
 
 			if (trg.unit->GetTransporter() != nullptr) {
-				if (!modInfo.targetableTransportedUnits)
+				if (!modRules.targetableTransportedUnits)
 					return false;
 				// the transportee might be "hidden" below terrain, in which case we can't target it
 				if (trg.unit->pos.y < CGround::GetHeightReal(trg.unit->pos.x, trg.unit->pos.z))

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -7,7 +7,7 @@
 #include "Sim/Misc/DamageArrayHandler.h"
 #include "Sim/Misc/DefinitionTag.h"
 #include "Sim/Misc/GlobalConstants.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "Sim/Projectiles/WeaponProjectiles/WeaponProjectileTypes.h"
 #include "Sim/Units/Scripts/CobInstance.h" // TAANG2RAD

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -58,7 +58,7 @@
 #include "Rendering/Textures/TextureAtlas.h"
 #include "Sim/Misc/DefinitionTag.h" // DefType
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "System/ScopedResource.h"
 #include "System/EventHandler.h"
@@ -840,7 +840,7 @@ void SpringApp::Reload(const std::string script)
 	gameSetup->ResetState();
 
 	CTimeProfiler::GetInstance().ResetState();
-	modInfo.ResetState();
+	modRules.ResetState();
 
 	LOG("[SpringApp::%s][11]", __func__);
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -61,7 +61,7 @@
 #include "Rendering/Textures/TextureAtlas.h"
 #include "Sim/Misc/DefinitionTag.h" // DefType
 #include "Sim/Misc/GlobalSynced.h"
-#include "Sim/Misc/ModInfo.h"
+#include "Sim/Misc/ModRules.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "System/ScopedResource.h"
 #include "System/EventHandler.h"
@@ -852,7 +852,7 @@ void SpringApp::Reload(const std::string script)
 	gameSetup->ResetState();
 
 	CTimeProfiler::GetInstance().ResetState();
-	modInfo.ResetState();
+	modRules.ResetState();
 
 	LOG("[SpringApp::%s][11]", __func__);
 


### PR DESCRIPTION
`CModInfo` represents the contents of `modrules.lua`, despite there also being a different file called `modinfo.lua` (who doesn't have its own class). This is confusing.