### PR TITLE
LuaTextures: log glTexImage failures instead of returning nil silently

### DIFF
--- a/rts/Lua/LuaTextures.cpp
+++ b/rts/Lua/LuaTextures.cpp
@@ -90,7 +90,9 @@ std::string LuaTextures::Create(const Texture& tex)
 		} break;
 	}
 
-	if (glGetError() != GL_NO_ERROR) {
+	if (const GLenum texErr = glGetError(); texErr != GL_NO_ERROR) {
+		LOG_L(L_ERROR, "[LuaTextures::%s] glTexImage failed: target=0x%x size=%dx%d fmt=0x%x dataFmt=0x%x dataType=0x%x border=%d glError=0x%x",
+			__func__, tex.target, tex.xsize, tex.ysize, tex.format, dataFormat, dataType, tex.border, texErr);
 		glDeleteTextures(1, &texID);
 		glBindTexture(tex.target, currentBinding);
 		return "";


### PR DESCRIPTION
## What

Reworked per review (thanks @sprunk). Dropped the `CTextureAtlas::GetTexID` null-guard part — the consensus is that a failed atlas should be noticed and not used, rather than masked by returning id `0`. This keeps only the diagnostic the review liked:

`LuaTextures::Create` logged nothing when `glTexImage` failed (it returned an empty string). It now logs target/size/format/dataFormat/dataType/glError so texture-creation failures can be diagnosed.

## Why this is cross-platform

Purely an added log on the existing failure path; no behavior change otherwise.

## Provenance

Extracted from `1e75080731` in #2991. The null-guard hunk from that commit is intentionally omitted (see review discussion); the macOS crash it papered over should be handled at the call site. cc @iamaperson000.
