### PR TITLE
DemoTool: link nowide and fmt for their include directories

### DIFF
--- a/tools/DemoTool/CMakeLists.txt
+++ b/tools/DemoTool/CMakeLists.txt
@@ -70,6 +70,8 @@ target_link_libraries(demotool
 		gflags_nothreads_static
 		7zip
 		${ZLIB_LIBRARY}
+		nowide::nowide
+		fmt::fmt
 		${PLATFORM_LIBS}
 		Tracy::TracyClient
 	)


### PR DESCRIPTION
## What

Add `nowide::nowide` and `fmt::fmt` to the `demotool` target's `target_link_libraries` in `tools/DemoTool/CMakeLists.txt`.

## Why

DemoTool compiles engine FileSystem sources (`FileHandler`, `FileSystem`) which include `nowide/fstream.hpp` and `fmt/printf.h`. The engine builds obtain those include directories transitively through the `nowide::nowide` and `fmt::fmt` INTERFACE targets, but the `demotool` target linked neither, so the build failed when the headers were not on a default compiler search path:

```
rts/System/FileSystem/FileHandler.h:9: fatal error: nowide/fstream.hpp: No such file or directory
rts/System/FileSystem/FileSystem.cpp:19: fatal error: fmt/printf.h: No such file or directory
```

This was observed building the `demotool` target on macOS (Homebrew GCC), where these bundled-library headers are not on a default include path. Linking the two INTERFACE targets propagates their include directories to `demotool`.

## Testing

- `cmake --build <dir> --target demotool` previously failed at the includes above; with this change it builds and links cleanly, producing a working `demotool` binary (verified on macOS arm64). No behavioural change to the tool.

## AI usage disclosure

CMake change identified and drafted with AI assistance (Claude); reviewed and build-verified by a human.