### PR TITLE
CMake: drop redundant simdjson include dir, rely on simdjson::simdjson link

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -142,7 +142,6 @@ make_global_var(engineSources
 		${sources_engine_ExternalAI}
 	)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/assimp/include) #FIXME: hack for rts/Rendering/Models/IModelParser.cpp
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/simdjson/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/fastgltf/include)
 
 ### Add headers for generated project files (e.g. Code::Blocks)


### PR DESCRIPTION
## What

Removes the manual `include_directories(.../lib/simdjson/include)` entry from `rts/CMakeLists.txt` and lets header resolution ride on the `simdjson::simdjson` link edge instead.

## Why

Per @p2004a's review: a target that links `simdjson::simdjson` already gets the vendored include path as a usage requirement, so the explicit `include_directories` line should not be needed. I verified that every `<simdjson.h>` consumer does link the target - `GLTFParser.cpp` through the engine's `engineCommonLibraries`, and `fastgltf` links `simdjson::simdjson` privately in its own CMake. Nothing was relying on the global include line for header resolution.

The reason the line looked load-bearing on macOS is DevIL: its Homebrew headers live at `/opt/homebrew/include/IL/il.h`, so `FindDevIL` resolves `IL_INCLUDE_DIR` to the broad `/opt/homebrew/include` prefix, which also contains a stray Homebrew `simdjson.h`. But `DevIL::IL` is an **imported** target, so CMake emits its include as `-isystem`, and the compiler searches every `-I` dir (including the vendored simdjson path from the link) before any `-isystem` dir. So the vendored header wins on its own and the manual entry is redundant. This supersedes the earlier include-order approach.

## Verification

Reasoned from the link graph and CMake's `-I`/`-isystem` ordering; **not yet confirmed with a macOS build**. Needs a build on macOS (Homebrew DevIL + a Homebrew `simdjson` present) to confirm `<simdjson.h>` still resolves to the vendored copy after the line is removed. Linux/Windows are unaffected (DevIL there resolves to an implicit system dir that CMake drops entirely).

If a macOS build shows the vendored header no longer winning, the correct root-cause follow-up is to stop `DevIL::IL` from advertising the broad `/opt/homebrew/include` prefix (or force it system), rather than reinstating a simdjson-specific include override.

## AI disclosure

Analysis and patch prepared with AI assistance (Claude); the reasoning about link edges and `-I`/`-isystem` ordering was verified against the CMake by a human, and the macOS build check is outstanding.
