### PR TITLE
Fix: skip legacy ARB-extension name check on core-profile GL contexts

### DIFF
--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -782,6 +782,12 @@ void CGlobalRendering::CheckGLExtensions()
 	if (underExternalDebug)
 		return;
 
+	// In an OpenGL CORE profile context these ARB extensions are not advertised
+	// by name (they were folded into GL 1.3/2.0/3.0 long ago) but their
+	// functionality is guaranteed by the spec. Skip the legacy-extension check.
+	if (globalRenderingInfo.glContextIsCore)
+		return;
+
 	char extMsg[ 128] = {0};
 	char errMsg[2048] = {0};
 	char* ptr = &extMsg[0];


### PR DESCRIPTION
## What

`CGlobalRendering::CheckGLExtensions()` validates a list of legacy ARB extensions by name. In an OpenGL **core profile** context these ARB extensions are not advertised by name (they were folded into GL 1.3/2.0/3.0 long ago), even though their functionality is guaranteed by the spec. The name check therefore fails spuriously on a perfectly valid core context.

This adds an early return when `globalRenderingInfo.glContextIsCore` is set, skipping the legacy-extension name check on core profiles.

## Why this is cross-platform

The guard is on the runtime `glContextIsCore` flag, **not** `__APPLE__`. It is correct for any core-profile context on any platform; it is a no-op for compatibility-profile contexts (the common case today).

## Provenance

Extracted unmodified (via `git cherry-pick`) from commit `17c55deecf` in #2991 (the interim macOS bring-up). Original author credit is preserved. `glContextIsCore` already exists on `master`, so the change is self-contained.
