### PR TITLE
Fix demotool build and truncated sync checksum dump

### DIFF
--- a/tools/DemoTool/CMakeLists.txt
+++ b/tools/DemoTool/CMakeLists.txt
@@ -70,6 +70,8 @@ target_link_libraries(demotool
 		gflags_nothreads_static
 		7zip
 		${ZLIB_LIBRARY}
+		nowide::nowide
+		fmt::fmt
 		${PLATFORM_LIBS}
 		Tracy::TracyClient
 	)

--- a/tools/DemoTool/DemoTool.cpp
+++ b/tools/DemoTool/DemoTool.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <iostream>
@@ -417,7 +418,7 @@ void TrafficDump(CDemoReader& reader, bool trafficStats)
 				//uchar myPlayerNum; int frameNum; uint checksum;
 				std::cout << "NETMSG_SYNCRESPONSE: Playernum: "<< (unsigned)buffer[1];
 				std::cout << " Framenum: " << *(int*)(buffer+2);
-				std::cout << " Checksum: " << (unsigned)buffer[6];
+				std::cout << " Checksum: " << *(uint32_t*)(buffer+6);
 				std::cout << std::endl;
 				break;
 			case NETMSG_DIRECT_CONTROL:


### PR DESCRIPTION
Makes the `demotool` target build again and fixes the truncated sync-checksum value in its packet dump.

## Attribution

This builds directly on #3030 by @burnhamrobertp, which first diagnosed both the build breakage and the checksum bug. Credit for the investigation and the fixes belongs to @burnhamrobertp:

- The checksum fix here is their commit **verbatim**, with original authorship preserved.
- The build-fix commit is **co-authored** with @burnhamrobertp (`Co-authored-by`), differing only in using the canonical CMake INTERFACE targets.

This PR exists to combine both fixes with a slightly tidier CMake approach; it is not intended to supersede the credit due to #3030. Happy to defer to #3030 instead if the maintainers prefer.

## Changes

1. **Build fix** (`tools/DemoTool/CMakeLists.txt`)
   DemoTool compiles engine FileSystem sources (`FileHandler`, `FileSystem`) which include `nowide/fstream.hpp` and `fmt/printf.h`. The `demotool` target linked neither library, so it failed on those headers once #2235 (the UTF-8 paths rework) pulled nowide/fmt into the filesystem code:
   ```
   fatal error: nowide/fstream.hpp: No such file or directory
   fatal error: fmt/printf.h: No such file or directory
   ```
   This links the `nowide::nowide` and `fmt::fmt` INTERFACE targets so their include directories propagate to `demotool`. (#3030 fixed the same root cause via a hardcoded `include_directories(.../lib/nowide/include)` and a raw `fmt` link; using the canonical interface targets is more robust to layout changes.)

2. **Checksum fix** (`tools/DemoTool/DemoTool.cpp`) — by @burnhamrobertp
   The packet dump printed only one byte of the 4-byte sync checksum. Reads and prints the full `uint32_t` (and adds the missing `<cstdint>` include).

## Testing

- Builds cleanly with `cmake --build <build-dir> --target demotool` and produces a working binary (verified on macOS arm64 / Homebrew GCC 16; #3030 verified the same fixes on Linux).
- Note: a full macOS demotool build also currently requires the unrelated FastMath circular-include fix (#3046); this PR is independent of that and builds clean on platforms where that issue is not present (e.g. Linux) or once #3046 lands.

Closes #2764.

## AI usage disclosure

Changes assembled with AI assistance (Claude Code); reviewed and build-verified by a human. The checksum fix originates from #3030 (also developed with Claude Code) and retains its original author, @burnhamrobertp.