### PR TITLE
macOS: thread affinity handling (no-op guard + QoS performance-core hint)

### DIFF
--- a/rts/System/Platform/ThreadAffinityGuard.cpp
+++ b/rts/System/Platform/ThreadAffinityGuard.cpp
@@ -3,6 +3,8 @@
 #include "System/Log/ILog.h"
 #ifdef _WIN32
 #include <windows.h>
+#elif defined(__APPLE__)
+// macOS has no portable per-thread CPU affinity API; nothing to include.
 #else
 #include <sched.h>
 #include <unistd.h>
@@ -18,6 +20,8 @@ ThreadAffinityGuard::ThreadAffinityGuard() : affinitySaved(false) {
 	if (!affinitySaved) {
 		LOG_L(L_WARNING, "GetThreadAffinityMask failed with error code: %lu", GetLastError());
 	}
+#elif defined(__APPLE__)
+	// no portable affinity API on macOS; leave affinitySaved == false
 #else
 	tid = syscall(SYS_gettid);  // Get thread ID
 	CPU_ZERO(&savedAffinity);
@@ -36,6 +40,8 @@ ThreadAffinityGuard::~ThreadAffinityGuard() {
 		if (!SetThreadAffinityMask(threadHandle, savedAffinity)) {
 			LOG_L(L_WARNING, "SetThreadAffinityMask failed with error code: %lu", GetLastError());
 		}
+#elif defined(__APPLE__)
+		// unreachable on macOS: affinitySaved is never set
 #else
 		if (sched_setaffinity(tid, sizeof(cpu_set_t), &savedAffinity) != 0) {
 			LOG_L(L_WARNING, "Failed to restore thread affinity.");

--- a/rts/System/Platform/ThreadAffinityGuard.h
+++ b/rts/System/Platform/ThreadAffinityGuard.h
@@ -3,6 +3,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#elif defined(__APPLE__)
+// macOS has no portable per-thread CPU affinity API; the guard is a no-op.
 #else
 #include <sched.h>
 #endif
@@ -12,6 +14,8 @@ private:
 #ifdef _WIN32
 	DWORD_PTR savedAffinity;
 	HANDLE threadHandle;
+#elif defined(__APPLE__)
+	// no affinity state to track on macOS
 #else
 	cpu_set_t savedAffinity;
 	pid_t tid;

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -280,11 +280,20 @@ namespace Threading {
 			return (~0);
 
 	#if defined(__APPLE__)
+		// A mask of ~0 says "run anywhere". That is the scheduler's default, and
+		// the one caller that asks for it (the game server thread) is background
+		// work, so promoting it would be the opposite of what it asked for.
+		if (coreMask == (~0u))
+			return (~0);
+
 		// macOS has no per-thread CPU affinity API. The closest equivalent is a
 		// QoS hint: QOS_CLASS_USER_INTERACTIVE biases the scheduler toward the
 		// performance cores (and away from the efficiency cores). We can't honor
 		// the specific coreMask, so apply the hint and report the affinity as
 		// "not set" (~0) -- final core placement is left to the scheduler.
+		//
+		// The mask's bits are not mapped onto QoS classes because they are
+		// synthetic on macOS, see Platform/Mac/CpuTopology.cpp.
 		pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
 		return (~0);
 

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -17,7 +17,9 @@
 #include <memory>
 #include <numeric>
 #include <cinttypes>
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__APPLE__)
+	#include <pthread/qos.h>
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	#include <windows.h>
 	#include "System/Platform/Win/DllLib.h"
@@ -277,7 +279,16 @@ namespace Threading {
 		if (coreMask == 0)
 			return (~0);
 
-	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+	#if defined(__APPLE__)
+		// macOS has no per-thread CPU affinity API. The closest equivalent is a
+		// QoS hint: QOS_CLASS_USER_INTERACTIVE biases the scheduler toward the
+		// performance cores (and away from the efficiency cores). We can't honor
+		// the specific coreMask, so apply the hint and report the affinity as
+		// "not set" (~0) -- final core placement is left to the scheduler.
+		pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+		return (~0);
+
+	#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 		// These platforms don't support thread affinity; return ~0 ("not set")
 		return (~0);
 


### PR DESCRIPTION
## What

macOS thread-affinity handling, in the two places the engine touches affinity. macOS / Apple Silicon has no portable per-thread CPU affinity API — no `sched_*`/`cpu_set_t`, and Mach's `THREAD_AFFINITY_POLICY` is a no-op on Apple Silicon — so neither hard pinning nor save/restore is possible.

**1. `ThreadAffinityGuard` → no-op on macOS**
`affinitySaved` stays `false` (its constructor default), so the destructor's restore is skipped, and the `cpu_set_t`/`sched_*` code is excluded from the macOS compile. Kept deliberately minimal: no placeholder member, no extra includes, and the existing cross-platform comments are left intact.

**2. `Threading::SetAffinity` → QoS "prefer performance cores" hint**
Instead of a hard affinity mask, macOS applies `pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)`, which biases the scheduler toward the performance cores and away from the efficiency cores. The specific `coreMask` can't be honored, so the affinity is reported as "not set" (`~0`) and final placement is left to the scheduler.

## Scope / intent

This is a **prefer**, not a **force** — hard pinning to specific cores doesn't exist on Apple Silicon, so QoS is the strongest available lever, and the scheduler retains the final say. Accurate P/E-core *sizing* of the worker pool (e.g. via `hw.perflevel0.physicalcpu`) is a separate, later concern and not needed for this hint.

## Cross-platform safety

Purely additive on the macOS path. Windows and Linux are unchanged; FreeBSD/OpenBSD keep their existing affinity no-op. The `__APPLE__` branch was split out of the previous `__APPLE__ || __FreeBSD__ || __OpenBSD__` group so only macOS pulls in `<pthread/qos.h>` and the QoS call.

Extracted/adapted from the macOS bring-up (#2991) as a standalone, reviewable piece.
