### PR TITLE
MemPoolTypes: portable thread-id cast for logging (pointer pthread_t)

### DIFF
--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -431,7 +431,7 @@ inline size_t StablePosAllocator<T>::Allocate(size_t numElems)
 	if (positionToSize.empty()) {
 		size_t returnPos = data.size();
 		data.resize(data.size() + numElems);
-		myLog("StablePosAllocator<T>::Allocate(%u) = %u [thread_id = %u]", uint32_t(numElems), uint32_t(returnPos), static_cast<uint32_t>(Threading::GetCurrentThreadId()));
+		myLog("StablePosAllocator<T>::Allocate(%u) = %u [thread_id = %u]", uint32_t(numElems), uint32_t(returnPos), Threading::GetCurrentThreadIdAsU32());
 		return returnPos;
 	}
 

--- a/rts/System/Platform/Threading.h
+++ b/rts/System/Platform/Threading.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <functional>
+#include <type_traits>
 
 #include <cinttypes>
 #include <cstring>
@@ -54,6 +55,19 @@ namespace Threading {
 #endif
 	NativeThreadHandle GetCurrentThread();
 	NativeThreadId GetCurrentThreadId();
+
+	// Convert a NativeThreadId to a 32-bit value for logging. NativeThreadId is a
+	// pointer (pthread_t) on macOS/BSD and an integer elsewhere; the template lets
+	// `if constexpr` select a cast that is valid for the actual type on each target
+	// (it would not be discarded in a non-template function).
+	template<class TId>
+	inline std::uint32_t ThreadIdAsU32(TId id) {
+		if constexpr (std::is_pointer_v<TId>)
+			return static_cast<std::uint32_t>(reinterpret_cast<std::uintptr_t>(id));
+		else
+			return static_cast<std::uint32_t>(id);
+	}
+	inline std::uint32_t GetCurrentThreadIdAsU32() { return ThreadIdAsU32(GetCurrentThreadId()); }
 
 #ifndef _WIN32
 	extern thread_local std::shared_ptr<ThreadControls> localThreadControls;


### PR DESCRIPTION
## What

`StablePosAllocator::Allocate` logs the current thread id:

```cpp
static_cast<uint32_t>(Threading::GetCurrentThreadId())
```

`NativeThreadId` is `pthread_t` — an **integer** on Linux but a **pointer** (`_opaque_pthread_t*`) on macOS. The direct `static_cast` to `uint32_t` is therefore invalid on macOS and fails to compile under GCC:

```
rts/System/MemPoolTypes.h:434: error: invalid 'static_cast' from type
'Threading::NativeThreadId' {aka '_opaque_pthread_t*'} to type 'uint32_t'
```

This casts via `uintptr_t` first (valid for both pointer and integer thread-id representations), then narrows to `uint32_t` for the log line.

## Notes

- The log line is debug-only (`reportWork` is `false`), but the template body still has to **compile**, so the cast must be valid on every platform.
- No behavior change on Linux/Windows — `uintptr_t(integer)` is just a widening cast there.
- Surfaced building the headless `unitsync` target on macOS with GCC.