### PR TITLE
Use system SDL2 on Linux instead of Conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ endif (RECOIL_DETAILED_TRACY_ZONING)
 
 # Note the missing REQUIRED, as headless & dedi may not depend on those.
 #  So req. checks are done in the build target's CMakeLists.txt.
-find_package(SDL2)
+find_package(SDL2 MODULE)
 
 find_package_static(DevIL 1.8.0 REQUIRED)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,12 @@ class RecoilConan(ConanFile):
         self.requires("zstd/1.5.7", override=True)
         self.requires("ogg/1.3.5")
         self.requires("vorbis/1.3.7")
-        self.requires("sdl/2.32.10")
+        # On Linux we link against the system SDL2: the Conan recipe hard-links
+        # Wayland/EGL into the binary instead of dlopen-ing them at runtime (unlike
+        # X11), which breaks SDL's portable Linux model. On Windows there's no system
+        # SDL2 to rely on, so we take it from Conan.
+        if self.settings.os == "Windows":
+            self.requires("sdl/2.32.10")
         self.requires("libcurl/8.19.0")
         # There newer 3.5.* and 3.6.* branches fail to compile for us on mingw version
         # we use at the moment due to https://github.com/openssl/openssl/issues/29818
@@ -33,9 +38,10 @@ class RecoilConan(ConanFile):
         self.requires("openal-soft/1.23.1")
 
     def configure(self):
-        self.options["sdl"].shared = False
-        self.options["sdl"].vulkan = False
-        self.options["sdl"].opengles = False
+        if self.settings.os == "Windows":
+            self.options["sdl"].shared = False
+            self.options["sdl"].vulkan = False
+            self.options["sdl"].opengles = False
         self.options["zlib"].shared = False
         self.options["libcurl"].shared = False
         self.options["libcurl"].with_ssl = "openssl"  # Want openssl on all platforms
@@ -57,11 +63,6 @@ class RecoilConan(ConanFile):
         self.options["libcurl"].with_form_api = False
         self.options["libcurl"].with_websockets = False
 
-        if self.settings.os == "Linux":
-            self.options["sdl"].wayland = True
-            self.options["sdl"].pulse = False
-            self.options["sdl"].alsa = False
-            self.options["sdl"].hidapi = False
         if self.settings_build.os == "Windows":
             self.options["sdl"].directx = False
 

--- a/docker-build-v2/images/all-linux/Dockerfile
+++ b/docker-build-v2/images/all-linux/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
  && apt-get install --no-install-recommends --yes \
     file curl gcc-13 g++-13 git ninja-build curl p7zip-full \
     pkg-config python3.8 python3.8-distutils jq \
+    libsdl2-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 10 \

--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -46,7 +46,7 @@ if    (NOT NO_SOUND)
 	find_package_static(OpenAL 1.18.2 REQUIRED)
 	find_package_static(OggVorbis 1.3.4 REQUIRED)
 
-	find_package(SDL2 REQUIRED)
+	find_package(SDL2 MODULE REQUIRED)
 
 	include_directories(${CMAKE_SOURCE_DIR}/include/)
 	include_directories(${CMAKE_SOURCE_DIR}/include/AL)

--- a/rts/build/cmake/FindSDL2.cmake
+++ b/rts/build/cmake/FindSDL2.cmake
@@ -1,0 +1,40 @@
+# Locate SDL2 and provide the SDL2::SDL2 imported target.
+#
+# Two cases are supported:
+#  - A SDL2 CMake config package is available (e.g. provided by Conan on Windows).
+#    It is used directly and exposes SDL2::SDL2.
+#  - No config package (e.g. Linux, where we link against the system libsdl2-dev,
+#    which is too old to ship a usable CMake config). We locate it via pkg-config.
+#    Only glibc and SDL2 are linked; SDL dlopen()s X11/Wayland/EGL at runtime, which
+#    is SDL's recommended portable Linux behaviour.
+
+# Prefer a config package if one is available.
+find_package(SDL2 CONFIG QUIET)
+if (SDL2_FOUND AND TARGET SDL2::SDL2)
+	return()
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_SDL2 QUIET sdl2)
+
+find_path(SDL2_INCLUDE_DIR
+	NAMES SDL.h
+	HINTS ${PC_SDL2_INCLUDE_DIRS}
+	PATH_SUFFIXES SDL2
+)
+find_library(SDL2_LIBRARY
+	NAMES SDL2
+	HINTS ${PC_SDL2_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SDL2 DEFAULT_MSG SDL2_LIBRARY SDL2_INCLUDE_DIR)
+mark_as_advanced(SDL2_INCLUDE_DIR SDL2_LIBRARY)
+
+if (SDL2_FOUND AND NOT TARGET SDL2::SDL2)
+	add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+	set_target_properties(SDL2::SDL2 PROPERTIES
+		INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
+		IMPORTED_LOCATION "${SDL2_LIBRARY}"
+	)
+endif()

--- a/rts/builds/legacy/CMakeLists.txt
+++ b/rts/builds/legacy/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(Game PRIVATE
 )
 
 ### Assemble libraries
-find_package(SDL2 REQUIRED)
+find_package(SDL2 MODULE REQUIRED)
 
 set(engineLibraries SDL2::SDL2)
 

--- a/rts/lib/headlessStubs/CMakeLists.txt
+++ b/rts/lib/headlessStubs/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(headlessStubsSources
 		"sdlstub.c"
 	)
 
-find_package(SDL2 REQUIRED)
+find_package(SDL2 MODULE REQUIRED)
 
 ADD_LIBRARY(headlessStubs STATIC EXCLUDE_FROM_ALL ${headlessStubsSources})
 target_link_libraries(headlessStubs PUBLIC $<COMPILE_ONLY:SDL2::SDL2>)

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -25,7 +25,7 @@ if (WIN32)
 	list(APPEND unitsync_libs ${WINMM_LIBRARY})
 endif (WIN32)
 
-find_package(SDL2 REQUIRED)
+find_package(SDL2 MODULE REQUIRED)
 list(APPEND unitsync_libs SDL2::SDL2)
 
 if    (MINGW)


### PR DESCRIPTION
Stacked on top of #2900 (the Conan migration). Targets the `conan` branch.

## Problem

The conan-center SDL2 recipe hard-links Wayland/EGL into the binary instead of letting SDL `dlopen()` them at runtime — unlike X11, which the recipe already lets SDL load dynamically. Concretely the recipe ties `SDL_WAYLAND_SHARED` to the (static) conan `wayland` dependency and force-injects `wayland`/`xkbcommon`/`egl` into the consumer link line. The result is the runtime Wayland breakage reported in #2900 (segfaults unless `EGL_PLATFORM=wayland` is set).

This is Marek's sanctioned **option 1**: keep taking SDL2 from the system on Linux (where the distro `libSDL2.so` already follows SDL's portable "link glibc, dlopen the rest" model), and only use the Conan SDL2 on Windows where there's no system SDL2 to rely on.

An upstream fix for the recipe itself is tracked in conan-io/conan-center-index#30465 — if accepted, Linux could take SDL2 from Conan again and this workaround could be retired.

## Changes

- `conanfile.py` — require & configure `sdl` only on Windows
- `docker-build-v2/images/all-linux/Dockerfile` — install `libsdl2-dev`
- `rts/build/cmake/FindSDL2.cmake` — restored: use a Conan config package if present, otherwise locate the system SDL2 via pkg-config
- `find_package(SDL2 MODULE ...)` at the call sites — needed because Conan's toolchain sets `CMAKE_FIND_PACKAGE_PREFER_CONFIG ON` and Ubuntu 18.04's `sdl2-config.cmake` (2.0.8) sets `SDL2_LIBRARIES` but defines **no** `SDL2::SDL2` target; without `MODULE` the finder is bypassed and the target is never created

## Verification

Built natively on `arm64-linux` (image + engine) and inspected the link signature:

- `conan graph info`: SDL/Wayland/EGL gone from the Linux graph; `sdl/2.32.10` still present for Windows
- engine compiles (`rc=0`)
- `readelf -d spring`: links `libSDL2-2.0.so.0` (system, dynamic), `libX11`/`libXcursor` (the engine's own usage), and **no** `libwayland*` / `libEGL` direct entries — matching the current working release
- `spring-headless` / `spring-dedicated`: no SDL (stub only)

## Caveats

- Runtime not exercised — only the link signature was verified (no display on the build host). It now matches the known-good release linkage; a live X11 + Wayland run would close the loop.
- `libstdc++.so.6` still appears as a `NEEDED` entry on `spring`; that's a pre-existing item on the `conan` branch, unrelated to this change.

Draft pending a runtime check and review.
