### PR TITLE
legacy: only require X11 on non-Apple UNIX

### DIFF
--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -49,7 +49,7 @@ find_freetype_hack() # hack to find different named freetype.dll
 find_package_static(Freetype 2.8.1 REQUIRED)
 list(APPEND engineLibraries Freetype::Freetype)
 
-if    (UNIX)
+if    (UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	target_link_libraries(Game PRIVATE X11::Xcursor)
 	list(APPEND engineLibraries ${X11_Xcursor_LIB} ${X11_X11_LIB})


### PR DESCRIPTION
## What

```diff
-if    (UNIX)
+if    (UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	target_link_libraries(Game PRIVATE X11::Xcursor)
```

## Why

The legacy build did `find_package(X11 REQUIRED)` under a plain `if(UNIX)` guard. macOS is `UNIX` in CMake but does not use X11 (it uses Cocoa), so configuring the engine on macOS failed at `find_package(X11)`. An `if(APPLE)` block already follows immediately (for Foundation), so this just excludes Apple from the X11 branch.

Surfaced configuring the `spring-headless` target on macOS (which reuses the legacy `Game` target). No effect on Linux/Windows.

---
*Assisted by Claude Code; verified by configuring the macOS build.*