### PR TITLE
FastMath: break macOS circular include for math::sqrtf

### DIFF
--- a/rts/System/FastMath.h
+++ b/rts/System/FastMath.h
@@ -8,6 +8,14 @@
 
 // Tell streflop_cond.h not to define math::sqrt(float) - we'll provide a faster one
 #define MATH_SQRT_OVERRIDE 1
+// streflop_cond.h includes this header back, and on macOS its std::hypot
+// fallback uses math::sqrtf before our definition below is reached (a circular
+// include). Provide an early declaration so that fallback resolves; the real
+// (faster) definition still follows further down.
+#ifdef __APPLE__
+#include <cmath>
+namespace math { inline float sqrtf(float x) { return std::sqrt(x); } }
+#endif
 #include "lib/streflop/streflop_cond.h"
 #include "System/MainDefines.h"
 #include "System/MathConstants.h"


### PR DESCRIPTION
## What

Adds an early `math::sqrtf` declaration on `__APPLE__`, before `FastMath.h` includes `streflop_cond.h`.

## Why

`streflop_cond.h` includes `FastMath.h`, and `FastMath.h` includes `streflop_cond.h` back — a circular include. On macOS, `streflop_cond.h` has a `std::hypot` fallback that calls `math::sqrtf`. When a TU enters via `FastMath.h` first, that hypot block runs *before* `FastMath.h` reaches its own `math::sqrtf` definition (further down the file), so the build fails:

```
rts/lib/streflop/streflop_cond.h:185: error: 'sqrtf' is not a member of 'math'
```

(hit while compiling streflop's own libm sources, e.g. `e_cosh.cpp`.)

The early declaration lets the fallback resolve; the real (faster) definition still follows. Guarded by `__APPLE__`; no effect on Linux/Windows.

Surfaced building the `spring-headless` target on macOS with Homebrew GCC.

---
*Assisted by Claude Code; verified by compiling the macOS headless build.*