### PR TITLE
Sim/COB: avoid UB in float-to-short angle casts (fixes arm64/x86 desync)

### DIFF
--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -42,6 +42,20 @@
 /******************************************************************************/
 /******************************************************************************/
 
+// COB scripts encode angles as TA units where a full turn is COBSCALE (65536),
+// so any angle past a half turn exceeds the range of a signed short and is meant
+// to wrap around (it is a circular 16-bit angle). Truncating the scaled value to
+// int first is well defined for the bounded angles the sim feeds in, and the
+// following int->short narrowing performs that modular wrap deterministically.
+// Converting straight from float to short would be undefined behaviour once the
+// value leaves short's range, and produced different results on arm64 vs x86,
+// desyncing multiplayer.
+static inline short RadAngleToCobShort(float radAngle)
+{
+	return static_cast<short>(static_cast<int>(radAngle * RAD2TAANG));
+}
+
+
 CR_BIND_DERIVED(CCobInstance, CUnitScript, )
 
 CR_REG_METADATA(CCobInstance, (
@@ -237,7 +251,7 @@ void CCobInstance::WindChanged(float heading, float speed)
 {
 	ZoneScoped;
 	Call(COBFN_SetSpeed, int(speed * 3000.0f));
-	Call(COBFN_SetDirection, short(int(heading * RAD2TAANG)));
+	Call(COBFN_SetDirection, RadAngleToCobShort(heading));
 }
 
 
@@ -387,8 +401,8 @@ void CCobInstance::StartBuilding(float heading, float pitch)
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
-	callinArgs[1] = short(int(heading * RAD2TAANG));
-	callinArgs[2] = short(int(  pitch * RAD2TAANG));
+	callinArgs[1] = RadAngleToCobShort(heading);
+	callinArgs[2] = RadAngleToCobShort(pitch);
 
 	Call(COBFN_StartBuilding, callinArgs);
 }
@@ -439,8 +453,8 @@ void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch)
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
-	callinArgs[1] = short(int(heading * RAD2TAANG));
-	callinArgs[2] = short(int(  pitch * RAD2TAANG));
+	callinArgs[1] = RadAngleToCobShort(heading);
+	callinArgs[2] = RadAngleToCobShort(pitch);
 
 	Call(COBFN_AimPrimary + COBFN_Weapon_Funcs * weaponNum, callinArgs, CBAimWeapon, weaponNum, nullptr);
 }

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -237,7 +237,7 @@ void CCobInstance::WindChanged(float heading, float speed)
 {
 	ZoneScoped;
 	Call(COBFN_SetSpeed, int(speed * 3000.0f));
-	Call(COBFN_SetDirection, short(heading * RAD2TAANG));
+	Call(COBFN_SetDirection, short(int(heading * RAD2TAANG)));
 }
 
 
@@ -387,8 +387,8 @@ void CCobInstance::StartBuilding(float heading, float pitch)
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
-	callinArgs[1] = short(heading * RAD2TAANG);
-	callinArgs[2] = short(  pitch * RAD2TAANG);
+	callinArgs[1] = short(int(heading * RAD2TAANG));
+	callinArgs[2] = short(int(  pitch * RAD2TAANG));
 
 	Call(COBFN_StartBuilding, callinArgs);
 }
@@ -439,8 +439,8 @@ void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch)
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;
-	callinArgs[1] = short(heading * RAD2TAANG);
-	callinArgs[2] = short(  pitch * RAD2TAANG);
+	callinArgs[1] = short(int(heading * RAD2TAANG));
+	callinArgs[2] = short(int(  pitch * RAD2TAANG));
 
 	Call(COBFN_AimPrimary + COBFN_Weapon_Funcs * weaponNum, callinArgs, CBAimWeapon, weaponNum, nullptr);
 }


### PR DESCRIPTION
## What

Casting a floating-point heading/pitch expression directly to `short` is undefined behaviour when the truncated value does not fit in `short`, and this is genuinely reached in the COB angle math: `RAD2TAANG = COBSCALE_HALF / pi` with `COBSCALE_HALF = 32768`, so `heading * RAD2TAANG` equals `+-32768` at `heading = +-pi` — one past `short`'s `32767` maximum.

This routes the conversion through `int` first (`short(int(expr))`) at every affected site, which is well-defined: `float -> int` truncates toward zero (the magnitudes here always fit `int`), then `int -> short` performs the intended 16-bit TA-angle wraparound.

## Why it matters (determinism)

Because the direct `float -> short` is UB, arm64 and x86 produced different values at the angle extremes, which was observed as an **arm64/x86 multiplayer desync**.

This is synced simulation code, so the fix must not change results on the platform that was already correct. It doesn't: x86 already lowers `short(float)` as `float -> int -> short` (`cvttss2si` into a 32-bit register, then narrow), so making the `int()` step explicit leaves the x86 result unchanged while pinning arm64 (whose `fcvtzs` saturated differently) to that same value.

## Sites

Fixed in `rts/Sim/Units/Scripts/CobInstance.cpp`:

- `WindChanged` (`SetDirection`)
- `StartBuilding` (heading + pitch)
- `AimWeapon` (heading + pitch)

Siblings checked and deliberately left untouched (not the same bug):

- `UnitScript.cpp:1058` casts `asin(...) * RAD2TAANG` — range `+-16384`, always fits `short`, no UB.
- `UnitScript.cpp:1095/1099` already route through `int`.
- `CobThread.cpp` has no such casts.

## Testing

- Built `engine-headless` cleanly (CobInstance compiles into the sim).
- Verified by reasoning that the `int()` step reproduces x86's existing lowering, so the already-correct platform is unaffected.
- A true determinism check requires cross-arch runs; **cross-arch sync validation is recommended** before merge.

## Origin / credit

The fix was discussed in PR #2991's review thread (credit to BambaDamba); it was never committed there. Implemented here from that description and verified independently.

## AI disclosure

Implemented with Claude Code (Anthropic) from a written plan. Reasoning, scope decisions, and the build verification were reviewed by a human (per `AI_POLICY.md`).
