### PR TITLE
CUtils: use const dirent* for the scandir selector on all platforms

### DIFF
--- a/AI/Wrappers/CUtils/Util.c
+++ b/AI/Wrappers/CUtils/Util.c
@@ -487,11 +487,7 @@ static void util_initFileSelector(const char* suffix) {
 	fileSelectorSuffix = suffix;
 }
 
-#if defined(__APPLE__)
-static int util_fileSelector(struct dirent* fileDesc) {
-#else
 static int util_fileSelector(const struct dirent* fileDesc) {
-#endif
 	return util_endsWith(fileDesc->d_name, fileSelectorSuffix);
 }
 


### PR DESCRIPTION
## What

`util_fileSelector` (the `scandir` selector) was declared with a **non-const** `struct dirent*` on `__APPLE__` and **const** elsewhere:

```c
#if defined(__APPLE__)
static int util_fileSelector(struct dirent* fileDesc) {
#else
static int util_fileSelector(const struct dirent* fileDesc) {
#endif
```

This drops the split and uses `const struct dirent*` unconditionally.

## Why

POSIX/macOS `scandir()` expects the selector as `int (*)(const struct dirent *)`, so the non-const Apple variant failed to compile under GCC:

```
AI/Wrappers/CUtils/Util.c:500: error: passing argument 3 of 'scandir' from incompatible pointer type
```

Both branches had otherwise identical bodies, so the `__APPLE__` split was both wrong (non-const on the one platform that needs const) and redundant. `const struct dirent*` is correct on Linux and Windows too.

Surfaced building the `spring-headless` target on macOS.

---
*Assisted by Claude Code; verified by compiling the macOS headless build.*