### PR TITLE
macOS: add ThreadSupport (no-op suspend/resume)

### DIFF
--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -144,7 +144,6 @@ set(sources_engine_System_Platform_Mac
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/MessageBox.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/CrashHandler.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/WindowManagerHelper.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/ThreadSupport.cpp"
 	)
 set(sources_engine_System_Platform_Windows
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Win/CrashHandler.cpp"
@@ -157,6 +156,7 @@ set(sources_engine_System_Platform_Windows
 
 set(sources_engine_System_Threading_Mac
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/Signal.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/ThreadSupport.cpp"
 	)
 set(sources_engine_System_Threading_Linux
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/CpuTopology.cpp"

--- a/rts/System/Platform/Mac/ThreadSupport.cpp
+++ b/rts/System/Platform/Mac/ThreadSupport.cpp
@@ -1,0 +1,55 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "System/Platform/Threading.h"
+
+#include <memory>
+#include <pthread.h>
+
+// macOS thread-control support.
+//
+// The Linux implementation suspends/resumes threads via a SIGUSR1 signal
+// handler plus getcontext()/ucontext_t, which has no portable macOS
+// equivalent. macOS therefore provides no-op Suspend()/Resume().
+//
+// Performance-core preference is NOT applied here: it is a QoS hint applied
+// in Threading::SetAffinity(), which the main and worker threads already
+// reach through SetAffinityHelper().
+
+namespace Threading {
+
+void SetupCurrentThreadControls(std::shared_ptr<ThreadControls>& threadCtls)
+{
+	threadCtls.reset(new Threading::ThreadControls());
+	threadCtls->handle = pthread_self();
+}
+
+void ThreadStart(
+	std::function<void()> taskFunc,
+	std::shared_ptr<ThreadControls>* threadCtls,
+	ThreadControls* tempCtls)
+{
+	if (threadCtls != nullptr)
+		SetupCurrentThreadControls(*threadCtls);
+
+	// notify the caller that this thread is running
+	{
+		std::lock_guard<spring::mutex> lock(tempCtls->mutSuspend);
+		tempCtls->condInitialized.notify_one();
+	}
+
+	taskFunc();
+}
+
+SuspendResult ThreadControls::Suspend()
+{
+	// no-op on macOS (no signal-based suspend)
+	return Threading::THREADERR_NOT_RUNNING;
+}
+
+SuspendResult ThreadControls::Resume()
+{
+	// no-op on macOS
+	return Threading::THREADERR_NONE;
+}
+
+} // namespace Threading


### PR DESCRIPTION
## What

Adds `rts/System/Platform/Mac/ThreadSupport.cpp` and wires it into the Mac threading sources.

The Linux `ThreadSupport` suspends/resumes threads via a `SIGUSR1` signal handler plus `getcontext()`/`ucontext_t` — none of which has a portable macOS equivalent. This macOS version provides:

- **`Suspend()` / `Resume()`** as no-ops (macOS has no signal-based thread suspend).
- **`ThreadStart` / `SetupCurrentThreadControls`** — the thread setup/start plumbing (create the `ThreadControls`, record `pthread_self()`, signal initialization, run the task).

## QoS / performance cores

Deliberately **not** handled here. Performance-core preference is a QoS hint applied in `Threading::SetAffinity()` (see the macOS affinity change), which the main and worker threads already reach via `SetAffinityHelper()` (`ThreadPool.cpp`). Keeping it in one place avoids applying the QoS class twice.

## CMake

On `APPLE`, `sources_engine_System_Platform_Mac` previously pulled in `Platform/Linux/ThreadSupport.cpp` — which doesn't compile on macOS (it uses `SYS_gettid`/`sigaction`/`ucontext`). This swaps that out: the new `Mac/ThreadSupport.cpp` is added to `sources_engine_System_Threading_Mac`, and the Linux file is dropped from `sources_engine_System_Platform_Mac` (otherwise both would compile on APPLE → duplicate symbols).

## Cross-platform safety

Mac-only: the only lists touched are the `*_Mac` ones, used solely under `if(APPLE)`. Windows and Linux builds are byte-for-byte unaffected.

Adapted from the macOS bring-up (#2991) as a standalone, reviewable piece (minus the QoS, which lives with the affinity change).

> Note: macOS isn't in CI yet, so this is verified by inspection, not a build. It's part of standing up the headless `unitsync` build on Apple Silicon.
