### PR TITLE
macOS: add CpuTopology + SoLib to engine threading sources

### DIFF
--- a/rts/System/CMakeLists.txt
+++ b/rts/System/CMakeLists.txt
@@ -157,6 +157,8 @@ set(sources_engine_System_Platform_Windows
 
 set(sources_engine_System_Threading_Mac
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/Signal.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Mac/CpuTopology.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/SoLib.cpp"
 	)
 set(sources_engine_System_Threading_Linux
 		"${CMAKE_CURRENT_SOURCE_DIR}/Platform/Linux/CpuTopology.cpp"


### PR DESCRIPTION
## What

Adds `Platform/Mac/CpuTopology.cpp` and `Platform/Linux/SoLib.cpp` to `sources_engine_System_Threading_Mac`.

The macOS threading source list provided only `Signal.cpp`, whereas the Linux equivalent (`sources_engine_System_Threading_Linux`) also supplies `CpuTopology` and `SoLib`. Building **spring-dedicated** on macOS therefore failed at link:

```
Undefined symbols for architecture arm64:
  cpu_topology::GetProcessorCache() / GetProcessorMasks() / GetThreadPinPolicy()
  SoLib::SoLib(char const*) / SoLib::LoadFailed()
```

- `Platform/Mac/CpuTopology.cpp` — the macOS `cpu_topology` implementation (added in the unitsync-build PR; this wires it into the engine threading sources too).
- `Platform/Linux/SoLib.cpp` — `dlopen`-based shared-library loader; portable and used as-is on macOS (the Linux list groups it under threading).

## Notes

- Mac-only list — no effect on Linux/Windows.
- Part of the macOS bring-up stack. With this (plus the companion macOS PRs), `spring-dedicated` builds and runs as a native arm64 binary under Homebrew GCC — verified locally.
- Touches the same `sources_engine_System_Threading_Mac` block as the ThreadSupport PR (#3036); whichever merges second needs a trivial context rebase.