### PR TITLE
macOS: symbolicate arm64 crashes with atos -arch arm64

### DIFF
--- a/rts/System/Platform/Mac/CrashHandler.cpp
+++ b/rts/System/Platform/Mac/CrashHandler.cpp
@@ -73,7 +73,7 @@ static void TranslateStackTrace(StackTrace& stacktrace, const int logLevel)
 			stackFrame.path = "";
 		}
 
-		LOG_L(L_DEBUG, "\tsymbol = \"%s\", path = \"%s\", addr = 0x%lx", stackFrame.symbol.c_str(), path, stackFrame.ip);
+		LOG_L(L_DEBUG, "\tsymbol = \"%s\", path = \"%s\", addr = %p", stackFrame.symbol.c_str(), path, stackFrame.ip);
 	}
 
 	LOG_L(L_DEBUG, "[%s][2]", __func__);
@@ -116,7 +116,11 @@ static void TranslateStackTrace(StackTrace& stacktrace, const int logLevel)
 		execCommandString.clear();
 		stackFrameIndices.clear();
 
+	#if defined(__aarch64__) || defined(__arm64__)
+		execCommandBuffer << ADDR2LINE << " -o " << modulePath << " -arch arm64 -l " << std::hex << addrPathPair.first;
+	#else
 		execCommandBuffer << ADDR2LINE << " -o " << modulePath << " -arch x86_64 -l " << std::hex << addrPathPair.first;
+	#endif
 
 		// insert requested addresses that should be translated by atos
 		int i = 0;

--- a/rts/System/Platform/Mac/CrashHandler.cpp
+++ b/rts/System/Platform/Mac/CrashHandler.cpp
@@ -116,11 +116,14 @@ static void TranslateStackTrace(StackTrace& stacktrace, const int logLevel)
 		execCommandString.clear();
 		stackFrameIndices.clear();
 
-	#if defined(__aarch64__) || defined(__arm64__)
-		execCommandBuffer << ADDR2LINE << " -o " << modulePath << " -arch arm64 -l " << std::hex << addrPathPair.first;
+	#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
+		constexpr const char* atosArch = "x86_64";
+	#elif defined(__aarch64__) || defined(_M_ARM64)
+		constexpr const char* atosArch = "arm64";
 	#else
-		execCommandBuffer << ADDR2LINE << " -o " << modulePath << " -arch x86_64 -l " << std::hex << addrPathPair.first;
+		#error "Unsupported architecture"
 	#endif
+		execCommandBuffer << ADDR2LINE << " -o " << modulePath << " -arch " << atosArch << " -l " << std::hex << addrPathPair.first;
 
 		// insert requested addresses that should be translated by atos
 		int i = 0;


### PR DESCRIPTION
## What

Two fixes to the macOS crash handler (`rts/System/Platform/Mac/CrashHandler.cpp`):

1. **arm64 symbolication.** `TranslateStackTrace` invoked `atos` (`ADDR2LINE`) with a hardcoded `-arch x86_64`. On Apple Silicon that arch doesn't match the running binary, so symbolication produced no useful output. Select `-arch arm64` at compile time on `__aarch64__`/`__arm64__` targets, keeping `x86_64` for Intel.

2. **Format/argument mismatch.** The debug log of the frame address used `0x%lx` against `stackFrame.ip`, which is a `void*` — a format/argument mismatch (UB). Changed to `%p`.

## Why

Surfaced bringing up the native macOS (Apple Silicon) build. Without (1), a crash backtrace on arm64 is unsymbolicated and effectively useless for debugging.

## Safety

macOS-only file. The arch selection is compile-time, so a binary embeds the `atos -arch` matching the architecture it runs on. No effect on Linux/Windows.

Verified by inspection; macOS isn't in CI yet. Part of the "big mac" bring-up; an independent change extracted while reviewing #3060 (which re-derived the same arm64 fix).
