### PR TITLE
System: add missing <algorithm> includes for libc++

### DIFF
--- a/rts/System/Matrix44f.h
+++ b/rts/System/Matrix44f.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <array>
 #include <tuple>

--- a/rts/System/SpringHashMap.hpp
+++ b/rts/System/SpringHashMap.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <iterator>

--- a/rts/System/SpringHashSet.hpp
+++ b/rts/System/SpringHashSet.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib> // malloc
 #include <iterator>


### PR DESCRIPTION
## What

Add explicit `#include <algorithm>` to three headers that use `std::` algorithms but currently rely on the header being pulled in transitively:

| Header | Symbol requiring `<algorithm>` |
| --- | --- |
| `rts/System/Matrix44f.h` | `std::copy` |
| `rts/System/SpringHashMap.hpp` | `std::fill_n` |
| `rts/System/SpringHashSet.hpp` | `std::fill_n` |

## Why

libstdc++ happens to drag `<algorithm>` in transitively via other STL headers, so these compile by accident on GCC. libc++ (clang/macOS) has a leaner header graph and does not guarantee this, so the same code can fail to compile depending on the libc++ version. Adding the include is "include what you use" correctness and is a no-op on toolchains that already provide it transitively.

No functional change.

## Testing

- Confirmed each header genuinely uses the cited symbol on current `master` (not cargo-culted) and that none already included `<algorithm>`.
- Compiled the two self-contained hash headers under `clang++ -std=c++23 -stdlib=libc++ -fsyntax-only`: clean, no regression. (Note: Apple clang 21's libc++ still provides `std::fill_n` transitively, so it does not reproduce the original failure locally — the fix is justified by IWYU correctness and the ExaDev build evidence below, not a locally reproduced break.)

## Source

Cherry-picked from ExaDev/RecoilEngine: `0ed29d550e`, `0b4bd10a1e`, `3adabd005a`.

## AI disclosure

Changes identified and applied with Claude (Anthropic). Human-reviewed and compiled locally under clang/libc++ before submitting.