### PR TITLE
LuaMenu: load LuaSocket socket.lua from the base VFS

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -556,15 +556,9 @@ bool CLuaHandle::LoadCode(lua_State* L, std::string code, const string& debug)
 void CLuaHandle::InitLuaSocket(lua_State* L)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	std::string code;
-	// socket.lua ships in springcontent.sdz under LuaSocket/; load it from
-	// the base VFS. A previous menu/lobby path ("socket.lua", default VFS)
-	// never resolved, so LuaSocket support failed to initialise ("Error
-	// loading socket.lua"), breaking multiplayer server connections from
-	// Chobby. Shared by CLuaUI and CLuaMenu so both use the same path/mode.
-	std::string filename = "LuaSocket/socket.lua";
-	CFileHandler f(filename, SPRING_VFS_BASE);
 
+	const std::string filename = "LuaSocket/socket.lua";
+	CFileHandler f(filename, SPRING_VFS_BASE);
 	if (!f.FileExists()) {
 		LOG_L(L_ERROR, "Error loading %s (file does not exist)", filename.c_str());
 		return;
@@ -572,6 +566,7 @@ void CLuaHandle::InitLuaSocket(lua_State* L)
 
 	LUA_OPEN_LIB(L, luaopen_socket_core);
 
+	std::string code;
 	if (f.LoadStringData(code)) {
 		LoadCode(L, std::move(code), filename);
 	} else {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -41,6 +41,8 @@
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Weapons/Weapon.h"
 #include "Sim/Weapons/WeaponDef.h"
+#include "System/FileSystem/FileHandler.h"
+#include "System/FileSystem/VFSModes.h"
 #include "System/creg/SerializeLuaState.h"
 #include "System/Config/ConfigHandler.h"
 #include "System/EventHandler.h"
@@ -55,6 +57,8 @@
 
 
 #include "LuaInclude.h"
+
+#include "lib/luasocket/src/luasocket.h"
 
 #include <SDL_keyboard.h>
 #include <SDL_keycode.h>
@@ -546,6 +550,33 @@ bool CLuaHandle::LoadCode(lua_State* L, std::string code, const string& debug)
 
 	// call Initialize immediately after load
 	return (RunCallInTraceback(L, cmdStr, 0, 0, traceBack.GetErrFuncIdx(), false));
+}
+
+
+void CLuaHandle::InitLuaSocket(lua_State* L)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	std::string code;
+	// socket.lua ships in springcontent.sdz under LuaSocket/; load it from
+	// the base VFS. A previous menu/lobby path ("socket.lua", default VFS)
+	// never resolved, so LuaSocket support failed to initialise ("Error
+	// loading socket.lua"), breaking multiplayer server connections from
+	// Chobby. Shared by CLuaUI and CLuaMenu so both use the same path/mode.
+	std::string filename = "LuaSocket/socket.lua";
+	CFileHandler f(filename, SPRING_VFS_BASE);
+
+	if (!f.FileExists()) {
+		LOG_L(L_ERROR, "Error loading %s (file does not exist)", filename.c_str());
+		return;
+	}
+
+	LUA_OPEN_LIB(L, luaopen_socket_core);
+
+	if (f.LoadStringData(code)) {
+		LoadCode(L, std::move(code), filename);
+	} else {
+		LOG_L(L_ERROR, "Error loading %s", filename.c_str());
+	}
 }
 
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -329,6 +329,7 @@ class CLuaHandle : public CEventClient
 		bool AddBasicCalls(lua_State* L);
 		bool AddCommonModules(lua_State* L);
 		bool LoadCode(lua_State* L, std::string code, const std::string& debug);
+		void InitLuaSocket(lua_State* L);
 		static bool AddEntriesToTable(lua_State* L, const char* name, bool (*entriesFunc)(lua_State*));
 
 		/// returns error code and sets traceback on error

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -137,8 +137,18 @@ string CLuaMenu::LoadFile(const string& name) const
 void CLuaMenu::InitLuaSocket(lua_State* L) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	std::string code;
-	std::string filename = "socket.lua";
-	CFileHandler f(filename);
+	// socket.lua ships in springcontent.sdz under LuaSocket/; load it from
+	// the base VFS exactly as CLuaUI::InitLuaSocket does. The previous path
+	// ("socket.lua", default VFS) never resolved, so the menu/lobby's
+	// LuaSocket support failed to initialise ("Error loading socket.lua"),
+	// breaking multiplayer server connections from Chobby.
+	std::string filename = "LuaSocket/socket.lua";
+	CFileHandler f(filename, SPRING_VFS_BASE);
+
+	if (!f.FileExists()) {
+		LOG_L(L_ERROR, "Error loading %s (file does not exist)", filename.c_str());
+		return;
+	}
 
 	LUA_OPEN_LIB(L, luaopen_socket_core);
 

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -24,7 +24,6 @@
 #include "System/FileSystem/FileHandler.h"
 #include "System/FileSystem/FileSystem.h"
 #include "System/Threading/SpringThreading.h"
-#include "lib/luasocket/src/luasocket.h"
 #include "LuaUI.h"
 
 #include "System/Misc/TracyDefs.h"
@@ -131,32 +130,6 @@ string CLuaMenu::LoadFile(const string& name) const
 		code.clear();
 
 	return code;
-}
-
-
-void CLuaMenu::InitLuaSocket(lua_State* L) {
-	RECOIL_DETAILED_TRACY_ZONE;
-	std::string code;
-	// socket.lua ships in springcontent.sdz under LuaSocket/; load it from
-	// the base VFS exactly as CLuaUI::InitLuaSocket does. The previous path
-	// ("socket.lua", default VFS) never resolved, so the menu/lobby's
-	// LuaSocket support failed to initialise ("Error loading socket.lua"),
-	// breaking multiplayer server connections from Chobby.
-	std::string filename = "LuaSocket/socket.lua";
-	CFileHandler f(filename, SPRING_VFS_BASE);
-
-	if (!f.FileExists()) {
-		LOG_L(L_ERROR, "Error loading %s (file does not exist)", filename.c_str());
-		return;
-	}
-
-	LUA_OPEN_LIB(L, luaopen_socket_core);
-
-	if (f.LoadStringData(code)) {
-		LoadCode(L, std::move(code), filename);
-	} else {
-		LOG_L(L_ERROR, "Error loading %s", filename.c_str());
-	}
 }
 
 

--- a/rts/Lua/LuaMenu.h
+++ b/rts/Lua/LuaMenu.h
@@ -61,7 +61,6 @@ protected:
 	static bool LoadUnsyncedReadFunctions(lua_State* L);
 	static bool RemoveSomeOpenGLFunctions(lua_State* L);
 	static bool PushGameVersion(lua_State* L);
-	void InitLuaSocket(lua_State* L);
 protected:
 	QueuedAction queuedAction;
 };

--- a/rts/Lua/LuaUI.cpp
+++ b/rts/Lua/LuaUI.cpp
@@ -40,7 +40,6 @@
 #include "System/Config/ConfigHandler.h"
 #include "System/StringUtil.h"
 #include "System/Threading/SpringThreading.h"
-#include "lib/luasocket/src/luasocket.h"
 
 #include <cctype>
 
@@ -206,25 +205,6 @@ CLuaUI::~CLuaUI()
 GetWatchDef(Explosion)
 SetWatchDef(Explosion)
 
-
-void CLuaUI::InitLuaSocket(lua_State* L) {
-	std::string code;
-	std::string filename = "LuaSocket/socket.lua";
-	CFileHandler f(filename, SPRING_VFS_BASE);
-
-	if (!f.FileExists()) {
-		LOG_L(L_ERROR, "Error loading %s (file does not exist)", filename.c_str());
-		return;
-	}
-
-	LUA_OPEN_LIB(L, luaopen_socket_core);
-
-	if (f.LoadStringData(code)) {
-		LoadCode(L, std::move(code), filename);
-	} else {
-		LOG_L(L_ERROR, "Error loading %s", filename.c_str());
-	}
-}
 
 string CLuaUI::LoadFile(const string& name, const std::string& mode) const
 {

--- a/rts/Lua/LuaUI.h
+++ b/rts/Lua/LuaUI.h
@@ -83,7 +83,6 @@ protected:
 	string LoadFile(const string& name, const std::string& mode) const;
 
 	bool LoadCFunctions(lua_State* L);
-	void InitLuaSocket(lua_State* L);
 
 	bool BuildCmdDescTable(lua_State* L, const vector<SCommandDescription>& cmds);
 	bool GetLuaIntMap(lua_State* L, int index, spring::unordered_map<int, int>& intList);


### PR DESCRIPTION
## What

`CLuaMenu::InitLuaSocket` loaded a bare `"socket.lua"` from the default VFS (`SPRING_VFS_RAW_FIRST`). That path never resolves: the file actually ships in `springcontent.sdz` at `LuaSocket/socket.lua`. So the menu/lobby's LuaSocket layer never initialised, logged `Error loading socket.lua`, and Chobby could not connect to multiplayer servers. `CLuaUI::InitLuaSocket` already loaded the correct `LuaSocket/socket.lua` from `SPRING_VFS_BASE`, so in-game LuaSocket worked while the menu's did not.

The two methods were near-identical apart from that path/mode bug, so this hoists a single `CLuaHandle::InitLuaSocket` into the shared base class (with a `FileExists` guard, loading `LuaSocket/socket.lua` from `SPRING_VFS_BASE`) and removes the `CLuaMenu` and `CLuaUI` copies. Both handlers now inherit the one correct implementation.

## Why this is cross-platform

This is a general VFS-path bug, not platform-specific. The menu lookup failed on every platform because the requested path/mode never matched the file's actual location in the base content; it merely surfaced first during macOS lobby testing. Consolidating on `CLuaUI`'s already-correct path and mode fixes the menu everywhere and removes the duplicated init.

## Verification

`engine-headless` builds on macOS with the change. Building alone does not exercise the runtime path; functional verification (lobby connecting to a multiplayer server via Chobby) is recommended. The mechanism is straightforward: `socket.lua` now resolves from the base VFS, so `luaopen_socket_core` plus the Lua wrapper initialise. The in-game (`CLuaUI`) path is behaviourally unchanged since its previous logic became the shared base implementation.

## Provenance

The menu-path fix was ported from `e9ca2151b5` in ExaDev/RecoilEngine; the consolidation into `CLuaHandle` was added during review to remove the duplication between the menu and UI handlers.

## AI disclosure

Diagnosis and patch prepared with AI assistance (Claude). The change fixes the menu's VFS path and consolidates the duplicated socket init into the `CLuaHandle` base class; reviewed and built locally by a human.
