### PR TITLE
macOS: build the unitsync target on Apple Silicon

### DIFF
--- a/rts/System/BitUtils.h
+++ b/rts/System/BitUtils.h
@@ -1,0 +1,21 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <cstdint>
+#include <climits>
+
+namespace spring {
+
+// Returns a mask with the low `n` bits set. Saturates at the width of T to
+// avoid the undefined behavior of shifting by >= the type's bit width.
+template<class T = uint32_t>
+constexpr T LowBitsMask(unsigned int n) {
+	if (n == 0)
+		return T(0);
+	if (n >= sizeof(T) * CHAR_BIT)
+		return ~T(0);
+	return (T(1) << n) - T(1);
+}
+
+} // namespace spring

--- a/rts/System/Platform/Mac/CpuTopology.cpp
+++ b/rts/System/Platform/Mac/CpuTopology.cpp
@@ -1,0 +1,93 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "System/Platform/CpuTopology.h"
+#include <sys/sysctl.h>
+#include <thread>
+
+namespace cpu_topology {
+
+namespace {
+
+// Read an unsigned sysctl value by name. Returns 0 if the key is unavailable
+// (e.g. perflevel keys on Intel Macs or pre-Apple-Silicon kernels).
+unsigned int ReadSysctlUInt(const char* name) {
+	int value = 0;
+	size_t valueSize = sizeof(value);
+	if (sysctlbyname(name, &value, &valueSize, nullptr, 0) != 0)
+		return 0;
+	return (value > 0) ? static_cast<unsigned int>(value) : 0;
+}
+
+unsigned int BitsForCount(unsigned int n) {
+	if (n == 0) return 0;
+	if (n >= 32) return 0xFFFFFFFFu;
+	return (1u << n) - 1u;
+}
+
+} // namespace
+
+ThreadPinPolicy GetThreadPinPolicy() {
+	// macOS has no pthread_setaffinity_np equivalent. Scheduling locality is
+	// instead expressed via QOS classes; see Platform/Mac/ThreadSupport.cpp.
+	return THREAD_PIN_POLICY_NONE;
+}
+
+ProcessorMasks GetProcessorMasks() {
+	ProcessorMasks masks{};
+
+	// Apple Silicon exposes per-perflevel core counts. perflevel0 is the
+	// high-performance (P) cluster; perflevel1, when present, is the
+	// efficiency (E) cluster. Intel Macs and older kernels do not expose
+	// these keys; fall back to treating every core as a P-core there.
+	const unsigned int numPCores = ReadSysctlUInt("hw.perflevel0.physicalcpu");
+	const unsigned int numECores = ReadSysctlUInt("hw.perflevel1.physicalcpu");
+
+	if (numPCores > 0) {
+		masks.performanceCoreMask = BitsForCount(numPCores);
+		// E-cores occupy the bits above the P-cores in the combined mask.
+		const unsigned int totalCores = numPCores + numECores;
+		const unsigned int allMask = BitsForCount(totalCores);
+		masks.efficiencyCoreMask = allMask & ~masks.performanceCoreMask;
+	} else {
+		// Intel Mac / unknown topology: treat the visible core count as
+		// homogeneous P-cores. Matches prior behavior on those targets.
+		unsigned int numCores = std::thread::hardware_concurrency();
+		if (numCores == 0) numCores = 4;
+		masks.performanceCoreMask = BitsForCount(numCores);
+		masks.efficiencyCoreMask = 0;
+	}
+
+	// macOS does not expose SMT/HT details; report all visible cores as
+	// hyper-thread-low so callers consuming those masks stay consistent.
+	masks.hyperThreadLowMask = masks.performanceCoreMask | masks.efficiencyCoreMask;
+	masks.hyperThreadHighMask = 0;
+
+	return masks;
+}
+
+ProcessorCaches GetProcessorCache() {
+	ProcessorCaches caches;
+
+	ProcessorGroupCaches group;
+	unsigned int numCores = std::thread::hardware_concurrency();
+	if (numCores == 0) numCores = 4;
+	group.groupMask = BitsForCount(numCores);
+
+	// Try to get cache sizes via sysctl
+	size_t size = sizeof(uint64_t);
+	uint64_t cacheSize = 0;
+
+	if (sysctlbyname("hw.l1dcachesize", &cacheSize, &size, nullptr, 0) == 0)
+		group.cacheSizes[0] = static_cast<uint32_t>(cacheSize);
+
+	if (sysctlbyname("hw.l2cachesize", &cacheSize, &size, nullptr, 0) == 0)
+		group.cacheSizes[1] = static_cast<uint32_t>(cacheSize);
+
+	if (sysctlbyname("hw.l3cachesize", &cacheSize, &size, nullptr, 0) == 0)
+		group.cacheSizes[2] = static_cast<uint32_t>(cacheSize);
+
+	caches.groupCaches.push_back(group);
+	return caches;
+}
+
+} // namespace cpu_topology

--- a/rts/System/Platform/Mac/CpuTopology.cpp
+++ b/rts/System/Platform/Mac/CpuTopology.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
 
 #include "System/Platform/CpuTopology.h"
+#include "System/BitUtils.h"
 #include <sys/sysctl.h>
 #include <thread>
 
@@ -16,12 +17,6 @@ unsigned int ReadSysctlUInt(const char* name) {
 	if (sysctlbyname(name, &value, &valueSize, nullptr, 0) != 0)
 		return 0;
 	return (value > 0) ? static_cast<unsigned int>(value) : 0;
-}
-
-unsigned int BitsForCount(unsigned int n) {
-	if (n == 0) return 0;
-	if (n >= 32) return 0xFFFFFFFFu;
-	return (1u << n) - 1u;
 }
 
 } // namespace
@@ -43,17 +38,17 @@ ProcessorMasks GetProcessorMasks() {
 	const unsigned int numECores = ReadSysctlUInt("hw.perflevel1.physicalcpu");
 
 	if (numPCores > 0) {
-		masks.performanceCoreMask = BitsForCount(numPCores);
+		masks.performanceCoreMask = spring::LowBitsMask(numPCores);
 		// E-cores occupy the bits above the P-cores in the combined mask.
 		const unsigned int totalCores = numPCores + numECores;
-		const unsigned int allMask = BitsForCount(totalCores);
+		const unsigned int allMask = spring::LowBitsMask(totalCores);
 		masks.efficiencyCoreMask = allMask & ~masks.performanceCoreMask;
 	} else {
 		// Intel Mac / unknown topology: treat the visible core count as
 		// homogeneous P-cores. Matches prior behavior on those targets.
 		unsigned int numCores = std::thread::hardware_concurrency();
 		if (numCores == 0) numCores = 4;
-		masks.performanceCoreMask = BitsForCount(numCores);
+		masks.performanceCoreMask = spring::LowBitsMask(numCores);
 		masks.efficiencyCoreMask = 0;
 	}
 
@@ -71,7 +66,7 @@ ProcessorCaches GetProcessorCache() {
 	ProcessorGroupCaches group;
 	unsigned int numCores = std::thread::hardware_concurrency();
 	if (numCores == 0) numCores = 4;
-	group.groupMask = BitsForCount(numCores);
+	group.groupMask = spring::LowBitsMask(numCores);
 
 	// Try to get cache sizes via sysctl
 	size_t size = sizeof(uint64_t);

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -107,11 +107,16 @@ if (WIN32)
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/WinVersion.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/SharedLib.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/DllLib.cpp")
-else (WIN32)
+elseif (APPLE)
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Mac/CpuTopology.cpp")
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/Hardware.cpp")
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/SharedLib.cpp")
+	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/SoLib.cpp")
+else ()
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/CpuTopology.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/Hardware.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/ThreadSupport.cpp")
-endif (WIN32)
+endif ()
 
 set(unitsync_files
 	${sources_engine_System_FileSystem}


### PR DESCRIPTION
## What

Adds the platform pieces `unitsync` needs to build on macOS:

- **`System/Platform/Mac/CpuTopology.cpp`** — implements the `cpu_topology` API on macOS via `sysctl`. Splits performance vs efficiency cores using `hw.perflevel0/1.physicalcpu` on Apple Silicon (falls back to a homogeneous core count on Intel / older kernels), and returns `THREAD_PIN_POLICY_NONE` because macOS has no affinity-pinning API (scheduling locality is expressed as a QoS hint instead).
- **`tools/unitsync/CMakeLists.txt`** — an `elseif (APPLE)` branch in the per-platform source selection: pulls in the Mac `CpuTopology` plus the shared Linux `Hardware`/`SharedLib`/`SoLib` sources (the Linux `ThreadSupport` doesn't build on macOS).

## Result

`libunitsync.dylib` builds as a native **arm64** library under Homebrew GCC — verified locally (`file` reports `Mach-O 64-bit dynamically linked shared library arm64`, C API exports like `GetSpringVersion`/`GetMapCount` present).

## Notes

- Part of the macOS bring-up. To configure and compile cleanly it relies on the companion PRs (macOS CMake configure fixes, macOS threading: affinity/ThreadSupport, `FindSevenZip` `7zz`, `MemPoolTypes` thread-id). Each is independently correct; together they make the `unitsync` target build on Apple Silicon.
- No effect on Linux/Windows (additive `APPLE` branch + a new Mac-only file).
- The CpuTopology P/E split uses `hw.perflevel0`/`perflevel1` per earlier review feedback on the macOS PR.
- **"Builds" is verified; runtime correctness (reading a real game install, archive hash parity with the Linux build) is the next validation step and not yet done.**