### PR TITLE
AGENTS.md: use the Recoil engine file header for new files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,10 +109,13 @@ ctest -N
 - Line endings: platform-appropriate (LF on Linux, CRLF on Windows)
 
 ### File Headers
-All source files must begin with the GPL license header:
+New source files must begin with the GPL license header:
 ```cpp
-/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
 ```
+Many existing files carry the older `Spring engine` header (Recoil is a fork of
+the Spring RTS engine); those do not need to be changed en masse, but new files
+should use the `Recoil engine` header above.
 
 ### Include Guards
 Use `#pragma once` for new headers, migrate ifdef guards to `#pragma once` whenever you edit a header file.


### PR DESCRIPTION
## What

Updates the **File Headers** section of `AGENTS.md` to recommend the `Recoil engine` license header for new files, instead of the legacy `Spring engine` one:

```diff
-/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
```

Also adds a note that existing `Spring engine` headers (Recoil is a fork of Spring) do **not** need a mass migration — this is guidance for new files only.

## Why

A number of files in the tree already use the `Recoil engine` header, and it came up in review that new files should follow that convention rather than the documented `Spring engine` one. This aligns the doc with the intended convention.

---
*Assisted by Claude Code.*