### PR TITLE
Fix demotool build

### DIFF
--- a/tools/DemoTool/CMakeLists.txt
+++ b/tools/DemoTool/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ENGINE_SRC_ROOT_DIR "${CMAKE_SOURCE_DIR}/rts")
 find_package(ZLIB REQUIRED)
 
 include_directories(${ENGINE_SRC_ROOT_DIR})
+include_directories(${ENGINE_SRC_ROOT_DIR}/lib/nowide/include)
 include_directories(${CMAKE_BINARY_DIR}/src-generated/engine)
 include_directories(${gflags_BINARY_DIR}/include)
 
@@ -71,6 +72,7 @@ target_link_libraries(demotool
 		7zip
 		${ZLIB_LIBRARY}
 		${PLATFORM_LIBS}
+		fmt
 		Tracy::TracyClient
 	)
 add_dependencies(demotool generateVersionFiles)

--- a/tools/DemoTool/DemoTool.cpp
+++ b/tools/DemoTool/DemoTool.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <iostream>
@@ -417,7 +418,7 @@ void TrafficDump(CDemoReader& reader, bool trafficStats)
 				//uchar myPlayerNum; int frameNum; uint checksum;
 				std::cout << "NETMSG_SYNCRESPONSE: Playernum: "<< (unsigned)buffer[1];
 				std::cout << " Framenum: " << *(int*)(buffer+2);
-				std::cout << " Checksum: " << (unsigned)buffer[6];
+				std::cout << " Checksum: " << *(uint32_t*)(buffer+6);
 				std::cout << std::endl;
 				break;
 			case NETMSG_DIRECT_CONTROL:


### PR DESCRIPTION
Demotool stopped building a while back. Looks like #2235 (the UTF8 paths rework) made the file-system code pull in nowide and fmt, but the demotool CMake target was never given the nowide include path or set to link fmt, so it fails to compile on those headers. Adding both makes `cmake --build <build-dir> --target demotool` work again.

While I was in there I also fixed the packet dump printing only one byte of the sync checksum instead of the full 4-byte value.

I left EXCLUDE_FROM_ALL in place, so this just makes the tool buildable on demand rather than part of the default build. #2837 went at this earlier but only removed EXCLUDE_FROM_ALL without adding the nowide/fmt include and link, which is the part that actually breaks the build. Happy to un-exclude it and add an install rule in a follow-up if that's useful.

Built and ran it on Linux to confirm both fixes.

Closes #2764.

Worked through this with Claude Code.
