### PR TITLE
smmalloc: drop the leaked INLINE macro in a single wrapper header

### DIFF
--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -13,7 +13,7 @@
 #include <map>
 #include <memory>
 
-#include "smmalloc/smmalloc.h"
+#include "System/recoil-smmalloc.h"
 
 #include "System/UnorderedMap.hpp"
 #include "System/ContainerUtil.h"

--- a/rts/System/recoil-smmalloc.h
+++ b/rts/System/recoil-smmalloc.h
@@ -1,0 +1,15 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+// smmalloc.h leaks `#define INLINE inline` -- a very generic token that
+// collides with unrelated code (e.g. simdjson's layout_mode::INLINE
+// enumerator) whenever both end up in the same translation unit. Include
+// smmalloc only through this wrapper so the macro is dropped immediately and
+// never escapes into engine code.
+
+#include "smmalloc/smmalloc.h"
+
+#ifdef INLINE
+#undef INLINE
+#endif


### PR DESCRIPTION
## What

Reworked per review (thanks @sprunk). Instead of `#undef INLINE` in the one affected file, this centralizes the fix so it can't recur:

- New `rts/System/recoil-smmalloc.h` — includes `smmalloc.h` and drops the leaked `INLINE` macro.
- `MemPoolTypes.h` (the engine's single smmalloc include site) now goes through that wrapper.
- The per-file `#undef INLINE` in `GLTFParser.cpp` is reverted — it's no longer needed.

## Why

`smmalloc.h` defines `#define INLINE inline`, a very generic token that collides with unrelated code (e.g. simdjson's `layout_mode::INLINE`) whenever both land in one TU. `MemPoolTypes.h` is the only place engine code pulls in smmalloc, so routing it through the wrapper means the macro never escapes — a future file mixing smmalloc with json/etc. won't reintroduce the collision.

## Why this is cross-platform

No behavior change; just prevents a macro leak. Surfaced first on macOS (the system simdjson header hits this path).

## Provenance

Supersedes the per-file `#undef` version (cherry-picked from `16622a9707`, Mark Kropf — credited via `Co-authored-by`). The upstream smmalloc leak is worth fixing there too, as noted in review.
