### PR TITLE
LuaGaia: load from game first

### DIFF
--- a/rts/Lua/LuaGaia.cpp
+++ b/rts/Lua/LuaGaia.cpp
@@ -57,7 +57,7 @@ std::string CLuaGaia::GetSyncedFileName() const
 
 std::string CLuaGaia::GetInitFileModes() const
 {
-	return SPRING_VFS_MAP_BASE;
+	return SPRING_VFS_MOD SPRING_VFS_MAP_BASE;
 }
 
 int CLuaGaia::GetInitSelectTeam() const


### PR DESCRIPTION
Lets a game decide what to do about mapside LuaGaia.