### PR TITLE
Threading: route std::ranges::find_if through a Cpp20Compat polyfill

### DIFF
--- a/rts/System/Cpp20Compat.hpp
+++ b/rts/System/Cpp20Compat.hpp
@@ -1,0 +1,26 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <ranges>
+
+// Polyfill for C++20 features not available on all toolchains we target
+// (notably older Apple libc++), following the pattern of Cpp17Compat.hpp.
+
+namespace Recoil {
+	namespace ranges {
+
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L
+		using std::ranges::find_if;
+#else
+		// Minimal range overload of find_if for toolchains lacking std::ranges.
+		template<typename Range, typename Pred>
+		constexpr auto find_if(Range&& r, Pred pred) {
+			return std::find_if(std::begin(r), std::end(r), std::move(pred));
+		}
+#endif
+
+	} // namespace ranges
+} // namespace Recoil

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -4,6 +4,7 @@
 
 #include "System/Log/ILog.h"
 #include "System/Platform/CpuID.h"
+#include "System/Cpp20Compat.hpp"
 
 #ifndef UNIT_TEST
 	#include "System/Config/ConfigHandler.h"
@@ -197,7 +198,7 @@ namespace Threading {
 
 		// The cache groups from GetProcessorCaches() are sorted in order of largest first. Find the first group that
 		// has a logical processor that will be used to pin the main/worker threads.
-		auto preferredCache = std::ranges::find_if(pc.groupCaches
+		auto preferredCache = Recoil::ranges::find_if(pc.groupCaches
 			, [affinityMask](const auto& gc) -> bool { return !!(affinityMask & gc.groupMask); });
 		
 		std::call_once(preferredMaskDetailsLogFlag, [&](){


### PR DESCRIPTION
## What

Reworked per review (thanks @n-morales / @sprunk). Instead of rewriting the call site to the iterator-pair form, this keeps the readable range-style `find_if` and adds a small C++20 compat shim, following the existing `Cpp17Compat.hpp` pattern.

- New `rts/System/Cpp20Compat.hpp` exposing `Recoil::ranges::find_if`:
  - forwards to `std::ranges::find_if` when available (`__cpp_lib_ranges`)
  - otherwise provides a minimal range overload
- `Threading.cpp`: `std::ranges::find_if(pc.groupCaches, …)` → `Recoil::ranges::find_if(pc.groupCaches, …)`

## Why

`std::ranges::find_if` (C++20) isn't available across all standard libraries we target (notably older Apple libc++). The compat header keeps the modern call where the toolchain supports it and degrades gracefully where it doesn't, without sacrificing readability at the call site.

## Provenance

Surfaced by the macOS port (#2991). Supersedes the earlier iterator-pair version of this PR.
