### PR TITLE
float3: drop redundant direct streflop_cond.h include

### DIFF
--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -9,7 +9,6 @@
 #include <format>
 
 #include "System/BranchPrediction.h"
-#include "lib/streflop/streflop_cond.h"
 #include "System/creg/creg_cond.h"
 #include "System/FastMath.h"
 #include "System/type2.h"


### PR DESCRIPTION
## What

`float3.h` included `lib/streflop/streflop_cond.h` directly. This drops that one include:

```diff
 #include "System/BranchPrediction.h"
-#include "lib/streflop/streflop_cond.h"
 #include "System/creg/creg_cond.h"
 #include "System/FastMath.h"
 #include "System/type2.h"
```

## Why

`FastMath.h` does `#define MATH_SQRT_OVERRIDE 1` *before* it includes `streflop_cond.h`, so that streflop does not define its own `math::sqrt(float)` (FastMath provides a faster one). The direct include in `float3.h` sat ahead of `FastMath.h`, so `streflop_cond.h` could be processed before that override was set.

Dropping the direct include lets `FastMath.h` be the includer of `streflop_cond.h` (it pulls it in transitively, with the override in place). `float3.h` still gets streflop via `FastMath.h`, so nothing else changes.

`creg_cond.h` keeps its original position — its include tree (`creg_cond.h → creg.h → SyncedPrimitive.h`) does not reach `streflop_cond.h`, so it does not need to move.

## Why this is cross-platform

No behavior change on any platform; `master` builds fine today. This just removes a direct include whose ordering bypassed FastMath's `MATH_SQRT_OVERRIDE`, which is what the macOS port tripped over.

## Provenance

Surfaced by the macOS port (#2991, commit `cc3cad907f`, author Mark Kropf — credited via `Co-authored-by`). That commit also reordered `creg_cond.h`; this PR keeps the minimal change (the reorder was unnecessary).
