### PR TITLE
macOS: guard X11/Xlib.h include for non-X11 platforms

### DIFF
--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -13,7 +13,9 @@
 #undef KeyRelease
 #else
 #include <unistd.h> // isatty
+#ifndef __APPLE__
 #include <X11/Xlib.h> // XInitThreads
+#endif
 
 #undef KeyPress
 #undef KeyRelease


### PR DESCRIPTION
## What

Guard the `<X11/Xlib.h>` include in `rts/System/SpringApp.cpp` with `#ifndef __APPLE__`.

The include sat in the `#else` of `#ifdef _WIN32`, so every non-Windows platform pulled it in. macOS has no X11 headers by default, which breaks the native build at this include.

Its only consumer, `XInitThreads()` in `InitPlatformLibs()`, is already excluded on `__APPLE__` at the call site:

```cpp
#if !(defined(_WIN32) || defined(__APPLE__) || defined(HEADLESS)) || defined(__OpenBSD__)
    if (!XInitThreads()) { ... }
#endif
```

so guarding the include the same way leaves no dangling reference.

## Safety

Additive guard. Linux/Windows/BSD builds are unaffected (they still get the include and the call). macOS stops including a header it doesn't have.

Verified by inspection; macOS isn't in CI yet. Part of the "big mac" bring-up; extracted while reviewing #3060.
