### PR TITLE
fix: FileSystem::FindFiles should return relative paths

### DIFF
--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -643,15 +643,19 @@ namespace Impl {
 	{
 		const auto dirFullStr = FileSystem::ForwardSlashes(dataDir + dirStr);
 
-		auto dir = Recoil::filesystem::u8path(dirFullStr);
-		if (!fs::exists(dir))
+		const auto dirFullPath = Recoil::filesystem::u8path(dirFullStr);
+		if (!fs::exists(dirFullPath))
 			return;
+
+		// Each match is `dirStr + <entry below dirStr>`; the dataDir prefix must not leak
+		// in, so prepend dirStr ourselves instead of emitting the iterated full path.
+		const auto dirRelPrefix = FileSystem::ForwardSlashes(dirStr);
 
 		std::variant<fs::directory_iterator, fs::recursive_directory_iterator> dirIterator;
 		if ((flags & FileQueryFlags::RECURSE) != 0)
-			dirIterator = fs::recursive_directory_iterator(dir);
+			dirIterator = fs::recursive_directory_iterator(dirFullPath);
 		else
-			dirIterator = fs::directory_iterator(dir);
+			dirIterator = fs::directory_iterator(dirFullPath);
 
 		std::visit([&](auto&& dirIterator) {
 			for (const fs::directory_entry& entry : dirIterator) {
@@ -670,13 +674,14 @@ namespace Impl {
 				const auto entryPathFnStr = entry.path().filename().generic_u8string();
 
 				if (spring::regex_match(StoreUTF8AsString(entryPathFnStr), regexPattern)) {
-					auto entryPathStr = entry.path().generic_u8string();
+					const auto entryRelStr = entry.path().lexically_relative(dirFullPath).generic_u8string();
+					std::string entryPathStr = dirRelPrefix + Impl::StoreUTF8AsString(entryRelStr);
 
 					// the previous convention to add a trailing slash
-					if (isDir && !entryPathStr.empty() && entryPathStr.back() != u8'/') {
-						entryPathStr += u8'/';
+					if (isDir && !entryPathStr.empty() && entryPathStr.back() != '/') {
+						entryPathStr += '/';
 					}
-					matches.emplace_back(Impl::StoreUTF8AsString(entryPathStr));
+					matches.emplace_back(std::move(entryPathStr));
 				}
 			}
 		}, std::move(dirIterator));

--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -641,7 +641,7 @@ namespace Impl {
 
 	void FindFilesStd(std::vector<std::string>& matches, const std::string& dataDir, const std::string& dirStr, const spring::regex& regexPattern, int flags)
 	{
-		const auto dirFullStr = FileSystem::ForwardSlashes(dataDir + dirStr);
+		const std::string dirFullStr = FileSystem::ForwardSlashes(dataDir + dirStr);
 
 		const fs::path dirFullPath = Recoil::filesystem::u8path(dirFullStr);
 		if (!fs::exists(dirFullPath))
@@ -671,10 +671,10 @@ namespace Impl {
 
 				// hope std::regex_match will not trip up on UTF-8, if it does, will need to convert to std::wregex
 				// the previous implementation relied on checking the filename only
-				const auto entryPathFnStr = entry.path().filename().generic_u8string();
+				const std::u8string entryPathFnStr = entry.path().filename().generic_u8string();
 
 				if (spring::regex_match(StoreUTF8AsString(entryPathFnStr), regexPattern)) {
-					const auto entryRelStr = entry.path().lexically_relative(dirFullPath).generic_u8string();
+					const std::u8string entryRelStr = entry.path().lexically_relative(dirFullPath).generic_u8string();
 					std::string entryPathStr = dirRelPrefix + Impl::StoreUTF8AsString(entryRelStr);
 
 					// the previous convention to add a trailing slash

--- a/rts/System/FileSystem/FileSystem.cpp
+++ b/rts/System/FileSystem/FileSystem.cpp
@@ -643,13 +643,13 @@ namespace Impl {
 	{
 		const auto dirFullStr = FileSystem::ForwardSlashes(dataDir + dirStr);
 
-		const auto dirFullPath = Recoil::filesystem::u8path(dirFullStr);
+		const fs::path dirFullPath = Recoil::filesystem::u8path(dirFullStr);
 		if (!fs::exists(dirFullPath))
 			return;
 
 		// Each match is `dirStr + <entry below dirStr>`; the dataDir prefix must not leak
 		// in, so prepend dirStr ourselves instead of emitting the iterated full path.
-		const auto dirRelPrefix = FileSystem::ForwardSlashes(dirStr);
+		const std::string dirRelPrefix = FileSystem::ForwardSlashes(dirStr);
 
 		std::variant<fs::directory_iterator, fs::recursive_directory_iterator> dirIterator;
 		if ((flags & FileQueryFlags::RECURSE) != 0)

--- a/rts/System/FileSystem/FileSystem.h
+++ b/rts/System/FileSystem/FileSystem.h
@@ -124,6 +124,15 @@ public:
 	static char GetNativePathSeparator();
 	static bool IsAbsolutePath(const std::string& path);
 
+	/**
+	 * @brief list files/dirs matching @p regex under @p dataDir + @p dir
+	 *
+	 * Each match is returned as `dir + <path relative to dir>`. @p dataDir is the
+	 * filesystem root used only to locate the search directory and is NEVER part of
+	 * the result. Consequently the result is absolute iff @p dir is absolute:
+	 *   - relative dir:  dataDir = "/root/", dir = "sub/"   -> "sub/file"
+	 *   - absolute dir:  dataDir = "",       dir = "/abs/"  -> "/abs/file"
+	 */
 	static void FindFiles(std::vector<std::string>& matches, const std::string& dataDir, const std::string& dir, const std::string& regex, int flags);
 
 	/**

--- a/test/engine/System/FileSystem/TestFileSystem.cpp
+++ b/test/engine/System/FileSystem/TestFileSystem.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <string>
+#include <vector>
 #include <nowide/cstdio.hpp>
 #include <sys/stat.h>
 #include "System/Log/ILog.h"
@@ -7,6 +9,7 @@
 
 // needs to be included after catch
 #include "System/FileSystem/FileSystem.h"
+#include "System/FileSystem/FileQueryFlags.h"
 
 namespace {
 	struct PrepareFileSystem {
@@ -263,3 +266,85 @@ TEST_CASE("GetNormalizedPath - original failing tests")
 }
 
 #undef CHECK_NORM_PATH
+
+
+// Regression test for commit c3b8b6397a (#2235): the std::filesystem-based
+// FindFiles implementation was emitting absolute paths because it pushed the
+// iterated entry path verbatim (including the dataDir prefix). The contract is
+// that matches are relative to dataDir, i.e. `dir + <entry below dir>` only.
+// This is what made VFS.DirList / VFS.SubDirs (raw mode) return absolute paths.
+TEST_CASE("FindFiles - matches are relative to the data dir")
+{
+	// dataDir is the search root that must NOT appear in the results
+	const std::string dataDir = FileSystem::EnsurePathSepAtEnd(FileSystem::ForwardSlashes(pfs.testCwd));
+
+	// build a small tree under the data dir
+	REQUIRE(FileSystem::CreateDirectory("findDir"));
+	REQUIRE(FileSystem::CreateDirectory("findDir/sub"));
+	PrepareFileSystem::WriteFile("findDir/a.txt",     "a");
+	PrepareFileSystem::WriteFile("findDir/b.lua",     "b");
+	PrepareFileSystem::WriteFile("findDir/sub/c.txt", "c");
+
+	const std::string anyRegex = FileSystem::ConvertGlobToRegex("*");
+	const std::string txtRegex = FileSystem::ConvertGlobToRegex("*.txt");
+
+	SECTION("files, non-recursive") {
+		std::vector<std::string> matches;
+		FileSystem::FindFiles(matches, dataDir, "findDir/", anyRegex, 0);
+		std::sort(matches.begin(), matches.end());
+
+		// the dataDir prefix must not leak into the results
+		for (const std::string& m: matches)
+			CHECK(m.rfind(dataDir, 0) != 0);
+
+		REQUIRE(matches.size() == 2);
+		CHECK(matches[0] == "findDir/a.txt");
+		CHECK(matches[1] == "findDir/b.lua");
+	}
+
+	SECTION("pattern is honoured") {
+		std::vector<std::string> matches;
+		FileSystem::FindFiles(matches, dataDir, "findDir/", txtRegex, 0);
+
+		REQUIRE(matches.size() == 1);
+		CHECK(matches[0] == "findDir/a.txt");
+	}
+
+	SECTION("recursive descends but keeps paths relative") {
+		std::vector<std::string> matches;
+		FileSystem::FindFiles(matches, dataDir, "findDir/", anyRegex, FileQueryFlags::RECURSE);
+		std::sort(matches.begin(), matches.end());
+
+		REQUIRE(matches.size() == 3);
+		CHECK(matches[0] == "findDir/a.txt");
+		CHECK(matches[1] == "findDir/b.lua");
+		CHECK(matches[2] == "findDir/sub/c.txt");
+	}
+
+	SECTION("dirs only, with trailing slash") {
+		std::vector<std::string> matches;
+		FileSystem::FindFiles(matches, dataDir, "findDir/", anyRegex,
+			FileQueryFlags::ONLY_DIRS | FileQueryFlags::INCLUDE_DIRS);
+
+		REQUIRE(matches.size() == 1);
+		CHECK(matches[0] == "findDir/sub/");
+	}
+
+	SECTION("absolute lookup (empty dataDir) stays absolute") {
+		// the absolute-path branch passes dataDir="" and dir=<absolute path>;
+		// results should remain absolute, prefixed by the requested dir
+		const std::string absDir = dataDir + "findDir/";
+		std::vector<std::string> matches;
+		FileSystem::FindFiles(matches, "", absDir, txtRegex, 0);
+
+		REQUIRE(matches.size() == 1);
+		CHECK(matches[0] == absDir + "a.txt");
+	}
+
+	// cleanup (bottom-up: files before their dirs)
+	FileSystem::DeleteFile("findDir/sub/c.txt");
+	FileSystem::DeleteFile("findDir/a.txt");
+	FileSystem::DeleteFile("findDir/b.lua");
+	FileSystem::DeleteFile("findDir/sub");
+	FileSystem::DeleteFile("findDir");
+}


### PR DESCRIPTION
Fixes regression where we always return absolute paths, from c3b8b6397a.

See https://github.com/beyond-all-reason/BYAR-Chobby/issues/1183 for original issue report

## Testing
See screenshots below for fix, tested a patched 2026.06.07 in "Engine Test" lobby.

The newly added test passes:
```
      Start 14: testFileSystem
14/27 Test #14: testFileSystem ...................   Passed    0.00 sec
```
## Screenshots 

Broken replay list:
<img width="2217" height="734" alt="image" src="https://github.com/user-attachments/assets/254bfe8e-6134-4dbd-9dbe-ae0ef66a23e8" />

Fixed replay list:
<img width="2223" height="886" alt="image" src="https://github.com/user-attachments/assets/10506b01-43e3-4786-b556-9ad101fc35aa" />


## AI Disclosure
Claude code with hand edits by me