### PR TITLE
SafeUtil: include <type_traits> and <memory> directly

### DIFF
--- a/rts/System/SafeUtil.h
+++ b/rts/System/SafeUtil.h
@@ -5,6 +5,8 @@
 
 #include <limits>
 #include <cstring>
+#include <type_traits>
+#include <memory>
 
 namespace spring {
 	template<class T> inline void SafeDestruct(T*& p)
@@ -112,7 +114,7 @@ namespace spring {
         static_assert(sizeof(TIn) == sizeof(TOut), "Types must match sizes");
         static_assert(std::is_trivially_copyable<TIn>::value , "Requires TriviallyCopyable input");
         static_assert(std::is_trivially_copyable<TOut>::value, "Requires TriviallyCopyable output");
-        static_assert(std::is_trivially_constructible_v<TOut>,
+        static_assert(std::is_trivially_default_constructible<TOut>::value,
             "This implementation additionally requires destination type to be trivially constructible");
 
         TOut t2;

--- a/rts/System/SafeUtil.h
+++ b/rts/System/SafeUtil.h
@@ -115,7 +115,7 @@ namespace spring {
         static_assert(std::is_trivially_copyable<TIn>::value , "Requires TriviallyCopyable input");
         static_assert(std::is_trivially_copyable<TOut>::value, "Requires TriviallyCopyable output");
         static_assert(std::is_trivially_default_constructible<TOut>::value,
-            "This implementation additionally requires destination type to be trivially constructible");
+            "This implementation additionally requires destination type to be trivially default-constructible");
 
         TOut t2;
         std::memcpy(std::addressof(t2), std::addressof(t1), sizeof(TIn));


### PR DESCRIPTION
## What

`rts/System/SafeUtil.h` uses `std::addressof` (from `<memory>`), and `std::is_trivially_copyable` / `std::is_trivially_constructible_v` (from `<type_traits>`), but only pulled those headers in transitively via other includes. This includes them directly so the header is self-contained and not dependent on include order at its use sites.

It also switches the default-construction `static_assert` from `std::is_trivially_constructible_v<TOut>` to `std::is_trivially_default_constructible<TOut>::value` — equivalent semantics, slightly clearer intent.

## Why this is cross-platform

Pure include-what-you-use hygiene; no behavior change. It currently compiles on Linux/Windows by luck of transitive includes — this just removes that fragility (and is what surfaced under libc++ during the macOS port).

## Provenance

Extracted from commit `cc3cad907f` (author: Mark Kropf) in #2991, the interim macOS bring-up. Only the `SafeUtil.h` change is included here. The resulting file content is byte-identical to that commit's version; on `master` both includes are absent (the original commit's branch already had `<type_traits>`), so this adds both to reach the same end state. Original author credit is preserved on the commit.
