### PR TITLE
FindSevenZip: also accept the 7zz binary name

### DIFF
--- a/rts/build/cmake/FindSevenZip.cmake
+++ b/rts/build/cmake/FindSevenZip.cmake
@@ -23,7 +23,7 @@ ENDIF (SEVENZIP_BIN)
 set(progfilesx86 "ProgramFiles(x86)")
 
 find_program(SEVENZIP_BIN
-	NAMES 7z 7za
+	NAMES 7z 7za 7zz
 	HINTS "${MINGWDIR}" "${MINGWLIBS}/bin" "$ENV{${progfilesx86}}/7-zip" "$ENV{ProgramFiles}/7-zip" "$ENV{ProgramW6432}/7-zip"
 	PATH_SUFFIXES bin
 	DOC "7zip executable"


### PR DESCRIPTION
## What

Adds `7zz` to the binary names `FindSevenZip.cmake` searches for (currently `7z`, `7za`).

```diff
 find_program(SEVENZIP_BIN
-	NAMES 7z 7za
+	NAMES 7z 7za 7zz
```

## Why

Modern 7-Zip ships its CLI as **`7zz`**. Homebrew's `sevenzip` formula installs `/opt/homebrew/bin/7zz` (no `7z`/`7za`), and recent Linux distributions package `7zz` as well. With only `7z`/`7za` searched, configure fails:

```
CMake Error: Could NOT find SevenZip (missing: SEVENZIP_BIN)
```

Surfaced while configuring a native macOS build, but the fix is cross-platform — anywhere only `7zz` is installed.

## Safety

No effect on systems where `7z`/`7za` already exist (they're listed first). Pure additive name.