### PR TITLE
Optimize LuaPushNamedFoo using compile time key hashing

### DIFF
--- a/rts/Lua/LuaArchive.cpp
+++ b/rts/Lua/LuaArchive.cpp
@@ -356,21 +356,21 @@ int LuaArchive::GetAvailableAIs(lua_State* L)
 			lua_createtable(L, 0, 3); {
 				for (const auto& luaAIInfoItem: luaAIInfo) {
 					if (luaAIInfoItem.key == SKIRMISH_AI_PROPERTY_SHORT_NAME) {
-						HSTR_PUSH_STRING(L, "shortName", luaAIInfoItem.GetValueAsString());
+						LuaPushNamedString(L, "shortName", luaAIInfoItem.GetValueAsString());
 					} else if (luaAIInfoItem.key == SKIRMISH_AI_PROPERTY_VERSION) {
-						HSTR_PUSH_STRING(L, "version", luaAIInfoItem.GetValueAsString());
+						LuaPushNamedString(L, "version", luaAIInfoItem.GetValueAsString());
 					}
 				}
-				HSTR_PUSH_BOOL(L, "isLuaAI", true);
+				LuaPushNamedBool(L, "isLuaAI", true);
 			}
 			lua_rawseti(L, -2, ++count);
 		}
 
 		for (const auto& aiKey: skirmishAIKeys) {
 			lua_createtable(L, 0, 3); {
-				HSTR_PUSH_STRING(L, "shortName", aiKey.GetShortName());
-				HSTR_PUSH_STRING(L, "version", aiKey.GetVersion());
-				HSTR_PUSH_BOOL(L, "isLuaAI", false);
+				LuaPushNamedString(L, "shortName", aiKey.GetShortName());
+				LuaPushNamedString(L, "version", aiKey.GetVersion());
+				LuaPushNamedBool(L, "isLuaAI", false);
 			}
 			lua_rawseti(L, -2, ++count);
 		}

--- a/rts/Lua/LuaFBOs.cpp
+++ b/rts/Lua/LuaFBOs.cpp
@@ -64,9 +64,9 @@ bool LuaFBOs::CreateMetatable(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	luaL_newmetatable(L, "FBO");
-	HSTR_PUSH_CFUNC(L, "__gc",        meta_gc);
-	HSTR_PUSH_CFUNC(L, "__index",     meta_index);
-	HSTR_PUSH_CFUNC(L, "__newindex",  meta_newindex);
+	LuaPushNamedCFunc(L, "__gc",        meta_gc);
+	LuaPushNamedCFunc(L, "__index",     meta_index);
+	LuaPushNamedCFunc(L, "__newindex",  meta_newindex);
 	lua_pop(L, 1);
 	return true;
 }

--- a/rts/Lua/LuaFeatureDefs.cpp
+++ b/rts/Lua/LuaFeatureDefs.cpp
@@ -83,17 +83,17 @@ bool LuaFeatureDefs::PushEntries(lua_State* L)
 
 		lua_newtable(L); { // the metatable
 
-			LuaPushHString(L, "__index");
+			LuaPushString(L, "__index");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefIndex, 1);
 			lua_rawset(L, -3); // closure
 
-			LuaPushHString(L, "__newindex");
+			LuaPushString(L, "__newindex");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefNewIndex, 1);
 			lua_rawset(L, -3);
 
-			LuaPushHString(L, "__metatable");
+			LuaPushString(L, "__metatable");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefMetatable, 1);
 			lua_rawset(L, -3);
@@ -102,11 +102,11 @@ bool LuaFeatureDefs::PushEntries(lua_State* L)
 		lua_setmetatable(L, -2);
 	}
 
-	LuaPushHString(L, "pairs");
+	LuaPushString(L, "pairs");
 	lua_pushcfunction(L, Pairs);
 	lua_rawset(L, -3);
 
-	LuaPushHString(L, "next");
+	LuaPushString(L, "next");
 	lua_pushcfunction(L, Next);
 	lua_rawset(L, -3);
 

--- a/rts/Lua/LuaFeatureDefs.cpp
+++ b/rts/Lua/LuaFeatureDefs.cpp
@@ -83,17 +83,17 @@ bool LuaFeatureDefs::PushEntries(lua_State* L)
 
 		lua_newtable(L); { // the metatable
 
-			HSTR_PUSH(L, "__index");
+			LuaPushHString(L, "__index");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefIndex, 1);
 			lua_rawset(L, -3); // closure
 
-			HSTR_PUSH(L, "__newindex");
+			LuaPushHString(L, "__newindex");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefNewIndex, 1);
 			lua_rawset(L, -3);
 
-			HSTR_PUSH(L, "__metatable");
+			LuaPushHString(L, "__metatable");
 			lua_pushlightuserdata(L, (void*)fd);
 			lua_pushcclosure(L, FeatureDefMetatable, 1);
 			lua_rawset(L, -3);
@@ -102,11 +102,11 @@ bool LuaFeatureDefs::PushEntries(lua_State* L)
 		lua_setmetatable(L, -2);
 	}
 
-	HSTR_PUSH(L, "pairs");
+	LuaPushHString(L, "pairs");
 	lua_pushcfunction(L, Pairs);
 	lua_rawset(L, -3);
 
-	HSTR_PUSH(L, "next");
+	LuaPushHString(L, "next");
 	lua_pushcfunction(L, Next);
 	lua_rawset(L, -3);
 

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -46,8 +46,8 @@ bool LuaFonts::CreateMetatable(lua_State* L)
 	RECOIL_DETAILED_TRACY_ZONE;
 	luaL_newmetatable(L, "Font");
 
-	HSTR_PUSH_CFUNC(L, "__gc",        meta_gc);
-	HSTR_PUSH_CFUNC(L, "__index",     meta_index);
+	LuaPushNamedCFunc(L, "__gc",        meta_gc);
+	LuaPushNamedCFunc(L, "__index",     meta_index);
 	LuaPushNamedString(L, "__metatable", "protected metatable");
 
 		// push userdata callouts

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -3865,7 +3865,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 	lua_pushnumber(L, playerID);
 
 	if (type == MAPDRAW_POINT) {
-		LuaPushString(L, "point");
+		LuaPushString (L, "point");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3873,7 +3873,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 6;
 	}
 	else if (type == MAPDRAW_LINE) {
-		LuaPushString(L, "line");
+		LuaPushString (L, "line");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3883,7 +3883,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 8;
 	}
 	else if (type == MAPDRAW_ERASE) {
-		LuaPushString(L, "erase");
+		LuaPushString (L, "erase");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -116,7 +116,7 @@ void CLuaHandle::PushTracebackFuncToRegistry(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	SPRING_LUA_OPEN_LIB(L, luaopen_debug);
-		HSTR_PUSH(L, "traceback");
+		LuaPushHString(L, "traceback");
 		LuaUtils::PushDebugTraceback(L);
 		lua_rawset(L, LUA_REGISTRYINDEX);
 	// We only need the debug.traceback function, the others are unsafe for syncing.
@@ -2638,11 +2638,11 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
 		return false;
 
 	if (unit) {
-		HSTR_PUSH(L, "unit");
+		LuaPushHString(L, "unit");
 		lua_pushnumber(L, unit->id);
 	}
 	else if (feature) {
-		HSTR_PUSH(L, "feature");
+		LuaPushHString(L, "feature");
 		lua_pushnumber(L, feature->id);
 	}
 	else {
@@ -2653,14 +2653,14 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
 
 /* FIXME
 	else if (groundPos) {
-		HSTR_PUSH(L, "ground");
+		LuaPushHString(L, "ground");
 		lua_pushnumber(L, groundPos->x);
 		lua_pushnumber(L, groundPos->y);
 		lua_pushnumber(L, groundPos->z);
 		args = 4;
 	}
 	else {
-		HSTR_PUSH(L, "selection");
+		LuaPushHString(L, "selection");
 		args = 1;
 	}
 */
@@ -3179,10 +3179,10 @@ bool CLuaHandle::KeyPress(int keyCode, int scanCode, bool isRepeat)
 	lua_pushinteger(L, SDL21_keysyms(keyCode));
 
 	lua_createtable(L, 0, 4);
-	HSTR_PUSH_BOOL(L, "alt",   !!KeyInput::GetKeyModState(KMOD_ALT));
-	HSTR_PUSH_BOOL(L, "ctrl",  !!KeyInput::GetKeyModState(KMOD_CTRL));
-	HSTR_PUSH_BOOL(L, "meta",  !!KeyInput::GetKeyModState(KMOD_GUI));
-	HSTR_PUSH_BOOL(L, "shift", !!KeyInput::GetKeyModState(KMOD_SHIFT));
+	LuaPushNamedBool(L, "alt",   !!KeyInput::GetKeyModState(KMOD_ALT));
+	LuaPushNamedBool(L, "ctrl",  !!KeyInput::GetKeyModState(KMOD_CTRL));
+	LuaPushNamedBool(L, "meta",  !!KeyInput::GetKeyModState(KMOD_GUI));
+	LuaPushNamedBool(L, "shift", !!KeyInput::GetKeyModState(KMOD_SHIFT));
 
 	lua_pushboolean(L, isRepeat);
 
@@ -3242,10 +3242,10 @@ bool CLuaHandle::KeyRelease(int keyCode, int scanCode)
 	lua_pushinteger(L, SDL21_keysyms(keyCode));
 
 	lua_createtable(L, 0, 4);
-	HSTR_PUSH_BOOL(L, "alt",   !!KeyInput::GetKeyModState(KMOD_ALT));
-	HSTR_PUSH_BOOL(L, "ctrl",  !!KeyInput::GetKeyModState(KMOD_CTRL));
-	HSTR_PUSH_BOOL(L, "meta",  !!KeyInput::GetKeyModState(KMOD_GUI));
-	HSTR_PUSH_BOOL(L, "shift", !!KeyInput::GetKeyModState(KMOD_SHIFT));
+	LuaPushNamedBool(L, "alt",   !!KeyInput::GetKeyModState(KMOD_ALT));
+	LuaPushNamedBool(L, "ctrl",  !!KeyInput::GetKeyModState(KMOD_CTRL));
+	LuaPushNamedBool(L, "meta",  !!KeyInput::GetKeyModState(KMOD_GUI));
+	LuaPushNamedBool(L, "shift", !!KeyInput::GetKeyModState(KMOD_SHIFT));
 
 	CKeySet ks(keyCode);
 	lua_pushsstring(L, ks.GetString(true));
@@ -3789,24 +3789,24 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
 
 	int args;
 	if (unit) {
-		HSTR_PUSH(L, "unit");
+		LuaPushHString(L, "unit");
 		lua_pushnumber(L, unit->id);
 		args = 2;
 	}
 	else if (feature) {
-		HSTR_PUSH(L, "feature");
+		LuaPushHString(L, "feature");
 		lua_pushnumber(L, feature->id);
 		args = 2;
 	}
 	else if (groundPos) {
-		HSTR_PUSH(L, "ground");
+		LuaPushHString(L, "ground");
 		lua_pushnumber(L, groundPos->x);
 		lua_pushnumber(L, groundPos->y);
 		lua_pushnumber(L, groundPos->z);
 		args = 4;
 	}
 	else {
-		HSTR_PUSH(L, "selection");
+		LuaPushHString(L, "selection");
 		args = 1;
 	}
 
@@ -3865,7 +3865,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 	lua_pushnumber(L, playerID);
 
 	if (type == MAPDRAW_POINT) {
-		HSTR_PUSH(L, "point");
+		LuaPushHString(L, "point");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3873,7 +3873,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 6;
 	}
 	else if (type == MAPDRAW_LINE) {
-		HSTR_PUSH(L, "line");
+		LuaPushHString(L, "line");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3883,7 +3883,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 8;
 	}
 	else if (type == MAPDRAW_ERASE) {
-		HSTR_PUSH(L, "erase");
+		LuaPushHString(L, "erase");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -4225,29 +4225,29 @@ void CLuaHandle::CollectGarbage(bool forced)
 bool CLuaHandle::AddBasicCalls(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	HSTR_PUSH(L, "Script");
+	LuaPushHString(L, "Script");
 	lua_createtable(L, 0, 17); {
-		HSTR_PUSH_CFUNC(L, "Kill",            KillActiveHandle);
-		HSTR_PUSH_CFUNC(L, "UpdateCallIn",    CallOutUpdateCallIn);
-		HSTR_PUSH_CFUNC(L, "GetName",         CallOutGetName);
-		HSTR_PUSH_CFUNC(L, "GetSynced",       CallOutGetSynced);
-		HSTR_PUSH_CFUNC(L, "GetFullCtrl",     CallOutGetFullCtrl);
-		HSTR_PUSH_CFUNC(L, "GetFullRead",     CallOutGetFullRead);
-		HSTR_PUSH_CFUNC(L, "GetCtrlTeam",     CallOutGetCtrlTeam);
-		HSTR_PUSH_CFUNC(L, "GetReadTeam",     CallOutGetReadTeam);
-		HSTR_PUSH_CFUNC(L, "GetReadAllyTeam", CallOutGetReadAllyTeam);
-		HSTR_PUSH_CFUNC(L, "GetSelectTeam",   CallOutGetSelectTeam);
-		HSTR_PUSH_CFUNC(L, "GetGlobal",       CallOutGetGlobal);
-		HSTR_PUSH_CFUNC(L, "GetRegistry",     CallOutGetRegistry);
-		HSTR_PUSH_CFUNC(L, "GetCallInList",   CallOutGetCallInList);
-		HSTR_PUSH_CFUNC(L, "DelayByFrames",   CallOutDelayByFrames);
-		HSTR_PUSH_CFUNC(L, "IsEngineMinVersion", CallOutIsEngineMinVersion);
+		LuaPushNamedCFunc(L, "Kill",               KillActiveHandle);
+		LuaPushNamedCFunc(L, "UpdateCallIn",       CallOutUpdateCallIn);
+		LuaPushNamedCFunc(L, "GetName",            CallOutGetName);
+		LuaPushNamedCFunc(L, "GetSynced",          CallOutGetSynced);
+		LuaPushNamedCFunc(L, "GetFullCtrl",        CallOutGetFullCtrl);
+		LuaPushNamedCFunc(L, "GetFullRead",        CallOutGetFullRead);
+		LuaPushNamedCFunc(L, "GetCtrlTeam",        CallOutGetCtrlTeam);
+		LuaPushNamedCFunc(L, "GetReadTeam",        CallOutGetReadTeam);
+		LuaPushNamedCFunc(L, "GetReadAllyTeam",    CallOutGetReadAllyTeam);
+		LuaPushNamedCFunc(L, "GetSelectTeam",      CallOutGetSelectTeam);
+		LuaPushNamedCFunc(L, "GetGlobal",          CallOutGetGlobal);
+		LuaPushNamedCFunc(L, "GetRegistry",        CallOutGetRegistry);
+		LuaPushNamedCFunc(L, "GetCallInList",      CallOutGetCallInList);
+		LuaPushNamedCFunc(L, "DelayByFrames",      CallOutDelayByFrames);
+		LuaPushNamedCFunc(L, "IsEngineMinVersion", CallOutIsEngineMinVersion);
 		// special team constants
 
 		/*** @field Script.NO_ACCESS_TEAM -1 */
-		HSTR_PUSH_NUMBER(L, "NO_ACCESS_TEAM",  CEventClient::NoAccessTeam);
+		LuaPushNamedNumber(L, "NO_ACCESS_TEAM",  CEventClient::NoAccessTeam);
 		/*** @field Script.ALL_ACCESS_TEAM -2 */
-		HSTR_PUSH_NUMBER(L, "ALL_ACCESS_TEAM", CEventClient::AllAccessTeam);
+		LuaPushNamedNumber(L, "ALL_ACCESS_TEAM", CEventClient::AllAccessTeam);
 	}
 	lua_rawset(L, -3);
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -116,7 +116,7 @@ void CLuaHandle::PushTracebackFuncToRegistry(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	SPRING_LUA_OPEN_LIB(L, luaopen_debug);
-		LuaPushHString(L, "traceback");
+		LuaPushString(L, "traceback");
 		LuaUtils::PushDebugTraceback(L);
 		lua_rawset(L, LUA_REGISTRYINDEX);
 	// We only need the debug.traceback function, the others are unsafe for syncing.
@@ -2638,11 +2638,11 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
 		return false;
 
 	if (unit) {
-		LuaPushHString(L, "unit");
+		LuaPushString(L, "unit");
 		lua_pushnumber(L, unit->id);
 	}
 	else if (feature) {
-		LuaPushHString(L, "feature");
+		LuaPushString(L, "feature");
 		lua_pushnumber(L, feature->id);
 	}
 	else {
@@ -2653,14 +2653,14 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
 
 /* FIXME
 	else if (groundPos) {
-		LuaPushHString(L, "ground");
+		LuaPushString(L, "ground");
 		lua_pushnumber(L, groundPos->x);
 		lua_pushnumber(L, groundPos->y);
 		lua_pushnumber(L, groundPos->z);
 		args = 4;
 	}
 	else {
-		LuaPushHString(L, "selection");
+		LuaPushString(L, "selection");
 		args = 1;
 	}
 */
@@ -3789,24 +3789,24 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
 
 	int args;
 	if (unit) {
-		LuaPushHString(L, "unit");
+		LuaPushString(L, "unit");
 		lua_pushnumber(L, unit->id);
 		args = 2;
 	}
 	else if (feature) {
-		LuaPushHString(L, "feature");
+		LuaPushString(L, "feature");
 		lua_pushnumber(L, feature->id);
 		args = 2;
 	}
 	else if (groundPos) {
-		LuaPushHString(L, "ground");
+		LuaPushString(L, "ground");
 		lua_pushnumber(L, groundPos->x);
 		lua_pushnumber(L, groundPos->y);
 		lua_pushnumber(L, groundPos->z);
 		args = 4;
 	}
 	else {
-		LuaPushHString(L, "selection");
+		LuaPushString(L, "selection");
 		args = 1;
 	}
 
@@ -3865,7 +3865,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 	lua_pushnumber(L, playerID);
 
 	if (type == MAPDRAW_POINT) {
-		LuaPushHString(L, "point");
+		LuaPushString(L, "point");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3873,7 +3873,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 6;
 	}
 	else if (type == MAPDRAW_LINE) {
-		LuaPushHString(L, "line");
+		LuaPushString(L, "line");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -3883,7 +3883,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
 		args = 8;
 	}
 	else if (type == MAPDRAW_ERASE) {
-		LuaPushHString(L, "erase");
+		LuaPushString(L, "erase");
 		lua_pushnumber(L, pos0->x);
 		lua_pushnumber(L, pos0->y);
 		lua_pushnumber(L, pos0->z);
@@ -4225,7 +4225,7 @@ void CLuaHandle::CollectGarbage(bool forced)
 bool CLuaHandle::AddBasicCalls(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	LuaPushHString(L, "Script");
+	LuaPushString(L, "Script");
 	lua_createtable(L, 0, 17); {
 		LuaPushNamedCFunc(L, "Kill",               KillActiveHandle);
 		LuaPushNamedCFunc(L, "UpdateCallIn",       CallOutUpdateCallIn);

--- a/rts/Lua/LuaHashString.h
+++ b/rts/Lua/LuaHashString.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef LUA_HASH_STRING_H
-#define LUA_HASH_STRING_H
+#pragma once
 
 #include <algorithm>
 #include <string>
@@ -9,6 +8,12 @@
 #include "LuaInclude.h"
 #include "System/StringHash.h"
 
+template <unsigned N>
+static inline void LuaPushHString(lua_State* L, const char (&str)[N])
+{
+	static_assert(N > 1);
+	lua_pushhstring(L, LuaHashStringLiteral(str), str, N - 1);
+}
 
 struct LuaHashString {
 	public:
@@ -97,30 +102,3 @@ struct LuaHashString {
 		uint32_t slen = 0;
 		uint32_t hash = 0;
 };
-
-
-// NOTE: scoped to avoid name conflicts
-// NOTE: since all the following are static, if name can change (e.g. within a loop)
-//       peculiar things will happen. => Only use raw strings (and not variables) in name.
-
-#define HSTR_PUSH(L, name) \
-	{ lua_pushhstring(L, COMPILE_TIME_HASH(name), name, sizeof(name) - 1); }
-
-#define HSTR_PUSH_BOOL(L, name, val) \
-	{ HSTR_PUSH(L, name); lua_pushboolean(L, val); lua_rawset(L, -3); }
-
-#define HSTR_PUSH_NUMBER(L, name, val) \
-	{ HSTR_PUSH(L, name); lua_pushnumber(L, val); lua_rawset(L, -3); }
-
-#define HSTR_PUSH_STRING(L, name, val) \
-	{ HSTR_PUSH(L, name); lua_pushsstring(L, val); lua_rawset(L, -3); }
-
-#define HSTR_PUSH_CSTRING(L, name, val) \
-	{ HSTR_PUSH(L, name); lua_pushhstring(L, COMPILE_TIME_HASH(val), val, sizeof(val) - 1); lua_rawset(L, -3); }
-
-#define HSTR_PUSH_CFUNC(L, name, val) \
-	{ HSTR_PUSH(L, name); lua_pushcfunction(L, val); lua_rawset(L, -3); }
-
-
-#endif // LUA_HASH_STRING_H
-

--- a/rts/Lua/LuaHashString.h
+++ b/rts/Lua/LuaHashString.h
@@ -8,13 +8,6 @@
 #include "LuaInclude.h"
 #include "System/StringHash.h"
 
-template <unsigned N>
-static inline void LuaPushHString(lua_State* L, const char (&str)[N])
-{
-	static_assert(N > 1);
-	lua_pushhstring(L, LuaHashStringLiteral(str), str, N - 1);
-}
-
 struct LuaHashString {
 	public:
 		LuaHashString(const char* s): hash(lua_calchash(s, slen = strlen(s))) {

--- a/rts/Lua/LuaObjectRendering.cpp
+++ b/rts/Lua/LuaObjectRendering.cpp
@@ -106,9 +106,9 @@ void LuaObjectRenderingImpl::CreateMatRefMetatable(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	luaL_newmetatable(L, "MatRef");
-	HSTR_PUSH_CFUNC(L, "__gc",       material_gc);
-	HSTR_PUSH_CFUNC(L, "__index",    material_index);
-	HSTR_PUSH_CFUNC(L, "__newindex", material_newindex);
+	LuaPushNamedCFunc(L, "__gc",       material_gc);
+	LuaPushNamedCFunc(L, "__index",    material_index);
+	LuaPushNamedCFunc(L, "__newindex", material_newindex);
 	lua_pop(L, 1);
 }
 

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -4316,14 +4316,14 @@ int LuaOpenGL::TextureInfo(lua_State* L)
 
 	lua_createtable(L, 0, 5);
 	const auto [xsize, ysize, zsize] = tex.GetSize();
-	HSTR_PUSH_NUMBER(L, "xsize", xsize)
-	HSTR_PUSH_NUMBER(L, "ysize", ysize)
-	HSTR_PUSH_NUMBER(L, "zsize", zsize)
+	LuaPushNamedNumber(L, "xsize", xsize);
+	LuaPushNamedNumber(L, "ysize", ysize);
+	LuaPushNamedNumber(L, "zsize", zsize);
 
-	HSTR_PUSH_NUMBER(L, "id"    , tex.GetTextureID());
-	HSTR_PUSH_NUMBER(L, "target", tex.GetTextureTarget());
-	// HSTR_PUSH_BOOL(L,   "alpha", texInfo.alpha);  FIXME
-	// HSTR_PUSH_NUMBER(L, "type",  texInfo.type);
+	LuaPushNamedNumber(L, "id"    , tex.GetTextureID());
+	LuaPushNamedNumber(L, "target", tex.GetTextureTarget());
+	// LuaPushNamedBool  (L, "alpha", texInfo.alpha); // FIXME
+	// LuaPushNamedNumber(L, "type", texInfo.type);
 	return 1;
 }
 
@@ -5845,9 +5845,9 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 		GLint val = 0; glGetIntegerv(key, &val); \
 		if (toStr) { \
 			auto strIter = fixedStateEnumToString.find(val); \
-			HSTR_PUSH_STRING(L, #key, strIter != fixedStateEnumToString.end() ? strIter->second : fixedStateEnumToStringUnk); \
+			LuaPushNamedString(L, #key, strIter != fixedStateEnumToString.end() ? strIter->second : fixedStateEnumToStringUnk); \
 		} else { \
-			HSTR_PUSH_NUMBER(L, #key, val); \
+			LuaPushNamedNumber(L, #key, val); \
 		}; \
 	}
 
@@ -5891,10 +5891,10 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetIntegerv(GL_SCISSOR_BOX, rect);
 
 			lua_createtable(L, 0, 4);
-			HSTR_PUSH_NUMBER(L, "GL_SCISSOR_BOX_X", rect[0]);
-			HSTR_PUSH_NUMBER(L, "GL_SCISSOR_BOX_Y", rect[1]);
-			HSTR_PUSH_NUMBER(L, "GL_SCISSOR_BOX_W", rect[2]);
-			HSTR_PUSH_NUMBER(L, "GL_SCISSOR_BOX_H", rect[3]);
+			LuaPushNamedNumber(L, "GL_SCISSOR_BOX_X", rect[0]);
+			LuaPushNamedNumber(L, "GL_SCISSOR_BOX_Y", rect[1]);
+			LuaPushNamedNumber(L, "GL_SCISSOR_BOX_W", rect[2]);
+			LuaPushNamedNumber(L, "GL_SCISSOR_BOX_H", rect[3]);
 
 			return 2;
 		} break;
@@ -5911,10 +5911,10 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetBooleanv(GL_COLOR_WRITEMASK, mask);
 
 			lua_createtable(L, 0, 4);
-			HSTR_PUSH_BOOL(L, "GL_COLOR_WRITEMASK_R", mask[0]);
-			HSTR_PUSH_BOOL(L, "GL_COLOR_WRITEMASK_G", mask[1]);
-			HSTR_PUSH_BOOL(L, "GL_COLOR_WRITEMASK_B", mask[2]);
-			HSTR_PUSH_BOOL(L, "GL_COLOR_WRITEMASK_A", mask[3]);
+			LuaPushNamedBool(L, "GL_COLOR_WRITEMASK_R", mask[0]);
+			LuaPushNamedBool(L, "GL_COLOR_WRITEMASK_G", mask[1]);
+			LuaPushNamedBool(L, "GL_COLOR_WRITEMASK_B", mask[2]);
+			LuaPushNamedBool(L, "GL_COLOR_WRITEMASK_A", mask[3]);
 
 			return 1;
 		} break;
@@ -5946,7 +5946,7 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 
 			lua_createtable(L, 0, 2);
 			PushFixedState(GL_ALPHA_TEST_FUNC);
-			HSTR_PUSH_NUMBER(L, "GL_ALPHA_TEST_REF", alphaRef);
+			LuaPushNamedNumber(L, "GL_ALPHA_TEST_REF", alphaRef);
 
 			return 2;
 		} break;
@@ -5966,14 +5966,14 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetFloatv(GL_FOG_END, &fogEnd);
 
 			lua_createtable(L, 0, 8);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_COLOR_R", fogColor[0]);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_COLOR_G", fogColor[1]);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_COLOR_B", fogColor[2]);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_COLOR_A", fogColor[3]);
+			LuaPushNamedNumber(L, "GL_FOG_COLOR_R", fogColor[0]);
+			LuaPushNamedNumber(L, "GL_FOG_COLOR_G", fogColor[1]);
+			LuaPushNamedNumber(L, "GL_FOG_COLOR_B", fogColor[2]);
+			LuaPushNamedNumber(L, "GL_FOG_COLOR_A", fogColor[3]);
 
-			HSTR_PUSH_NUMBER(L, "GL_FOG_DENSITY", fogDensity);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_START", fogStart);
-			HSTR_PUSH_NUMBER(L, "GL_FOG_END", fogEnd);
+			LuaPushNamedNumber(L, "GL_FOG_DENSITY", fogDensity);
+			LuaPushNamedNumber(L, "GL_FOG_START",   fogStart);
+			LuaPushNamedNumber(L, "GL_FOG_END",     fogEnd);
 
 			PushFixedState(GL_FOG_MODE);
 
@@ -6003,8 +6003,8 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetIntegerv(GL_LINE_STIPPLE_REPEAT, &strippleRepeat);
 
 			lua_createtable(L, 0, 2);
-			HSTR_PUSH_NUMBER(L, "GL_LINE_STIPPLE_PATTERN", stripplePattern);
-			HSTR_PUSH_NUMBER(L, "GL_LINE_STIPPLE_REPEAT", strippleRepeat);
+			LuaPushNamedNumber(L, "GL_LINE_STIPPLE_PATTERN", stripplePattern);
+			LuaPushNamedNumber(L, "GL_LINE_STIPPLE_REPEAT",  strippleRepeat);
 
 			return 1;
 		} break;
@@ -6024,11 +6024,11 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetFloatv(GL_POLYGON_OFFSET_UNITS, &offsetDensity);
 
 			lua_createtable(L, 0, 5);
-			HSTR_PUSH_BOOL(L, "GL_POLYGON_OFFSET_FILL", glIsEnabled(GL_POLYGON_OFFSET_FILL));
-			HSTR_PUSH_BOOL(L, "GL_POLYGON_OFFSET_LINE", glIsEnabled(GL_POLYGON_OFFSET_LINE));
-			HSTR_PUSH_BOOL(L, "GL_POLYGON_OFFSET_POINT", glIsEnabled(GL_POLYGON_OFFSET_POINT));
-			HSTR_PUSH_NUMBER(L, "GL_POLYGON_OFFSET_FACTOR", offsetFactor);
-			HSTR_PUSH_NUMBER(L, "GL_POLYGON_OFFSET_UNITS", offsetDensity);
+			LuaPushNamedBool  (L, "GL_POLYGON_OFFSET_FILL",   glIsEnabled(GL_POLYGON_OFFSET_FILL));
+			LuaPushNamedBool  (L, "GL_POLYGON_OFFSET_LINE",   glIsEnabled(GL_POLYGON_OFFSET_LINE));
+			LuaPushNamedBool  (L, "GL_POLYGON_OFFSET_POINT",  glIsEnabled(GL_POLYGON_OFFSET_POINT));
+			LuaPushNamedNumber(L, "GL_POLYGON_OFFSET_FACTOR", offsetFactor);
+			LuaPushNamedNumber(L, "GL_POLYGON_OFFSET_UNITS",  offsetDensity);
 
 			return 2;
 		} break;
@@ -6045,12 +6045,12 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 			glGetIntegerv(GL_STENCIL_VALUE_MASK, &stencilValueMask);
 
 			lua_createtable(L, 0, 8);
-			HSTR_PUSH_NUMBER(L, "GL_STENCIL_WRITEMASK", stencilWriteMask);
+			LuaPushNamedNumber(L, "GL_STENCIL_WRITEMASK", stencilWriteMask);
 
-			HSTR_PUSH_NUMBER(L, "GL_STENCIL_BITS", stencilBits);
+			LuaPushNamedNumber(L, "GL_STENCIL_BITS", stencilBits);
 
-			HSTR_PUSH_NUMBER(L, "GL_STENCIL_VALUE_MASK", stencilValueMask);
-			HSTR_PUSH_NUMBER(L, "GL_STENCIL_REF", stencilValueMask);
+			LuaPushNamedNumber(L, "GL_STENCIL_VALUE_MASK", stencilValueMask);
+			LuaPushNamedNumber(L, "GL_STENCIL_REF", stencilValueMask);
 
 			PushFixedState(GL_STENCIL_FUNC);
 
@@ -6064,9 +6064,9 @@ int LuaOpenGL::GetFixedState(lua_State* L)
 				GLint stencilBackRef;
 				glGetIntegerv(GL_STENCIL_BACK_REF, &stencilBackRef);
 
-				HSTR_PUSH_NUMBER(L, "GL_STENCIL_BACK_WRITEMASK", stencilBackWriteMask);
-				HSTR_PUSH_NUMBER(L, "GL_STENCIL_BACK_VALUE_MASK", stencilBackValueMask);
-				HSTR_PUSH_NUMBER(L, "GL_STENCIL_BACK_REF", stencilBackRef);
+				LuaPushNamedNumber(L, "GL_STENCIL_BACK_WRITEMASK", stencilBackWriteMask);
+				LuaPushNamedNumber(L, "GL_STENCIL_BACK_VALUE_MASK", stencilBackValueMask);
+				LuaPushNamedNumber(L, "GL_STENCIL_BACK_REF", stencilBackRef);
 
 				PushFixedState(GL_STENCIL_BACK_FUNC);
 			}

--- a/rts/Lua/LuaPathFinder.cpp
+++ b/rts/Lua/LuaPathFinder.cpp
@@ -201,9 +201,9 @@ static int path_gc(lua_State* L)
 static void CreatePathMetatable(lua_State* L)
 {
 	luaL_newmetatable(L, "Path");
-	HSTR_PUSH_CFUNC(L, "__gc",       path_gc);
-	HSTR_PUSH_CFUNC(L, "__index",    path_index);
-	HSTR_PUSH_CFUNC(L, "__newindex", path_newindex);
+	LuaPushNamedCFunc(L, "__gc",       path_gc);
+	LuaPushNamedCFunc(L, "__index",    path_index);
+	LuaPushNamedCFunc(L, "__newindex", path_newindex);
 	lua_pop(L, 1);
 }
 

--- a/rts/Lua/LuaRBOs.cpp
+++ b/rts/Lua/LuaRBOs.cpp
@@ -41,9 +41,9 @@ bool LuaRBOs::PushEntries(lua_State* L)
 bool LuaRBOs::CreateMetatable(lua_State* L)
 {
 	luaL_newmetatable(L, "RBO");
-	HSTR_PUSH_CFUNC(L, "__gc",        meta_gc);
-	HSTR_PUSH_CFUNC(L, "__index",     meta_index);
-	HSTR_PUSH_CFUNC(L, "__newindex",  meta_newindex);
+	LuaPushNamedCFunc(L, "__gc",        meta_gc);
+	LuaPushNamedCFunc(L, "__index",     meta_index);
+	LuaPushNamedCFunc(L, "__newindex",  meta_newindex);
 	lua_pop(L, 1);
 	return true;
 }

--- a/rts/Lua/LuaScream.cpp
+++ b/rts/Lua/LuaScream.cpp
@@ -22,9 +22,9 @@ bool LuaScream::PushEntries(lua_State* L)
 bool LuaScream::CreateMetatable(lua_State* L)
 {
 	luaL_newmetatable(L, "Scream");
-	HSTR_PUSH_CFUNC(L, "__gc",        meta_gc);
-	HSTR_PUSH_CFUNC(L, "__index",     meta_index);
-	HSTR_PUSH_CFUNC(L, "__newindex",  meta_newindex);
+	LuaPushNamedCFunc(L, "__gc",        meta_gc);
+	LuaPushNamedCFunc(L, "__index",     meta_index);
+	LuaPushNamedCFunc(L, "__newindex",  meta_newindex);
 	lua_pop(L, 1);
 	return true;
 }

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -953,15 +953,15 @@ int LuaShaders::GetActiveUniforms(lua_State* L)
 	GLint i = 0;
 	for (const auto& [name, au] : prog->activeUniforms) {
 		lua_createtable(L, 0, 5); {
-			HSTR_PUSH_STRING(L, "name"    , name);
-			HSTR_PUSH_STRING(L, "type"    , UniformTypeString(au.type));
-			HSTR_PUSH_NUMBER(L, "length"  , name.size());
-			HSTR_PUSH_NUMBER(L, "size"    , au.size);
-			HSTR_PUSH_NUMBER(L, "location", prog->activeUniformLocations.at(name).location);
+			LuaPushNamedString(L, "name"    , name);
+			LuaPushNamedString(L, "type"    , UniformTypeString(au.type));
+			LuaPushNamedNumber(L, "length"  , name.size());
+			LuaPushNamedNumber(L, "size"    , au.size);
+			LuaPushNamedNumber(L, "location", prog->activeUniformLocations.at(name).location);
 		}
 		lua_rawseti(L, -2, i + 1);
 		++i;
-	}
+	} 
 
 	return 1;
 }

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -961,7 +961,7 @@ int LuaShaders::GetActiveUniforms(lua_State* L)
 		}
 		lua_rawseti(L, -2, i + 1);
 		++i;
-	} 
+	}
 
 	return 1;
 }

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -2078,35 +2078,35 @@ int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 					// the `stats.frame` var indicates the frame when a new entry needs to get added,
 					// for the most recent stats entry this lies obviously in the future,
 					// so we just output the current frame here
-					HSTR_PUSH_NUMBER(L, "time",         gs->GetLuaSimFrame() / GAME_SPEED);
-					HSTR_PUSH_NUMBER(L, "frame",        gs->GetLuaSimFrame());
+					LuaPushNamedNumber(L, "time",         gs->GetLuaSimFrame() / GAME_SPEED);
+					LuaPushNamedNumber(L, "frame",        gs->GetLuaSimFrame());
 				} else {
-					HSTR_PUSH_NUMBER(L, "time",         stats.frame / GAME_SPEED);
-					HSTR_PUSH_NUMBER(L, "frame",        stats.frame);
+					LuaPushNamedNumber(L, "time",         stats.frame / GAME_SPEED);
+					LuaPushNamedNumber(L, "frame",        stats.frame);
 				}
 
-				HSTR_PUSH_NUMBER(L, "metalUsed",        stats.metalUsed);
-				HSTR_PUSH_NUMBER(L, "metalProduced",    stats.metalProduced);
-				HSTR_PUSH_NUMBER(L, "metalExcess",      stats.metalExcess);
-				HSTR_PUSH_NUMBER(L, "metalReceived",    stats.metalReceived);
-				HSTR_PUSH_NUMBER(L, "metalSent",        stats.metalSent);
+				LuaPushNamedNumber(L, "metalUsed",        stats.metalUsed);
+				LuaPushNamedNumber(L, "metalProduced",    stats.metalProduced);
+				LuaPushNamedNumber(L, "metalExcess",      stats.metalExcess);
+				LuaPushNamedNumber(L, "metalReceived",    stats.metalReceived);
+				LuaPushNamedNumber(L, "metalSent",        stats.metalSent);
 
-				HSTR_PUSH_NUMBER(L, "energyUsed",       stats.energyUsed);
-				HSTR_PUSH_NUMBER(L, "energyProduced",   stats.energyProduced);
-				HSTR_PUSH_NUMBER(L, "energyExcess",     stats.energyExcess);
-				HSTR_PUSH_NUMBER(L, "energyReceived",   stats.energyReceived);
-				HSTR_PUSH_NUMBER(L, "energySent",       stats.energySent);
+				LuaPushNamedNumber(L, "energyUsed",       stats.energyUsed);
+				LuaPushNamedNumber(L, "energyProduced",   stats.energyProduced);
+				LuaPushNamedNumber(L, "energyExcess",     stats.energyExcess);
+				LuaPushNamedNumber(L, "energyReceived",   stats.energyReceived);
+				LuaPushNamedNumber(L, "energySent",       stats.energySent);
 
-				HSTR_PUSH_NUMBER(L, "damageDealt",      stats.damageDealt);
-				HSTR_PUSH_NUMBER(L, "damageReceived",   stats.damageReceived);
+				LuaPushNamedNumber(L, "damageDealt",      stats.damageDealt);
+				LuaPushNamedNumber(L, "damageReceived",   stats.damageReceived);
 
-				HSTR_PUSH_NUMBER(L, "unitsProduced",    stats.unitsProduced);
-				HSTR_PUSH_NUMBER(L, "unitsDied",        stats.unitsDied);
-				HSTR_PUSH_NUMBER(L, "unitsReceived",    stats.unitsReceived);
-				HSTR_PUSH_NUMBER(L, "unitsSent",        stats.unitsSent);
-				HSTR_PUSH_NUMBER(L, "unitsCaptured",    stats.unitsCaptured);
-				HSTR_PUSH_NUMBER(L, "unitsOutCaptured", stats.unitsOutCaptured);
-				HSTR_PUSH_NUMBER(L, "unitsKilled",      stats.unitsKilled);
+				LuaPushNamedNumber(L, "unitsProduced",    stats.unitsProduced);
+				LuaPushNamedNumber(L, "unitsDied",        stats.unitsDied);
+				LuaPushNamedNumber(L, "unitsReceived",    stats.unitsReceived);
+				LuaPushNamedNumber(L, "unitsSent",        stats.unitsSent);
+				LuaPushNamedNumber(L, "unitsCaptured",    stats.unitsCaptured);
+				LuaPushNamedNumber(L, "unitsOutCaptured", stats.unitsOutCaptured);
+				LuaPushNamedNumber(L, "unitsKilled",      stats.unitsKilled);
 			}
 			lua_rawseti(L, -2, count++);
 		}
@@ -2309,8 +2309,8 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 
 	// no unsynced Skirmish AI info for synchronized scripts
 	if (CLuaHandle::GetHandleSynced(L)) {
-		HSTR_PUSH(L, "SYNCED_NOSHORTNAME");
-		HSTR_PUSH(L, "SYNCED_NOVERSION");
+		LuaPushHString(L, "SYNCED_NOSHORTNAME");
+		LuaPushHString(L, "SYNCED_NOVERSION");
 		lua_newtable(L);
 	} else if (skirmishAIHandler.IsLocalSkirmishAI(skirmishAIId)) {
 		lua_pushsstring(L, aiData->shortName);
@@ -2324,8 +2324,8 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 			lua_rawset(L, -3);
 		}
 	} else {
-		HSTR_PUSH(L, "UNKNOWN");
-		HSTR_PUSH(L, "UNKNOWN");
+		LuaPushHString(L, "UNKNOWN");
+		LuaPushHString(L, "UNKNOWN");
 		lua_newtable(L);
 	}
 	numVals += 3;
@@ -2629,7 +2629,7 @@ int LuaSyncedRead::GetTeamUnitsSorted(lua_State* L)
 		}
 
 		if (!gtuObjectIDs.empty()) {
-			HSTR_PUSH(L, "unknown");
+			LuaPushHString(L, "unknown");
 
 			defCount += 1;
 			unitCount = 1;
@@ -2723,7 +2723,7 @@ int LuaSyncedRead::GetTeamUnitsCounts(lua_State* L)
 		defCount++;
 	}
 	if (unknownCount > 0) {
-		HSTR_PUSH_NUMBER(L, "unknown", unknownCount);
+		LuaPushNamedNumber(L, "unknown", unknownCount);
 		defCount++;
 	}
 
@@ -3736,16 +3736,16 @@ int LuaSyncedRead::GetUnitStates(lua_State* L)
 		lua_createtable(L, 0, 9);
 
 		{
-			HSTR_PUSH_NUMBER(L, "firestate",  unit->fireState);
-			HSTR_PUSH_NUMBER(L, "movestate",  unit->moveState);
-			HSTR_PUSH_NUMBER(L, "autorepairlevel", (mCAI != nullptr)? mCAI->repairBelowHealth: -1.0f);
+			LuaPushNamedNumber(L, "firestate",  unit->fireState);
+			LuaPushNamedNumber(L, "movestate",  unit->moveState);
+			LuaPushNamedNumber(L, "autorepairlevel", (mCAI != nullptr)? mCAI->repairBelowHealth: -1.0f);
 		}
 
 		if (binState) {
-			HSTR_PUSH_BOOL(L, "repeat",     unit->commandAI->repeatOrders);
-			HSTR_PUSH_BOOL(L, "cloak",      unit->wantCloak);
-			HSTR_PUSH_BOOL(L, "active",     unit->activated);
-			HSTR_PUSH_BOOL(L, "trajectory", unit->useHighTrajectory);
+			LuaPushNamedBool(L, "repeat",     unit->commandAI->repeatOrders);
+			LuaPushNamedBool(L, "cloak",      unit->wantCloak);
+			LuaPushNamedBool(L, "active",     unit->activated);
+			LuaPushNamedBool(L, "trajectory", unit->useHighTrajectory);
 		}
 
 		if (amtState) {
@@ -3753,14 +3753,14 @@ int LuaSyncedRead::GetUnitStates(lua_State* L)
 			const CStrafeAirMoveType* sAMT = nullptr;
 
 			if ((hAMT = dynamic_cast<const CHoverAirMoveType*>(mt)) != nullptr) {
-				HSTR_PUSH_BOOL(L, "autoland",       hAMT->autoLand);
-				HSTR_PUSH_BOOL(L, "loopbackattack", false);
+				LuaPushNamedBool(L, "autoland",       hAMT->autoLand);
+				LuaPushNamedBool(L, "loopbackattack", false);
 				return 1;
 			}
 
 			if ((sAMT = dynamic_cast<const CStrafeAirMoveType*>(mt)) != nullptr) {
-				HSTR_PUSH_BOOL(L, "autoland",       sAMT->autoLand);
-				HSTR_PUSH_BOOL(L, "loopbackattack", sAMT->loopbackAttack);
+				LuaPushNamedBool(L, "autoland",       sAMT->autoLand);
+				LuaPushNamedBool(L, "loopbackattack", sAMT->loopbackAttack);
 				return 1;
 			}
 		}
@@ -5908,17 +5908,17 @@ int LuaSyncedRead::GetUnitDefDimensions(lua_State* L)
 	const S3DModel& m = *model;
 	const float3& mid = model->relMidPos;
 	lua_createtable(L, 0, 11);
-	HSTR_PUSH_NUMBER(L, "height", m.height);
-	HSTR_PUSH_NUMBER(L, "radius", m.radius);
-	HSTR_PUSH_NUMBER(L, "midx",   mid.x);
-	HSTR_PUSH_NUMBER(L, "minx",   m.mins.x);
-	HSTR_PUSH_NUMBER(L, "maxx",   m.maxs.x);
-	HSTR_PUSH_NUMBER(L, "midy",   mid.y);
-	HSTR_PUSH_NUMBER(L, "miny",   m.mins.y);
-	HSTR_PUSH_NUMBER(L, "maxy",   m.maxs.y);
-	HSTR_PUSH_NUMBER(L, "midz",   mid.z);
-	HSTR_PUSH_NUMBER(L, "minz",   m.mins.z);
-	HSTR_PUSH_NUMBER(L, "maxz",   m.maxs.z);
+	LuaPushNamedNumber(L, "height", m.height);
+	LuaPushNamedNumber(L, "radius", m.radius);
+	LuaPushNamedNumber(L, "midx",   mid.x);
+	LuaPushNamedNumber(L, "minx",   m.mins.x);
+	LuaPushNamedNumber(L, "maxx",   m.maxs.x);
+	LuaPushNamedNumber(L, "midy",   mid.y);
+	LuaPushNamedNumber(L, "miny",   m.mins.y);
+	LuaPushNamedNumber(L, "maxy",   m.maxs.y);
+	LuaPushNamedNumber(L, "midz",   mid.z);
+	LuaPushNamedNumber(L, "minz",   m.mins.z);
+	LuaPushNamedNumber(L, "maxz",   m.maxs.z);
 	return 1;
 }
 
@@ -5966,49 +5966,49 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 	AMoveType* amt = unit->moveType;
 
 	lua_createtable(L, 0, 26);
-	HSTR_PUSH_NUMBER(L, "maxSpeed", amt->GetMaxSpeed() * GAME_SPEED);
-	HSTR_PUSH_NUMBER(L, "maxWantedSpeed", amt->GetMaxWantedSpeed() * GAME_SPEED);
-	HSTR_PUSH_NUMBER(L, "goalx", amt->goalPos.x);
-	HSTR_PUSH_NUMBER(L, "goaly", amt->goalPos.y);
-	HSTR_PUSH_NUMBER(L, "goalz", amt->goalPos.z);
+	LuaPushNamedNumber(L, "maxSpeed", amt->GetMaxSpeed() * GAME_SPEED);
+	LuaPushNamedNumber(L, "maxWantedSpeed", amt->GetMaxWantedSpeed() * GAME_SPEED);
+	LuaPushNamedNumber(L, "goalx", amt->goalPos.x);
+	LuaPushNamedNumber(L, "goaly", amt->goalPos.y);
+	LuaPushNamedNumber(L, "goalz", amt->goalPos.z);
 
 	switch (amt->progressState) {
 		case AMoveType::Done:
-			HSTR_PUSH_CSTRING(L, "progressState", "done");
+			LuaPushNamedString(L, "progressState", "done");
 			break;
 		case AMoveType::Active:
-			HSTR_PUSH_CSTRING(L, "progressState", "active");
+			LuaPushNamedString(L, "progressState", "active");
 			break;
 		case AMoveType::Failed:
-			HSTR_PUSH_CSTRING(L, "progressState", "failed");
+			LuaPushNamedString(L, "progressState", "failed");
 			break;
 	}
 
 	const CGroundMoveType* groundmt = dynamic_cast<CGroundMoveType*>(unit->moveType);
 
 	if (groundmt != nullptr) {
-		HSTR_PUSH_CSTRING(L, "name", "ground");
+		LuaPushNamedString(L, "name", "ground");
 
-		HSTR_PUSH_NUMBER(L, "turnRate", groundmt->GetTurnRate());
-		HSTR_PUSH_NUMBER(L, "accRate", groundmt->GetAccRate());
-		HSTR_PUSH_NUMBER(L, "decRate", groundmt->GetDecRate());
+		LuaPushNamedNumber(L, "turnRate", groundmt->GetTurnRate());
+		LuaPushNamedNumber(L, "accRate", groundmt->GetAccRate());
+		LuaPushNamedNumber(L, "decRate", groundmt->GetDecRate());
 
-		HSTR_PUSH_NUMBER(L, "maxReverseSpeed", groundmt->GetMaxReverseSpeed() * GAME_SPEED);
-		HSTR_PUSH_NUMBER(L, "wantedSpeed", groundmt->GetWantedSpeed() * GAME_SPEED);
-		HSTR_PUSH_NUMBER(L, "currentSpeed", groundmt->GetCurrentSpeed() * GAME_SPEED);
+		LuaPushNamedNumber(L, "maxReverseSpeed", groundmt->GetMaxReverseSpeed() * GAME_SPEED);
+		LuaPushNamedNumber(L, "wantedSpeed", groundmt->GetWantedSpeed() * GAME_SPEED);
+		LuaPushNamedNumber(L, "currentSpeed", groundmt->GetCurrentSpeed() * GAME_SPEED);
 
-		HSTR_PUSH_NUMBER(L, "goalRadius", groundmt->GetGoalRadius());
+		LuaPushNamedNumber(L, "goalRadius", groundmt->GetGoalRadius());
 
-		HSTR_PUSH_NUMBER(L, "currwaypointx", (groundmt->GetCurrWayPoint()).x);
-		HSTR_PUSH_NUMBER(L, "currwaypointy", (groundmt->GetCurrWayPoint()).y);
-		HSTR_PUSH_NUMBER(L, "currwaypointz", (groundmt->GetCurrWayPoint()).z);
-		HSTR_PUSH_NUMBER(L, "nextwaypointx", (groundmt->GetNextWayPoint()).x);
-		HSTR_PUSH_NUMBER(L, "nextwaypointy", (groundmt->GetNextWayPoint()).y);
-		HSTR_PUSH_NUMBER(L, "nextwaypointz", (groundmt->GetNextWayPoint()).z);
+		LuaPushNamedNumber(L, "currwaypointx", (groundmt->GetCurrWayPoint()).x);
+		LuaPushNamedNumber(L, "currwaypointy", (groundmt->GetCurrWayPoint()).y);
+		LuaPushNamedNumber(L, "currwaypointz", (groundmt->GetCurrWayPoint()).z);
+		LuaPushNamedNumber(L, "nextwaypointx", (groundmt->GetNextWayPoint()).x);
+		LuaPushNamedNumber(L, "nextwaypointy", (groundmt->GetNextWayPoint()).y);
+		LuaPushNamedNumber(L, "nextwaypointz", (groundmt->GetNextWayPoint()).z);
 
-		HSTR_PUSH_NUMBER(L, "requestedSpeed", 0.0f);
+		LuaPushNamedNumber(L, "requestedSpeed", 0.0f);
 
-		HSTR_PUSH_NUMBER(L, "pathFailures", 0);
+		LuaPushNamedNumber(L, "pathFailures", 0);
 
 		return 1;
 	}
@@ -6016,62 +6016,62 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 	const CHoverAirMoveType* hAMT = dynamic_cast<CHoverAirMoveType*>(unit->moveType);
 
 	if (hAMT != nullptr) {
-		HSTR_PUSH_CSTRING(L, "name", "gunship");
+		LuaPushNamedString(L, "name", "gunship");
 
-		HSTR_PUSH_NUMBER(L, "wantedHeight", hAMT->wantedHeight);
-		HSTR_PUSH_BOOL(L, "collide", hAMT->collide);
-		HSTR_PUSH_BOOL(L, "useSmoothMesh", hAMT->useSmoothMesh);
+		LuaPushNamedNumber(L, "wantedHeight", hAMT->wantedHeight);
+		LuaPushNamedBool(L, "collide", hAMT->collide);
+		LuaPushNamedBool(L, "useSmoothMesh", hAMT->useSmoothMesh);
 
 		switch (hAMT->aircraftState) {
 			case AAirMoveType::AIRCRAFT_LANDED:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "landed");
+				LuaPushNamedString(L, "aircraftState", "landed");
 				break;
 			case AAirMoveType::AIRCRAFT_FLYING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "flying");
+				LuaPushNamedString(L, "aircraftState", "flying");
 				break;
 			case AAirMoveType::AIRCRAFT_LANDING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "landing");
+				LuaPushNamedString(L, "aircraftState", "landing");
 				break;
 			case AAirMoveType::AIRCRAFT_CRASHING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "crashing");
+				LuaPushNamedString(L, "aircraftState", "crashing");
 				break;
 			case AAirMoveType::AIRCRAFT_TAKEOFF:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "takeoff");
+				LuaPushNamedString(L, "aircraftState", "takeoff");
 				break;
 			case AAirMoveType::AIRCRAFT_HOVERING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "hovering");
+				LuaPushNamedString(L, "aircraftState", "hovering");
 				break;
 		};
 
 		switch (hAMT->flyState) {
 			case CHoverAirMoveType::FLY_CRUISING:
-				HSTR_PUSH_CSTRING(L, "flyState", "cruising");
+				LuaPushNamedString(L, "flyState", "cruising");
 				break;
 			case CHoverAirMoveType::FLY_CIRCLING:
-				HSTR_PUSH_CSTRING(L, "flyState", "circling");
+				LuaPushNamedString(L, "flyState", "circling");
 				break;
 			case CHoverAirMoveType::FLY_ATTACKING:
-				HSTR_PUSH_CSTRING(L, "flyState", "attacking");
+				LuaPushNamedString(L, "flyState", "attacking");
 				break;
 			case CHoverAirMoveType::FLY_LANDING:
-				HSTR_PUSH_CSTRING(L, "flyState", "landing");
+				LuaPushNamedString(L, "flyState", "landing");
 				break;
 		}
 
-		HSTR_PUSH_NUMBER(L, "goalDistance", hAMT->goalDistance);
+		LuaPushNamedNumber(L, "goalDistance", hAMT->goalDistance);
 
-		HSTR_PUSH_BOOL(L, "bankingAllowed", hAMT->bankingAllowed);
-		HSTR_PUSH_NUMBER(L, "currentBank", hAMT->currentBank);
-		HSTR_PUSH_NUMBER(L, "currentPitch", hAMT->currentPitch);
+		LuaPushNamedBool  (L, "bankingAllowed", hAMT->bankingAllowed);
+		LuaPushNamedNumber(L, "currentBank", hAMT->currentBank);
+		LuaPushNamedNumber(L, "currentPitch", hAMT->currentPitch);
 
-		HSTR_PUSH_NUMBER(L, "turnRate", hAMT->turnRate);
-		HSTR_PUSH_NUMBER(L, "accRate", hAMT->accRate);
-		HSTR_PUSH_NUMBER(L, "decRate", hAMT->decRate);
-		HSTR_PUSH_NUMBER(L, "altitudeRate", hAMT->altitudeRate);
+		LuaPushNamedNumber(L, "turnRate",     hAMT->turnRate);
+		LuaPushNamedNumber(L, "accRate",      hAMT->accRate);
+		LuaPushNamedNumber(L, "decRate",      hAMT->decRate);
+		LuaPushNamedNumber(L, "altitudeRate", hAMT->altitudeRate);
 
-		HSTR_PUSH_NUMBER(L, "brakeDistance", -1.0f); // DEPRECATED
-		HSTR_PUSH_BOOL(L, "dontLand", hAMT->GetAllowLanding());
-		HSTR_PUSH_NUMBER(L, "maxDrift", hAMT->maxDrift);
+		LuaPushNamedNumber(L, "brakeDistance", -1.0f); // DEPRECATED
+		LuaPushNamedBool  (L, "dontLand", hAMT->GetAllowLanding());
+		LuaPushNamedNumber(L, "maxDrift", hAMT->maxDrift);
 
 		return 1;
 	}
@@ -6079,42 +6079,42 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 	const CStrafeAirMoveType* sAMT = dynamic_cast<CStrafeAirMoveType*>(unit->moveType);
 
 	if (sAMT != nullptr) {
-		HSTR_PUSH_CSTRING(L, "name", "airplane");
+		LuaPushNamedString(L, "name", "airplane");
 
 		switch (sAMT->aircraftState) {
 			case AAirMoveType::AIRCRAFT_LANDED:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "landed");
+				LuaPushNamedString(L, "aircraftState", "landed");
 				break;
 			case AAirMoveType::AIRCRAFT_FLYING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "flying");
+				LuaPushNamedString(L, "aircraftState", "flying");
 				break;
 			case AAirMoveType::AIRCRAFT_LANDING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "landing");
+				LuaPushNamedString(L, "aircraftState", "landing");
 				break;
 			case AAirMoveType::AIRCRAFT_CRASHING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "crashing");
+				LuaPushNamedString(L, "aircraftState", "crashing");
 				break;
 			case AAirMoveType::AIRCRAFT_TAKEOFF:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "takeoff");
+				LuaPushNamedString(L, "aircraftState", "takeoff");
 				break;
 			case AAirMoveType::AIRCRAFT_HOVERING:
-				HSTR_PUSH_CSTRING(L, "aircraftState", "hovering");
+				LuaPushNamedString(L, "aircraftState", "hovering");
 				break;
 		};
-		HSTR_PUSH_NUMBER(L, "wantedHeight", sAMT->wantedHeight);
-		HSTR_PUSH_BOOL(L, "collide", sAMT->collide);
-		HSTR_PUSH_BOOL(L, "useSmoothMesh", sAMT->useSmoothMesh);
+		LuaPushNamedNumber(L, "wantedHeight",  sAMT->wantedHeight);
+		LuaPushNamedBool  (L, "collide",       sAMT->collide);
+		LuaPushNamedBool  (L, "useSmoothMesh", sAMT->useSmoothMesh);
 
-		HSTR_PUSH_NUMBER(L, "myGravity", sAMT->myGravity);
+		LuaPushNamedNumber(L, "myGravity", sAMT->myGravity);
 
-		HSTR_PUSH_NUMBER(L, "maxBank", sAMT->maxBank);
-		HSTR_PUSH_NUMBER(L, "maxPitch", sAMT->maxBank);
-		HSTR_PUSH_NUMBER(L, "turnRadius", sAMT->turnRadius);
+		LuaPushNamedNumber(L, "maxBank",    sAMT->maxBank);
+		LuaPushNamedNumber(L, "maxPitch",   sAMT->maxBank);
+		LuaPushNamedNumber(L, "turnRadius", sAMT->turnRadius);
 
-		HSTR_PUSH_NUMBER(L, "maxAcc", sAMT->accRate);
-		HSTR_PUSH_NUMBER(L, "maxAileron", sAMT->maxAileron);
-		HSTR_PUSH_NUMBER(L, "maxElevator", sAMT->maxElevator);
-		HSTR_PUSH_NUMBER(L, "maxRudder", sAMT->maxRudder);
+		LuaPushNamedNumber(L, "maxAcc",      sAMT->accRate);
+		LuaPushNamedNumber(L, "maxAileron",  sAMT->maxAileron);
+		LuaPushNamedNumber(L, "maxElevator", sAMT->maxElevator);
+		LuaPushNamedNumber(L, "maxRudder",   sAMT->maxRudder);
 
 		return 1;
 	}
@@ -6122,18 +6122,18 @@ int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 	const CStaticMoveType* staticmt = dynamic_cast<CStaticMoveType*>(unit->moveType);
 
 	if (staticmt != nullptr) {
-		HSTR_PUSH_CSTRING(L, "name", "static");
+		LuaPushNamedString(L, "name", "static");
 		return 1;
 	}
 
 	const CScriptMoveType* scriptmt = dynamic_cast<CScriptMoveType*>(unit->moveType);
 
 	if (scriptmt != nullptr) {
-		HSTR_PUSH_CSTRING(L, "name", "script");
+		LuaPushNamedString(L, "name", "script");
 		return 1;
 	}
 
-	HSTR_PUSH_CSTRING(L, "name", "unknown");
+	LuaPushNamedString(L, "name", "unknown");
 	return 1;
 }
 
@@ -6152,14 +6152,14 @@ static void PackCommand(lua_State* L, const Command& cmd)
 {
 	lua_createtable(L, 0, 4);
 
-	HSTR_PUSH_NUMBER(L, "id", cmd.GetID());
+	LuaPushNamedNumber(L, "id", cmd.GetID());
 
 	// t["params"] = {[1] = param1, ...}
 	LuaUtils::PushCommandParamsTable(L, cmd, true);
 	// t["options"] = {key1 = val1, ...}
 	LuaUtils::PushCommandOptionsTable(L, cmd, true);
 
-	HSTR_PUSH_NUMBER(L, "tag", cmd.GetTag());
+	LuaPushNamedNumber(L, "tag", cmd.GetTag());
 }
 
 
@@ -7807,7 +7807,7 @@ int LuaSyncedRead::GetGroundBlocked(lua_State* L)
 			const CFeature* feature = dynamic_cast<const CFeature*>(s);
 			if (feature != nullptr) {
 				if (LuaUtils::IsFeatureVisible(L, feature)) {
-					HSTR_PUSH(L, "feature");
+					LuaPushHString(L, "feature");
 					lua_pushnumber(L, feature->id);
 					return 2;
 				}
@@ -7818,7 +7818,7 @@ int LuaSyncedRead::GetGroundBlocked(lua_State* L)
 			const CUnit* unit = dynamic_cast<const CUnit*>(s);
 			if (unit != nullptr) {
 				if (CLuaHandle::GetHandleFullRead(L) || (unit->losStatus[CLuaHandle::GetHandleReadAllyTeam(L)] & LOS_INLOS)) {
-					HSTR_PUSH(L, "unit");
+					LuaPushHString(L, "unit");
 					lua_pushnumber(L, unit->id);
 					return 2;
 				}
@@ -8291,13 +8291,13 @@ int LuaSyncedRead::GetUnitLosState(lua_State* L)
 
 	lua_createtable(L, 0, 3);
 	if (losStatus & LOS_INLOS) {
-		HSTR_PUSH_BOOL(L, "los", true);
+		LuaPushNamedBool(L, "los", true);
 	}
 	if (losStatus & LOS_INRADAR) {
-		HSTR_PUSH_BOOL(L, "radar", true);
+		LuaPushNamedBool(L, "radar", true);
 	}
 	if ((losStatus & LOS_INLOS) || isTyped) {
-		HSTR_PUSH_BOOL(L, "typed", true);
+		LuaPushNamedBool(L, "typed", true);
 	}
 	return 1;
 }
@@ -8539,10 +8539,10 @@ static int GetSolidObjectPieceList(lua_State* L, const CSolidObject* o)
 static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 {
 	lua_createtable(L, 0, 7);
-	HSTR_PUSH_STRING(L, "name", op.name);
-	HSTR_PUSH_STRING(L, "parent", ((op.parent != nullptr) ? op.parent->name : "[null]"));
+	LuaPushNamedString(L, "name",   op.name);
+	LuaPushNamedString(L, "parent", ((op.parent != nullptr) ? op.parent->name : "[null]"));
 
-	HSTR_PUSH(L, "children");
+	LuaPushHString(L, "children");
 	lua_createtable(L, op.children.size(), 0);
 	for (size_t c = 0; c < op.children.size(); c++) {
 		lua_pushsstring(L, op.children[c]->name);
@@ -8550,11 +8550,9 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	}
 	lua_rawset(L, -3);
 
-	HSTR_PUSH(L, "isEmpty");
-	lua_pushboolean(L, !op.HasGeometryData());
-	lua_rawset(L, -3);
+	LuaPushNamedBool(L, "isEmpty", !op.HasGeometryData());
 
-	HSTR_PUSH(L, "min");
+	LuaPushHString(L, "min");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.mins.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.mins.y); lua_rawseti(L, -2, 2);
@@ -8562,7 +8560,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	}
 	lua_rawset(L, -3);
 
-	HSTR_PUSH(L, "max");
+	LuaPushHString(L, "max");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.maxs.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.maxs.y); lua_rawseti(L, -2, 2);
@@ -8570,7 +8568,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	}
 	lua_rawset(L, -3);
 
-	HSTR_PUSH(L, "offset");
+	LuaPushHString(L, "offset");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.offset.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.offset.y); lua_rawseti(L, -2, 2);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -2309,8 +2309,8 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 
 	// no unsynced Skirmish AI info for synchronized scripts
 	if (CLuaHandle::GetHandleSynced(L)) {
-		LuaPushHString(L, "SYNCED_NOSHORTNAME");
-		LuaPushHString(L, "SYNCED_NOVERSION");
+		LuaPushString(L, "SYNCED_NOSHORTNAME");
+		LuaPushString(L, "SYNCED_NOVERSION");
 		lua_newtable(L);
 	} else if (skirmishAIHandler.IsLocalSkirmishAI(skirmishAIId)) {
 		lua_pushsstring(L, aiData->shortName);
@@ -2324,8 +2324,8 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 			lua_rawset(L, -3);
 		}
 	} else {
-		LuaPushHString(L, "UNKNOWN");
-		LuaPushHString(L, "UNKNOWN");
+		LuaPushString(L, "UNKNOWN");
+		LuaPushString(L, "UNKNOWN");
 		lua_newtable(L);
 	}
 	numVals += 3;
@@ -2629,7 +2629,7 @@ int LuaSyncedRead::GetTeamUnitsSorted(lua_State* L)
 		}
 
 		if (!gtuObjectIDs.empty()) {
-			LuaPushHString(L, "unknown");
+			LuaPushString(L, "unknown");
 
 			defCount += 1;
 			unitCount = 1;
@@ -7807,7 +7807,7 @@ int LuaSyncedRead::GetGroundBlocked(lua_State* L)
 			const CFeature* feature = dynamic_cast<const CFeature*>(s);
 			if (feature != nullptr) {
 				if (LuaUtils::IsFeatureVisible(L, feature)) {
-					LuaPushHString(L, "feature");
+					LuaPushString(L, "feature");
 					lua_pushnumber(L, feature->id);
 					return 2;
 				}
@@ -7818,7 +7818,7 @@ int LuaSyncedRead::GetGroundBlocked(lua_State* L)
 			const CUnit* unit = dynamic_cast<const CUnit*>(s);
 			if (unit != nullptr) {
 				if (CLuaHandle::GetHandleFullRead(L) || (unit->losStatus[CLuaHandle::GetHandleReadAllyTeam(L)] & LOS_INLOS)) {
-					LuaPushHString(L, "unit");
+					LuaPushString(L, "unit");
 					lua_pushnumber(L, unit->id);
 					return 2;
 				}
@@ -8542,7 +8542,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	LuaPushNamedString(L, "name",   op.name);
 	LuaPushNamedString(L, "parent", ((op.parent != nullptr) ? op.parent->name : "[null]"));
 
-	LuaPushHString(L, "children");
+	LuaPushString(L, "children");
 	lua_createtable(L, op.children.size(), 0);
 	for (size_t c = 0; c < op.children.size(); c++) {
 		lua_pushsstring(L, op.children[c]->name);
@@ -8552,7 +8552,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 
 	LuaPushNamedBool(L, "isEmpty", !op.HasGeometryData());
 
-	LuaPushHString(L, "min");
+	LuaPushString(L, "min");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.mins.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.mins.y); lua_rawseti(L, -2, 2);
@@ -8560,7 +8560,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	}
 	lua_rawset(L, -3);
 
-	LuaPushHString(L, "max");
+	LuaPushString(L, "max");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.maxs.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.maxs.y); lua_rawseti(L, -2, 2);
@@ -8568,7 +8568,7 @@ static int GetSolidObjectPieceInfoHelper(lua_State* L, const S3DModelPiece& op)
 	}
 	lua_rawset(L, -3);
 
-	LuaPushHString(L, "offset");
+	LuaPushString(L, "offset");
 	lua_createtable(L, 3, 0); {
 		lua_pushnumber(L, op.offset.x); lua_rawseti(L, -2, 1);
 		lua_pushnumber(L, op.offset.y); lua_rawseti(L, -2, 2);

--- a/rts/Lua/LuaSyncedTable.cpp
+++ b/rts/Lua/LuaSyncedTable.cpp
@@ -91,7 +91,7 @@ static int SyncTableMetatable(lua_State* L)
  */
 bool LuaSyncedTable::PushEntries(lua_State* L)
 {
-	LuaPushHString(L, "SYNCED");
+	LuaPushString(L, "SYNCED");
 	lua_newtable(L); { // the proxy table
 
 		lua_createtable(L, 0, 3); { // the metatable

--- a/rts/Lua/LuaSyncedTable.cpp
+++ b/rts/Lua/LuaSyncedTable.cpp
@@ -91,7 +91,7 @@ static int SyncTableMetatable(lua_State* L)
  */
 bool LuaSyncedTable::PushEntries(lua_State* L)
 {
-	HSTR_PUSH(L, "SYNCED");
+	LuaPushHString(L, "SYNCED");
 	lua_newtable(L); { // the proxy table
 
 		lua_createtable(L, 0, 3); { // the metatable

--- a/rts/Lua/LuaUICommand.cpp
+++ b/rts/Lua/LuaUICommand.cpp
@@ -40,20 +40,20 @@ int LuaUICommand::GetUICommands(lua_State* L)
 		const ISyncedActionExecutor* exec = pair.second;
 
 		lua_createtable(L, 0, 4);
-		HSTR_PUSH_STRING(L, "command",     exec->GetCommand());
-		HSTR_PUSH_STRING(L, "description", exec->GetDescription());
-		HSTR_PUSH_BOOL(L,   "synced",      exec->IsSynced());
-		HSTR_PUSH_BOOL(L,   "cheat",       exec->IsCheatRequired());
+		LuaPushNamedString(L, "command",     exec->GetCommand());
+		LuaPushNamedString(L, "description", exec->GetDescription());
+		LuaPushNamedBool(L,   "synced",      exec->IsSynced());
+		LuaPushNamedBool(L,   "cheat",       exec->IsCheatRequired());
 		lua_rawseti(L, -2, count++);
 	}
 	for (const auto& pair: unsyncedExecutors) {
 		const IUnsyncedActionExecutor* exec = pair.second;
 
 		lua_createtable(L, 0, 4);
-		HSTR_PUSH_STRING(L, "command",     exec->GetCommand());
-		HSTR_PUSH_STRING(L, "description", exec->GetDescription());
-		HSTR_PUSH_BOOL(L,   "synced",      exec->IsSynced());
-		HSTR_PUSH_BOOL(L,   "cheat",       exec->IsCheatRequired());
+		LuaPushNamedString(L, "command",     exec->GetCommand());
+		LuaPushNamedString(L, "description", exec->GetDescription());
+		LuaPushNamedBool(L,   "synced",      exec->IsSynced());
+		LuaPushNamedBool(L,   "cheat",       exec->IsCheatRequired());
 		lua_rawseti(L, -2, count++);
 	}
 	return 1;

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -370,18 +370,18 @@ static int WeaponsTable(lua_State* L, const void* data)
 
 		lua_pushnumber(L, i + LUA_WEAPON_BASE_INDEX);
 		lua_createtable(L, 0, 10); {
-			HSTR_PUSH_NUMBER(L, "weaponDef",   wd->id);
-			HSTR_PUSH_NUMBER(L, "slavedTo",    udw.slavedTo - 1 + LUA_WEAPON_BASE_INDEX);
-			HSTR_PUSH_NUMBER(L, "maxAngleDif", udw.maxMainDirAngleDif);
-			HSTR_PUSH_NUMBER(L, "mainDirX",    udw.mainDir.x);
-			HSTR_PUSH_NUMBER(L, "mainDirY",    udw.mainDir.y);
-			HSTR_PUSH_NUMBER(L, "mainDirZ",    udw.mainDir.z);
+			LuaPushNamedNumber(L, "weaponDef",   wd->id);
+			LuaPushNamedNumber(L, "slavedTo",    udw.slavedTo - 1 + LUA_WEAPON_BASE_INDEX);
+			LuaPushNamedNumber(L, "maxAngleDif", udw.maxMainDirAngleDif);
+			LuaPushNamedNumber(L, "mainDirX",    udw.mainDir.x);
+			LuaPushNamedNumber(L, "mainDirY",    udw.mainDir.y);
+			LuaPushNamedNumber(L, "mainDirZ",    udw.mainDir.z);
 
-			HSTR_PUSH(L, "badTargets");
+			LuaPushHString(L, "badTargets");
 			CategorySetFromBits(L, &udw.badTargetCat);
 			lua_rawset(L, -3);
 
-			HSTR_PUSH(L, "onlyTargets");
+			LuaPushHString(L, "onlyTargets");
 			CategorySetFromBits(L, &udw.onlyTargetCat);
 			lua_rawset(L, -3);
 		}
@@ -404,10 +404,10 @@ static void PushGuiSoundSet(lua_State* L, const string& name,
 		lua_pushnumber(L, i + 1);
 		lua_createtable(L, 0, CLuaHandle::GetHandleSynced(L) ? 2 : 3);
 		const GuiSoundSetData& sound = soundSet.GetSoundData(i);
-		HSTR_PUSH_STRING(L, "name",   sound.name);
-		HSTR_PUSH_NUMBER(L, "volume", sound.volume);
+		LuaPushNamedString(L, "name",   sound.name);
+		LuaPushNamedNumber(L, "volume", sound.volume);
 		if (!CLuaHandle::GetHandleSynced(L)) {
-			HSTR_PUSH_NUMBER(L, "id", sound.id);
+			LuaPushNamedNumber(L, "id", sound.id);
 		}
 		lua_rawset(L, -3);
 	}
@@ -451,22 +451,22 @@ static int MoveDefTable(lua_State* L, const void* data)
 	assert(md->pathType == mdPathType);
 	lua_createtable(L, 0, 14);
 
-	HSTR_PUSH_NUMBER(L, "id"           , md->pathType);
-	HSTR_PUSH_NUMBER(L, "smClass"      , md->speedModClass);
-	HSTR_PUSH_NUMBER(L, "xsize"        , md->xsize);
-	HSTR_PUSH_NUMBER(L, "zsize"        , md->zsize);
-	HSTR_PUSH_NUMBER(L, "depth"        , md->depth);
-	HSTR_PUSH_NUMBER(L, "maxSlope"     , md->maxSlope);
-	HSTR_PUSH_NUMBER(L, "slopeMod"     , md->slopeMod);
-	HSTR_PUSH_NUMBER(L, "depthMod"     , md->depthModParams[MoveDef::DEPTHMOD_LIN_COEFF]);
-	HSTR_PUSH_NUMBER(L, "crushStrength", md->crushStrength);
-	HSTR_PUSH_BOOL  (L, "isSubmarine"  , md->isSubmarine);
+	LuaPushNamedNumber(L, "id"           , md->pathType);
+	LuaPushNamedNumber(L, "smClass"      , md->speedModClass);
+	LuaPushNamedNumber(L, "xsize"        , md->xsize);
+	LuaPushNamedNumber(L, "zsize"        , md->zsize);
+	LuaPushNamedNumber(L, "depth"        , md->depth);
+	LuaPushNamedNumber(L, "maxSlope"     , md->maxSlope);
+	LuaPushNamedNumber(L, "slopeMod"     , md->slopeMod);
+	LuaPushNamedNumber(L, "depthMod"     , md->depthModParams[MoveDef::DEPTHMOD_LIN_COEFF]);
+	LuaPushNamedNumber(L, "crushStrength", md->crushStrength);
+	LuaPushNamedBool  (L, "isSubmarine"  , md->isSubmarine);
 
-	HSTR_PUSH_BOOL  (L, "heatMapping"  , md->heatMapping);
-	HSTR_PUSH_NUMBER(L, "heatMod"      , md->heatMod);
-	HSTR_PUSH_NUMBER(L, "heatProduced" , md->heatProduced);
+	LuaPushNamedBool  (L, "heatMapping"  , md->heatMapping);
+	LuaPushNamedNumber(L, "heatMod"      , md->heatMod);
+	LuaPushNamedNumber(L, "heatProduced" , md->heatProduced);
 
-	HSTR_PUSH_STRING(L, "name"         , md->name);
+	LuaPushNamedString(L, "name"         , md->name);
 
 	return 1;
 }

--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -377,11 +377,11 @@ static int WeaponsTable(lua_State* L, const void* data)
 			LuaPushNamedNumber(L, "mainDirY",    udw.mainDir.y);
 			LuaPushNamedNumber(L, "mainDirZ",    udw.mainDir.z);
 
-			LuaPushHString(L, "badTargets");
+			LuaPushString(L, "badTargets");
 			CategorySetFromBits(L, &udw.badTargetCat);
 			lua_rawset(L, -3);
 
-			LuaPushHString(L, "onlyTargets");
+			LuaPushString(L, "onlyTargets");
 			CategorySetFromBits(L, &udw.onlyTargetCat);
 			lua_rawset(L, -3);
 		}

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3092,7 +3092,7 @@ int LuaUnsyncedRead::GetCameraFOV(lua_State* L)
 int LuaUnsyncedRead::GetCameraVectors(lua_State* L)
 {
 #define PACK_CAMERA_VECTOR(s,n) \
-	HSTR_PUSH(L, #s);           \
+	lua_pushhstring(L, LuaHashStringLiteral(#s), #s, sizeof(#s) - 1); \
 	lua_createtable(L, 3, 0);            \
 	lua_pushnumber(L, camera-> n .x); lua_rawseti(L, -2, 1); \
 	lua_pushnumber(L, camera-> n .y); lua_rawseti(L, -2, 2); \

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3092,7 +3092,7 @@ int LuaUnsyncedRead::GetCameraFOV(lua_State* L)
 int LuaUnsyncedRead::GetCameraVectors(lua_State* L)
 {
 #define PACK_CAMERA_VECTOR(s,n) \
-	lua_pushhstring(L, LuaHashStringLiteral(#s), #s, sizeof(#s) - 1); \
+	lua_pushhstring(L, CompileTimeHash(#s), #s, sizeof(#s) - 1); \
 	lua_createtable(L, 3, 0);            \
 	lua_pushnumber(L, camera-> n .x); lua_rawseti(L, -2, 1); \
 	lua_pushnumber(L, camera-> n .y); lua_rawseti(L, -2, 2); \

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -762,9 +762,9 @@ int LuaUtils::PushModelRadius(lua_State* L, const SolidObjectDef* def, bool isUn
 int LuaUtils::PushFeatureModelDrawType(lua_State* L, const FeatureDef* def)
 {
 	switch (def->drawType) {
-		case DRAWTYPE_NONE:  { LuaPushHString(L, "none"); } break;
-		case DRAWTYPE_MODEL: { LuaPushHString(L, "model"); } break;
-		default:             { LuaPushHString(L, "tree"); } break;
+		case DRAWTYPE_NONE:  { LuaPushString(L,  "none"); } break;
+		case DRAWTYPE_MODEL: { LuaPushString(L, "model"); } break;
+		default:             { LuaPushString(L,  "tree"); } break;
 	}
 
 	return 1;
@@ -828,7 +828,7 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 		LuaPushNamedNumber(L, "midz", 0.0f);
 	}
 
-	LuaPushHString(L, "textures");
+	LuaPushString(L, "textures");
 	lua_createtable(L, 0, model != nullptr ? 2 : 0);
 
 	if (model != nullptr) {
@@ -917,7 +917,7 @@ int LuaUtils::ParseColVolData(lua_State* L, int idx, CollisionVolume* vol)
 void LuaUtils::PushCommandParamsTable(lua_State* L, const Command& cmd, bool subtable)
 {
 	if (subtable)
-		LuaPushHString(L, "params");
+		LuaPushString(L, "params");
 
 	lua_createtable(L, cmd.GetNumParams(), 0);
 
@@ -950,7 +950,7 @@ void LuaUtils::PushCommandParamsTable(lua_State* L, const Command& cmd, bool sub
 void LuaUtils::PushCommandOptionsTable(lua_State* L, const Command& cmd, bool subtable)
 {
 	if (subtable)
-		LuaPushHString(L, "options");
+		LuaPushString(L, "options");
 
 	lua_createtable(L, 0, 7);
 	LuaPushNamedNumber(L, "coded", cmd.GetOpts());
@@ -1605,13 +1605,13 @@ void LuaUtils::PushCommandDesc(lua_State* L, const SCommandDescription& cd)
 	LuaPushNamedString(L, "tooltip",     cd.tooltip);
 	LuaPushNamedString(L, "texture",     cd.iconname);
 	LuaPushNamedString(L, "cursor",      cd.mouseicon);
-	LuaPushNamedBool(L,   "queueing",    cd.queueing);
-	LuaPushNamedBool(L,   "hidden",      cd.hidden);
-	LuaPushNamedBool(L,   "disabled",    cd.disabled);
-	LuaPushNamedBool(L,   "showUnique",  cd.showUnique);
-	LuaPushNamedBool(L,   "onlyTexture", cd.onlyTexture);
+	LuaPushNamedBool  (L, "queueing",    cd.queueing);
+	LuaPushNamedBool  (L, "hidden",      cd.hidden);
+	LuaPushNamedBool  (L, "disabled",    cd.disabled);
+	LuaPushNamedBool  (L, "showUnique",  cd.showUnique);
+	LuaPushNamedBool  (L, "onlyTexture", cd.onlyTexture);
 
-	LuaPushHString(L, "params");
+	LuaPushString(L, "params");
 
 	lua_createtable(L, 0, numParams);
 

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -762,9 +762,9 @@ int LuaUtils::PushModelRadius(lua_State* L, const SolidObjectDef* def, bool isUn
 int LuaUtils::PushFeatureModelDrawType(lua_State* L, const FeatureDef* def)
 {
 	switch (def->drawType) {
-		case DRAWTYPE_NONE:  { HSTR_PUSH(L,  "none"); } break;
-		case DRAWTYPE_MODEL: { HSTR_PUSH(L, "model"); } break;
-		default:             { HSTR_PUSH(L,  "tree"); } break;
+		case DRAWTYPE_NONE:  { LuaPushHString(L, "none"); } break;
+		case DRAWTYPE_MODEL: { LuaPushHString(L, "model"); } break;
+		default:             { LuaPushHString(L, "tree"); } break;
 	}
 
 	return 1;
@@ -805,30 +805,30 @@ int LuaUtils::PushModelTable(lua_State* L, const SolidObjectDef* def) {
 
 	if (model != nullptr) {
 		// unit, or non-tree feature
-		HSTR_PUSH_NUMBER(L, "minx", model->mins.x);
-		HSTR_PUSH_NUMBER(L, "miny", model->mins.y);
-		HSTR_PUSH_NUMBER(L, "minz", model->mins.z);
-		HSTR_PUSH_NUMBER(L, "maxx", model->maxs.x);
-		HSTR_PUSH_NUMBER(L, "maxy", model->maxs.y);
-		HSTR_PUSH_NUMBER(L, "maxz", model->maxs.z);
+		LuaPushNamedNumber(L, "minx", model->mins.x);
+		LuaPushNamedNumber(L, "miny", model->mins.y);
+		LuaPushNamedNumber(L, "minz", model->mins.z);
+		LuaPushNamedNumber(L, "maxx", model->maxs.x);
+		LuaPushNamedNumber(L, "maxy", model->maxs.y);
+		LuaPushNamedNumber(L, "maxz", model->maxs.z);
 
-		HSTR_PUSH_NUMBER(L, "midx", model->relMidPos.x);
-		HSTR_PUSH_NUMBER(L, "midy", model->relMidPos.y);
-		HSTR_PUSH_NUMBER(L, "midz", model->relMidPos.z);
+		LuaPushNamedNumber(L, "midx", model->relMidPos.x);
+		LuaPushNamedNumber(L, "midy", model->relMidPos.y);
+		LuaPushNamedNumber(L, "midz", model->relMidPos.z);
 	} else {
-		HSTR_PUSH_NUMBER(L, "minx", 0.0f);
-		HSTR_PUSH_NUMBER(L, "miny", 0.0f);
-		HSTR_PUSH_NUMBER(L, "minz", 0.0f);
-		HSTR_PUSH_NUMBER(L, "maxx", 0.0f);
-		HSTR_PUSH_NUMBER(L, "maxy", 0.0f);
-		HSTR_PUSH_NUMBER(L, "maxz", 0.0f);
+		LuaPushNamedNumber(L, "minx", 0.0f);
+		LuaPushNamedNumber(L, "miny", 0.0f);
+		LuaPushNamedNumber(L, "minz", 0.0f);
+		LuaPushNamedNumber(L, "maxx", 0.0f);
+		LuaPushNamedNumber(L, "maxy", 0.0f);
+		LuaPushNamedNumber(L, "maxz", 0.0f);
 
-		HSTR_PUSH_NUMBER(L, "midx", 0.0f);
-		HSTR_PUSH_NUMBER(L, "midy", 0.0f);
-		HSTR_PUSH_NUMBER(L, "midz", 0.0f);
+		LuaPushNamedNumber(L, "midx", 0.0f);
+		LuaPushNamedNumber(L, "midy", 0.0f);
+		LuaPushNamedNumber(L, "midz", 0.0f);
 	}
 
-	HSTR_PUSH(L, "textures");
+	LuaPushHString(L, "textures");
 	lua_createtable(L, 0, model != nullptr ? 2 : 0);
 
 	if (model != nullptr) {
@@ -850,16 +850,16 @@ int LuaUtils::PushColVolTable(lua_State* L, const CollisionVolume* vol) {
 	lua_createtable(L, 0, 11);
 	switch (vol->GetVolumeType()) {
 		case CollisionVolume::COLVOL_TYPE_ELLIPSOID:
-			HSTR_PUSH_CSTRING(L, "type", "ellipsoid");
+			LuaPushNamedString(L, "type", "ellipsoid");
 			break;
 		case CollisionVolume::COLVOL_TYPE_CYLINDER:
-			HSTR_PUSH_CSTRING(L, "type", "cylinder");
+			LuaPushNamedString(L, "type", "cylinder");
 			break;
 		case CollisionVolume::COLVOL_TYPE_BOX:
-			HSTR_PUSH_CSTRING(L, "type", "box");
+			LuaPushNamedString(L, "type", "box");
 			break;
 		case CollisionVolume::COLVOL_TYPE_SPHERE:
-			HSTR_PUSH_CSTRING(L, "type", "sphere");
+			LuaPushNamedString(L, "type", "sphere");
 			break;
 	}
 
@@ -917,7 +917,7 @@ int LuaUtils::ParseColVolData(lua_State* L, int idx, CollisionVolume* vol)
 void LuaUtils::PushCommandParamsTable(lua_State* L, const Command& cmd, bool subtable)
 {
 	if (subtable)
-		HSTR_PUSH(L, "params");
+		LuaPushHString(L, "params");
 
 	lua_createtable(L, cmd.GetNumParams(), 0);
 
@@ -950,16 +950,16 @@ void LuaUtils::PushCommandParamsTable(lua_State* L, const Command& cmd, bool sub
 void LuaUtils::PushCommandOptionsTable(lua_State* L, const Command& cmd, bool subtable)
 {
 	if (subtable)
-		HSTR_PUSH(L, "options");
+		LuaPushHString(L, "options");
 
 	lua_createtable(L, 0, 7);
-	HSTR_PUSH_NUMBER(L, "coded", cmd.GetOpts());
-	HSTR_PUSH_BOOL(L, "alt",      !!(cmd.GetOpts() & ALT_KEY        ));
-	HSTR_PUSH_BOOL(L, "ctrl",     !!(cmd.GetOpts() & CONTROL_KEY    ));
-	HSTR_PUSH_BOOL(L, "shift",    !!(cmd.GetOpts() & SHIFT_KEY      ));
-	HSTR_PUSH_BOOL(L, "right",    !!(cmd.GetOpts() & RIGHT_MOUSE_KEY));
-	HSTR_PUSH_BOOL(L, "meta",     !!(cmd.GetOpts() & META_KEY       ));
-	HSTR_PUSH_BOOL(L, "internal", !!(cmd.GetOpts() & INTERNAL_ORDER ));
+	LuaPushNamedNumber(L, "coded", cmd.GetOpts());
+	LuaPushNamedBool(L, "alt",      !!(cmd.GetOpts() & ALT_KEY        ));
+	LuaPushNamedBool(L, "ctrl",     !!(cmd.GetOpts() & CONTROL_KEY    ));
+	LuaPushNamedBool(L, "shift",    !!(cmd.GetOpts() & SHIFT_KEY      ));
+	LuaPushNamedBool(L, "right",    !!(cmd.GetOpts() & RIGHT_MOUSE_KEY));
+	LuaPushNamedBool(L, "meta",     !!(cmd.GetOpts() & META_KEY       ));
+	LuaPushNamedBool(L, "internal", !!(cmd.GetOpts() & INTERNAL_ORDER ));
 
 	if (subtable)
 		lua_rawset(L, -3);
@@ -1598,20 +1598,20 @@ void LuaUtils::PushCommandDesc(lua_State* L, const SCommandDescription& cd)
 	lua_checkstack(L, 1 + 1 + 1 + 1);
 	lua_createtable(L, 0, numTblKeys);
 
-	HSTR_PUSH_NUMBER(L, "id",          cd.id);
-	HSTR_PUSH_NUMBER(L, "type",        cd.type);
-	HSTR_PUSH_STRING(L, "name",        cd.name);
-	HSTR_PUSH_STRING(L, "action",      cd.action);
-	HSTR_PUSH_STRING(L, "tooltip",     cd.tooltip);
-	HSTR_PUSH_STRING(L, "texture",     cd.iconname);
-	HSTR_PUSH_STRING(L, "cursor",      cd.mouseicon);
-	HSTR_PUSH_BOOL(L,   "queueing",    cd.queueing);
-	HSTR_PUSH_BOOL(L,   "hidden",      cd.hidden);
-	HSTR_PUSH_BOOL(L,   "disabled",    cd.disabled);
-	HSTR_PUSH_BOOL(L,   "showUnique",  cd.showUnique);
-	HSTR_PUSH_BOOL(L,   "onlyTexture", cd.onlyTexture);
+	LuaPushNamedNumber(L, "id",          cd.id);
+	LuaPushNamedNumber(L, "type",        cd.type);
+	LuaPushNamedString(L, "name",        cd.name);
+	LuaPushNamedString(L, "action",      cd.action);
+	LuaPushNamedString(L, "tooltip",     cd.tooltip);
+	LuaPushNamedString(L, "texture",     cd.iconname);
+	LuaPushNamedString(L, "cursor",      cd.mouseicon);
+	LuaPushNamedBool(L,   "queueing",    cd.queueing);
+	LuaPushNamedBool(L,   "hidden",      cd.hidden);
+	LuaPushNamedBool(L,   "disabled",    cd.disabled);
+	LuaPushNamedBool(L,   "showUnique",  cd.showUnique);
+	LuaPushNamedBool(L,   "onlyTexture", cd.onlyTexture);
 
-	HSTR_PUSH(L, "params");
+	LuaPushHString(L, "params");
 
 	lua_createtable(L, 0, numParams);
 

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -256,7 +256,7 @@ static void PushObjectDefProxyTable(
 template <unsigned N>
 static inline void LuaPushNamedNil(lua_State* L, const char (&key) [N])
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushnil(L);
 	lua_rawset(L, -3);
 }
@@ -272,7 +272,7 @@ static inline void LuaPushNamedNil(lua_State* L,
 template <unsigned N>
 static inline void LuaPushNamedBool(lua_State* L, const char (&key) [N], bool value)
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushboolean(L, value);
 	lua_rawset(L, -3);
 }
@@ -287,7 +287,7 @@ static inline void LuaPushNamedBool(lua_State* L, const string& key, bool value)
 template <unsigned N>
 static inline void LuaPushNamedNumber(lua_State* L, const char (&key) [N], lua_Number value) 
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushnumber(L, value);
 	lua_rawset(L, -3);
 }
@@ -302,7 +302,7 @@ static inline void LuaPushNamedNumber(lua_State* L, const string& key, lua_Numbe
 template <unsigned N>
 static inline void LuaPushNamedChar(lua_State* L, const char (&key) [N], char value)
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushlstring(L, &value, 1);
 	lua_rawset(L, -3);
 }
@@ -317,15 +317,15 @@ static inline void LuaPushNamedChar(lua_State* L, char const *name, char value)
 template <unsigned N0, unsigned N1>
 static inline void LuaPushNamedString(lua_State* L, const char (&key) [N0], const char (&value) [N1])
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N0 - 1);
-	lua_pushhstring(L, LuaHashStringLiteral(value), value, N1 - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N0 - 1);
+	lua_pushhstring(L, CompileTimeHash(value), value, N1 - 1);
 	lua_rawset(L, -3);
 }
 
 template <unsigned N>
 static inline void LuaPushNamedString(lua_State* L, const char (&key) [N], const string& value)
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushsstring(L, value);
 	lua_rawset(L, -3);
 }
@@ -340,7 +340,7 @@ static inline void LuaPushNamedString(lua_State* L, const string& key, const str
 template <unsigned N>
 static inline void LuaPushNamedCFunc(lua_State* L, const char (&key) [N], lua_CFunction func)
 {
-	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushhstring(L, CompileTimeHash(key), key, N - 1);
 	lua_pushcfunction(L, func);
 	lua_rawset(L, -3);
 }
@@ -358,6 +358,17 @@ static inline void LuaPushRawNamedCFunc(lua_State* L, const char* key, lua_CFunc
 	lua_pushcfunction(L, func);
 	lua_rawset(L, -3);
 }
+
+template <unsigned N>
+static inline void LuaPushString(lua_State* L, const char (&str)[N])
+{
+	static_assert(N > 1);
+	lua_pushhstring(L, CompileTimeHash(str), str, N - 1);
+}
+
+static inline void LuaPushString(lua_State* L, const string& str) {
+	lua_pushsstring(L, str);
+} 
 
 #define REGISTER_LUA_CFUNC(func)                LuaPushRawNamedCFunc(L, #func,        func)
 #define REGISTER_NAMED_LUA_CFUNC(name, func)    LuaPushRawNamedCFunc(L,  name,        func)

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -12,6 +12,7 @@
 #include "LuaInclude.h"
 #include "LuaHandle.h"
 #include "LuaDefs.h"
+#include "System/StringHash.h"
 // FIXME: use fwd-decls
 #include "System/EventClient.h"
 #include "Sim/Units/CommandAI/Command.h"
@@ -247,7 +248,18 @@ static void PushObjectDefProxyTable(
 	lua_rawset(L, -3); // set the proxy table
 }
 
+// Note: The `const char (&key) [N]` overloads are a specialization for string literals to allow hashing at compile time.
+//		 For a `char buf[N]` the hasher will assume its a C style string of size N terminated at index N-1.
+//		 This can lead to hashing after the null terminator if the string only uses part of the buffer. 
+//       Use a std::string if you want to pass in dynamic keys.
 
+template <unsigned N>
+static inline void LuaPushNamedNil(lua_State* L, const char (&key) [N])
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushnil(L);
+	lua_rawset(L, -3);
+}
 
 static inline void LuaPushNamedNil(lua_State* L,
                              const string& key)
@@ -257,6 +269,13 @@ static inline void LuaPushNamedNil(lua_State* L,
 	lua_rawset(L, -3);
 }
 
+template <unsigned N>
+static inline void LuaPushNamedBool(lua_State* L, const char (&key) [N], bool value)
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushboolean(L, value);
+	lua_rawset(L, -3);
+}
 
 static inline void LuaPushNamedBool(lua_State* L, const string& key, bool value)
 {
@@ -265,6 +284,13 @@ static inline void LuaPushNamedBool(lua_State* L, const string& key, bool value)
 	lua_rawset(L, -3);
 }
 
+template <unsigned N>
+static inline void LuaPushNamedNumber(lua_State* L, const char (&key) [N], lua_Number value) 
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushnumber(L, value);
+	lua_rawset(L, -3);
+}
 
 static inline void LuaPushNamedNumber(lua_State* L, const string& key, lua_Number value)
 {
@@ -273,11 +299,34 @@ static inline void LuaPushNamedNumber(lua_State* L, const string& key, lua_Numbe
 	lua_rawset(L, -3);
 }
 
+template <unsigned N>
+static inline void LuaPushNamedChar(lua_State* L, const char (&key) [N], char value)
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushlstring(L, &value, 1);
+	lua_rawset(L, -3);
+}
 
 static inline void LuaPushNamedChar(lua_State* L, char const *name, char value)
 {
 	lua_pushstring(L, name);
 	lua_pushlstring(L, &value, 1);
+	lua_rawset(L, -3);
+}
+
+template <unsigned N0, unsigned N1>
+static inline void LuaPushNamedString(lua_State* L, const char (&key) [N0], const char (&value) [N1])
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N0 - 1);
+	lua_pushhstring(L, LuaHashStringLiteral(value), value, N1 - 1);
+	lua_rawset(L, -3);
+}
+
+template <unsigned N>
+static inline void LuaPushNamedString(lua_State* L, const char (&key) [N], const string& value)
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushsstring(L, value);
 	lua_rawset(L, -3);
 }
 
@@ -288,6 +337,13 @@ static inline void LuaPushNamedString(lua_State* L, const string& key, const str
 	lua_rawset(L, -3);
 }
 
+template <unsigned N>
+static inline void LuaPushNamedCFunc(lua_State* L, const char (&key) [N], lua_CFunction func)
+{
+	lua_pushhstring(L, LuaHashStringLiteral(key), key, N - 1);
+	lua_pushcfunction(L, func);
+	lua_rawset(L, -3);
+}
 
 static inline void LuaPushNamedCFunc(lua_State* L, const string& key, lua_CFunction func)
 {

--- a/rts/Lua/LuaVFS.cpp
+++ b/rts/Lua/LuaVFS.cpp
@@ -149,57 +149,57 @@ bool LuaVFS::PushCommon(lua_State* L)
 {
 
 	/*** @field VFS.RAW "r" Only select uncompressed files. */
-	HSTR_PUSH_CSTRING(L, "RAW",       SPRING_VFS_RAW);
+	LuaPushNamedString(L, "RAW",       SPRING_VFS_RAW);
 	/*** @field VFS.GAME "M" */
-	HSTR_PUSH_CSTRING(L, "GAME",      SPRING_VFS_MOD); // synonym to MOD
+	LuaPushNamedString(L, "GAME",      SPRING_VFS_MOD); // synonym to MOD
 	/*** @field VFS.MAP "m" */
-	HSTR_PUSH_CSTRING(L, "MAP",       SPRING_VFS_MAP);
+	LuaPushNamedString(L, "MAP",       SPRING_VFS_MAP);
 	/*** @field VFS.BASE "b" */
-	HSTR_PUSH_CSTRING(L, "BASE",      SPRING_VFS_BASE);
+	LuaPushNamedString(L, "BASE",      SPRING_VFS_BASE);
 	/*** @field VFS.MENU "e" */
-	HSTR_PUSH_CSTRING(L, "MENU",      SPRING_VFS_MENU);
+	LuaPushNamedString(L, "MENU",      SPRING_VFS_MENU);
 	/*** @field VFS.ZIP "Mmeb" Only select compressed files (`.sdz`, `.sd7`). */
-	HSTR_PUSH_CSTRING(L, "ZIP",       SPRING_VFS_ZIP);
+	LuaPushNamedString(L, "ZIP",       SPRING_VFS_ZIP);
 	/*** @field VFS.RAW_FIRST "rMmeb" Try uncompressed files first, then compressed. */
-	HSTR_PUSH_CSTRING(L, "RAW_FIRST", SPRING_VFS_RAW_FIRST);
+	LuaPushNamedString(L, "RAW_FIRST", SPRING_VFS_RAW_FIRST);
 	/*** @field VFS.ZIP_FIRST "Mmebr" Try compressed files first, then uncompressed. */
-	HSTR_PUSH_CSTRING(L, "ZIP_FIRST", SPRING_VFS_ZIP_FIRST);
+	LuaPushNamedString(L, "ZIP_FIRST", SPRING_VFS_ZIP_FIRST);
 
 	/***
 	 * @deprecated
 	 * @field VFS.MOD "M" Older spelling for `VFS.GAME`
 	 */
-	HSTR_PUSH_CSTRING(L, "MOD",       SPRING_VFS_MOD);
+	LuaPushNamedString(L, "MOD",       SPRING_VFS_MOD);
 	/***
 	 * @deprecated
 	 * @field VFS.RAW_ONLY "r"
 	 */
-	HSTR_PUSH_CSTRING(L, "RAW_ONLY",  SPRING_VFS_RAW); // backwards compatibility
+	LuaPushNamedString(L, "RAW_ONLY",  SPRING_VFS_RAW); // backwards compatibility
 	/***
 	 * @deprecated
 	 * @field VFS.ZIP_ONLY "Mmeb"
 	 */
-	HSTR_PUSH_CSTRING(L, "ZIP_ONLY",  SPRING_VFS_ZIP); // backwards compatibility
+	LuaPushNamedString(L, "ZIP_ONLY",  SPRING_VFS_ZIP); // backwards compatibility
 
-	HSTR_PUSH_CFUNC(L, "PackU8",    PackU8);
-	HSTR_PUSH_CFUNC(L, "PackU16",   PackU16);
-	HSTR_PUSH_CFUNC(L, "PackU32",   PackU32);
-	HSTR_PUSH_CFUNC(L, "PackS8",    PackS8);
-	HSTR_PUSH_CFUNC(L, "PackS16",   PackS16);
-	HSTR_PUSH_CFUNC(L, "PackS32",   PackS32);
-	HSTR_PUSH_CFUNC(L, "PackF32",   PackF32);
-	HSTR_PUSH_CFUNC(L, "UnpackU8",  UnpackU8);
-	HSTR_PUSH_CFUNC(L, "UnpackU16", UnpackU16);
-	HSTR_PUSH_CFUNC(L, "UnpackU32", UnpackU32);
-	HSTR_PUSH_CFUNC(L, "UnpackS8",  UnpackS8);
-	HSTR_PUSH_CFUNC(L, "UnpackS16", UnpackS16);
-	HSTR_PUSH_CFUNC(L, "UnpackS32", UnpackS32);
-	HSTR_PUSH_CFUNC(L, "UnpackF32", UnpackF32);
+	LuaPushNamedCFunc(L, "PackU8",    PackU8);
+	LuaPushNamedCFunc(L, "PackU16",   PackU16);
+	LuaPushNamedCFunc(L, "PackU32",   PackU32);
+	LuaPushNamedCFunc(L, "PackS8",    PackS8);
+	LuaPushNamedCFunc(L, "PackS16",   PackS16);
+	LuaPushNamedCFunc(L, "PackS32",   PackS32);
+	LuaPushNamedCFunc(L, "PackF32",   PackF32);
+	LuaPushNamedCFunc(L, "UnpackU8",  UnpackU8);
+	LuaPushNamedCFunc(L, "UnpackU16", UnpackU16);
+	LuaPushNamedCFunc(L, "UnpackU32", UnpackU32);
+	LuaPushNamedCFunc(L, "UnpackS8",  UnpackS8);
+	LuaPushNamedCFunc(L, "UnpackS16", UnpackS16);
+	LuaPushNamedCFunc(L, "UnpackS32", UnpackS32);
+	LuaPushNamedCFunc(L, "UnpackF32", UnpackF32);
 
 	// compression should be safe in synced context
-	HSTR_PUSH_CFUNC(L, "ZlibCompress", ZlibCompress);
-	HSTR_PUSH_CFUNC(L, "ZlibDecompress", ZlibDecompress);
-	HSTR_PUSH_CFUNC(L, "CalculateHash", CalculateHash);
+	LuaPushNamedCFunc(L, "ZlibCompress", ZlibCompress);
+	LuaPushNamedCFunc(L, "ZlibDecompress", ZlibDecompress);
+	LuaPushNamedCFunc(L, "CalculateHash", CalculateHash);
 
 	return true;
 }
@@ -209,11 +209,11 @@ bool LuaVFS::PushSynced(lua_State* L)
 {
 	PushCommon(L);
 
-	HSTR_PUSH_CFUNC(L, "Include",    SyncInclude);
-	HSTR_PUSH_CFUNC(L, "LoadFile",   SyncLoadFile);
-	HSTR_PUSH_CFUNC(L, "FileExists", SyncFileExists);
-	HSTR_PUSH_CFUNC(L, "DirList",    SyncDirList);
-	HSTR_PUSH_CFUNC(L, "SubDirs",    SyncSubDirs);
+	LuaPushNamedCFunc(L, "Include",    SyncInclude);
+	LuaPushNamedCFunc(L, "LoadFile",   SyncLoadFile);
+	LuaPushNamedCFunc(L, "FileExists", SyncFileExists);
+	LuaPushNamedCFunc(L, "DirList",    SyncDirList);
+	LuaPushNamedCFunc(L, "SubDirs",    SyncSubDirs);
 
 	return true;
 }
@@ -223,21 +223,21 @@ bool LuaVFS::PushUnsynced(lua_State* L)
 {
 	PushCommon(L);
 
-	HSTR_PUSH_CFUNC(L, "Include",             UnsyncInclude);
-	HSTR_PUSH_CFUNC(L, "LoadFile",            UnsyncLoadFile);
-	HSTR_PUSH_CFUNC(L, "FileExists",          UnsyncFileExists);
-	HSTR_PUSH_CFUNC(L, "DirList",             UnsyncDirList);
-	HSTR_PUSH_CFUNC(L, "SubDirs",             UnsyncSubDirs);
+	LuaPushNamedCFunc(L, "Include",             UnsyncInclude);
+	LuaPushNamedCFunc(L, "LoadFile",            UnsyncLoadFile);
+	LuaPushNamedCFunc(L, "FileExists",          UnsyncFileExists);
+	LuaPushNamedCFunc(L, "DirList",             UnsyncDirList);
+	LuaPushNamedCFunc(L, "SubDirs",             UnsyncSubDirs);
 
-	HSTR_PUSH_CFUNC(L, "GetFileAbsolutePath",      GetFileAbsolutePath);
-	HSTR_PUSH_CFUNC(L, "GetArchiveContainingFile", GetArchiveContainingFile);
+	LuaPushNamedCFunc(L, "GetFileAbsolutePath",      GetFileAbsolutePath);
+	LuaPushNamedCFunc(L, "GetArchiveContainingFile", GetArchiveContainingFile);
 
-	HSTR_PUSH_CFUNC(L, "UseArchive",     UseArchive);
-	HSTR_PUSH_CFUNC(L, "CompressFolder", CompressFolder);
+	LuaPushNamedCFunc(L, "UseArchive",     UseArchive);
+	LuaPushNamedCFunc(L, "CompressFolder", CompressFolder);
 
 	// Removed due to sync unsafety, see commit 0ee88788931f9f0b195eb5f895f1092fde4211c0
-	// HSTR_PUSH_CFUNC(L, "MapArchive",     MapArchive);
-	// HSTR_PUSH_CFUNC(L, "UnmapArchive",   UnmapArchive);
+	// LuaPushNamedCFunc(L, "MapArchive",     MapArchive);
+	// LuaPushNamedCFunc(L, "UnmapArchive",   UnmapArchive);
 
 	return true;
 }

--- a/rts/Lua/LuaWeaponDefs.cpp
+++ b/rts/Lua/LuaWeaponDefs.cpp
@@ -245,11 +245,11 @@ static int DamagesArray(lua_State* L, const void* data)
 	const DamageArray& d = *static_cast<const DamageArray*>(data);
 
 	lua_createtable(L, damageArrayHandler.GetNumTypes(), 5);
-	HSTR_PUSH_NUMBER(L, "impulseFactor",      d.impulseFactor);
-	HSTR_PUSH_NUMBER(L, "impulseBoost",       d.impulseBoost);
-	HSTR_PUSH_NUMBER(L, "craterMult",         d.craterMult);
-	HSTR_PUSH_NUMBER(L, "craterBoost",        d.craterBoost);
-	HSTR_PUSH_NUMBER(L, "paralyzeDamageTime", d.paralyzeDamageTime);
+	LuaPushNamedNumber(L, "impulseFactor",      d.impulseFactor);
+	LuaPushNamedNumber(L, "impulseBoost",       d.impulseBoost);
+	LuaPushNamedNumber(L, "craterMult",         d.craterMult);
+	LuaPushNamedNumber(L, "craterBoost",        d.craterBoost);
+	LuaPushNamedNumber(L, "paralyzeDamageTime", d.paralyzeDamageTime);
 
 	// damage values
 	for (int i = 0, n = damageArrayHandler.GetNumTypes(); i < n; i++) {
@@ -266,34 +266,34 @@ static int VisualsTable(lua_State* L, const void* data)
 {
 	const struct WeaponDef::Visuals& v = *static_cast<const struct WeaponDef::Visuals*>(data);
 	lua_createtable(L, 0, 28);
-	HSTR_PUSH_STRING(L, "modelName",            modelLoader.FindModelPath(v.modelName));
-	HSTR_PUSH_NUMBER(L, "colorR",               v.color.x);
-	HSTR_PUSH_NUMBER(L, "colorG",               v.color.y);
-	HSTR_PUSH_NUMBER(L, "colorB",               v.color.z);
-	HSTR_PUSH_NUMBER(L, "color2R",              v.color2.x);
-	HSTR_PUSH_NUMBER(L, "color2G",              v.color2.y);
-	HSTR_PUSH_NUMBER(L, "color2B",              v.color2.z);
-	HSTR_PUSH_BOOL  (L, "smokeTrail",           v.smokeTrail);
-	HSTR_PUSH_BOOL  (L, "smokeTrailCastShadow", v.smokeTrailCastShadow);
-	HSTR_PUSH_NUMBER(L, "smokePeriod",          v.smokePeriod);
-	HSTR_PUSH_NUMBER(L, "smokeTime",            v.smokeTime);
-	HSTR_PUSH_NUMBER(L, "smokeSize",            v.smokeSize);
-	HSTR_PUSH_NUMBER(L, "smokeColor",           v.smokeColor);
-	HSTR_PUSH_NUMBER(L, "tileLength",           v.tilelength);
-	HSTR_PUSH_NUMBER(L, "scrollSpeed",          v.scrollspeed);
-	HSTR_PUSH_NUMBER(L, "pulseSpeed",           v.pulseSpeed);
-	HSTR_PUSH_NUMBER(L, "laserFlareSize",       v.laserflaresize);
-	HSTR_PUSH_NUMBER(L, "thickness",            v.thickness);
-	HSTR_PUSH_NUMBER(L, "coreThickness",        v.corethickness);
-	HSTR_PUSH_NUMBER(L, "beamDecay",            v.beamdecay);
-	HSTR_PUSH_NUMBER(L, "stages",               v.stages);
-	HSTR_PUSH_NUMBER(L, "sizeDecay",            v.sizeDecay);
-	HSTR_PUSH_NUMBER(L, "alphaDecay",           v.alphaDecay);
-	HSTR_PUSH_NUMBER(L, "separation",           v.separation);
-	HSTR_PUSH_BOOL  (L, "castShadow",           v.castShadow);
-	HSTR_PUSH_BOOL  (L, "noGap",                v.noGap);
-	HSTR_PUSH_BOOL  (L, "alwaysVisible",        v.alwaysVisible);
-	HSTR_PUSH_BOOL  (L, "beamWeapon",           false); // DEPRECATED
+	LuaPushNamedString(L, "modelName",            modelLoader.FindModelPath(v.modelName));
+	LuaPushNamedNumber(L, "colorR",               v.color.x);
+	LuaPushNamedNumber(L, "colorG",               v.color.y);
+	LuaPushNamedNumber(L, "colorB",               v.color.z);
+	LuaPushNamedNumber(L, "color2R",              v.color2.x);
+	LuaPushNamedNumber(L, "color2G",              v.color2.y);
+	LuaPushNamedNumber(L, "color2B",              v.color2.z);
+	LuaPushNamedBool  (L, "smokeTrail",           v.smokeTrail);
+	LuaPushNamedBool  (L, "smokeTrailCastShadow", v.smokeTrailCastShadow);
+	LuaPushNamedNumber(L, "smokePeriod",          v.smokePeriod);
+	LuaPushNamedNumber(L, "smokeTime",            v.smokeTime);
+	LuaPushNamedNumber(L, "smokeSize",            v.smokeSize);
+	LuaPushNamedNumber(L, "smokeColor",           v.smokeColor);
+	LuaPushNamedNumber(L, "tileLength",           v.tilelength);
+	LuaPushNamedNumber(L, "scrollSpeed",          v.scrollspeed);
+	LuaPushNamedNumber(L, "pulseSpeed",           v.pulseSpeed);
+	LuaPushNamedNumber(L, "laserFlareSize",       v.laserflaresize);
+	LuaPushNamedNumber(L, "thickness",            v.thickness);
+	LuaPushNamedNumber(L, "coreThickness",        v.corethickness);
+	LuaPushNamedNumber(L, "beamDecay",            v.beamdecay);
+	LuaPushNamedNumber(L, "stages",               v.stages);
+	LuaPushNamedNumber(L, "sizeDecay",            v.sizeDecay);
+	LuaPushNamedNumber(L, "alphaDecay",           v.alphaDecay);
+	LuaPushNamedNumber(L, "separation",           v.separation);
+	LuaPushNamedBool  (L, "castShadow",           v.castShadow);
+	LuaPushNamedBool  (L, "noGap",                v.noGap);
+	LuaPushNamedBool  (L, "alwaysVisible",        v.alwaysVisible);
+	LuaPushNamedBool  (L, "beamWeapon",           false); // DEPRECATED
 
 	return 1;
 }
@@ -409,11 +409,11 @@ static int GuiSoundSetTable(lua_State* L, const void* data)
 
 		const GuiSoundSetData& sound = soundSet.GetSoundData(i);
 
-		HSTR_PUSH_STRING(L, "name",   sound.name);
-		HSTR_PUSH_NUMBER(L, "volume", sound.volume);
+		LuaPushNamedString(L, "name",   sound.name);
+		LuaPushNamedNumber(L, "volume", sound.volume);
 
 		if (!CLuaHandle::GetHandleSynced(L)) {
-			HSTR_PUSH_NUMBER(L, "id", sound.id);
+			LuaPushNamedNumber(L, "id", sound.id);
 		}
 
 		lua_rawset(L, -3);

--- a/rts/Lua/LuaZip.cpp
+++ b/rts/Lua/LuaZip.cpp
@@ -36,6 +36,7 @@
 #include "LuaZip.h"
 #include "LuaInclude.h"
 #include "LuaHashString.h"
+#include "LuaUtils.h"
 #include "System/FileSystem/Archives/IArchive.h"
 #include "System/FileSystem/ArchiveLoader.h"
 #include "System/FileSystem/DataDirsAccess.h"
@@ -79,7 +80,7 @@ bool LuaZipFileWriter::PushUnsynced(lua_State* L)
 	CreateMetatable(L);
 
 	// FIXME when this is enabled LuaGaia/LuaRules unsynced has access to it too!
-	//HSTR_PUSH_CFUNC(L, "CreateZipFileWriter", open);
+	// LuaPushNamedCFunc(L, "CreateZipFileWriter", open);
 
 	return true;
 }
@@ -93,10 +94,10 @@ bool LuaZipFileWriter::CreateMetatable(lua_State* L)
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "__index");
 
-	HSTR_PUSH_CFUNC(L, "__gc",  meta_gc);
-	HSTR_PUSH_CFUNC(L, "close", meta_gc);
-	HSTR_PUSH_CFUNC(L, "open",  meta_open);
-	HSTR_PUSH_CFUNC(L, "write", meta_write);
+	LuaPushNamedCFunc(L, "__gc",  meta_gc);
+	LuaPushNamedCFunc(L, "close", meta_gc);
+	LuaPushNamedCFunc(L, "open",  meta_open);
+	LuaPushNamedCFunc(L, "write", meta_write);
 
 	lua_pop(L, 1);
 	return true;
@@ -238,7 +239,7 @@ bool LuaZipFileReader::PushUnsynced(lua_State* L)
 	CreateMetatable(L);
 
 	// FIXME when this is enabled LuaGaia/LuaRules unsynced has access to it too!
-	//HSTR_PUSH_CFUNC(L, "CreateZipFileReader", open);
+	// LuaPushNamedCFunc(L, "CreateZipFileReader", open);
 
 	return true;
 }
@@ -252,10 +253,10 @@ bool LuaZipFileReader::CreateMetatable(lua_State* L)
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "__index");
 
-	HSTR_PUSH_CFUNC(L, "__gc",  meta_gc);
-	HSTR_PUSH_CFUNC(L, "close", meta_gc);
-	HSTR_PUSH_CFUNC(L, "open",  meta_open);
-	HSTR_PUSH_CFUNC(L, "read",  meta_read);
+	LuaPushNamedCFunc(L, "__gc",  meta_gc);
+	LuaPushNamedCFunc(L, "close", meta_gc);
+	LuaPushNamedCFunc(L, "open",  meta_open);
+	LuaPushNamedCFunc(L, "read",  meta_read);
 
 	lua_pop(L, 1);
 	return true;

--- a/rts/System/StringHash.h
+++ b/rts/System/StringHash.h
@@ -37,8 +37,8 @@ struct compileTimeHasher<length, step, idx, idx> {
 };
 
 template <unsigned N>
-[[nodiscard]] constexpr uint32_t LuaHashStringLiteral(const char (&literal)[N]) noexcept
+[[nodiscard]] constexpr uint32_t CompileTimeHash(const char (&literal)[N]) noexcept
 {
-	static_assert(N > 0);
+	static_assert(N > 1);
 	return compileTimeHasher<N - 1>::hash(literal);
 }

--- a/rts/System/StringHash.h
+++ b/rts/System/StringHash.h
@@ -36,4 +36,9 @@ struct compileTimeHasher<length, step, idx, idx> {
 	}
 };
 
-#define COMPILE_TIME_HASH(str) compileTimeHasher<sizeof(str) - 1>::hash(str)
+template <unsigned N>
+[[nodiscard]] constexpr uint32_t LuaHashStringLiteral(const char (&literal)[N]) noexcept
+{
+	static_assert(N > 0);
+	return compileTimeHasher<N - 1>::hash(literal);
+}


### PR DESCRIPTION
Addresses #2891 

I've added an overload for the LuaPushNamedFoo functions changing the const std::string& param to a reference to char arrays. Then it calls the compileTimeHash structs hash function like the macros did prior. If passed a string literal it hashes at compile time properly which I've checked with godbolt. Similar to the old macros which had a warning not to pass in a c style char array calling lua push named foo with one can lead to bugs so I added a warning. I didn't see any callers doing this, passing in a std::string if not using a compile time constant should be used instead which it is. Used copilot for searching and updating the old callsites then I went through and verified it. First PR so not sure what the proper way is to test my changes, ran unit tests and these failed but they were also failing prior to my modifications.