### PR TITLE
sound: use openal-soft instead of the frozen system OpenAL on macOS

### DIFF
--- a/rts/System/Sound/CMakeLists.txt
+++ b/rts/System/Sound/CMakeLists.txt
@@ -44,6 +44,26 @@ if    (NOT NO_SOUND)
 			OpenAL/VorbisShared.cpp
 		)
 
+	if    (APPLE)
+		# macOS' system OpenAL.framework is frozen at a pre-EFX version and does
+		# not ship efx.h / alext.h, so the EFX sound code cannot build (nor would
+		# it work) against it. Prefer openal-soft, which implements EFX. Homebrew
+		# installs it keg-only, so locate it explicitly and search it ahead of
+		# system frameworks.
+		find_program(BREW_COMMAND brew)
+		if    (BREW_COMMAND)
+			execute_process(
+				COMMAND ${BREW_COMMAND} --prefix openal-soft
+				OUTPUT_VARIABLE OPENAL_SOFT_PREFIX
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+				ERROR_QUIET)
+			if    (OPENAL_SOFT_PREFIX AND IS_DIRECTORY "${OPENAL_SOFT_PREFIX}")
+				list(PREPEND CMAKE_PREFIX_PATH "${OPENAL_SOFT_PREFIX}")
+				set(CMAKE_FIND_FRAMEWORK LAST)
+			endif ()
+		endif (BREW_COMMAND)
+	endif (APPLE)
+
 	find_package_static(OpenAL 1.18.2 REQUIRED)
 	find_package_static(OggVorbis 1.3.4 REQUIRED)
 


### PR DESCRIPTION
## What

On macOS, steer `find_package(OpenAL)` toward **openal-soft** instead of the system `OpenAL.framework`.

## Why

macOS' system `OpenAL.framework` is frozen at a pre-EFX version and does not ship `efx.h` / `alext.h`. With `find_package(OpenAL)` selecting it, the EFX sound code fails to compile (and would not work at runtime even if it did):

```
fatal error: efx.h: No such file or directory
fatal error: alext.h: No such file or directory
```

openal-soft implements EFX, but Homebrew installs it **keg-only**, so it is not on the default search path and `find_package` keeps picking the framework. On `APPLE`, this locates the keg via `brew --prefix openal-soft`, prepends it to `CMAKE_PREFIX_PATH`, and sets `CMAKE_FIND_FRAMEWORK LAST` so openal-soft's headers/library are found ahead of the framework. It falls back to the previous behaviour when brew / openal-soft are unavailable.

Requires `openal-soft` to be installed (`brew install openal-soft`).

## Testing

- Before: building the `sound` target on macOS failed on the `efx.h` / `alext.h` includes shown above.
- After (with `openal-soft` installed): `find_package(OpenAL)` resolves to `/opt/homebrew/opt/openal-soft` (verified in the cache), and the OpenAL/EFX include errors are gone. Remaining build errors on plain `master` are unrelated, pre-existing macOS portability issues (FastMath circular include, MemPool thread-id cast) tracked separately; with those present the `sound` target builds cleanly on macOS arm64 (Homebrew GCC 16). No change on non-Apple platforms.

## AI usage disclosure

Identified and drafted with AI assistance (Claude Code); reviewed and build-verified by a human.