### PR TITLE
fix: guard against already-dead reclaim targets

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -891,13 +891,13 @@ void CBuilderCAI::ExecuteGuard(Command& c)
 				StopSlowGuard();
 			}
 			return;
-		} else if (b->curReclaim && owner->unitDef->canReclaim) {
+		} else if (b->curReclaim && !b->curReclaim->detached && owner->unitDef->canReclaim) {
 			StopSlowGuard();
 			if (!ReclaimObject(b->curReclaim)) {
 				StopMove();
 			}
 			return;
-		} else if (b->curResurrect && owner->unitDef->canResurrect) {
+		} else if (b->curResurrect && !b->curResurrect->detached && owner->unitDef->canResurrect) {
 			StopSlowGuard();
 			if (!ResurrectObject(b->curResurrect)) {
 				StopMove();

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -605,6 +605,15 @@ void CBuilder::SetRepairTarget(CUnit* target)
 void CBuilder::SetReclaimTarget(CSolidObject* target)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// A target already being destroyed (detached) cannot have a death dependence
+	// registered (AddDeathDependence no-ops on detached objects), which would leave
+	// curReclaim dangling. This happens when ~CObject's DependentDied cascade re-enters
+	// reclaim logic mid-deletion (e.g. CBuilderCAI::ExecuteGuard reading a guardee's
+	// stale curReclaim) on the very feature being freed. Refuse the dead target.
+	assert(target != nullptr);
+	if (target->detached)
+		return;
+
 	if (dynamic_cast<CFeature*>(target) != nullptr && !static_cast<CFeature*>(target)->def->reclaimable)
 		return;
 
@@ -630,6 +639,11 @@ void CBuilder::SetReclaimTarget(CSolidObject* target)
 void CBuilder::SetResurrectTarget(CFeature* target)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// see SetReclaimTarget: never depend on an object that is already being destroyed
+	assert(target != nullptr);
+	if (target->detached)
+		return;
+
 	if (curResurrect == target || target->udef == nullptr)
 		return;
 
@@ -646,6 +660,11 @@ void CBuilder::SetResurrectTarget(CFeature* target)
 void CBuilder::SetCaptureTarget(CUnit* target)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// see SetReclaimTarget: never depend on an object that is already being destroyed
+	assert(target != nullptr);
+	if (target->detached)
+		return;
+
 	if (target == curCapture)
 		return;
 


### PR DESCRIPTION
Engine crash thread: https://discordapp.com/channels/549281623154229250/1516994684591931535

Bugged Scenario: A reclaimer A is guarding another reclaimer B, while both reclaiming the same wreck. A can be notified of wreck death BEFORE the guarded unit B is notified, leading to trying to reclaim the same (actively-deleting) wreck because B's reference hasn't been cleaned up yet.

This leads to an eventual segfault.

So: the short term/easy fix is to skip reclaiming of a dead/dying target.

Screenshot of fix working:
<img width="1888" height="1200" alt="image" src="https://github.com/user-attachments/assets/bc6ce07b-9ba7-45cb-8048-3f09964a9bfd" />

### AI Disclosure
Claude Code to help hunt down the potential root causes + best place for fixes
