### PR TITLE
fix: address sse2neon/streflop macro redefinition warning

### DIFF
--- a/rts/System/simd_compat.h
+++ b/rts/System/simd_compat.h
@@ -3,6 +3,24 @@
 
 #ifdef SSE2NEON
     #include "lib/sse2neon/sse2neon.h"
+    // sse2neon.h includes <fenv.h> purely to implement its rounding-mode
+    // helpers; it captures the FE_XXX values into its own inline code at this
+    // point and exposes only _MM_ROUND_* publicly. The leaked system FE_XXX
+    // macros, however, collide with the ones streflop (re)defines for its NEON
+    // FPU control, making streflop emit a redefinition #warning in every TU
+    // that includes it afterwards. Drop the leaked macros to contain the leak
+    // at this boundary; streflop then sees a clean slate and defines its own.
+    #undef FE_INVALID
+    #undef FE_DENORMAL
+    #undef FE_DIVBYZERO
+    #undef FE_OVERFLOW
+    #undef FE_UNDERFLOW
+    #undef FE_INEXACT
+    #undef FE_ALL_EXCEPT
+    #undef FE_TONEAREST
+    #undef FE_DOWNWARD
+    #undef FE_UPWARD
+    #undef FE_TOWARDZERO
 #else
     #ifdef _MSC_VER
         #include <intrin.h>   // MSVC umbrella

--- a/rts/System/simd_compat.h
+++ b/rts/System/simd_compat.h
@@ -3,13 +3,8 @@
 
 #ifdef SSE2NEON
     #include "lib/sse2neon/sse2neon.h"
-    // sse2neon.h includes <fenv.h> purely to implement its rounding-mode
-    // helpers; it captures the FE_XXX values into its own inline code at this
-    // point and exposes only _MM_ROUND_* publicly. The leaked system FE_XXX
-    // macros, however, collide with the ones streflop (re)defines for its NEON
-    // FPU control, making streflop emit a redefinition #warning in every TU
-    // that includes it afterwards. Drop the leaked macros to contain the leak
-    // at this boundary; streflop then sees a clean slate and defines its own.
+    // sse2neon leaks <fenv.h>'s FE_XXX macros, which collide with the ones streflop
+    // redefines and trigger a #warning. Undef them here so streflop gets a clean slate.
     #undef FE_INVALID
     #undef FE_DENORMAL
     #undef FE_DIVBYZERO


### PR DESCRIPTION
A separate PR for this arm-setup-specific warning. My understanding is that streflop adds some macros into fenv.h and then sse2neon ALSO creates macros by the same name, causing a warning. The most straightforward way to fix this is we force sse2neon to be truly encapsulated by undef'ing the macros it defines, so the streflop ones still take precedence but without emitting a warning.