### PR TITLE
Move `isHeadless` from `Engine` to `Platform`.

### DIFF
--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -74,7 +74,7 @@ This is the bleeding-edge changelog since version 2025.06, for **pre-release 202
 - add `Spring.GetClosestEnemyUnit(x, y, z, range = inf, allyTeamID, bool useLoS = true, bool spherical = false, bool requireEnemyToSeePos = false) → unitID?` to LuaRules.
 - large QTPFS perf improvements.
 - always output logs to stdout.
-- add `Engine.isHeadless`, available in unsynced only.
+- add boolean `Platform.isHeadless`.
 - archive cache version 20 → 21.
 
 ## Fixes

--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -59,9 +59,6 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "buildFlags"     , SpringVersion::GetAdditional());
 	LuaPushNamedNumber(L, "wordSize", (!CLuaHandle::GetHandleSynced(L))? Platform::NativeWordSize() * 8: 0);
 
-	if (!CLuaHandle::GetHandleSynced(L))
-		LuaPushNamedBool(L, "isHeadless", SpringVersion::IsHeadless());
-
 	LuaPushNamedNumber(L, "gameSpeed", GAME_SPEED);
 	LuaPushNamedNumber(L, "maxCustomPaletteID", MAX_CUSTOM_COLORS - 1);
 

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -2,6 +2,7 @@
 
 #include "LuaConstPlatform.h"
 #include "LuaUtils.h"
+#include "Game/GameVersion.h"
 #include "System/Platform/Hardware.h"
 #include "System/Platform/Misc.h"
 #include "Rendering/GlobalRendering.h"
@@ -146,6 +147,9 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "sysInfoHash", Platform::GetSysInfoHash());
 	/*** @field Platform.macAddrHash string */
 	LuaPushNamedString(L, "macAddrHash", Platform::GetMacAddrHash());
+
+	/*** @field Platform.isHeadless boolean Is this a headless build which only simulates and doesnt offer interactive IO? */
+	LuaPushNamedBool(L, "isHeadless", SpringVersion::IsHeadless());
 
 	return true;
 }


### PR DESCRIPTION
New var so nobody uses it yet. `Platform` feels more appropriate since in the release version, everything there is unsynced and everything in `Engine` is synced.