### PR TITLE
unitsync: link generic cpu_topology instead of per-platform detection

### DIFF
--- a/rts/System/Platform/CpuTopologyGeneric.cpp
+++ b/rts/System/Platform/CpuTopologyGeneric.cpp
@@ -1,0 +1,45 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+// Generic, platform-agnostic cpu_topology implementation for tool builds
+// (e.g. unitsync) that link the thread pool for parallel work but never pin
+// threads. It reports every logical core as a single group of performance
+// cores with no P/E split, no SMT/hyper-threading distinction and no cache
+// grouping, and requests no thread pinning. This satisfies the three
+// cpu_topology symbols pulled in by CpuID/Threading without dragging in the
+// real per-platform topology detection (Platform/{Linux,Win,Mac}/CpuTopology.cpp).
+//
+// The engine and dedicated server do NOT use this; they link the real
+// per-platform implementation for sim-worker pinning.
+
+#include "CpuTopology.h"
+
+#include <algorithm>
+#include <thread>
+
+namespace cpu_topology {
+
+ThreadPinPolicy GetThreadPinPolicy() {
+	return THREAD_PIN_POLICY_NONE;
+}
+
+ProcessorMasks GetProcessorMasks() {
+	ProcessorMasks processorMasks;
+
+	// Masks are 32 bits wide; cap to match the real per-platform implementations
+	// (MAX_CPUS == 32). Treat every logical core as a performance core so that
+	// CPUID::EnumerateCores() derives a correct logical-core count for the pool.
+	const unsigned int logicalCores = std::min(32u, std::thread::hardware_concurrency());
+
+	processorMasks.performanceCoreMask =
+		(logicalCores >= 32u) ? ~0u : ((1u << logicalCores) - 1u);
+
+	return processorMasks;
+}
+
+ProcessorCaches GetProcessorCache() {
+	// No cache grouping: the only consumers (the affinity/pinning helpers in
+	// Threading.cpp) are never reached on the tool path.
+	return ProcessorCaches{};
+}
+
+} // namespace cpu_topology

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -82,6 +82,10 @@ set(main_files
 	"${ENGINE_SRC_ROOT}/System/Misc/SpringTime.cpp"
 	"${ENGINE_SRC_ROOT}/System/Platform/CpuID.cpp"
 	"${ENGINE_SRC_ROOT}/System/Platform/CpuTopologyCommon.cpp"
+	## unitsync needs the thread pool (for parallel archive scanning) but never
+	## pins threads, so it links a generic cpu_topology instead of the real
+	## per-platform Platform/{Linux,Win,Mac}/CpuTopology.cpp detection.
+	"${ENGINE_SRC_ROOT}/System/Platform/CpuTopologyGeneric.cpp"
 	"${ENGINE_SRC_ROOT}/System/Platform/Misc.cpp"
 	"${ENGINE_SRC_ROOT}/System/Platform/ScopedFileLock.cpp"
 	"${ENGINE_SRC_ROOT}/System/Platform/Threading.cpp"
@@ -102,20 +106,24 @@ set(main_files
 	"${ENGINE_SRC_ROOT}/System/StringUtil.cpp"
 	)
 if (WIN32)
-	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/CpuTopology.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/Hardware.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/WinVersion.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/SharedLib.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Win/DllLib.cpp")
 else (WIN32)
-	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/CpuTopology.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/Hardware.cpp")
 	list(APPEND main_files "${ENGINE_SRC_ROOT}/System/Platform/Linux/ThreadSupport.cpp")
 endif (WIN32)
 
+# The shared engine threading source list pulls in the real per-platform
+# Platform/{Linux,Win,Mac}/CpuTopology.cpp. unitsync links a generic
+# cpu_topology instead (see main_files above), so strip the platform file here.
+set(unitsync_threading_files ${sources_engine_System_Threading})
+list(FILTER unitsync_threading_files EXCLUDE REGEX "Platform/(Linux|Win|Mac)/CpuTopology\\.cpp$")
+
 set(unitsync_files
 	${sources_engine_System_FileSystem}
-	${sources_engine_System_Threading}
+	${unitsync_threading_files}
 	${sources_engine_System_Log}
 	${sources_engine_System_Log_sinkFile}
 	${sources_engine_System_Log_sinkOutputDebugString}


### PR DESCRIPTION
## What

unitsync links a generic, platform-agnostic `cpu_topology` implementation instead of the per-platform `Platform/{Linux,Win,Mac}/CpuTopology.cpp`, removing unitsync's dependency on real CPU topology detection on all platforms.

This is an alternative to #3042's "add `Mac/CpuTopology.cpp` to unitsync" — it instead makes unitsync stop needing per-platform topology at all, which is what @sprunk asked for on that PR.

## Why

unitsync wraps `FileSystemInitializer::Initialize()` in the thread pool so archive scanning/hashing parallelizes via `for_mt`, so it genuinely needs the pool. It does **not** pin threads, so it does not need real CPU topology (P/E core masks, cache groups, pin policy).

The dependency was incidental: `CPUID::EnumerateCores()` (called from the `CPUID` singleton ctor) eagerly calls `cpu_topology::GetProcessorMasks()` + `GetProcessorCache()`, and `Threading::GetChosenThreadPinPolicy()` calls `cpu_topology::GetThreadPinPolicy()`. Those are link-time references in TUs unitsync compiles, so it had to link a per-platform `CpuTopology.cpp` even though it never pins.

## Approach

A generic `CpuTopologyGeneric.cpp` reports every logical core as a single group of performance cores (so `CPUID::EnumerateCores()` still derives a correct logical-core count for the pool) and requests `THREAD_PIN_POLICY_NONE`. unitsync links that instead of the per-platform file. The change is contained to `tools/unitsync/CMakeLists.txt` + the new file; **no shared engine CMake or threading logic is touched**, so the engine/dedicated server keep linking the real per-platform topology for sim-worker pinning.

### Note on the "make CPUID lazy" alternative

An earlier idea was to make `CPUID::EnumerateCores()` compute topology lazily so the core-count path wouldn't pull `cpu_topology`. That does **not** work for unitsync: it's a `SHARED` library and on macOS/Windows the build sets no `-fvisibility=hidden` (gated to Linux in `TestCXXFlags.cmake`), so the `Threading`/`CpuTopologyCommon` free functions that reference the symbols stay exported and can't be dead-stripped. Deferring *when* a call runs doesn't remove a link-time *reference*. So a generic impl is the approach that actually drops the per-platform file.

This satisfies the dependency with a trivial stub rather than eliminating the symbol references entirely; a literal "drop" would require `#ifdef UNITSYNC` stubs through `CpuID.cpp`/`Threading.cpp`/`CpuTopologyCommon.cpp` (shared core files). Happy to go that route instead if preferred.

## Verification

Built `unitsync` on macOS (Homebrew GCC 16):
- Links cleanly.
- Link line contains `CpuTopologyGeneric.cpp.o`, not `Mac/CpuTopology.cpp.o`.
- `nm` on `libunitsync.dylib`: zero undefined `cpu_topology` symbols; none of the real platform internals (`detect_cpu_vendor`, `collect_intel`, `get_thread_siblings`) are linked.

Engine targets are untouched in their source wiring, so they keep the real topology.

Refs #3042.

*Assisted by Claude Code; verified by building on macOS.*
