### PR TITLE
macOS: add Brewfile listing native build dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,23 @@
+# Homebrew dependencies for building the Recoil engine natively on macOS.
+#
+# Usage:
+#   brew bundle install
+#
+# This installs the toolchain and libraries needed to configure and build the
+# engine (and the headless unitsync target) on Apple Silicon. The engine is
+# compiled with Homebrew GCC for parity with the Linux/Windows build toolchain.
+#
+# This list is maintained as the macOS build is brought up; it is the
+# authoritative record of system-level build prerequisites.
+
+# Toolchain
+brew "cmake"
+brew "gcc"          # Homebrew GCC (engine is built with gcc, not Apple clang)
+brew "pkg-config"
+
+# Libraries
+brew "sdl2"
+brew "devil"        # image loading (DevIL / libIL)
+brew "minizip"
+brew "sevenzip"     # provides the 7zz archiver binary
+brew "freetype"

--- a/Brewfile
+++ b/Brewfile
@@ -21,3 +21,4 @@ brew "devil"        # image loading (DevIL / libIL)
 brew "minizip"
 brew "sevenzip"     # provides the 7zz archiver binary
 brew "freetype"
+brew "openal-soft"  # macOS ships a frozen OpenAL 1.1 without EFX


### PR DESCRIPTION
## What

Adds a `Brewfile` at the repo root documenting the Homebrew packages needed to build the engine natively on macOS (Apple Silicon):

- **Toolchain:** `cmake`, `gcc`, `pkg-config`
- **Libraries:** `sdl2`, `devil`, `minizip`, `sevenzip`, `freetype`

https://docs.brew.sh/Brew-Bundle-and-Brewfile

With this we can check and install all the dependencies on Mac with `brew bundle check || brew bundle install`

## Notes

Additive only — a new file, no build/behavior change for any existing platform. The list will grow as more of the macOS build is brought up.