### PR TITLE
macOS: compile Objective-C sources with clang when building with GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,30 @@ else  (APPLE)
 	set(MACOSX_BUNDLE FALSE)
 endif (APPLE)
 
+# Objective-C / Objective-C++ are needed for some macOS platform integration
+# (e.g. Metal presentation glue in the renderer). GCC on macOS cannot target
+# Apple's Objective-C runtime, so when the engine is built with GCC we route
+# .m / .mm sources to clang while everything else keeps building with GCC.
+# CMake selects the compiler per source language (.m -> OBJC, .mm -> OBJCXX)
+# and links libc++ for such targets automatically, so no per-file or
+# per-target handling is required. Objective-C sources used this way must keep
+# an extern "C" boundary: clang compiles them against libc++, so no C++
+# standard-library types may cross to the libstdc++ side of the engine.
+if    (APPLE)
+	if    (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		find_program(OBJC_CLANG   NAMES clang)
+		find_program(OBJCXX_CLANG NAMES clang++)
+		if    (NOT OBJC_CLANG OR NOT OBJCXX_CLANG)
+			message(FATAL_ERROR "Building on macOS with GCC requires clang/clang++ for Objective-C sources, but they were not found")
+		endif ()
+		set(CMAKE_OBJC_COMPILER   "${OBJC_CLANG}")
+		set(CMAKE_OBJCXX_COMPILER "${OBJCXX_CLANG}")
+		message(STATUS "macOS: compiling Objective-C/C++ with clang (${OBJCXX_CLANG}); C/C++ use ${CMAKE_CXX_COMPILER}")
+	endif ()
+	enable_language(OBJC)
+	enable_language(OBJCXX)
+endif (APPLE)
+
 ### Compiler flags and defines based on build type
 include(TestCXXFlags)
 


### PR DESCRIPTION
## What

On macOS, enable the `OBJC`/`OBJCXX` languages and — when the C/C++ compiler is GCC — route Objective-C / Objective-C++ (`.m` / `.mm`) sources to **clang**, while the rest of the engine keeps building with GCC.

## Why

GCC on macOS cannot target Apple's Objective-C runtime, so any `.m` / `.mm` source fails to build (or interoperate) under a GCC toolchain. macOS platform integration in the renderer needs a small amount of Objective-C (e.g. Metal presentation glue), so today the only way to compile those few files is to build the **entire** engine with AppleClang.

This lets the engine stay on GCC for everything except the handful of Objective-C files. CMake selects a compiler per source language (`.m`→OBJC, `.mm`→OBJCXX, `.c`/`.cpp`→C/CXX), so Objective-C sources are routed to clang **automatically** — no per-file or per-target handling. CMake also links `libc++` for targets containing those objects automatically.

This is deliberately a standalone, atomic change so that both in-flight macOS renderer efforts (the Mesa/Zink path #2991 and the EGL path #3060 — each of which adds a single `.mm`) can build on a shared, gcc-primary foundation instead of carrying their own toolchain plumbing.

## Scope / ABI note

Objective-C only. clang compiles `.m`/`.mm` against **libc++**, so these sources must expose an `extern "C"` boundary — no C++ standard-library type may cross to the engine's libstdc++ side. C++ that must be compiled with clang is intentionally **out of scope**: that would need clang to use libstdc++ for ABI compatibility, which macOS does not ship; such code should instead be isolated behind a C boundary.

## Testing

- Configures cleanly on macOS arm64 with Homebrew GCC 16 (`enable_language(OBJC/OBJCXX)` test-compiles Objective-C with clang during configure); normal GCC targets (e.g. `fmt`) build unaffected.
- Verified the routing itself with a minimal CMake project: a target mixing `main.cpp` + `plain.cpp` + `objc.mm` compiles the `.cpp` files with `g++` and `objc.mm` with `clang++ -x objective-c++`, links (CMake auto-adds `-lc++`), and runs correctly.
- No change on non-Apple platforms; no change when already building with AppleClang.

## AI usage disclosure

Designed and drafted with AI assistance (Claude Code); reviewed and build/PoC-verified by a human.