### PR TITLE
SolLua: use sol::lua_nil instead of the sol::nil alias

### DIFF
--- a/rts/Rml/SolLua/bind/Context.cpp
+++ b/rts/Rml/SolLua/bind/Context.cpp
@@ -131,7 +131,7 @@ struct lua_iterator_state
 			sol::state_view l{s};
 			int index = 0;
 			int count = keytable.size();
-			while (keytable.get<sol::object>(++index).get_type() != sol::type::nil && index <= count) {
+			while (keytable.get<sol::object>(++index).get_type() != sol::type::lua_nil && index <= count) {
 				this->keys.emplace_back(sol::object(l, sol::in_place, index));
 			}
 		} else {
@@ -199,7 +199,7 @@ createNewIndexFunction(std::shared_ptr<Rml::SolLua::SolLuaDataModel> data, const
 		}
 		if (value.is<sol::table>()) {
 			auto value_raw = value.as<sol::table>().raw_get<sol::object>("__raw");
-			if (value_raw != sol::nil && value_raw.is<sol::function>()) {
+			if (value_raw != sol::lua_nil && value_raw.is<sol::function>()) {
 				// new value is a datamodel proxy, so get the underlying table to assign
 				prop.as<sol::table>().raw_set(solkey, value_raw.as<sol::function>().call<sol::object>(value));
 			} else {
@@ -290,7 +290,7 @@ sol::table openDataModel(Rml::Context& self, const Rml::String& name, sol::objec
 			}
 			if (value.is<sol::table>()) {
 				auto value_raw = value.as<sol::table>().raw_get<sol::object>("__raw");
-				if (value_raw != sol::nil && value_raw.is<sol::function>()) {
+				if (value_raw != sol::lua_nil && value_raw.is<sol::function>()) {
 					// new value is a datamodel proxy, so get the underlying table to assign
 					data->Table.raw_set(key, value_raw.as<sol::function>().call<sol::object>(value));
 				} else {

--- a/rts/Rml/SolLua/bind/Element.cpp
+++ b/rts/Rml/SolLua/bind/Element.cpp
@@ -158,7 +158,7 @@ namespace Rml::SolLua
 
 			void Set(const sol::this_state L, const std::string& name, const sol::object& value)
 			{
-				if (value.get_type() == sol::type::nil) {
+				if (value.get_type() == sol::type::lua_nil) {
 					m_element->RemoveProperty(name);
 					return;
 				}

--- a/rts/Rml/SolLua/bind/bind.cpp
+++ b/rts/Rml/SolLua/bind/bind.cpp
@@ -39,7 +39,7 @@ namespace Rml::SolLua
 
 	sol::object makeObjectFromVariant(const Rml::Variant* variant, sol::state_view s)
 	{
-		if (!variant) return sol::make_object(s, sol::nil);
+		if (!variant) return sol::make_object(s, sol::lua_nil);
 
 		switch (variant->GetType())
 		{
@@ -69,10 +69,10 @@ namespace Rml::SolLua
 		case Rml::Variant::VOIDPTR:
 			return sol::make_object(s, variant->Get<void*>());
 		default:
-			return sol::make_object(s, sol::nil);
+			return sol::make_object(s, sol::lua_nil);
 		}
 
-		return sol::make_object(s, sol::nil);
+		return sol::make_object(s, sol::lua_nil);
 	}
 
 } // end namespace Rml::SolLua


### PR DESCRIPTION
## What

A handful of `SolLua` bindings still referenced `sol::nil` / `sol::type::nil`, while the surrounding code in the same files already uses `sol::lua_nil` / `sol::type::lua_nil`. This converts the remaining spots:

- `bind/Context.cpp` (3)
- `bind/Element.cpp` (1)
- `bind/bind.cpp` (3)

## Why

In the vendored sol2 (`rts/lib/sol2/sol.hpp`), `nil` is a thin alias for `lua_nil` (`inline constexpr const nil_t& nil = lua_nil;`) and `type::nil = type::lua_nil`. So this is a no-op behaviorally. The `lua_nil` spelling is preferred because the bare `nil` collides with the `nil` macro that Objective-C headers `#define`, which breaks the bare alias on macOS toolchains. It also makes these files internally consistent — most of the code already uses `lua_nil`.

## Why this is cross-platform

No behavior change on any platform; `lua_nil` already exists in the vendored sol2 and is already used throughout these files. CI compiles the SolLua bindings, so this is exercised on Linux/Windows.

## Provenance

Extracted from commit `cc3cad907f` (author: Mark Kropf) in #2991, the interim macOS bring-up. Only the three `SolLua/bind` files from that commit are included here; the other files in that commit are unrelated and are being proposed separately or omitted. Original author credit is preserved on the commit.
