### PR TITLE
glad: do not build the GLX loader on macOS

### DIFF
--- a/rts/lib/glad/CMakeLists.txt
+++ b/rts/lib/glad/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(Glad)
 
-if    (UNIX AND NOT MINGW)
+if    (UNIX AND NOT MINGW AND NOT APPLE)
 	add_library(glad glad.c glad_glx.c)
-else  (UNIX AND NOT MINGW)
+else  (UNIX AND NOT MINGW AND NOT APPLE)
 	add_library(glad glad.c)
-endif (UNIX AND NOT MINGW)
+endif (UNIX AND NOT MINGW AND NOT APPLE)
 
 target_include_directories(glad PUBLIC /)


### PR DESCRIPTION
## What

Exclude `glad_glx.c` from the `glad` library on macOS (`APPLE`).

## Why

`glad_glx.c` includes `X11/X.h` to provide the GLX windowing-system bindings, but macOS has no X11/GLX. The Glad CMakeLists added `glad_glx.c` for every `UNIX AND NOT MINGW` platform, which includes macOS, so building any GL-enabled target (e.g. `engine-legacy`) on macOS fails immediately:

```
fatal error: X11/X.h: No such file or directory
```

macOS resolves GL entry points without GLX, and the engine's `glxHandler.cpp` is already `#ifdef`'d out on `__APPLE__`, so nothing references the GLX loader there. This builds only the core `glad.c` on Apple.

## Testing

- `cmake --build <build-dir> --target glad` previously failed on the `X11/X.h` include; with this change the `glad` target builds cleanly on macOS arm64 (Homebrew GCC 16). No change on Linux/Windows (still build `glad_glx.c` / Windows path as before).

## AI usage disclosure

Identified and drafted with AI assistance (Claude Code); reviewed and build-verified by a human.