### PR TITLE
Gamepad support: add SDL controller input polling API for LuaUI

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -135,13 +135,15 @@ void CMouseHandler::InitStatic()
 	controllerInput = CControllerInput::GetInstance();
 	mouse = new CMouseHandler();
 }
+
 void CMouseHandler::KillStatic()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	spring::SafeDelete(mouse);
-	CControllerInput::FreeInstance(controllerInput);
+	CControllerInput::FreeInstance();
 	IMouseInput::FreeInstance(mouseInput);
 }
+
 
 void CMouseHandler::ReloadCursors()
 {

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -3,6 +3,7 @@
 #include "MouseHandler.h"
 
 #include "CommandColors.h"
+#include "System/Input/ControllerInput.h"
 #include "InputReceiver.h"
 #include "GuiHandler.h"
 #include "MiniMap.h"
@@ -128,18 +129,19 @@ void CMouseHandler::InitStatic()
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(mouse == nullptr);
 	assert(mouseInput == nullptr);
+	assert(controllerInput == nullptr);
 
 	mouseInput = IMouseInput::GetInstance(configHandler->GetBool("MouseRelativeModeWarp"));
+	controllerInput = CControllerInput::GetInstance();
 	mouse = new CMouseHandler();
 }
-
 void CMouseHandler::KillStatic()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	spring::SafeDelete(mouse);
+	CControllerInput::FreeInstance(controllerInput);
 	IMouseInput::FreeInstance(mouseInput);
 }
-
 
 void CMouseHandler::ReloadCursors()
 {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3979,38 +3979,38 @@ int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
  * @section controllerinput
 ******************************************************************************/
 
-static void PushControllerInfo(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+static void PushControllerInfo(lua_State* L, const CControllerInput::ControllerState& controller)
 {
 	lua_createtable(L, 0, 3);
-	HSTR_PUSH_NUMBER(L, "instanceId", controller.instanceId);
-	HSTR_PUSH_NUMBER(L, "deviceId", controller.deviceId);
+	HSTR_PUSH_NUMBER(L, "instanceID", controller.instanceID);
+	HSTR_PUSH_NUMBER(L, "deviceID", controller.deviceID);
 	HSTR_PUSH_STRING(L, "name", controller.name);
 }
 
-static void PushControllerButtons(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+static void PushControllerButtons(lua_State* L, const CControllerInput::ControllerState& controller)
 {
 	lua_createtable(L, static_cast<int>(controller.buttons.size()), 0);
 
-	for (size_t buttonId = 0; buttonId < controller.buttons.size(); ++buttonId) {
-		lua_pushnumber(L, controller.buttons[buttonId]);
-		lua_rawseti(L, -2, static_cast<int>(buttonId));
+	for (size_t buttonID = 0; buttonID < controller.buttons.size(); ++buttonID) {
+		lua_pushnumber(L, controller.buttons[buttonID]);
+		lua_rawseti(L, -2, static_cast<int>(buttonID + 1));
 	}
 }
 
-static void PushControllerAxes(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+static void PushControllerAxes(lua_State* L, const CControllerInput::ControllerState& controller)
 {
 	lua_createtable(L, static_cast<int>(controller.axes.size()), 0);
 
-	for (size_t axisId = 0; axisId < controller.axes.size(); ++axisId) {
-		lua_pushnumber(L, controller.axes[axisId]);
-		lua_rawseti(L, -2, static_cast<int>(axisId));
+	for (size_t axisID = 0; axisID < controller.axes.size(); ++axisID) {
+		lua_pushnumber(L, controller.axes[axisID]);
+		lua_rawseti(L, -2, static_cast<int>(axisID + 1));
 	}
 }
 
-static void PushControllerState(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+static void PushControllerState(lua_State* L, const CControllerInput::ControllerState& controller)
 {
 	lua_createtable(L, 0, 4);
-	HSTR_PUSH_NUMBER(L, "instanceId", controller.instanceId);
+	HSTR_PUSH_NUMBER(L, "instanceID", controller.instanceID);
 	HSTR_PUSH_STRING(L, "name", controller.name);
 
 	HSTR_PUSH(L, "buttons");
@@ -4025,7 +4025,7 @@ static void PushControllerState(lua_State* L, const CControllerInput::Controller
 /***
  *
  * @function Spring.GetAvailableControllers
- * @return { instanceId: number, deviceId: number, name: string }[] controllers
+ * @return { instanceID: number, deviceID: number, name: string }[] controllers
  */
 int LuaUnsyncedRead::GetAvailableControllers(lua_State* L)
 {
@@ -4048,21 +4048,21 @@ int LuaUnsyncedRead::GetAvailableControllers(lua_State* L)
 /***
  *
  * @function Spring.GetControllerState
- * @param instanceId number
- * @return table? controllerState with 0-based `buttons` and `axes` tables keyed by SDL id
+ * @param instanceID number
+ * @return table? controllerState with `buttons` and `axes` as 1-indexed Lua arrays in SDL controller enum order
  */
 int LuaUnsyncedRead::GetControllerState(lua_State* L)
 {
 	if (controllerInput == nullptr)
 		return 0;
 
-	const int instanceId = luaL_checkint(L, 1);
+	const int instanceID = luaL_checkint(L, 1);
 
-	CControllerInput::ControllerStateSnapshot controller;
-	if (!controllerInput->GetControllerState(instanceId, controller))
+	const auto controller = controllerInput->GetControllerState(instanceID);
+	if (!controller.has_value())
 		return 0;
 
-	PushControllerState(L, controller);
+	PushControllerState(L, *controller);
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -66,6 +66,7 @@
 #include "System/TimeProfiler.h"
 #include "System/Config/ConfigHandler.h"
 #include "System/Config/ConfigVariable.h"
+#include "System/Input/ControllerInput.h"
 #include "System/Input/KeyInput.h"
 #include "System/LoadSave/DemoReader.h"
 #include "System/LoadSave/DemoRecorder.h"
@@ -252,6 +253,8 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetMouseState);
 	REGISTER_LUA_CFUNC(GetMouseCursor);
 	REGISTER_LUA_CFUNC(GetMouseStartPosition);
+	REGISTER_LUA_CFUNC(GetAvailableControllers);
+	REGISTER_LUA_CFUNC(GetControllerState);
 
 	REGISTER_LUA_CFUNC(GetKeyFromScanSymbol);
 	REGISTER_LUA_CFUNC(GetKeyState);
@@ -3968,6 +3971,99 @@ int LuaUnsyncedRead::GetMouseButtonsPressed(lua_State* L)
 	}
 
 	return numArgs;
+}
+
+
+/******************************************************************************
+ * Controller Input
+ * @section controllerinput
+******************************************************************************/
+
+static void PushControllerInfo(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+{
+	lua_createtable(L, 0, 3);
+	HSTR_PUSH_NUMBER(L, "instanceId", controller.instanceId);
+	HSTR_PUSH_NUMBER(L, "deviceId", controller.deviceId);
+	HSTR_PUSH_STRING(L, "name", controller.name);
+}
+
+static void PushControllerButtons(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+{
+	lua_createtable(L, static_cast<int>(controller.buttons.size()), 0);
+
+	for (size_t buttonId = 0; buttonId < controller.buttons.size(); ++buttonId) {
+		lua_pushnumber(L, controller.buttons[buttonId]);
+		lua_rawseti(L, -2, static_cast<int>(buttonId));
+	}
+}
+
+static void PushControllerAxes(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+{
+	lua_createtable(L, static_cast<int>(controller.axes.size()), 0);
+
+	for (size_t axisId = 0; axisId < controller.axes.size(); ++axisId) {
+		lua_pushnumber(L, controller.axes[axisId]);
+		lua_rawseti(L, -2, static_cast<int>(axisId));
+	}
+}
+
+static void PushControllerState(lua_State* L, const CControllerInput::ControllerStateSnapshot& controller)
+{
+	lua_createtable(L, 0, 4);
+	HSTR_PUSH_NUMBER(L, "instanceId", controller.instanceId);
+	HSTR_PUSH_STRING(L, "name", controller.name);
+
+	HSTR_PUSH(L, "buttons");
+	PushControllerButtons(L, controller);
+	lua_rawset(L, -3);
+
+	HSTR_PUSH(L, "axes");
+	PushControllerAxes(L, controller);
+	lua_rawset(L, -3);
+}
+
+/***
+ *
+ * @function Spring.GetAvailableControllers
+ * @return { instanceId: number, deviceId: number, name: string }[] controllers
+ */
+int LuaUnsyncedRead::GetAvailableControllers(lua_State* L)
+{
+	if (controllerInput == nullptr) {
+		lua_createtable(L, 0, 0);
+		return 1;
+	}
+
+	const auto controllers = controllerInput->GetAvailableControllers();
+	lua_createtable(L, static_cast<int>(controllers.size()), 0);
+
+	for (size_t i = 0; i < controllers.size(); ++i) {
+		PushControllerInfo(L, controllers[i]);
+		lua_rawseti(L, -2, static_cast<int>(i + 1));
+	}
+
+	return 1;
+}
+
+/***
+ *
+ * @function Spring.GetControllerState
+ * @param instanceId number
+ * @return table? controllerState with 0-based `buttons` and `axes` tables keyed by SDL id
+ */
+int LuaUnsyncedRead::GetControllerState(lua_State* L)
+{
+	if (controllerInput == nullptr)
+		return 0;
+
+	const int instanceId = luaL_checkint(L, 1);
+
+	CControllerInput::ControllerStateSnapshot controller;
+	if (!controllerInput->GetControllerState(instanceId, controller))
+		return 0;
+
+	PushControllerState(L, controller);
+	return 1;
 }
 
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4025,7 +4025,7 @@ static void PushControllerState(lua_State* L, const CControllerInput::Controller
 /***
  *
  * @function Spring.GetAvailableControllers
- * @return { instanceID: number, deviceID: number, name: string }[] controllers
+ * @return table controllers 1-indexed array of controller info tables. Each controller info table has instanceID, deviceID, and name fields.
  */
 int LuaUnsyncedRead::GetAvailableControllers(lua_State* L)
 {
@@ -4049,7 +4049,7 @@ int LuaUnsyncedRead::GetAvailableControllers(lua_State* L)
  *
  * @function Spring.GetControllerState
  * @param instanceID number
- * @return table? controllerState with `buttons` and `axes` as 1-indexed Lua arrays in SDL controller enum order
+ * @return table? controllerState controller state table with instanceID, name, buttons, and axes fields. The buttons and axes fields are 1-indexed Lua arrays in SDL controller enum order.
  */
 int LuaUnsyncedRead::GetControllerState(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -152,6 +152,8 @@ class LuaUnsyncedRead {
 		static int GetMouseState(lua_State* L);
 		static int GetMouseCursor(lua_State* L);
 		static int GetMouseStartPosition(lua_State* L);
+		static int GetAvailableControllers(lua_State* L);
+		static int GetControllerState(lua_State* L);
 
 		static int GetKeyFromScanSymbol(lua_State* L);
 		static int GetKeyState(lua_State* L);

--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -22,6 +22,7 @@ make_global_var(sources_engine_System_common
 		"${CMAKE_CURRENT_SOURCE_DIR}/EventHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/GlobalConfig.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Info.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Input/ControllerInput.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Input/InputHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Input/KeyInput.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Input/MouseInput.cpp"

--- a/rts/System/Input/ControllerInput.cpp
+++ b/rts/System/Input/ControllerInput.cpp
@@ -34,6 +34,8 @@ void CControllerInput::FreeInstance()
 	controllerInput = nullptr;
 }
 
+#ifndef HEADLESS
+
 std::vector<CControllerInput::ControllerState> CControllerInput::GetAvailableControllers() const
 {
 	std::vector<ControllerState> controllers;
@@ -55,8 +57,6 @@ std::optional<CControllerInput::ControllerState> CControllerInput::GetController
 
 	return controllerIt->second;
 }
-
-#ifndef HEADLESS
 
 CControllerInput::CControllerInput()
 {
@@ -283,6 +283,16 @@ void CControllerInput::HandleAxisMotion(int instanceID, int axisID, std::int16_t
 
 CControllerInput::CControllerInput() = default;
 CControllerInput::~CControllerInput() = default;
+
+std::vector<CControllerInput::ControllerState> CControllerInput::GetAvailableControllers() const
+{
+	return {};
+}
+
+std::optional<CControllerInput::ControllerState> CControllerInput::GetControllerState(int) const
+{
+	return std::nullopt;
+}
 
 bool CControllerInput::HandleSDLControllerEvent(const SDL_Event&)
 {

--- a/rts/System/Input/ControllerInput.cpp
+++ b/rts/System/Input/ControllerInput.cpp
@@ -1,0 +1,316 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "ControllerInput.h"
+
+#include "System/Input/InputHandler.h"
+#include "System/Log/ILog.h"
+
+#ifndef CONTROLLER_INPUT_LOG_EVENTS
+#define CONTROLLER_INPUT_LOG_EVENTS 0
+#endif
+
+#ifndef HEADLESS
+#include <SDL.h>
+#include <SDL_events.h>
+#include <SDL_error.h>
+#include <SDL_gamecontroller.h>
+#include <SDL_joystick.h>
+#endif
+
+CControllerInput* controllerInput = nullptr;
+
+CControllerInput* CControllerInput::GetInstance()
+{
+	if (controllerInput == nullptr) {
+		controllerInput = new CControllerInput();
+	}
+
+	return controllerInput;
+}
+
+void CControllerInput::FreeInstance(CControllerInput* controllerInputPtr)
+{
+	if (controllerInputPtr == controllerInput) {
+		delete controllerInput;
+		controllerInput = nullptr;
+	}
+}
+
+CControllerInput::ControllerStateSnapshot CControllerInput::MakeControllerStateSnapshot(const ControllerState& state)
+{
+	ControllerStateSnapshot snapshot;
+	snapshot.deviceId = state.deviceId;
+	snapshot.instanceId = state.instanceId;
+	snapshot.name = state.name;
+	snapshot.axes = state.axes;
+	snapshot.buttons = state.buttons;
+
+	return snapshot;
+}
+
+std::vector<CControllerInput::ControllerStateSnapshot> CControllerInput::GetAvailableControllers() const
+{
+	std::vector<ControllerStateSnapshot> controllers;
+	controllers.reserve(controllersByInstanceId.size());
+
+	for (const auto& controllerIt : controllersByInstanceId) {
+		controllers.push_back(MakeControllerStateSnapshot(controllerIt.second));
+	}
+
+	return controllers;
+}
+
+bool CControllerInput::GetControllerState(int instanceId, ControllerStateSnapshot& state) const
+{
+	auto controllerIt = controllersByInstanceId.find(instanceId);
+	if (controllerIt == controllersByInstanceId.end()) {
+		return false;
+	}
+
+	state = MakeControllerStateSnapshot(controllerIt->second);
+	return true;
+}
+
+#ifndef HEADLESS
+
+CControllerInput::CControllerInput()
+{
+	if (SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) != 0) {
+		LOG_L(L_WARNING, "[ControllerInput] Failed to initialize SDL joystick/gamecontroller subsystem: %s", SDL_GetError());
+	} else {
+		LOG_L(L_INFO, "[ControllerInput] SDL joystick/gamecontroller subsystem initialized");
+	}
+
+	SDL_GameControllerEventState(SDL_ENABLE);
+	SDL_JoystickEventState(SDL_ENABLE);
+
+	inputCon = input.AddHandler([this](const SDL_Event& event) {
+		return this->HandleSDLControllerEvent(event);
+	});
+
+	LOG_L(L_INFO, "[ControllerInput] SDL_NumJoysticks at init: %d", SDL_NumJoysticks());
+	ScanExistingControllers();
+
+	LOG_L(L_INFO, "[ControllerInput] Initialized SDL controller input handler");
+}
+
+CControllerInput::~CControllerInput()
+{
+	for (auto& controllerIt : controllersByInstanceId) {
+		auto& state = controllerIt.second;
+
+		if (state.gameController != nullptr) {
+			SDL_GameControllerClose(state.gameController);
+			state.gameController = nullptr;
+		}
+	}
+
+	controllersByInstanceId.clear();
+
+	LOG_L(L_INFO, "[ControllerInput] Shutting down SDL controller input handler");
+}
+
+bool CControllerInput::HandleSDLControllerEvent(const SDL_Event& event)
+{
+	switch (event.type) {
+		case SDL_CONTROLLERDEVICEADDED: {
+			HandleDeviceAdded(event.cdevice.which);
+		} break;
+
+		case SDL_CONTROLLERDEVICEREMOVED: {
+			HandleDeviceRemoved(event.cdevice.which);
+		} break;
+
+		case SDL_CONTROLLERDEVICEREMAPPED: {
+			HandleDeviceRemapped(event.cdevice.which);
+		} break;
+
+		case SDL_CONTROLLERBUTTONDOWN: {
+			HandleButtonDown(event.cbutton.which, event.cbutton.button, event.cbutton.state);
+		} break;
+
+		case SDL_CONTROLLERBUTTONUP: {
+			HandleButtonUp(event.cbutton.which, event.cbutton.button, event.cbutton.state);
+		} break;
+
+		case SDL_CONTROLLERAXISMOTION: {
+			HandleAxisMotion(event.caxis.which, event.caxis.axis, event.caxis.value);
+		} break;
+
+		default:
+			break;
+	}
+
+	return false;
+}
+
+void CControllerInput::LogAvailableController(int deviceId) const
+{
+	if (SDL_IsGameController(deviceId)) {
+		const char* name = SDL_GameControllerNameForIndex(deviceId);
+		LOG_L(L_INFO, "[ControllerInput] SDL game controller available: deviceId=%d name=%s", deviceId, name != nullptr ? name : "unknown");
+		return;
+	}
+
+	const char* name = SDL_JoystickNameForIndex(deviceId);
+	LOG_L(L_INFO, "[ControllerInput] SDL joystick available but not game controller: deviceId=%d name=%s", deviceId, name != nullptr ? name : "unknown");
+}
+
+void CControllerInput::ScanExistingControllers()
+{
+	const int joystickCount = SDL_NumJoysticks();
+	LOG_L(L_INFO, "[ControllerInput] Scanning existing SDL joysticks: count=%d", joystickCount);
+
+	for (int deviceId = 0; deviceId < joystickCount; ++deviceId) {
+		LogAvailableController(deviceId);
+
+		if (SDL_IsGameController(deviceId)) {
+			HandleDeviceAdded(deviceId);
+			continue;
+		}
+
+		LOG_L(L_INFO, "[ControllerInput] Skipping existing non-game-controller device: deviceId=%d", deviceId);
+	}
+}
+
+void CControllerInput::HandleDeviceAdded(int deviceId)
+{
+	LOG_L(L_INFO, "[ControllerInput] Controller device added: deviceId=%d", deviceId);
+	LogAvailableController(deviceId);
+
+	if (!SDL_IsGameController(deviceId)) {
+		LOG_L(L_INFO, "[ControllerInput] Ignoring non-game-controller device: deviceId=%d", deviceId);
+		return;
+	}
+
+	SDL_GameController* gameController = SDL_GameControllerOpen(deviceId);
+	if (gameController == nullptr) {
+		LOG_L(L_WARNING, "[ControllerInput] Failed to open SDL game controller: deviceId=%d error=%s", deviceId, SDL_GetError());
+		return;
+	}
+
+	SDL_Joystick* joystick = SDL_GameControllerGetJoystick(gameController);
+	const int instanceId = joystick != nullptr ? SDL_JoystickInstanceID(joystick) : -1;
+
+	if (instanceId < 0) {
+		LOG_L(L_WARNING, "[ControllerInput] Failed to get joystick instance id: deviceId=%d", deviceId);
+		SDL_GameControllerClose(gameController);
+		return;
+	}
+
+	ControllerState state;
+	state.deviceId = deviceId;
+	state.instanceId = instanceId;
+
+	const char* name = SDL_GameControllerName(gameController);
+	state.name = name != nullptr ? name : "unknown";
+	state.gameController = gameController;
+
+	auto existingIt = controllersByInstanceId.find(instanceId);
+	if (existingIt != controllersByInstanceId.end() && existingIt->second.gameController != nullptr) {
+		SDL_GameControllerClose(existingIt->second.gameController);
+	}
+
+	controllersByInstanceId[instanceId] = state;
+
+	LOG_L(L_INFO, "[ControllerInput] Controller connected: deviceId=%d instanceId=%d name=%s", deviceId, instanceId, state.name.c_str());
+}
+
+void CControllerInput::HandleDeviceRemoved(int instanceId)
+{
+	LOG_L(L_INFO, "[ControllerInput] Controller device removed: instanceId=%d", instanceId);
+
+	auto it = controllersByInstanceId.find(instanceId);
+	if (it == controllersByInstanceId.end()) {
+		return;
+	}
+
+	LOG_L(L_INFO, "[ControllerInput] Removed tracked controller: instanceId=%d name=%s", instanceId, it->second.name.c_str());
+
+	if (it->second.gameController != nullptr) {
+		SDL_GameControllerClose(it->second.gameController);
+		it->second.gameController = nullptr;
+	}
+
+	controllersByInstanceId.erase(it);
+}
+
+void CControllerInput::HandleDeviceRemapped(int instanceId)
+{
+	LOG_L(L_INFO, "[ControllerInput] Controller remapped: instanceId=%d", instanceId);
+}
+
+void CControllerInput::HandleButtonDown(int instanceId, int buttonId, std::uint8_t value)
+{
+	auto controllerIt = controllersByInstanceId.find(instanceId);
+	if (controllerIt == controllersByInstanceId.end()) {
+		return;
+	}
+
+	auto& state = controllerIt->second;
+
+	if (buttonId >= 0 && buttonId < static_cast<int>(state.buttons.size())) {
+		state.buttons[buttonId] = value;
+	}
+
+#if CONTROLLER_INPUT_LOG_EVENTS
+	LOG_L(L_INFO, "[ControllerInput] ButtonDown: instanceId=%d buttonId=%d value=%u", instanceId, buttonId, static_cast<unsigned int>(value));
+#endif
+}
+
+void CControllerInput::HandleButtonUp(int instanceId, int buttonId, std::uint8_t value)
+{
+	auto controllerIt = controllersByInstanceId.find(instanceId);
+	if (controllerIt == controllersByInstanceId.end()) {
+		return;
+	}
+
+	auto& state = controllerIt->second;
+
+	if (buttonId >= 0 && buttonId < static_cast<int>(state.buttons.size())) {
+		state.buttons[buttonId] = value;
+	}
+
+#if CONTROLLER_INPUT_LOG_EVENTS
+	LOG_L(L_INFO, "[ControllerInput] ButtonUp: instanceId=%d buttonId=%d value=%u", instanceId, buttonId, static_cast<unsigned int>(value));
+#endif
+}
+
+void CControllerInput::HandleAxisMotion(int instanceId, int axisId, std::int16_t value)
+{
+	auto controllerIt = controllersByInstanceId.find(instanceId);
+	if (controllerIt == controllersByInstanceId.end()) {
+		return;
+	}
+
+	auto& state = controllerIt->second;
+
+	if (axisId >= 0 && axisId < static_cast<int>(state.axes.size())) {
+		state.axes[axisId] = value;
+	}
+
+#if CONTROLLER_INPUT_LOG_EVENTS
+	LOG_L(L_INFO, "[ControllerInput] AxisMotion: instanceId=%d axisId=%d value=%d", instanceId, axisId, static_cast<int>(value));
+#endif
+}
+
+#else
+
+CControllerInput::CControllerInput() = default;
+CControllerInput::~CControllerInput() = default;
+
+bool CControllerInput::HandleSDLControllerEvent(const SDL_Event&)
+{
+	return false;
+}
+
+void CControllerInput::LogAvailableController(int) const {}
+void CControllerInput::ScanExistingControllers() {}
+void CControllerInput::HandleDeviceAdded(int) {}
+void CControllerInput::HandleDeviceRemoved(int) {}
+void CControllerInput::HandleDeviceRemapped(int) {}
+void CControllerInput::HandleButtonDown(int, int, std::uint8_t) {}
+void CControllerInput::HandleButtonUp(int, int, std::uint8_t) {}
+void CControllerInput::HandleAxisMotion(int, int, std::int16_t) {}
+
+#endif

--- a/rts/System/Input/ControllerInput.cpp
+++ b/rts/System/Input/ControllerInput.cpp
@@ -1,4 +1,4 @@
-/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
 
 #include "ControllerInput.h"
 
@@ -28,47 +28,32 @@ CControllerInput* CControllerInput::GetInstance()
 	return controllerInput;
 }
 
-void CControllerInput::FreeInstance(CControllerInput* controllerInputPtr)
+void CControllerInput::FreeInstance()
 {
-	if (controllerInputPtr == controllerInput) {
-		delete controllerInput;
-		controllerInput = nullptr;
-	}
+	delete controllerInput;
+	controllerInput = nullptr;
 }
 
-CControllerInput::ControllerStateSnapshot CControllerInput::MakeControllerStateSnapshot(const ControllerState& state)
+std::vector<CControllerInput::ControllerState> CControllerInput::GetAvailableControllers() const
 {
-	ControllerStateSnapshot snapshot;
-	snapshot.deviceId = state.deviceId;
-	snapshot.instanceId = state.instanceId;
-	snapshot.name = state.name;
-	snapshot.axes = state.axes;
-	snapshot.buttons = state.buttons;
+	std::vector<ControllerState> controllers;
+	controllers.reserve(controllersByInstanceID.size());
 
-	return snapshot;
-}
-
-std::vector<CControllerInput::ControllerStateSnapshot> CControllerInput::GetAvailableControllers() const
-{
-	std::vector<ControllerStateSnapshot> controllers;
-	controllers.reserve(controllersByInstanceId.size());
-
-	for (const auto& controllerIt : controllersByInstanceId) {
-		controllers.push_back(MakeControllerStateSnapshot(controllerIt.second));
+	for (const auto& controllerIt : controllersByInstanceID) {
+		controllers.push_back(controllerIt.second);
 	}
 
 	return controllers;
 }
 
-bool CControllerInput::GetControllerState(int instanceId, ControllerStateSnapshot& state) const
+std::optional<CControllerInput::ControllerState> CControllerInput::GetControllerState(int instanceID) const
 {
-	auto controllerIt = controllersByInstanceId.find(instanceId);
-	if (controllerIt == controllersByInstanceId.end()) {
-		return false;
+	const auto controllerIt = controllersByInstanceID.find(instanceID);
+	if (controllerIt == controllersByInstanceID.end()) {
+		return std::nullopt;
 	}
 
-	state = MakeControllerStateSnapshot(controllerIt->second);
-	return true;
+	return controllerIt->second;
 }
 
 #ifndef HEADLESS
@@ -96,7 +81,7 @@ CControllerInput::CControllerInput()
 
 CControllerInput::~CControllerInput()
 {
-	for (auto& controllerIt : controllersByInstanceId) {
+	for (auto& controllerIt : controllersByInstanceID) {
 		auto& state = controllerIt.second;
 
 		if (state.gameController != nullptr) {
@@ -105,7 +90,7 @@ CControllerInput::~CControllerInput()
 		}
 	}
 
-	controllersByInstanceId.clear();
+	controllersByInstanceID.clear();
 
 	LOG_L(L_INFO, "[ControllerInput] Shutting down SDL controller input handler");
 }
@@ -144,16 +129,16 @@ bool CControllerInput::HandleSDLControllerEvent(const SDL_Event& event)
 	return false;
 }
 
-void CControllerInput::LogAvailableController(int deviceId) const
+void CControllerInput::LogAvailableController(int deviceID) const
 {
-	if (SDL_IsGameController(deviceId)) {
-		const char* name = SDL_GameControllerNameForIndex(deviceId);
-		LOG_L(L_INFO, "[ControllerInput] SDL game controller available: deviceId=%d name=%s", deviceId, name != nullptr ? name : "unknown");
+	if (SDL_IsGameController(deviceID)) {
+		const char* name = SDL_GameControllerNameForIndex(deviceID);
+		LOG_L(L_INFO, "[ControllerInput] SDL game controller available: deviceID=%d name=%s", deviceID, name != nullptr ? name : "unknown");
 		return;
 	}
 
-	const char* name = SDL_JoystickNameForIndex(deviceId);
-	LOG_L(L_INFO, "[ControllerInput] SDL joystick available but not game controller: deviceId=%d name=%s", deviceId, name != nullptr ? name : "unknown");
+	const char* name = SDL_JoystickNameForIndex(deviceID);
+	LOG_L(L_INFO, "[ControllerInput] SDL joystick available but not game controller: deviceID=%d name=%s", deviceID, name != nullptr ? name : "unknown");
 }
 
 void CControllerInput::ScanExistingControllers()
@@ -161,136 +146,136 @@ void CControllerInput::ScanExistingControllers()
 	const int joystickCount = SDL_NumJoysticks();
 	LOG_L(L_INFO, "[ControllerInput] Scanning existing SDL joysticks: count=%d", joystickCount);
 
-	for (int deviceId = 0; deviceId < joystickCount; ++deviceId) {
-		LogAvailableController(deviceId);
+	for (int deviceID = 0; deviceID < joystickCount; ++deviceID) {
+		LogAvailableController(deviceID);
 
-		if (SDL_IsGameController(deviceId)) {
-			HandleDeviceAdded(deviceId);
+		if (SDL_IsGameController(deviceID)) {
+			HandleDeviceAdded(deviceID);
 			continue;
 		}
 
-		LOG_L(L_INFO, "[ControllerInput] Skipping existing non-game-controller device: deviceId=%d", deviceId);
+		LOG_L(L_INFO, "[ControllerInput] Skipping existing non-game-controller device: deviceID=%d", deviceID);
 	}
 }
 
-void CControllerInput::HandleDeviceAdded(int deviceId)
+void CControllerInput::HandleDeviceAdded(int deviceID)
 {
-	LOG_L(L_INFO, "[ControllerInput] Controller device added: deviceId=%d", deviceId);
-	LogAvailableController(deviceId);
+	LOG_L(L_INFO, "[ControllerInput] Controller device added: deviceID=%d", deviceID);
+	LogAvailableController(deviceID);
 
-	if (!SDL_IsGameController(deviceId)) {
-		LOG_L(L_INFO, "[ControllerInput] Ignoring non-game-controller device: deviceId=%d", deviceId);
+	if (!SDL_IsGameController(deviceID)) {
+		LOG_L(L_INFO, "[ControllerInput] Ignoring non-game-controller device: deviceID=%d", deviceID);
 		return;
 	}
 
-	SDL_GameController* gameController = SDL_GameControllerOpen(deviceId);
+	SDL_GameController* gameController = SDL_GameControllerOpen(deviceID);
 	if (gameController == nullptr) {
-		LOG_L(L_WARNING, "[ControllerInput] Failed to open SDL game controller: deviceId=%d error=%s", deviceId, SDL_GetError());
+		LOG_L(L_WARNING, "[ControllerInput] Failed to open SDL game controller: deviceID=%d error=%s", deviceID, SDL_GetError());
 		return;
 	}
 
 	SDL_Joystick* joystick = SDL_GameControllerGetJoystick(gameController);
-	const int instanceId = joystick != nullptr ? SDL_JoystickInstanceID(joystick) : -1;
+	const int instanceID = joystick != nullptr ? SDL_JoystickInstanceID(joystick) : -1;
 
-	if (instanceId < 0) {
-		LOG_L(L_WARNING, "[ControllerInput] Failed to get joystick instance id: deviceId=%d", deviceId);
+	if (instanceID < 0) {
+		LOG_L(L_WARNING, "[ControllerInput] Failed to get joystick instance ID: deviceID=%d", deviceID);
 		SDL_GameControllerClose(gameController);
 		return;
 	}
 
-	ControllerState state;
-	state.deviceId = deviceId;
-	state.instanceId = instanceId;
+	TrackedControllerState state;
+	state.deviceID = deviceID;
+	state.instanceID = instanceID;
 
 	const char* name = SDL_GameControllerName(gameController);
 	state.name = name != nullptr ? name : "unknown";
 	state.gameController = gameController;
 
-	auto existingIt = controllersByInstanceId.find(instanceId);
-	if (existingIt != controllersByInstanceId.end() && existingIt->second.gameController != nullptr) {
+	auto existingIt = controllersByInstanceID.find(instanceID);
+	if (existingIt != controllersByInstanceID.end() && existingIt->second.gameController != nullptr) {
 		SDL_GameControllerClose(existingIt->second.gameController);
 	}
 
-	controllersByInstanceId[instanceId] = state;
+	controllersByInstanceID[instanceID] = state;
 
-	LOG_L(L_INFO, "[ControllerInput] Controller connected: deviceId=%d instanceId=%d name=%s", deviceId, instanceId, state.name.c_str());
+	LOG_L(L_INFO, "[ControllerInput] Controller connected: deviceID=%d instanceID=%d name=%s", deviceID, instanceID, state.name.c_str());
 }
 
-void CControllerInput::HandleDeviceRemoved(int instanceId)
+void CControllerInput::HandleDeviceRemoved(int instanceID)
 {
-	LOG_L(L_INFO, "[ControllerInput] Controller device removed: instanceId=%d", instanceId);
+	LOG_L(L_INFO, "[ControllerInput] Controller device removed: instanceID=%d", instanceID);
 
-	auto it = controllersByInstanceId.find(instanceId);
-	if (it == controllersByInstanceId.end()) {
+	auto it = controllersByInstanceID.find(instanceID);
+	if (it == controllersByInstanceID.end()) {
 		return;
 	}
 
-	LOG_L(L_INFO, "[ControllerInput] Removed tracked controller: instanceId=%d name=%s", instanceId, it->second.name.c_str());
+	LOG_L(L_INFO, "[ControllerInput] Removed tracked controller: instanceID=%d name=%s", instanceID, it->second.name.c_str());
 
 	if (it->second.gameController != nullptr) {
 		SDL_GameControllerClose(it->second.gameController);
 		it->second.gameController = nullptr;
 	}
 
-	controllersByInstanceId.erase(it);
+	controllersByInstanceID.erase(it);
 }
 
-void CControllerInput::HandleDeviceRemapped(int instanceId)
+void CControllerInput::HandleDeviceRemapped(int instanceID)
 {
-	LOG_L(L_INFO, "[ControllerInput] Controller remapped: instanceId=%d", instanceId);
+	LOG_L(L_INFO, "[ControllerInput] Controller remapped: instanceID=%d", instanceID);
 }
 
-void CControllerInput::HandleButtonDown(int instanceId, int buttonId, std::uint8_t value)
+void CControllerInput::HandleButtonDown(int instanceID, int buttonID, std::uint8_t value)
 {
-	auto controllerIt = controllersByInstanceId.find(instanceId);
-	if (controllerIt == controllersByInstanceId.end()) {
+	auto controllerIt = controllersByInstanceID.find(instanceID);
+	if (controllerIt == controllersByInstanceID.end()) {
 		return;
 	}
 
 	auto& state = controllerIt->second;
 
-	if (buttonId >= 0 && buttonId < static_cast<int>(state.buttons.size())) {
-		state.buttons[buttonId] = value;
+	if (buttonID >= 0 && buttonID < static_cast<int>(state.buttons.size())) {
+		state.buttons[buttonID] = value;
 	}
 
 #if CONTROLLER_INPUT_LOG_EVENTS
-	LOG_L(L_INFO, "[ControllerInput] ButtonDown: instanceId=%d buttonId=%d value=%u", instanceId, buttonId, static_cast<unsigned int>(value));
+	LOG_L(L_INFO, "[ControllerInput] ButtonDown: instanceID=%d buttonID=%d value=%u", instanceID, buttonID, static_cast<unsigned int>(value));
 #endif
 }
 
-void CControllerInput::HandleButtonUp(int instanceId, int buttonId, std::uint8_t value)
+void CControllerInput::HandleButtonUp(int instanceID, int buttonID, std::uint8_t value)
 {
-	auto controllerIt = controllersByInstanceId.find(instanceId);
-	if (controllerIt == controllersByInstanceId.end()) {
+	auto controllerIt = controllersByInstanceID.find(instanceID);
+	if (controllerIt == controllersByInstanceID.end()) {
 		return;
 	}
 
 	auto& state = controllerIt->second;
 
-	if (buttonId >= 0 && buttonId < static_cast<int>(state.buttons.size())) {
-		state.buttons[buttonId] = value;
+	if (buttonID >= 0 && buttonID < static_cast<int>(state.buttons.size())) {
+		state.buttons[buttonID] = value;
 	}
 
 #if CONTROLLER_INPUT_LOG_EVENTS
-	LOG_L(L_INFO, "[ControllerInput] ButtonUp: instanceId=%d buttonId=%d value=%u", instanceId, buttonId, static_cast<unsigned int>(value));
+	LOG_L(L_INFO, "[ControllerInput] ButtonUp: instanceID=%d buttonID=%d value=%u", instanceID, buttonID, static_cast<unsigned int>(value));
 #endif
 }
 
-void CControllerInput::HandleAxisMotion(int instanceId, int axisId, std::int16_t value)
+void CControllerInput::HandleAxisMotion(int instanceID, int axisID, std::int16_t value)
 {
-	auto controllerIt = controllersByInstanceId.find(instanceId);
-	if (controllerIt == controllersByInstanceId.end()) {
+	auto controllerIt = controllersByInstanceID.find(instanceID);
+	if (controllerIt == controllersByInstanceID.end()) {
 		return;
 	}
 
 	auto& state = controllerIt->second;
 
-	if (axisId >= 0 && axisId < static_cast<int>(state.axes.size())) {
-		state.axes[axisId] = value;
+	if (axisID >= 0 && axisID < static_cast<int>(state.axes.size())) {
+		state.axes[axisID] = value;
 	}
 
 #if CONTROLLER_INPUT_LOG_EVENTS
-	LOG_L(L_INFO, "[ControllerInput] AxisMotion: instanceId=%d axisId=%d value=%d", instanceId, axisId, static_cast<int>(value));
+	LOG_L(L_INFO, "[ControllerInput] AxisMotion: instanceID=%d axisID=%d value=%d", instanceID, axisID, static_cast<int>(value));
 #endif
 }
 

--- a/rts/System/Input/ControllerInput.h
+++ b/rts/System/Input/ControllerInput.h
@@ -1,4 +1,4 @@
-/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
 
 #pragma once
 
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -17,51 +18,42 @@ class CControllerInput
 {
 public:
 	static CControllerInput* GetInstance();
-	static void FreeInstance(CControllerInput* controllerInput);
+	static void FreeInstance();
 
 	CControllerInput();
 	~CControllerInput();
 
-	struct ControllerStateSnapshot {
-		int deviceId = -1;
-		int instanceId = -1;
+	struct ControllerState {
+		int deviceID = -1;
+		int instanceID = -1;
 		std::string name;
 
-		std::array<std::int16_t, 16> axes = {};
-		std::array<std::uint8_t, 32> buttons = {};
+		std::array<std::int16_t, SDL_CONTROLLER_AXIS_MAX> axes = {};
+		std::array<std::uint8_t, SDL_CONTROLLER_BUTTON_MAX> buttons = {};
 	};
 
-	std::vector<ControllerStateSnapshot> GetAvailableControllers() const;
-	bool GetControllerState(int instanceId, ControllerStateSnapshot& state) const;
+	std::vector<ControllerState> GetAvailableControllers() const;
+	std::optional<ControllerState> GetControllerState(int instanceID) const;
 
 	bool HandleSDLControllerEvent(const SDL_Event& event);
 
 private:
-	struct ControllerState {
-		int deviceId = -1;
-		int instanceId = -1;
-		std::string name;
-
+	struct TrackedControllerState : public ControllerState {
 		SDL_GameController* gameController = nullptr;
-
-		std::array<std::int16_t, 16> axes = {};
-		std::array<std::uint8_t, 32> buttons = {};
 	};
 
-	static ControllerStateSnapshot MakeControllerStateSnapshot(const ControllerState& state);
-
-	void LogAvailableController(int deviceId) const;
+	void LogAvailableController(int deviceID) const;
 	void ScanExistingControllers();
-	void HandleDeviceAdded(int deviceId);
-	void HandleDeviceRemoved(int instanceId);
-	void HandleDeviceRemapped(int instanceId);
-	void HandleButtonDown(int instanceId, int buttonId, std::uint8_t value);
-	void HandleButtonUp(int instanceId, int buttonId, std::uint8_t value);
-	void HandleAxisMotion(int instanceId, int axisId, std::int16_t value);
+	void HandleDeviceAdded(int deviceID);
+	void HandleDeviceRemoved(int instanceID);
+	void HandleDeviceRemapped(int instanceID);
+	void HandleButtonDown(int instanceID, int buttonID, std::uint8_t value);
+	void HandleButtonUp(int instanceID, int buttonID, std::uint8_t value);
+	void HandleAxisMotion(int instanceID, int axisID, std::int16_t value);
 
 private:
 	InputHandler::HandlerTokenT inputCon;
-	std::unordered_map<int, ControllerState> controllersByInstanceId;
+	std::unordered_map<int, TrackedControllerState> controllersByInstanceID;
 };
 
 extern CControllerInput* controllerInput;

--- a/rts/System/Input/ControllerInput.h
+++ b/rts/System/Input/ControllerInput.h
@@ -1,0 +1,67 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <SDL_events.h>
+#include <SDL_gamecontroller.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "System/Input/InputHandler.h"
+
+class CControllerInput
+{
+public:
+	static CControllerInput* GetInstance();
+	static void FreeInstance(CControllerInput* controllerInput);
+
+	CControllerInput();
+	~CControllerInput();
+
+	struct ControllerStateSnapshot {
+		int deviceId = -1;
+		int instanceId = -1;
+		std::string name;
+
+		std::array<std::int16_t, 16> axes = {};
+		std::array<std::uint8_t, 32> buttons = {};
+	};
+
+	std::vector<ControllerStateSnapshot> GetAvailableControllers() const;
+	bool GetControllerState(int instanceId, ControllerStateSnapshot& state) const;
+
+	bool HandleSDLControllerEvent(const SDL_Event& event);
+
+private:
+	struct ControllerState {
+		int deviceId = -1;
+		int instanceId = -1;
+		std::string name;
+
+		SDL_GameController* gameController = nullptr;
+
+		std::array<std::int16_t, 16> axes = {};
+		std::array<std::uint8_t, 32> buttons = {};
+	};
+
+	static ControllerStateSnapshot MakeControllerStateSnapshot(const ControllerState& state);
+
+	void LogAvailableController(int deviceId) const;
+	void ScanExistingControllers();
+	void HandleDeviceAdded(int deviceId);
+	void HandleDeviceRemoved(int instanceId);
+	void HandleDeviceRemapped(int instanceId);
+	void HandleButtonDown(int instanceId, int buttonId, std::uint8_t value);
+	void HandleButtonUp(int instanceId, int buttonId, std::uint8_t value);
+	void HandleAxisMotion(int instanceId, int axisId, std::int16_t value);
+
+private:
+	InputHandler::HandlerTokenT inputCon;
+	std::unordered_map<int, ControllerState> controllersByInstanceId;
+};
+
+extern CControllerInput* controllerInput;


### PR DESCRIPTION
## Summary

This PR adds an SDL game controller input backend to Recoil and exposes controller state to unsynced Lua through polling-style read functions.

This is the engine-side foundation used by my currently working BAR controller-support prototype. (see below)
https://github.com/UnderarmCape/underarmcape-bar-controller-support-attempt-01/releases
v0.4.5 Video Gameplay:
https://youtu.be/ga1uJImbEL4

## What this PR adds

Engine-side controller backend:

- Adds `rts/System/Input/ControllerInput.cpp`
- Adds `rts/System/Input/ControllerInput.h`
- Registers the controller input handler during engine initialization
- Uses SDL game controller APIs
- Initializes the SDL joystick/gamecontroller subsystem
- Enables SDL controller and joystick events
- Scans already-connected controllers at startup
- Handles controller added/removed/remapped events
- Tracks button and axis state by SDL joystick instance id

Lua API exposure:

- Adds `Spring.GetAvailableControllers()`
- Adds `Spring.GetControllerState(instanceId)`

Build integration:

- Adds the new controller input source file to the Recoil build.

## API behavior

This implementation exposes controller input through polling-style Lua read functions.

It does not add immediate Lua call-ins such as:

- `ControllerButtonDown`
- `ControllerButtonUp`
- `ControllerAxisMotion`

The current design is intentionally conservative: LuaUI can poll the current controller state when needed.

## Log behavior

High-frequency input-event logs are disabled by default behind:

`CONTROLLER_INPUT_LOG_EVENTS`

The following logs are gated by default:

- `ButtonDown`
- `ButtonUp`
- `AxisMotion`

State updates still happen unconditionally.

Low-frequency lifecycle logs remain enabled:

- SDL controller subsystem initialization
- startup joystick count
- scanning existing controllers
- controller connected
- controller removed
- controller remapped
- warnings/errors

## Tested proof-of-concept

This was tested in a BAR controller-support prototype using an Xbox controller.

Known-good experimental engine release:

https://github.com/UnderarmCape/controllersupport-RecoilEngine-attempt-01/releases/tag/controller-engine-v0.3.6-detection-restored-logspam-fixed

Matching BAR-side prototype release:

https://github.com/UnderarmCape/underarmcape-bar-controller-support-attempt-01/releases/tag/controller-support-v0.3.6-detection-restored-logspam-fixed

The v0.3.6 test confirmed:

- Recoil engine build launched successfully
- SDL controller subsystem initialized
- Xbox controller detected at startup
- controller state reached LuaUI
- controller camera/widget prototype worked
- high-frequency input log spam was removed
- camera snapping issue was resolved separately by config, not engine code

## Notes for reviewers

I am looking for feedback on:

- whether this belongs in Recoil as a generic controller polling API;
- whether the Lua API shape is acceptable;
- whether controller state should be exposed differently;
- whether the SDL initialization/handler ownership should live somewhere else;
- whether this should be split into smaller PRs.

I am happy to revise the structure based on maintainer guidance.

## Development note

This prototype was developed with AI-assisted coding and then tested in a live BAR controller-support setup. I am submitting it for maintainer review because the proof-of-concept works, but I expect the implementation may need cleanup, restructuring, or splitting before it is suitable for upstream.