### PR TITLE
Implemented GetUnitFactoryBuilding() method

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -4722,27 +4722,11 @@ int LuaSyncedRead::GetUnitFactoryBuilding(lua_State* L)
 	if (unit == nullptr)
 		return 0;
 
-	if (!unit->beingBuilt)
+	if (unit->producingFactory == nullptr)
 		return 0;
 
-	if (unit->soloBuilder != nullptr) {
-		if (const auto factory = dynamic_cast<const CFactory*>(unit->soloBuilder); factory) {
-			lua_pushnumber(L, factory->id);
-			return 1;
-		}
-		return 0;
-	}
-
-	for (const CUnit* potentialBuilder : unitHandler.GetActiveUnits()) {
-		if (const auto factory = dynamic_cast<const CFactory*>(potentialBuilder); factory) {
-			if (factory->curBuild == unit) {
-				lua_pushnumber(L, factory->id);
-				return 1;
-			}
-		}
-	}
-
-	return 0;
+	lua_pushnumber(L, unit->producingFactory->id);
+	return 1;
 }
 
 /***

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -245,6 +245,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitBuildFacing);
 	REGISTER_LUA_CFUNC(GetUnitIsBuilding);
 	REGISTER_LUA_CFUNC(GetUnitWorkerTask);
+	REGISTER_LUA_CFUNC(GetUnitFactoryBuilding);
 	REGISTER_LUA_CFUNC(GetUnitEffectiveBuildRange);
 	REGISTER_LUA_CFUNC(GetUnitCurrentBuildPower);
 	REGISTER_LUA_CFUNC(GetUnitHarvestStorage);
@@ -4704,6 +4705,42 @@ int LuaSyncedRead::GetUnitWorkerTask(lua_State* L)
 		return GetBuilderWorkerTask(L, builder);
 	if (const auto factory = dynamic_cast <const CFactory *> (unit); factory)
 		return GetFactoryWorkerTask(L, factory);
+
+	return 0;
+}
+
+/*** Returns the factory producing given unit.
+ *
+ * @function Spring.GetUnitFactoryBuilding
+ *
+ * @param unitID integer
+ * @return integer factoryID of the factory currently building the unit, or nil if not being built by a factory
+ */
+int LuaSyncedRead::GetUnitFactoryBuilding(lua_State* L)
+{
+	const auto unit = ParseInLosUnit(L, __func__, 1);
+	if (unit == nullptr)
+		return 0;
+
+	if (!unit->beingBuilt)
+		return 0;
+
+	if (unit->soloBuilder != nullptr) {
+		if (const auto factory = dynamic_cast<const CFactory*>(unit->soloBuilder); factory) {
+			lua_pushnumber(L, factory->id);
+			return 1;
+		}
+		return 0;
+	}
+
+	for (const CUnit* potentialBuilder : unitHandler.GetActiveUnits()) {
+		if (const auto factory = dynamic_cast<const CFactory*>(potentialBuilder); factory) {
+			if (factory->curBuild == unit) {
+				lua_pushnumber(L, factory->id);
+				return 1;
+			}
+		}
+	}
 
 	return 0;
 }

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -144,6 +144,7 @@ class LuaSyncedRead {
 		static int GetUnitBuildFacing(lua_State* L);
 		static int GetUnitIsBuilding(lua_State* L);
 		static int GetUnitWorkerTask(lua_State* L);
+		static int GetUnitFactoryBuilding(lua_State* L);
 		static int GetUnitEffectiveBuildRange(lua_State* L);
 		static int GetUnitCurrentBuildPower(lua_State* L);
 		static int GetUnitHarvestStorage(lua_State* L);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -2919,6 +2919,7 @@ CR_REG_METADATA(CUnit, (
 
 	CR_MEMBER(soloBuilder),
 	CR_MEMBER(lastAttacker),
+	CR_MEMBER(producingFactory),
 	CR_MEMBER(transporter),
 
 	CR_MEMBER(fpsControlPlayer),

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -27,6 +27,7 @@
 #include "Sim/Units/Scripts/LuaUnitScript.h"
 
 
+class CFactory;
 class CPlayer;
 class CCommandAI;
 class CGroup;
@@ -283,6 +284,7 @@ public:
 
 	CUnit* soloBuilder = nullptr;
 	CUnit* lastAttacker = nullptr;
+	CFactory* producingFactory = nullptr;
 	// transport that the unit is currently in
 	CUnit* transporter = nullptr;
 

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -70,6 +70,7 @@ void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int 
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (curBuild != nullptr) {
+		curBuild->producingFactory = nullptr;
 		curBuild->KillUnit(nullptr, false, true, -CSolidObject::DAMAGE_FACTORY_KILLED);
 		curBuild = nullptr;
 	}
@@ -193,6 +194,7 @@ void CFactory::StartBuild(const UnitDef* buildeeDef) {
 		buildee->AddDeathDependence(this, DEPENDENCE_BUILDER);
 	}
 
+	buildee->producingFactory = this;
 	AddDeathDependence(buildee, DEPENDENCE_BUILD);
 	script->StartBuilding();
 
@@ -318,6 +320,7 @@ void CFactory::StopBuild()
 			AddResources({curBuild->cost.metal * curBuild->buildProgress, 0.0f}, false);
 			curBuild->KillUnit(nullptr, false, true, -CSolidObject::DAMAGE_FACTORY_CANCEL);
 		}
+		curBuild->producingFactory = nullptr;
 		DeleteDeathDependence(curBuild, DEPENDENCE_BUILD);
 	}
 


### PR DESCRIPTION
As per https://github.com/beyond-all-reason/RecoilEngine/issues/2892 - added a new method to fetch factory's ID of given unit being build. 

As discussed in the issue's thread - this covers factories exclusively and doesn't account for mobile builders. 