### PR TITLE
Explicitly use InSonarJammer or InJammer depending on the tested sensor

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -8157,7 +8157,12 @@ int LuaSyncedRead::GetPositionLosState(lua_State* L)
 
 	const bool inLos    = losHandler->InLos(pos, allyTeamID);
 	const bool inRadar  = losHandler->InRadar(pos, allyTeamID);
-	const bool inJammer = losHandler->InJammer(pos, allyTeamID);
+	bool inJammer;
+	if (pos.y < 0.0f) {
+		inJammer = losHandler->InSonarJammer(pos, allyTeamID);
+	} else {
+		inJammer = losHandler->InJammer(pos, allyTeamID);
+	}
 
 	lua_pushboolean(L, inLos || inRadar);
 	lua_pushboolean(L, inLos);
@@ -8393,8 +8398,18 @@ int LuaSyncedRead::IsUnitInJammer(lua_State* L)
 		luaL_argerror(L, 2, "Invalid allyTeam");
 		return 0;
 	}
-
-	lua_pushboolean(L, losHandler->InJammer(unit, allyTeamID)); //FIXME
+	bool inJammer;
+	if (unit->IsUnderWater()) {
+		inJammer = losHandler->InSonarJammer(unit, allyTeamID);
+	}
+	else if (unit->IsInWater()) {
+		inJammer = (losHandler->InSonarJammer(unit, allyTeamID) && (losHandler->InJammer(unit, allyTeamID)));
+	} 
+	else 
+	{
+		inJammer = losHandler->InJammer(unit, allyTeamID);
+	}
+	lua_pushboolean(L, inJammer);
 	return 1;
 }
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -8157,12 +8157,7 @@ int LuaSyncedRead::GetPositionLosState(lua_State* L)
 
 	const bool inLos    = losHandler->InLos(pos, allyTeamID);
 	const bool inRadar  = losHandler->InRadar(pos, allyTeamID);
-	bool inJammer;
-	if (pos.y < 0.0f) {
-		inJammer = losHandler->InSonarJammer(pos, allyTeamID);
-	} else {
-		inJammer = losHandler->InJammer(pos, allyTeamID);
-	}
+	const bool inJammer = losHandler->InJammer(pos, allyTeamID);
 
 	lua_pushboolean(L, inLos || inRadar);
 	lua_pushboolean(L, inLos);
@@ -8398,18 +8393,8 @@ int LuaSyncedRead::IsUnitInJammer(lua_State* L)
 		luaL_argerror(L, 2, "Invalid allyTeam");
 		return 0;
 	}
-	bool inJammer;
-	if (unit->IsUnderWater()) {
-		inJammer = losHandler->InSonarJammer(unit, allyTeamID);
-	}
-	else if (unit->IsInWater()) {
-		inJammer = (losHandler->InSonarJammer(unit, allyTeamID) && (losHandler->InJammer(unit, allyTeamID)));
-	} 
-	else 
-	{
-		inJammer = losHandler->InJammer(unit, allyTeamID);
-	}
-	lua_pushboolean(L, inJammer);
+
+	lua_pushboolean(L, losHandler->InJammer(unit, allyTeamID)); //FIXME
 	return 1;
 }
 

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -951,22 +951,24 @@ bool CLosHandler::InRadar(const float3 pos, int allyTeam) const
 bool CLosHandler::InRadar(const CUnit* unit, int allyTeam) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	// unit is discoverable by sonar
+	// first attempt to discover with sonar:
+	// unit is discoverable by sonar only if not sonarStealth or not sonarJammed
 	if (unit->IsInWater()) {
 		if ((!unit->sonarStealth || unit->beingBuilt) &&
 		    sonar.InSight(unit->pos, allyTeam) &&
-		    !InJammer(unit, allyTeam))
+		    !InSonarJammer(unit, allyTeam))
 			return true;
 	}
 
-	// unit is completely submerged, only sonar can see it
+	// unit is InWater and UnderWater, but was not previously caught by sonar, skip it
 	if (unit->IsUnderWater())
 		return false;
 
-	// radar stealth
+	// then attempt to discover with radar
+	// unit is radar stealth, can't be discovered
 	if (unit->stealth && !unit->beingBuilt)
 		return false;
-
+	// use radar jamming, not sonar jamming here
 	return (radar.InSight(unit->pos, allyTeam) && !InJammer(unit, allyTeam));
 }
 
@@ -976,12 +978,8 @@ bool CLosHandler::InJammer(const float3 pos, int allyTeam) const
 	RECOIL_DETAILED_TRACY_ZONE;
 	const int jammerAlly = modInfo.separateJammers ? allyTeam : 0;
 
-	if (pos.y < 0.0f)
-		return sonarJammer.InSight(pos, jammerAlly);
-
 	return jammer.InSight(pos, jammerAlly);
 }
-
 
 bool CLosHandler::InJammer(const CUnit* unit, int allyTeam) const
 {
@@ -990,11 +988,27 @@ bool CLosHandler::InJammer(const CUnit* unit, int allyTeam) const
 		return false;
 
 	//TODO handle ingame alliances
+	const int jammerAlly = modInfo.separateJammers ? unit->allyteam : 0;
+	
+	return jammer.InSight(unit->pos, jammerAlly);
+}
 
+bool CLosHandler::InSonarJammer(const float3 pos, int allyTeam) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	const int jammerAlly = modInfo.separateJammers ? allyTeam : 0;
+
+	return sonarJammer.InSight(pos, jammerAlly);
+}
+
+bool CLosHandler::InSonarJammer(const CUnit* unit, int allyTeam) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	if (allyTeam == unit->allyteam)
+		return false;
+	
+	//TODO handle ingame alliances
 	const int jammerAlly = modInfo.separateJammers ? unit->allyteam : 0;
 
-	if (unit->IsUnderWater()) {
-		return sonarJammer.InSight(unit->pos, jammerAlly);
-	}
-	return jammer.InSight(unit->pos, jammerAlly);
+	return sonarJammer.InSight(unit->pos, jammerAlly);
 }

--- a/rts/Sim/Misc/LosHandler.h
+++ b/rts/Sim/Misc/LosHandler.h
@@ -253,10 +253,15 @@ public:
 	bool InRadar(const CUnit* unit, int allyTeam) const;
 
 
-	// returns whether a square is being radar- or sonar-jammed
-	// (even when the square is not in radar- or sonar-coverage)
+	// returns whether a square is being radar-jammed
+	// (even when the square is not in radar-coverage)
 	bool InJammer(const float3 pos, int allyTeam) const;
 	bool InJammer(const CUnit* unit, int allyTeam) const;
+
+	// returns whether a square is being sonar-jammed
+	// (even when the square is not in sonar-coverage)
+	bool InSonarJammer(const float3 pos, int allyTeam) const;
+	bool InSonarJammer(const CUnit* unit, int allyTeam) const;
 
 
 	bool InSeismicDistance(const CUnit* unit, int allyTeam) const {


### PR DESCRIPTION
Separate sonar detection path from radar detection path when testing for InJammer(), making sure sonarJammer only affects sonar detection, and Jammer only affects radar detection.

Test results with separateJammers = false
```
Dolphin = sonar stealth
construction ship = sonar + radar stealth
skater = radar stealth
Destroyer = sonar jammer
cruiser = regular ship
submarine = regular submarine
The rest is obvious
```

https://www.youtube.com/watch?v=dDTIGJGFwpo

with separateJammers = true,
https://www.youtube.com/watch?v=cZ5CcwruACE

The split by allyteam logic remains functional.

Now marking as ready for review