### PR TITLE
Unit: iterate SResourcePack by index instead of std::views::enumerate

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -965,7 +965,8 @@ static auto SplitResourcePackIntoPositiveNegative (const SResourcePack &pack)
 {
 	SResourcePack positive {0.0f}, negative {0.0f};
 
-	for (auto [resourceID, value] : std::views::enumerate (pack)) {
+	for (int resourceID = 0; resourceID < SResourcePack::MAX_RESOURCES; ++resourceID) {
+		const auto value = pack.res[resourceID];
 		if (value < 0.0f)
 			negative[resourceID] = -value;
 		else


### PR DESCRIPTION
## What

`SplitResourcePackIntoPositiveNegative` in `Unit.cpp` iterated a `SResourcePack` with `std::views::enumerate`:

```cpp
for (auto [resourceID, value] : std::views::enumerate (pack)) { ... }
```

This is the only `std::ranges`/`std::views` use in the file. It's replaced with a plain index loop:

```cpp
for (int resourceID = 0; resourceID < SResourcePack::MAX_RESOURCES; ++resourceID) {
    const auto value = pack.res[resourceID];
    ...
}
```

## Why

`std::views::enumerate` (C++23, P2164) is not available across all standard libraries we target — notably libc++ on Apple Clang. The index loop is portable, behavior-identical, and **matches how the rest of the codebase already iterates `SResourcePack`** — `rts/Sim/Misc/Resource.h` uses `for (int i = 0; i < MAX_RESOURCES; ++i)` throughout. The `enumerate` call here was the odd one out.

`MAX_RESOURCES` is 2, so there is no readability cost.

## Why this is cross-platform

No behavior change on any platform; `master` builds fine today, this just removes a libc++ portability blocker so no platform-specific fallback is needed downstream.

## Provenance

Surfaced by the macOS port (#2991), which carried this same index loop as an `__APPLE__`-gated fallback (author: iamaperson000, credited via `Co-authored-by`). Applying it unconditionally means the macOS branch needs no gate here at all.
