### PR TITLE
perf: draw alpha optimizations (POC)

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
@@ -232,6 +232,8 @@ ShieldSegmentProjectile::ShieldSegmentProjectile(
 	useAirLos     = true;
 	drawRadius    = shieldWeaponDef->shieldRadius * 0.4f;
 	mygravity     = 0.0f;
+	// Draw() mutates the shared ShieldSegmentCollection and calls eventHandler.DrawShield (Lua)
+	drawThreaded  = false;
 
 	vertices = GetSegmentVertices(xpart, ypart);
 	texCoors = GetSegmentTexCoords(collection->GetShieldTexture(), xpart, ypart);

--- a/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
@@ -26,6 +26,7 @@ CTracerProjectile::CTracerProjectile()
 	, drawLength(0.0f)
 {
 	checkCol = false;
+	drawThreaded = false; // Draw() self-draws GL (VA_TYPE_TC lines)
 }
 
 CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const float3& spd, const float range)
@@ -36,6 +37,7 @@ CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const floa
 	SetRadiusAndHeight(1.0f, 0.0f);
 
 	checkCol = false;
+	drawThreaded = false; // Draw() self-draws GL (VA_TYPE_TC lines)
 	// Projectile::Init has been called by base ctor, so .w is defined
 	// FIXME: constant, assumes |speed| never changes after creation
 	speedf = this->speed.w;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -779,12 +779,20 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	if (doBuild) {
 		for (auto& dp : drawParticles)
 			dp.clear();
+		serialParticles.clear();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
 			for (CProjectile* p : renderProjectiles) {
 				if (!ShouldDrawProjectile(p, buildMask))
 					continue;
+
+				// particles that can't be filled off-thread (GL / shared state / Lua)
+				// are collected separately and drawn serially below.
+				if (!p->drawThreaded) {
+					serialParticles.emplace_back(p);
+					continue;
+				}
 
 				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
 			}
@@ -804,17 +812,59 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		// record the index range this build appends so reuse passes can re-submit it
 		build.eboStart = rb.GetIndcs().size();
 
+		// flat draw list: sorted bucket (back-to-front) followed by unsorted; both are
+		// parallel-safe. Chunks are contiguous slices, so an in-order concat of the
+		// per-chunk accumulators reproduces the exact serial vertex/index order.
+		drawList.clear();
+		drawList.insert(drawList.end(), drawParticles[ true].begin(), drawParticles[ true].end());
+		drawList.insert(drawList.end(), drawParticles[false].begin(), drawParticles[false].end());
+
 		{
-			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-			for (auto p : drawParticles[ true]) {
-				p->Draw();
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS+DU)");
+
+			const int listSize = static_cast<int>(drawList.size());
+			const int numChunks = (listSize > 0)
+				? std::clamp(4 * ThreadPool::GetNumThreads(), 1, std::min(ThreadPool::MAX_THREADS, listSize))
+				: 0;
+
+			if (numChunks <= 1) {
+				// inline fast path (also the empty case): fill the primary directly (tls null)
+				for (CProjectile* p : drawList)
+					p->Draw();
+			} else {
+				const int chunkSize = (listSize + numChunks - 1) / numChunks;
+
+				for_mt(0, numChunks, [this, chunkSize, listSize](int c) {
+					auto& acc = fillBuffers[c];
+					acc.GetElems().clear();
+					acc.GetIndcs().clear();
+
+					CExpGenSpawnable::SetThreadRenderBuffer(&acc);
+
+					const int bb = c * chunkSize;
+					const int ee = std::min(bb + chunkSize, listSize);
+					for (int i = bb; i < ee; ++i)
+						drawList[i]->Draw();
+
+					CExpGenSpawnable::SetThreadRenderBuffer(nullptr);
+				});
+
+				// serial in-order concat => byte-identical to the serial fill
+				for (int c = 0; c < numChunks; ++c) {
+					const auto& acc = fillBuffers[c];
+					const auto base = static_cast<int32_t>(rb.GetElems().size());
+					rb.AddVertices(acc.GetElems());
+					rb.AddIndices(acc.GetIndcs(), base);
+				}
 			}
 		}
+
+		// serial bucket (render thread, tls null): shields append to the primary buffer
+		// (inside the cached range), tracers self-draw GL (append nothing). Once per build.
 		{
-			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-			for (auto p : drawParticles[false]) {
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DSerial)");
+			for (CProjectile* p : serialParticles)
 				p->Draw();
-			}
 		}
 
 		build.eboCount = rb.GetIndcs().size() - build.eboStart;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -372,6 +372,10 @@ void CProjectileDrawer::UpdateDrawFlags()
 {
 	ZoneScopedN("ProjectileDrawer::UpdateDrawFlags");
 
+	// invalidate the per-camera alpha-particle geometry cache for the new frame
+	for (auto& build : alphaBuilds)
+		build.valid = false;
+
 	for_mt(0, renderProjectiles.size(), [this](int i) {
 		CProjectile* p = renderProjectiles[i];
 		const bool hasModel = (p->model != nullptr);
@@ -753,46 +757,68 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	};
 	const auto& clipPlane = clipPlanes[1U * drawBelowWater + 2U * drawAboveWater];
 
-	const uint8_t thisPassMask =
-		(1 - (drawReflection || drawRefraction)) * DrawFlags::SO_ALPHAF_FLAG +
-		(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
-		(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
+	// Only the player and underwater-reflection cameras reach DrawAlpha. All three
+	// player passes (below-water, above-water, refraction) produce identical billboard
+	// geometry and sort order; they differ only in the clip-plane uniform, soften state
+	// and target FBO. So build the geometry once per camera and re-submit the cached
+	// vertex/index range for the remaining passes. SO_REFRAC_FLAG ⊆ SO_ALPHAF_FLAG, so
+	// the player build uses the ALPHAF superset; above-water quads in the refraction pass
+	// are clipped in hardware (gl_ClipDistance) just as the REFRAC subset would be.
+	const uint32_t camType = camera->GetCamType();
+	assert(camType == CCamera::CAMTYPE_PLAYER || camType == CCamera::CAMTYPE_UWREFL);
 
-	for (auto& dp : drawParticles)
-		dp.clear();
+	auto& build = alphaBuilds[camType];
+	const bool doBuild = !build.valid;
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
-		for (CProjectile* p : renderProjectiles) {
-			if (!ShouldDrawProjectile(p, thisPassMask))
-				continue;
+	const uint8_t buildMask = (camType == CCamera::CAMTYPE_UWREFL)
+		? DrawFlags::SO_REFLEC_FLAG
+		: DrawFlags::SO_ALPHAF_FLAG;
 
-			drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+	auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
+
+	if (doBuild) {
+		for (auto& dp : drawParticles)
+			dp.clear();
+
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
+			for (CProjectile* p : renderProjectiles) {
+				if (!ShouldDrawProjectile(p, buildMask))
+					continue;
+
+				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+			}
 		}
-	}
 
-	// set static variable to facilite sorting
-	sortCamType = camera->GetCamType();
+		// set static variable to facilite sorting
+		sortCamType = camType;
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-		if (wantDrawOrder)
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
-		else
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
-	}
-
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-		for (auto p : drawParticles[ true]) {
-			p->Draw();
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
+			if (wantDrawOrder)
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
+			else
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
 		}
-	}
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-		for (auto p : drawParticles[false]) {
-			p->Draw();
+
+		// record the index range this build appends so reuse passes can re-submit it
+		build.eboStart = rb.GetIndcs().size();
+
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
+			for (auto p : drawParticles[ true]) {
+				p->Draw();
+			}
 		}
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
+			for (auto p : drawParticles[false]) {
+				p->Draw();
+			}
+		}
+
+		build.eboCount = rb.GetIndcs().size() - build.eboStart;
+		build.valid = true;
 	}
 
 	{
@@ -809,8 +835,9 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 
 		eventHandler.DrawWorldPreParticles(drawAboveWater, drawBelowWater, drawReflection, drawRefraction);
 
-		auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
-		if (!rb.ShouldSubmit())
+		// gate on the cached count, not ShouldSubmit(): a reuse pass appends nothing,
+		// so ShouldSubmit() would be false and wrongly skip the re-submit.
+		if (build.eboCount == 0)
 			return;
 
 		const bool needSoften = (wantSoften > 0) && !drawReflection && !drawRefraction;
@@ -835,7 +862,13 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		fxShader->SetUniform("fogColor", sky->fogColor.x, sky->fogColor.y, sky->fogColor.z);
 		fxShader->SetUniform("fogParams", sky->fogStart * camPlayer->GetFarPlaneDist(), sky->fogEnd * camPlayer->GetFarPlaneDist());
 
-		rb.DrawElements(GL_TRIANGLES);
+		// build pass: rewinding draw of the just-appended range (also advances the
+		// buffer's start indices so a later build / consumer appends cleanly).
+		// reuse pass: non-advancing draw of the cached range.
+		if (doBuild)
+			rb.DrawElements(GL_TRIANGLES);
+		else
+			rb.DrawElementsRange(GL_TRIANGLES, build.eboStart, build.eboCount);
 
 		fxShader->Disable();
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -55,6 +55,47 @@ static bool CProjectileSortingPredicate(const CProjectile* p1, const CProjectile
 	return std::forward_as_tuple(p1->GetSortDist(sortCamType), p1) > std::forward_as_tuple(p2->GetSortDist(sortCamType), p2);
 };
 
+// below this bucket size std::sort with the tuple comparator beats the radix overhead
+static constexpr size_t PROJECTILE_RADIX_SORT_MIN = 256;
+
+// Map a float to a uint32 whose unsigned order matches the float's ordering, for all
+// floats incl. negatives (sortDist can carry a negative sortDistOffset).
+static inline uint32_t FloatToSortableU32(float f) noexcept {
+	const uint32_t u = std::bit_cast<uint32_t>(f);
+	return u ^ ((static_cast<uint32_t>(-static_cast<int32_t>(u >> 31))) | 0x80000000u);
+}
+
+// Stable LSD radix sort (8-bit passes) of (key, ptr) pairs by ascending key, using
+// `aux` as ping-pong scratch. `passes` low bytes; 4 and 8 are both even so the sorted
+// result lands back in `keys`. Stability gives deterministic ties (replacing the
+// pointer tiebreak the tuple comparator used).
+static void RadixSortByKey(std::vector<std::pair<uint64_t, CProjectile*>>& keys,
+                           std::vector<std::pair<uint64_t, CProjectile*>>& aux, int passes) noexcept
+{
+	const size_t n = keys.size();
+	aux.resize(n);
+
+	auto* src = keys.data();
+	auto* dst = aux.data();
+
+	for (int pass = 0; pass < passes; ++pass) {
+		const int shift = pass * 8;
+		size_t count[256] = {};
+		for (size_t i = 0; i < n; ++i)
+			++count[(src[i].first >> shift) & 0xFFu];
+
+		size_t offset[256];
+		for (size_t k = 0, sum = 0; k < 256; ++k) { offset[k] = sum; sum += count[k]; }
+
+		for (size_t i = 0; i < n; ++i)
+			dst[offset[(src[i].first >> shift) & 0xFFu]++] = src[i];
+
+		std::swap(src, dst);
+	}
+
+	assert(src == keys.data()); // passes is even (4 or 8)
+}
+
 CProjectileDrawer* projectileDrawer = nullptr;
 
 // can not be a CProjectileDrawer; destruction in global
@@ -803,10 +844,39 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-			if (wantDrawOrder)
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
-			else
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
+			auto& sorted = drawParticles[true];
+
+			if (sorted.size() < PROJECTILE_RADIX_SORT_MIN) {
+				if (wantDrawOrder)
+					std::sort(sorted.begin(), sorted.end(), CProjectileDrawOrderSortingPredicate);
+				else
+					std::sort(sorted.begin(), sorted.end(), CProjectileSortingPredicate);
+			} else {
+				// O(n) radix on a composite key: ascending drawOrder (primary), then
+				// descending sortDist (back-to-front). When drawOrder is uniform (the
+				// common case / !wantDrawOrder) the high 32 bits don't vary, so 4 byte
+				// passes over the low word suffice instead of 8.
+				sortKeys.clear();
+				sortKeys.reserve(sorted.size());
+
+				uint32_t hi0 = 0;
+				bool hiUniform = true;
+				for (CProjectile* p : sorted) {
+					const uint32_t distDesc = ~FloatToSortableU32(p->GetSortDist(camType));
+					const uint32_t hi = wantDrawOrder ? (static_cast<uint32_t>(p->drawOrder) ^ 0x80000000u) : 0u;
+
+					if (sortKeys.empty())
+						hi0 = hi;
+					hiUniform &= (hi == hi0);
+
+					sortKeys.emplace_back((static_cast<uint64_t>(hi) << 32) | distDesc, p);
+				}
+
+				RadixSortByKey(sortKeys, sortKeysAux, hiUniform ? 4 : 8);
+
+				for (size_t i = 0, n = sorted.size(); i < n; ++i)
+					sorted[i] = sortKeys[i].second;
+			}
 		}
 
 		// record the index range this build appends so reuse passes can re-submit it

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -170,6 +170,12 @@ private:
 	/// used to render particle effects in back-to-front order. {unsorted, sorted}
 	std::array<std::vector<CProjectile*>, 2> drawParticles;
 
+	/// per-frame cache of the alpha-particle geometry built per camera, so the
+	/// DP+SO+DS+DU pipeline runs once per camera instead of once per pass. Only
+	/// CAMTYPE_PLAYER and CAMTYPE_UWREFL reach DrawAlpha. Reset in UpdateDrawFlags.
+	struct AlphaBuild { bool valid = false; size_t eboStart = 0; size_t eboCount = 0; };
+	std::array<AlphaBuild, 2> alphaBuilds;
+
 	bool drawSorted = true;
 
 	Shader::IProgramObject* fxShader = nullptr;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -178,6 +178,10 @@ private:
 	/// Default-constructed => no GL objects; persistent so capacity is reused.
 	std::array<TypedRenderBuffer<VA_TYPE_PROJ>, ThreadPool::MAX_THREADS> fillBuffers;
 
+	/// reusable scratch for the radix sort of the sorted alpha bucket ({sortKey, ptr})
+	std::vector<std::pair<uint64_t, CProjectile*>> sortKeys;
+	std::vector<std::pair<uint64_t, CProjectile*>> sortKeysAux;
+
 	/// per-frame cache of the alpha-particle geometry built per camera, so the
 	/// DP+SO+DS+DU pipeline runs once per camera instead of once per pass. Only
 	/// CAMTYPE_PLAYER and CAMTYPE_UWREFL reach DrawAlpha. Reset in UpdateDrawFlags.

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -170,6 +170,14 @@ private:
 	/// used to render particle effects in back-to-front order. {unsorted, sorted}
 	std::array<std::vector<CProjectile*>, 2> drawParticles;
 
+	/// flat draw list (sorted then unsorted) consumed by the parallel billboard fill
+	std::vector<CProjectile*> drawList;
+	/// particles whose Draw() must run on the render thread (GL / shared state / Lua)
+	std::vector<CProjectile*> serialParticles;
+	/// per-chunk CPU-only accumulators for the parallel fill; concatenated in order.
+	/// Default-constructed => no GL objects; persistent so capacity is reused.
+	std::array<TypedRenderBuffer<VA_TYPE_PROJ>, ThreadPool::MAX_THREADS> fillBuffers;
+
 	/// per-frame cache of the alpha-particle geometry built per camera, so the
 	/// DP+SO+DS+DU pipeline runs once per camera instead of once per pass. Only
 	/// CAMTYPE_PLAYER and CAMTYPE_UWREFL reach DrawAlpha. Reset in UpdateDrawFlags.

--- a/rts/Rendering/GL/RenderBuffers.h
+++ b/rts/Rendering/GL/RenderBuffers.h
@@ -587,6 +587,9 @@ public:
 	void AssertBoundShader() const;
 	void DrawArrays(uint32_t mode, bool rewind = true);
 	void DrawElements(uint32_t mode, bool rewind = true);
+	// draw an explicit, already-uploaded index sub-range without advancing or
+	// rewinding any start/upload index (for re-submitting cached geometry)
+	void DrawElementsRange(uint32_t mode, size_t eboOffset, size_t eboCount);
 	void DropCurrent();
 
 	TypedRenderBuffer<T> CopyCurrent(bool readOnly) const;
@@ -908,6 +911,33 @@ inline void TypedRenderBuffer<T>::DrawElements(uint32_t mode, bool rewind)
 
 	vboStartIndex = verts.size();
 
+	numSubmits[1] += 1;
+}
+
+template<typename T>
+inline void TypedRenderBuffer<T>::DrawElementsRange(uint32_t mode, size_t eboOffset, size_t eboCount)
+{
+	AssertBoundShader();
+
+	// the requested range was uploaded by the build that produced it; these are
+	// idempotent for already-resident data and pick up any later appends.
+	UploadVBO();
+	UploadEBO();
+
+	if (eboCount == 0)
+		return;
+
+	#define BUFFER_OFFSET(T, n) (reinterpret_cast<void*>(sizeof(T) * (n)))
+#ifndef HEADLESS
+	assert(vao.GetIdRaw() > 0);
+#endif
+	vao.Bind();
+	glDrawElements(mode, static_cast<GLsizei>(eboCount), GL_UNSIGNED_INT, BUFFER_OFFSET(uint32_t, ebo->BufferElemOffset() + eboOffset));
+	vao.Unbind();
+	#undef BUFFER_OFFSET
+
+	// deliberately do NOT touch eboStartIndex/vboStartIndex/upload indices: this is a
+	// re-submit of cached geometry, not a consume of newly appended data.
 	numSubmits[1] += 1;
 }
 

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -144,6 +144,19 @@ TypedRenderBuffer<VA_TYPE_PROJ>& CExpGenSpawnable::GetPrimaryRenderBuffer()
 	return RenderBuffer::GetTypedRenderBuffer<VA_TYPE_PROJ>();
 }
 
+// per-thread redirect target for the parallel billboard fill (see DrawAlpha)
+static thread_local TypedRenderBuffer<VA_TYPE_PROJ>* tlsRenderBuffer = nullptr;
+
+void CExpGenSpawnable::SetThreadRenderBuffer(TypedRenderBuffer<VA_TYPE_PROJ>* rb)
+{
+	tlsRenderBuffer = rb;
+}
+
+TypedRenderBuffer<VA_TYPE_PROJ>& CExpGenSpawnable::GetRenderBuffer()
+{
+	return (tlsRenderBuffer != nullptr) ? *tlsRenderBuffer : GetPrimaryRenderBuffer();
+}
+
 template<typename Spawnable>
 CExpGenSpawnable::SpawnableTuple GetSpawnableEntryImpl()
 {
@@ -237,7 +250,7 @@ void CExpGenSpawnable::AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl
 		((maxT = std::max(maxT, arg.t)), ...);
 	}, tl, tr, br, bl);
 
-	auto& rb = GetPrimaryRenderBuffer();
+	auto& rb = GetRenderBuffer();
 
 	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
 	const auto animInfo = float3{ ap.x, ap.y, p };
@@ -264,7 +277,7 @@ void CExpGenSpawnable::AddEffectsQuadImpl(uint32_t pageNum, const VA_TYPE_TC& tl
 		((maxT = std::max(maxT, arg.t)), ...);
 	}, tl, tr, br, bl);
 
-	auto& rb = GetPrimaryRenderBuffer();
+	auto& rb = GetRenderBuffer();
 
 	const auto uvInfo = float4{ minS, minT, maxS - minS, maxT - minT };
 	static constexpr auto animInfo = float3{ 1.0f, 1.0f , 0.0f };

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -35,6 +35,12 @@ public:
 	//Memory handled in projectileHandler
 	static CExpGenSpawnable* CreateSpawnable(int spawnableID);
 	static TypedRenderBuffer<VA_TYPE_PROJ>& GetPrimaryRenderBuffer();
+
+	// Redirect target for the per-particle billboard fill. When set (during the
+	// parallel DS+DU fill in ProjectileDrawer::DrawAlpha), AddEffectsQuad appends to
+	// this thread-local buffer instead of the shared primary buffer. Null otherwise.
+	static void SetThreadRenderBuffer(TypedRenderBuffer<VA_TYPE_PROJ>* rb);
+	static TypedRenderBuffer<VA_TYPE_PROJ>& GetRenderBuffer();
 protected:
 	CExpGenSpawnable();
 

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -116,6 +116,9 @@ public:
 
 	bool castShadow = false;
 	bool drawSorted = true;
+	// false => Draw() must run on the render thread (calls GL directly, touches shared
+	// aggregator state, or invokes eventHandler/Lua); excluded from the parallel fill.
+	bool drawThreaded = true;
 
 	bool blockPreciseCol = false;
 


### PR DESCRIPTION
so uhh... -50% draw frame cost zoomed out on ultra settings on hellas basin

Commit 2 + 3 generally improve performance of alphas, Commit 1 optimizes for any water maps since they do multiple cpu-duplicated passes (one pre-water, one post-water).

### Performance results
On BAR **ultra** graphics settings:
| Build | Draw mean (ms) | Δ mean vs master | Render FPS | Δ FPS vs master |
|---|---|---|---|---|
| master | 12.13 | — | 46.0 | — |
| + Commit 1 (per-camera build cache) | 9.13 | −24.7% | 59.8 | +29.8% |
| + Commit 2 (parallel billboard fill) | 7.12 | −41.3% | 72.9 | +58.3% |
| + Commit 3 (radix sort) | 6.37 | −47.5% | 81.3 | +76.5% |

### Screenshots
Before:
<img width="1642" height="675" alt="image2" src="https://github.com/user-attachments/assets/bc8c274e-54b2-4fdc-8ebb-9853fec71ec6" />

After:
<img width="1643" height="649" alt="image1" src="https://github.com/user-attachments/assets/9334f7c8-5f23-473b-977e-e8215709a174" />

### Setup
Ultra-late game, zoomed out, hellas basin v1.4 (has water), ~5000 sim frames worth of gameplay @ 0.5x:
<img width="2559" height="1440" alt="image" src="https://github.com/user-attachments/assets/8ab5249f-6d89-4781-b2fa-fcede9a71b10" />

