### PR TITLE
macOS: skip Libunwind on Apple + fix DevIL include-dir lookup

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -106,7 +106,7 @@ if    (USE_MIMALLOC)
 endif (USE_MIMALLOC)
 
 
-if(UNIX AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
+if(UNIX AND NOT APPLE AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	find_package_static(Libunwind 1.4.0 REQUIRED)
 	prefer_static_libs()
 	find_library(LZMA_LIBRARY lzma)

--- a/rts/build/cmake/FindDevIL.cmake
+++ b/rts/build/cmake/FindDevIL.cmake
@@ -66,9 +66,13 @@ This module sets:
 
 include(FindPackageHandleStandardArgs)
 
-find_path(IL_INCLUDE_DIR il.h
-          PATH_SUFFIXES include IL
-          DOC "The path to the directory that contains il.h"
+# Search for IL/il.h (not bare il.h) so IL_INCLUDE_DIR is the directory that
+# makes the code's #include <IL/il.h> resolve. Searching for il.h directly
+# returned the IL/ subdirectory itself on some layouts (e.g. Homebrew's
+# <prefix>/include/IL), which broke the angle-bracket include.
+find_path(IL_INCLUDE_DIR IL/il.h
+          PATH_SUFFIXES include
+          DOC "The path to the directory that contains IL/il.h"
 )
 
 #message("IL_INCLUDE_DIR is ${IL_INCLUDE_DIR}")

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -24,7 +24,7 @@ list(APPEND engineDedicatedLibraries ${Boost_REGEX_LIBRARY})
 list(APPEND engineDedicatedLibraries lua archives_nothreadpool 7zip prd::jsoncpp
 	${SPRING_MINIZIP_LIBRARY} ZLIB::ZLIB gflags_nothreads_static Tracy::TracyClient)
 list(APPEND engineDedicatedLibraries headlessStubs engineSystemNet)
-if(UNIX AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
+if(UNIX AND NOT APPLE AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	list(APPEND engineDedicatedLibraries libunwind::libunwind)
 endif()
 list(APPEND engineDedicatedLibraries ${LZMA_LIBRARY})


### PR DESCRIPTION
## What

Configure/link fixes for building on macOS.

**1. Skip Libunwind on Apple** — in both places it's referenced (`rts/CMakeLists.txt` find+link, and `rts/builds/dedicated/CMakeLists.txt` link list). `find_package(Libunwind REQUIRED)` targets the LLVM/nongnu libunwind used on Linux/BSD; macOS has its own unwinding and the package isn't present. Both guards get `NOT APPLE` (OpenBSD was already excluded).

**2. Fix `FindDevIL` at the root** *(reworked per review — answering "how did devil work before?")*

```diff
-find_path(IL_INCLUDE_DIR il.h
-          PATH_SUFFIXES include IL
+find_path(IL_INCLUDE_DIR IL/il.h
+          PATH_SUFFIXES include
```

The module searched for bare `il.h` and set `IL_INCLUDE_DIR` to *the directory containing it*. The code does `#include <IL/il.h>`, which needs the **parent**. On Homebrew (`<prefix>/include/IL/il.h`) that landed on `<prefix>/include/IL`, so `<IL/il.h>` didn't resolve. **On Linux the system include path (`/usr/include`) masked this**, which is why it "worked before".

Searching for `IL/il.h` makes `IL_INCLUDE_DIR` the parent on every platform — which also matches how it's already consumed elsewhere (`tools/scripts/prepare_static_spring.sh` passes the parent include dir as `IL_INCLUDE_DIR`). This replaces the earlier downstream workaround in `rts/CMakeLists.txt` with a root-cause fix in the Find module.

Verified: `Found DevIL: /opt/homebrew/lib/libIL.dylib` and `<IL/il.h>` resolves on macOS; `find_path(IL/il.h)` returns `/opt/homebrew/include` vs the old `/opt/homebrew/include/IL`.

## Safety

Configure/link-only. libunwind guards add `NOT APPLE` (Linux/BSD unchanged). The FindDevIL change returns the parent dir on all platforms, matching existing `IL_INCLUDE_DIR` usage.

Surfaced building `unitsync` / `spring-dedicated` on macOS with Homebrew GCC.

---
*Assisted by Claude Code; verified by configuring on macOS.*