### PR TITLE
POC perf fixing ghosts

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -271,7 +271,13 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 	
 	Transform tx;
 	if (staticModel) {
-		tx = transforms[instData.x + bID0];
+		// matrixMode == 2 (static instanced): pieces come from the bind-pose block (instData.w),
+		// because instData.x holds the per-instance world transform instead of the bind pose.
+		// matrixMode == 1 (static): for model submits instData.x == instData.w == bind pose.
+		if (matrixMode == 2)
+			tx = transforms[instData.w + bID0];
+		else
+			tx = transforms[instData.x + bID0];
 	} else {
 		// do interpolation
 		tx = Lerp(
@@ -333,7 +339,13 @@ void main(void)
 	vec3 modelNormal;
 	GetModelSpaceVertex(modelPos, modelNormal);
 
-	if (staticModel) {
+	if (matrixMode == 2) {
+		// static instanced: per-instance world transform read from the SSBO (no interpolation)
+		Transform wtx = transforms[instData.x + 0u];
+		worldPos = ApplyTransform(wtx, modelPos);
+		wtx.trSc = vec4(0, 0, 0, 1); //nullify the translation part for the normal
+		worldNormal = ApplyTransform(wtx, modelNormal);
+	} else if (staticModel) {
 		worldPos = staticModelMatrix * modelPos;
 		worldNormal = mat3(staticModelMatrix) * modelNormal;
 	} else {

--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -271,13 +271,10 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 	
 	Transform tx;
 	if (staticModel) {
-		// matrixMode == 2 (static instanced): pieces come from the bind-pose block (instData.w),
-		// because instData.x holds the per-instance world transform instead of the bind pose.
-		// matrixMode == 1 (static): for model submits instData.x == instData.w == bind pose.
-		if (matrixMode == 2)
-			tx = transforms[instData.w + bID0];
-		else
-			tx = transforms[instData.x + bID0];
+		// pieces always come from the bind-pose block (instData.w). In ARRAY_MATMODE
+		// instData.x is the per-instance world transform, not the bind pose; for static
+		// model submits instData.x == instData.w anyway, so instData.w is correct for both.
+		tx = transforms[instData.w + bID0];
 	} else {
 		// do interpolation
 		tx = Lerp(

--- a/rts/Rendering/Models/3DModelVAO.cpp
+++ b/rts/Rendering/Models/3DModelVAO.cpp
@@ -330,6 +330,30 @@ bool S3DModelVAO::AddToSubmission(const S3DModel* model, uint16_t paletteIndex)
 	return AddToSubmissionImpl(model, model->indxStart, model->indxCount, paletteIndex);
 }
 
+bool S3DModelVAO::AddToSubmission(const S3DModel* model, uint32_t worldTransformOffset, uint16_t paletteIndex)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(model);
+
+	// bind-pose block for the model's pieces (read via instData.w in ARRAY_MATMODE)
+	const auto bposeIndex = transformsUploader.GetElemOffset(model);
+	if (bposeIndex == TransformsMemStorage::INVALID_INDEX)
+		return false;
+
+	const auto uniIndex = modelUniformsStorage.GetObjOffset(model); //sentinel for bare models; unused by the shader
+
+	auto& modelInstanceData = modelDataToInstance[SIndexAndCount{ model->indxStart, model->indxCount }];
+	modelInstanceData.emplace_back(SInstanceData(
+		worldTransformOffset,                         // matOffset = instData.x = per-instance world transform
+		paletteIndex,
+		static_cast<uint16_t>(model->numPieces),
+		static_cast<uint32_t>(uniIndex),
+		static_cast<uint32_t>(bposeIndex)             // bposeMatOffset = instData.w = model bind pose
+	));
+
+	return true;
+}
+
 bool S3DModelVAO::AddToSubmission(const CUnit* unit)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Rendering/Models/3DModelVAO.hpp
+++ b/rts/Rendering/Models/3DModelVAO.hpp
@@ -66,6 +66,10 @@ public:
 	void DrawElements(GLenum prim, uint32_t vboIndxStart, uint32_t vboIndxCount) const;
 
 	bool AddToSubmission(const S3DModel* model, uint16_t paletteIndex);
+	// static-instanced submission: the per-instance world transform is supplied explicitly
+	// (a 1-element slot in transformsMemStorage) and read by the shader in ARRAY_MATMODE;
+	// model pieces are taken from the model's bind pose. Used for ghost buildings.
+	bool AddToSubmission(const S3DModel* model, uint32_t worldTransformOffset, uint16_t paletteIndex);
 
 	bool AddToSubmission(const CUnit* unit);
 	bool AddToSubmission(const CFeature* feature);

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -2,6 +2,8 @@
 
 #include "UnitDrawer.h"
 
+#include <map>
+
 #include "Game/Camera.h"
 #include "Game/CameraHandler.h"
 #include "Game/Game.h"
@@ -1742,88 +1744,88 @@ void CUnitDrawerGL4::DrawAlphaObjects(int modelType, bool drawReflection, bool d
 	if (gu->spectatingFullView)
 		return;
 
-	const auto& deadGhostBuildings = modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam, modelType);
+	// Ghost buildings are static (no animation, never move), so each gets a single world-transform
+	// slot in the transforms SSBO and is drawn batched through ARRAY_MATMODE - one multidraw per
+	// (color bucket x texture type) instead of one immediate draw per ghost.
+	const auto oldMM = modelDrawerState->SetMatrixMode(ShaderMatrixModes::ARRAY_MATMODE);
 
-	const auto oldMM = modelDrawerState->SetMatrixMode(ShaderMatrixModes::STATIC_MATMODE);
-	// deadGhostedBuildings
+	struct GhostInstance {
+		const S3DModel* model;
+		uint32_t worldTransformOffset;
+		uint8_t team;
+	};
+	// bind the texture once per group, accumulate, then one Submit (=one multidraw) per texture type
+	const auto flushGhosts = [&](const std::map<int, std::vector<GhostInstance>>& byTex) {
+		for (const auto& [texType, instances] : byTex) {
+			CModelDrawerHelper::BindModelTypeTexture(modelType, texType);
+			for (const auto& gi : instances)
+				smv.AddToSubmission(gi.model, gi.worldTransformOffset, gi.team);
+			smv.Submit(GL_TRIANGLES, false);
+		}
+	};
+
+	// deadGhostedBuildings (single color state)
 	{
-		modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
-		modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y); //teamID doesn't matter here
+		const auto& deadGhostBuildings = modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam, modelType);
 
-		int prevModelType = -1;
-		int prevTexType = -1;
+		static std::map<int, std::vector<GhostInstance>> byTex;
+		byTex.clear();
 		for (const auto* dgb : deadGhostBuildings) {
-			if (!camera->InView(dgb->pos, dgb->GetModel()->GetDrawRadius()))
+			const S3DModel* model = dgb->GetModel();
+			if (!camera->InView(dgb->pos, model->GetDrawRadius()))
+				continue;
+			if (dgb->worldTransformOffset == TransformsMemStorage::INVALID_INDEX)
 				continue;
 
-			static CMatrix44f staticWorldMat;
+			byTex[model->textureType].push_back({ model, static_cast<uint32_t>(dgb->worldTransformOffset), dgb->team });
+		}
 
-			staticWorldMat.LoadIdentity();
-			staticWorldMat.Translate(dgb->pos);
-
-			staticWorldMat.RotateY(-dgb->facing * math::DEG_TO_RAD * 90.0f);
-
-			if (prevModelType != modelType || prevTexType != dgb->GetModel()->textureType) {
-				prevModelType = modelType; prevTexType = dgb->GetModel()->textureType;
-				CModelDrawerHelper::BindModelTypeTexture(modelType, dgb->GetModel()->textureType); //inefficient rendering, but w/e
-			}
-
-			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(dgb->GetModel(), static_cast<uint16_t>(dgb->team)); //need to submit immediately every model because of static per-model matrix
+		if (!byTex.empty()) {
+			modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y); //teamID is per-instance
+			flushGhosts(byTex);
 		}
 	}
 
-	// liveGhostedBuildings
+	// liveGhostedBuildings (two color states: normal and CONTRADAR)
 	{
 		const auto& liveGhostedBuildings = modelDrawerData->GetLiveGhostBuildings(gu->myAllyTeam, modelType);
 
-		int prevModelType = -1;
-		int prevTexType = -1;
+		static std::map<int, std::vector<GhostInstance>> byTexNormal;
+		static std::map<int, std::vector<GhostInstance>> byTexContradar;
+		byTexNormal.clear();
+		byTexContradar.clear();
+
 		for (const auto* lgb : liveGhostedBuildings) {
 			if (!camera->InView(lgb->pos, lgb->model->GetDrawRadius()))
 				continue;
 
 			// check for decoy models
 			const UnitDef* decoyDef = lgb->unitDef->decoyDef;
-			const S3DModel* model = nullptr;
-
-			if (decoyDef == nullptr) {
-				model = lgb->model;
-			}
-			else {
-				model = decoyDef->LoadModel();
-			}
+			const S3DModel* model = (decoyDef == nullptr) ? lgb->model : decoyDef->LoadModel();
 
 			// FIXME: needs a second pass
 			if (model->type != modelType)
 				continue;
 
-			static CMatrix44f staticWorldMat;
-
-			staticWorldMat.LoadIdentity();
-			staticWorldMat.Translate(lgb->pos);
-
-			staticWorldMat.RotateY(-lgb->buildFacing * math::DEG_TO_RAD * 90.0f);
+			const size_t xfOffset = modelDrawerData->GetLiveGhostTransform(lgb);
+			if (xfOffset == TransformsMemStorage::INVALID_INDEX)
+				continue;
 
 			const unsigned short losStatus = lgb->losStatus[gu->myAllyTeam];
+			auto& byTex = (losStatus & LOS_CONTRADAR) ? byTexContradar : byTexNormal;
+			byTex[model->textureType].push_back({ model, static_cast<uint32_t>(xfOffset), static_cast<uint8_t>(lgb->team) });
+		}
 
-			// ghosted enemy units
-			if (losStatus & LOS_CONTRADAR) {
-				modelDrawerState->SetColorMultiplier(0.9f, 0.9f, 0.9f, IModelDrawerState::alphaValues.z);
-				modelDrawerState->SetTeamColor(lgb->team, IModelDrawerState::alphaValues.z);
-			}
-			else {
-				modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
-				modelDrawerState->SetTeamColor(lgb->team, IModelDrawerState::alphaValues.y);
-			}
-
-			if (prevModelType != modelType || prevTexType != model->textureType) {
-				prevModelType = modelType; prevTexType = model->textureType;
-				CModelDrawerHelper::BindModelTypeTexture(modelType, model->textureType); //inefficient rendering, but w/e
-			}
-
-			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(model, static_cast<uint16_t>(lgb->team)); //need to submit immediately every model because of static per-model matrix
+		if (!byTexNormal.empty()) {
+			modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y);
+			flushGhosts(byTexNormal);
+		}
+		if (!byTexContradar.empty()) {
+			modelDrawerState->SetColorMultiplier(0.9f, 0.9f, 0.9f, IModelDrawerState::alphaValues.z);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.z);
+			flushGhosts(byTexContradar);
 		}
 	}
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -29,8 +29,21 @@
 #include "Map/ReadMap.h"
 
 #include "System/Misc/TracyDefs.h"
+#include "System/Matrix44f.h"
+#include "System/MathConstants.h"
+#include "System/Transform.hpp"
+#include "Rendering/Models/ModelsMemStorage.h"
 
 static FixedDynMemPoolT<MAX_UNITS / 1000, MAX_UNITS / 32, GhostSolidObject> ghostMemPool;
+
+// world transform of a (static) ghost building, matching the legacy staticModelMatrix construction
+static Transform MakeGhostWorldTransform(const float3& pos, int facing)
+{
+	CMatrix44f m;
+	m.Translate(pos);
+	m.RotateY(-facing * math::DEG_TO_RAD * 90.0f);
+	return Transform::FromMatrix(m);
+}
 
 ///////////////////////////
 
@@ -50,6 +63,7 @@ CR_REG_METADATA(GhostSolidObject, (
 	CR_MEMBER(team),
 	CR_IGNORED(currentIconIndex),
 
+	CR_IGNORED(worldTransformOffset),
 	CR_IGNORED(model),
 
 	CR_POSTLOAD(PostLoad)
@@ -88,6 +102,10 @@ void GhostSolidObject::PostLoad()
 	RECOIL_DETAILED_TRACY_ZONE;
 	model = nullptr;
 	GetModel();
+
+	// the GPU world transform slot is render-only state; re-create it from the saved pos/facing
+	worldTransformOffset = transformsMemStorage.Allocate(1);
+	transformsMemStorage.UpdateForced(worldTransformOffset, MakeGhostWorldTransform(pos, facing));
 }
 
 const S3DModel* GhostSolidObject::GetModel() const
@@ -157,6 +175,9 @@ CUnitDrawerData::~CUnitDrawerData()
 				if (tmpGso->DecRef())
 					continue;
 
+				if (tmpGso->worldTransformOffset != TransformsMemStorage::INVALID_INDEX)
+					transformsMemStorage.Free(tmpGso->worldTransformOffset, 1, &Transform::Zero());
+
 				// <ghost> might be the gbOwner of a decal; groundDecals is deleted after us
 				groundDecals->GhostDestroyed(tmpGso);
 				ghostMemPool.free(tmpGso);
@@ -165,6 +186,11 @@ CUnitDrawerData::~CUnitDrawerData()
 			lgb.clear();
 		}
 	}
+	for (auto& [unit, entry] : liveGhostTransforms) {
+		if (entry.first != TransformsMemStorage::INVALID_INDEX)
+			transformsMemStorage.Free(entry.first, 1, &Transform::Zero());
+	}
+	liveGhostTransforms.clear();
 	assert(ghostMemPool.allocs() == 0);
 	ghostMemPool.clear();
 
@@ -215,6 +241,8 @@ void CUnitDrawerData::Update()
 		for (CUnit* unit : unsortedObjects)
 			updateBody(unit);
 	}
+
+	UpdateLiveGhostTransforms();
 
 	if ((useDistToGroundForIcons = (camHandler->GetCurrentController()).GetUseDistToGroundForIcons())) {
 		const float3& camPos = camera->GetPos();
@@ -625,6 +653,9 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 
 				gso->iconRadius = u->iconRadius;
 
+				gso->worldTransformOffset = transformsMemStorage.Allocate(1);
+				transformsMemStorage.UpdateForced(gso->worldTransformOffset, MakeGhostWorldTransform(gso->pos, gso->facing));
+
 				groundDecals->GhostCreated(u, gso);
 
 			}
@@ -696,6 +727,40 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	UpdateCurrentUnitIcon(unit);
 }
 
+void CUnitDrawerData::UpdateLiveGhostTransforms()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	// Maintain one world-transform slot per live ghost building drawn for the local allyTeam.
+	// Ghosts are static, so each slot is filled once on first sight; entries not seen this sweep
+	// (units that regained LOS, died, or belong to a different allyTeam now) are freed.
+	const int stamp = ++liveGhostSweepStamp;
+
+	for (int modelType = MODELTYPE_3DO; modelType < MODELTYPE_CNT; modelType++) {
+		for (const CUnit* u : savedData.liveGhostBuildings[gu->myAllyTeam][modelType]) {
+			const auto it = liveGhostTransforms.find(u);
+			if (it == liveGhostTransforms.end()) {
+				const size_t off = transformsMemStorage.Allocate(1);
+				transformsMemStorage.UpdateForced(off, MakeGhostWorldTransform(u->pos, u->buildFacing));
+				liveGhostTransforms.emplace(u, std::make_pair(off, stamp));
+			}
+			else {
+				it->second.second = stamp;
+			}
+		}
+	}
+
+	for (auto it = liveGhostTransforms.begin(); it != liveGhostTransforms.end(); ) {
+		if (it->second.second != stamp) {
+			if (it->second.first != TransformsMemStorage::INVALID_INDEX)
+				transformsMemStorage.Free(it->second.first, 1, &Transform::Zero());
+			it = liveGhostTransforms.erase(it);
+		}
+		else {
+			++it;
+		}
+	}
+}
+
 void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost)
 {
 	if (unit->leavesGhost) {
@@ -732,6 +797,9 @@ void CUnitDrawerData::PlayerChanged(int playerID)
 void CUnitDrawerData::RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index)
 {
 	if (!gso->DecRef()) {
+		if (gso->worldTransformOffset != TransformsMemStorage::INVALID_INDEX)
+			transformsMemStorage.Free(gso->worldTransformOffset, 1, &Transform::Zero());
+
 		groundDecals->GhostDestroyed(gso);
 		ghostMemPool.free(gso);
 	}

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -36,6 +36,10 @@ public:
 	int facing; //FIXME replaced with dir-vector just legacy decal drawer uses this
 	uint8_t team;
 	size_t currentIconIndex;
+
+	// 1-element world transform slot in transformsMemStorage, used by the batched
+	// (ARRAY_MATMODE) ghost draw path. Filled once at creation; not serialized (rebuilt in PostLoad).
+	size_t worldTransformOffset = TransformsMemStorage::INVALID_INDEX;
 private:
 	mutable const S3DModel* model;
 };
@@ -151,6 +155,12 @@ public:
 		return savedData.liveGhostBuildings[allyTeam][modelType];
 	}
 
+	// world transform slot (in transformsMemStorage) for a live ghost building; INVALID_INDEX if none
+	size_t GetLiveGhostTransform(const CUnit* unit) const {
+		const auto it = liveGhostTransforms.find(unit);
+		return (it != liveGhostTransforms.end()) ? it->second.first : TransformsMemStorage::INVALID_INDEX;
+	}
+
 	auto*       GetSavedData()       { return &savedData; }
 	const auto* GetSavedData() const { return &savedData; }
 protected:
@@ -190,6 +200,13 @@ private:
 
 	S3DModel* GetUnitModel(const CUnit* unit) const;
 	void RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index);
+
+	// rebuilds the per-unit world transform slots for live ghost buildings of the local allyTeam.
+	// scan-based so it self-heals across savegame load, allyTeam/spectator changes and leavesGhost toggles.
+	void UpdateLiveGhostTransforms();
+	// maps unit -> { world transform slot, last sweep stamp seen }
+	spring::unordered_map<const CUnit*, std::pair<size_t, int>> liveGhostTransforms;
+	int liveGhostSweepStamp = 0;
 
 	// icons
 	bool useDistToGroundForIcons;


### PR DESCRIPTION
NOTE: purely LLM generated, I have little experience with opengl. This is meant to be a reference for someone who knows more to implement - and for testing the idea.

The idea is that each call to the gpu for ghost buildings was causing a synchronization with the gpu, because there was a 1 byte data xfer. 
old:
<img width="2559" height="1373" alt="image" src="https://github.com/user-attachments/assets/532edd9d-8af7-4cde-85bb-b0d0cebe92f4" />
<img width="1298" height="768" alt="image" src="https://github.com/user-attachments/assets/f157832c-9732-4b2f-93f7-bcc7f58c6d5f" />

This is because the world position data was moved in local uniforms?

The patch is to move the world position data to a large contiguous block of memory so the data is transferred once and then a batched set of draw calls can run more efficiently on the gpu. Similar to how we draw opaque units.

 With fix:
<img width="2553" height="1357" alt="image" src="https://github.com/user-attachments/assets/5f903c3b-1055-483f-b8a1-faaf499f3cff" />
<img width="1311" height="770" alt="image" src="https://github.com/user-attachments/assets/143e55ac-d21c-4eac-ac2f-3aa7da8d01f9" />
