### PR TITLE
fix: address the final few compile warnings

### DIFF
--- a/AI/Skirmish/CMakeLists.txt
+++ b/AI/Skirmish/CMakeLists.txt
@@ -37,6 +37,8 @@ set(_skirmish_ai_clang_warns
 set(_skirmish_ai_gcc_warns
 	-Wno-maybe-uninitialized
 	-Wno-deprecated-declarations
+	-Wno-deprecated
+	-Wno-sign-compare
 )
 foreach    (skirmishAIDir ${SKIRMISH_AI_DIRS})
 	add_subdirectory(${skirmishAIDir})

--- a/AI/Wrappers/Cpp/bin/combine_wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/combine_wrappCallback.awk
@@ -23,7 +23,7 @@ BEGIN {
 	# initialize things
 
 	# define the field splitter(-regex)
-	FS = "(,)|(\\()|(\\)\\;)";
+	FS = "(,)|(\\()|(\\);)";
 
 	# These vars can be assigned externally, see file header.
 	# Set the default values if they were not supplied on the command line.
@@ -183,7 +183,7 @@ function wrappFunction(funcDef, commentEolTot) {
 	doParse = 1; # add a function in case you want to exclude some
 
 	if (doParse) {
-		size_funcParts = split(funcDef, funcParts, "(,)|(\\()|(\\)\\;)");
+		size_funcParts = split(funcDef, funcParts, "(,)|(\\()|(\\);)");
 		# because the empty part after ");" would count as part as well
 		size_funcParts--;
 		retType_c   = trim(funcParts[1]);
@@ -267,7 +267,7 @@ function canDeleteDocumentation() {
 	# remove possible comment at end of line: // foo bar
 	sub(/\/\/.*$/, "", funcStartLine);
 	funcStartLine = trim(funcStartLine);
-	if (match(funcStartLine, /\;$/)) {
+	if (match(funcStartLine, /;$/)) {
 		# function ends in this line
 		wrappFunction(funcStartLine, commentEolTot);
 	} else {

--- a/AI/Wrappers/Cpp/bin/wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/wrappCallback.awk
@@ -20,7 +20,7 @@ BEGIN {
 	# initialize things
 
 	# define the field splitter(-regex)
-	FS = "(\\()|(\\)\\;)";
+	FS = "(\\()|(\\);)";
 	IGNORECASE = 0;
 
 	# These vars can be assigned externally, see file header.
@@ -1410,7 +1410,7 @@ function doWrappMember(fullName_dwm) {
 #EXPORT(float) bridged_UnitDef_getUpkeep(int _skirmishAIId, int unitDefId, int resourceId); // REF:resourceId->Resource
 function wrappFunctionDef(funcDef, commentEolTot) {
 
-	size_funcParts = split(funcDef, funcParts, "(\\()|(\\)[ \t]+bridged_)|(\\)\\;)");
+	size_funcParts = split(funcDef, funcParts, "(\\()|(\\)[ \t]+bridged_)|(\\);)");
 	# because the empty part after ");" would count as part as well
 	size_funcParts--;
 
@@ -1453,7 +1453,7 @@ function canDeleteDocumentation() {
 	# remove possible comment at end of line: // foo bar
 	sub(/\/\/.*$/, "", funcLine);
 	funcLine = trim(funcLine);
-	if (match(funcLine, /\;$/)) {
+	if (match(funcLine, /;$/)) {
 		wrappFunctionDef(funcLine, commentEol);
 	} else {
 		print("Error: Function not declared in a single line.");
@@ -1466,7 +1466,7 @@ function canDeleteDocumentation() {
 #UNUSED
 function wrappFunctionPointerDef(funcDef) {
 
-	size_funcParts = split(funcDef, funcParts, "(\\()|(\\)\\;)");
+	size_funcParts = split(funcDef, funcParts, "(\\()|(\\);)");
 	# because the empty part after ");" would count as part aswell
 	size_funcParts--;
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,12 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 		check_and_add_flags(CMAKE_CXX_FLAGS "-fdiagnostics-color=auto")
 	endif (UNIX)
 
+	if (IS_ARM64_BUILD)
+		# -Wpsabi just notes GCC 10.1's aarch64 aggregate-passing ABI change. That only
+		# matters when mixing pre/post-10.1 objects, which we never do. Drop the spam.
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
+	endif ()
+
 	if (NOT MARCH_FLAG)
 		set(MARCH_FLAG "generic")
 	endif (NOT MARCH_FLAG)

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -29,9 +29,6 @@ if (USE_MIMALLOC)
 		# Temporarily remove _WIN32_WINNT to avoid redefinition warning with mimalloc
 		# mimalloc defines _WIN32_WINNT=0x600 for MinGW in its CMakeLists.txt
 		remove_definitions(-D_WIN32_WINNT=0x0601)
-
-		# Suppress visibility attribute warnings for ALL mimalloc targets.
-		add_compile_options(-Wno-attributes)
 	endif()
 
 	ADD_SUBDIRECTORY(mimalloc)
@@ -39,6 +36,15 @@ if (USE_MIMALLOC)
 	if(MINGW)
 		# Restore _WIN32_WINNT definition after mimalloc
 		add_definitions(-D_WIN32_WINNT=0x0601)
+
+		# mimalloc's MinGW build trips two warnings we silence here:
+		#  - -Wno-attributes: visibility-attribute warnings on mimalloc's exports
+		#  - -Wno-array-bounds: false positive on the gs-segment TEB read (NtCurrentTeb)
+		foreach(_mi_tgt mimalloc-static mimalloc-obj mimalloc)
+			if(TARGET ${_mi_tgt})
+				target_compile_options(${_mi_tgt} PRIVATE -Wno-attributes -Wno-array-bounds)
+			endif()
+		endforeach()
 	endif()
 endif()
 

--- a/rts/lib/lua/include/LuaUser.cpp
+++ b/rts/lib/lua/include/LuaUser.cpp
@@ -381,7 +381,7 @@ static const inline int FastLog10(const float f)
 {
 	assert(f != 0.0f); // log10(0) = -inf
 
-	if (f < 1.0f || f >= (SPRING_INT64_MAX >> 1))
+	if (f < 1.0f || f >= static_cast<float>(SPRING_INT64_MAX >> 1))
 		return std::floor(std::log10(f));
 
 	const std::int64_t i = f;


### PR DESCRIPTION
There's a final few compiler warnings that slipped through the earlier testing, as with before I will add comments to each with the warning printed.

### AI Disclosure
I worked with claude code to help find the right way to address each warning.