### PR TITLE
Semi-optionally reduce buffering to improve latency

### DIFF
--- a/doc/site/data/configs.json
+++ b/doc/site/data/configs.json
@@ -2022,7 +2022,7 @@
     "declarationLine": 58,
     "description": "Buffer network packets for a few frames in an attempt to reduce lag from packet time variance. Introduces a fixed lag.",
     "defaultValue": 1,
-    "type": "bool"
+    "type": "int"
   },
   "UsePBO": {
     "declarationFile": "/spring/rts/Rendering/GL/VBO.cpp",

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -188,10 +188,16 @@ public:
 	/// Prevents spectator msgs from being seen by players
 	bool noSpectatorChat = false;
 
-	// to smooth out SimFrame calls
+	// to smooth out SimFrame calls (Used for globalConfig.useNetMessageSmoothingBuffer < 2)
 	float msgProcTimeLeft = 0.0f;  ///< How many SimFrame() calls we still may do.
 	float consumeSpeedMult = 1.0f; ///< How fast we should eat NETMSG_NEWFRAMEs.
 
+	// to smooth out SimFrame calls (Used for globalConfig.useNetMessageSmoothingBuffer == 2)
+	spring_time expectedFrameTime;
+	float lastFrameOffset = 1.0f;
+	float targetOffset = 1.0f;
+	float volatilityScore = 1.0f;
+	spring_time nextFrameTargetProcessTime;
 
 	#if 0
 	int skipStartFrame = 0;

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1753,9 +1753,9 @@ public:
 
 	bool Execute(const UnsyncedAction& action) const final {
 		const char* fmt = "net-message smoothing %s";
-		const char* strs[] = {"disabled", "enabled"};
+		const char* strs[] = {"moderate", "generous", "aggressive"};
 
-		LOG(fmt, strs[globalConfig.useNetMessageSmoothingBuffer = !globalConfig.useNetMessageSmoothingBuffer]);
+		LOG(fmt, strs[globalConfig.useNetMessageSmoothingBuffer = (globalConfig.useNetMessageSmoothingBuffer + 1) % 3]);
 		return true;
 	}
 };

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -185,7 +185,7 @@ void CGame::UpdateNumQueuedSimFrames()
 	//   only reason in that case is to handle NETMSG_GAME_FRAME_PROGRESS
 	const uint32_t numQueuedFrames = GetNumQueuedSimFrameMessages(-1u);
 
-	if (globalConfig.useNetMessageSmoothingBuffer) {
+	if (globalConfig.useNetMessageSmoothingBuffer == 1) {
 		if (numQueuedFrames < lastNumQueuedSimFrames) {
 			// conservative policy: take minimum of current and previous queue size
 			// we *NEVER* want the queue to run completely dry (by not keeping a few
@@ -261,17 +261,23 @@ void CGame::ClientReadNet()
 	// first look ahead so we can adapt consumeSpeedMult to network fluctuations
 	// (smooths simframes across each full second, and balances the time spent in
 	// sim & drawing)
-	UpdateNumQueuedSimFrames();
-	UpdateNetMessageProcessingTimeLeft();
+	if (globalConfig.useNetMessageSmoothingBuffer != 2) {
+		UpdateNumQueuedSimFrames();
+		UpdateNetMessageProcessingTimeLeft();
+	}
 
 	const spring_time msgProcEndTime = spring_gettime() + spring_msecs(GetNetMessageProcessingTimeLimit());
 
 	const bool haveServerDemo = (gameServer != nullptr && gameServer->GetDemoReader() != nullptr);
 	const bool haveClientDemo = (clientNet->GetDemoRecorder() != nullptr);
 
+	// const float timeBeganSimFrames = spring_gettime().toMilliSecsf();
+
 	// now really process the messages
-	while (true) {
-		if (msgProcTimeLeft <= 0.0f)
+	while (globalConfig.useNetMessageSmoothingBuffer != 2 || spring_gettime() >= nextFrameTargetProcessTime) {
+	// while (globalConfig.useNetMessageSmoothingBuffer != 2 || ((spring_gettime().toMilliSecsf() < timeBeganSimFrames + 500.0f) && (spring_gettime().toMilliSecsf() >= nextFrameTargetProcessTime)) {
+
+		if (globalConfig.useNetMessageSmoothingBuffer != 2 && msgProcTimeLeft <= 0.0f)
 			break;
 		if (spring_gettime() > msgProcEndTime)
 			break;
@@ -391,6 +397,12 @@ void CGame::ClientReadNet()
 				}
 
 				gs->paused = !!inbuf[2];
+				
+				if (globalConfig.useNetMessageSmoothingBuffer == 2 && !gs->paused) {
+					expectedFrameTime = spring_gettime();
+					nextFrameTargetProcessTime = expectedFrameTime + spring_msecs(targetOffset);
+				}
+
 
 				LOG("%s %s the game", playerHandler.Player(playerNum)->name.c_str(), (gs->paused ? "paused" : "unpaused"));
 
@@ -612,7 +624,49 @@ void CGame::ClientReadNet()
 				TracyPlot(tracingSpeedFactor, gs->speedFactor);
 				TracyPlot(tracingWantedSpeedFactor, gs->wantedSpeedFactor);
 				
-				msgProcTimeLeft -= 1000.0f;
+				if (globalConfig.useNetMessageSmoothingBuffer == 2) {
+					if (expectedFrameTime <= spring_time(0))
+						expectedFrameTime = packet->receiveTime;
+
+					const float currentFrameOffset = (packet->receiveTime - expectedFrameTime).toMilliSecsf();
+					targetOffset = fmax(currentFrameOffset, (targetOffset - lastFrameOffset) * volatilityScore + lastFrameOffset);
+
+					/*
+					latencyDegree is a magic number that describes how close to the target latency we're at.
+					via volatilityScore, we will generate a multiplier (~ -1 - 1.001) that we'll apply to our 
+					
+					At its root, we have `(targetOffset - currentFrameOffset) / targetOffset`, which describes how close currentFrameOffset is to targetOffset.
+					This will at its minimum (0) if currentFrameOffset >= targetOffset (see above, where we clamp targetOffset to currentFrameOffset).
+					It will be greater (usually 0-1) otherwise. (It is rare, but possible with very low latencies, that currentFrameOffset will be negative.)
+
+					This root proportion is used to inform and adjust our buffer duration according to the filters described below.
+
+					Filter 1 - pow(x, 4): This greatly collapses the range towards 0 - more aggressively the lower it is.
+					                      Thus having less spare time is weighted much heavier than having more spare time.
+					Filter 2 - fmin(2, x): This caps the range from 0-2, to limit the benefit of 
+					Filter 3 - 1.0f - x: This inverts the distribution: before 0 corresponded to a later time and 1 was an earlier time:
+					                     Now 1 corresponds to a later time and 0 to an earlier time (and -1 to the minimum time).
+					Filter 4. - * 1.001: This shifts the distribution, such that a value of 1 after filter 4 corresponds to a value of 0.177 before filter 1.
+										 This allows the multiplier to signal an increase in targetOffset, not just a decrease, to maintain a desired buffer.
+					                     Ultimately, this creates a time buffer of about 117.7% the highest offset we've seen recently. 
+					                     E.g. if currentFrameOffset fluctuates between 5 - 50ms, we'll settle with a targetOffset of about 58.9ms.
+					*/
+					const float latencyDegree = (1.0f - fmin(2, pow((targetOffset - currentFrameOffset) / targetOffset, 4))) * 1.001;
+					/*
+					volatility score is used as a multiplier against the current expectedFrameTime.
+					This is very aggressively smoothed and should result in very gradual changes to targetOffset.
+					High latencyDegree will hoist volatilityScore to ensure that we need a very long period of low latencyDegree
+					before we will see more rapid changes in targetOffset.
+					*/
+					volatilityScore = fmax(latencyDegree, latencyDegree * 0.0001 + volatilityScore * 0.9999);
+
+					expectedFrameTime = expectedFrameTime + spring_msecs(1000.0f / (GAME_SPEED * gs->speedFactor));
+					nextFrameTargetProcessTime = expectedFrameTime + spring_msecs(targetOffset);
+
+					lastFrameOffset = currentFrameOffset;
+				} else {
+					msgProcTimeLeft -= 1000.0f;
+				}
 				lastSimFrameNetPacketTime = spring_gettime();
 
 				SimFrame();

--- a/rts/System/GlobalConfig.cpp
+++ b/rts/System/GlobalConfig.cpp
@@ -61,7 +61,11 @@ CONFIG(int, TeamHighlight)
 	.minimumValue(CTeamHighlight::HIGHLIGHT_FIRST)
 	.maximumValue(CTeamHighlight::HIGHLIGHT_LAST);
 
-CONFIG(bool, UseNetMessageSmoothingBuffer).defaultValue(true).description("Buffer network packets for a few frames in an attempt to reduce lag from packet time variance. Introduces a fixed lag.");
+CONFIG(int, UseNetMessageSmoothingBuffer)
+	.defaultValue(1)
+	.minimumValue(0)
+	.maximumValue(2)
+	.description("Buffer network packets for a few frames in an attempt to reduce lag from packet time variance. Introduces a fixed lag.");
 
 CONFIG(bool, LuaWritableConfigFile).defaultValue(true);
 CONFIG(bool, VFSCacheArchiveFiles).defaultValue(true);
@@ -96,7 +100,7 @@ void GlobalConfig::Init()
 	if (linkIncomingMaxPacketRate > 0 && linkIncomingSustainedBandwidth <= 0)
 		linkIncomingSustainedBandwidth = linkIncomingPeakBandwidth = 1024 * 1024;
 
-	useNetMessageSmoothingBuffer = configHandler->GetBool("UseNetMessageSmoothingBuffer");
+	useNetMessageSmoothingBuffer = configHandler->GetInt("UseNetMessageSmoothingBuffer");
 	luaWritableConfigFile = configHandler->GetBool("LuaWritableConfigFile");
 	vfsCacheArchiveFiles = configHandler->GetBool("VFSCacheArchiveFiles");
 

--- a/rts/System/GlobalConfig.h
+++ b/rts/System/GlobalConfig.h
@@ -90,7 +90,7 @@ public:
 	 * messages for smoothing network jitter at the cost of increased
 	 * latency (running further behind the server)
 	 */
-	bool useNetMessageSmoothingBuffer = true;
+	int useNetMessageSmoothingBuffer = 1;
 
 	/**
 	 * @brief luaWritableConfigFile

--- a/rts/System/Net/RawPacket.cpp
+++ b/rts/System/Net/RawPacket.cpp
@@ -6,6 +6,7 @@
 #include "RawPacket.h"
 
 #include "System/Log/ILog.h"
+#include "System/Misc/SpringTime.h"
 
 namespace netcode
 {
@@ -15,6 +16,7 @@ RawPacket::RawPacket(const uint8_t* const tdata, const uint32_t newLength): leng
 	if (length > 0) {
 		data = new uint8_t[length];
 		memcpy(data, tdata, length);
+		receiveTime = spring_gettime();
 	} else {
 		LOG_L(L_ERROR, "[%s] tried to pack a zero-length packet", __func__);
 		// TODO handle error

--- a/rts/System/Net/RawPacket.h
+++ b/rts/System/Net/RawPacket.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "System/Misc/NonCopyable.h"
+#include "System/Misc/SpringTime.h"
 #include "System/SafeVector.h"
 
 namespace netcode
@@ -67,6 +68,8 @@ public:
 
 		length = p.length;
 		p.length = 0;
+
+		receiveTime = p.receiveTime;
 
 		return *this;
 	}
@@ -126,6 +129,7 @@ public:
 public:
 	uint8_t id = 0;
 	uint8_t* data = nullptr;
+	spring_time receiveTime = spring_gettime();
 
 	uint32_t pos = 0;
 	uint32_t length = 0;

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -705,15 +705,24 @@ void UDPConnection::Flush(const bool forced)
 	// if the packet is tiny, reduce the send frequency further
 	const int requiredLength = ((200 >> netLossFactor) - spring_tomsecs(curTime - lastChunkCreatedTime)) / 10;
 
+	bool containsNewFrame = false;
+
+	for (auto pi = outgoingData.begin(); (pi != outgoingData.end()); ++pi) {
+		if ((*pi)->data[0] == NETMSG_KEYFRAME || (*pi)->data[0] == NETMSG_NEWFRAME) {
+			containsNewFrame = true;
+			break;
+		}
+	}
+
 	int outgoingLength = 0;
 
-	if (!waitMore) {
+	if (containsNewFrame || !waitMore) {
 		for (auto pi = outgoingData.begin(); (pi != outgoingData.end()) && (outgoingLength <= requiredLength); ++pi) {
 			outgoingLength += (*pi)->length;
 		}
 	}
 
-	if (forced || (!waitMore && outgoingLength > requiredLength)) {
+	if (forced || containsNewFrame || (!waitMore && outgoingLength > requiredLength)) {
 		std::uint8_t buffer[udpMaxPacketSize];
 		unsigned pos = 0;
 


### PR DESCRIPTION
# [Stage 1](https://github.com/beyond-all-reason/RecoilEngine/pull/3010/changes/4045a4709fc09c83ab0fe3c2ea88e921412c7eee): Flush netmsg buffer if a sim frame has completed
Sim frames are the most latency-dependent message, so it's important they're sent on time. When connecting to spring-dedicated on my own machine, server-side buffering was leading to massive (100+ms) inconsistencies in sim frame latencies from the client's PoV.

This single change massively reduces latency with existing smoothing methods in my very non-representative test case.

I don't know what impact this would have in a real-world situation, where there may be enough messages to consistently trigger the buffer being sent in a timely manner.

**Implementation drawback:** Surely it'd be better to set a flag on the buffer when sending a frame packet, rather than scanning the buffer on every call to `Flush`? I couldn't find a sane way of implementing this.

# [Stage 2](https://github.com/beyond-all-reason/RecoilEngine/pull/3010/changes/1c186673e41bd7748e021917368d111c25445d93): Add 3rd `UseNetMessageSmoothingBuffer` mode based on packet timings

The algorithm is detailed in the code, but high-level view: rather than relying on the number of packets in the buffer, we keep track of when the packets arrive and schedule each frame to be processed at a time by which we're confident we should have received it. On my LAN, this decreases client buffer-induced-latency from 66ms to ~4ms with no noticeable stutter. (It's yet to be seen how this performs in a more real-world environment - however, I have attempted to simulate how it would behave against some latency data obtained by pinging EU, AU, and US autohosts and I'm ~90% confident it will perform within expectations.)

To enable the new smoothing method, set `UseNetMessageSmoothingBuffer = 2` in `springsettings.cfg`. BAR (I think) likes to reset this to 0 after every game, so you'll have to re-edit the config between launches.

**Implementation Drawback:** Network polling is currently tied to `CGame::Update()`, thus when vsync is enabled (or FPS is otherwise reduced) the network is checked less often. This decreases the precision of `RawPacket.receiveTime` which decreases the effectiveness of the new smoothing method.

**Implementation Drawback:** There's a lot of complexity with `if (globalConfig.useNetMessageSmoothingBuffer == X)` which seems like a minefield. Hypothetically, this new smoothing method could be tuned to supercede both the other smoothing methods (e.g. buffering aggressiveness could be changed with a single parameter if desired. See in-line docs for more detail on the algorithm and what levers can be pulled to change how the algorithm behaves.)

**Implementation Drawback** There's some rounding issues going between `int`/`spring_time` and `float` reducing the overall precision of the algorithm, but I don't think this matters much.

AI Disclosure: No use of AI at any stage in this process.