### PR TITLE
Fix: persist logical window size on HiDPI displays

### DIFF
--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -1599,8 +1599,19 @@ void CGlobalRendering::SaveWindowPosAndSize()
 	// do not notify about changes to block update loop
 	configHandler->Set("WindowPosX", winPosX, false, false);
 	configHandler->Set("WindowPosY", winPosY, false, false);
-	configHandler->Set("XResolutionWindowed", winSizeX, false, false);
-	configHandler->Set("YResolutionWindowed", winSizeY, false, false);
+
+	// Persist the logical (point) window size, not backing pixels.
+	// GetCfgWinRes feeds the saved value straight to SDL_CreateWindow, which
+	// expects logical points. On HiDPI displays (macOS Retina, Wayland/X11
+	// HiDPI) winSizeX/Y can hold the backing-pixel size; persisting that
+	// round-tripped to a 2x-too-big request each launch, then clamped to the
+	// screen as a portrait sliver. Querying SDL directly here pins the saved
+	// value to logical points regardless of how winSize is wired upstream.
+	int saveW = winSizeX, saveH = winSizeY;
+	if (sdlWindow != nullptr)
+		SDL_GetWindowSize(sdlWindow, &saveW, &saveH);
+	configHandler->Set("XResolutionWindowed", saveW, false, false);
+	configHandler->Set("YResolutionWindowed", saveH, false, false);
 }
 
 


### PR DESCRIPTION
## What

`CGlobalRendering::SaveWindowPosAndSize()` persisted `winSizeX/winSizeY` directly into `XResolutionWindowed` / `YResolutionWindowed`. On HiDPI displays those fields can hold the **backing-pixel** size, but `GetCfgWinRes` feeds the saved value straight to `SDL_CreateWindow`, which expects **logical points**. The result: each launch requests a 2×-too-large window, which then gets clamped to the screen as a portrait sliver.

This queries `SDL_GetWindowSize()` directly so the saved value is pinned to logical points regardless of how `winSize` is wired upstream.

## Why this is cross-platform

This is **not** macOS-specific — it affects any HiDPI setup (macOS Retina, Wayland/X11 HiDPI). The change has no platform guard.

## Provenance

Extracted unmodified (via `git cherry-pick`) from commit `13a0c60ffb` in #2991 (the interim macOS bring-up). Original author credit is preserved. Pulling it out so the fix can land on its own merits independent of the larger macOS effort.
