### PR TITLE
ci: cross-architecture streflop/sim determinism gate (x86 vs arm64)

### DIFF
--- a/.github/workflows/streflop-sync-crossarch.yml
+++ b/.github/workflows/streflop-sync-crossarch.yml
@@ -1,0 +1,88 @@
+name: STREFLOP Cross-Arch Sync Test
+
+# Cross-architecture floating-point determinism gate. Builds the standalone
+# streflop float test on x86_64 (SSE) and arm64 (NEON via sse2neon), then
+# asserts the two produce bit-identical results. Multiplayer sync requires that
+# Apple-Silicon/ARM players agree with x86 players byte for byte, so the NEON
+# code path needs guarding against codegen/library drift.
+#
+# Complements streflop-float-test.yml, which is x86-only and compares against a
+# checked-in NEON reference snapshot; this workflow builds and runs both arches
+# live so it catches divergence in the actual NEON output, not a frozen copy.
+#
+# Manual (workflow_dispatch) for now: the submodules and FastMath paths it
+# covers change rarely, so it is run on demand rather than gating every PR.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-run:
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: x86_64 (SSE)
+            mode: SSE
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            label: arm64 (NEON)
+            mode: NEON
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init streflop + sse2neon submodules
+        run: git submodule update --init --recursive rts/lib/streflop rts/lib/sse2neon
+
+      - name: Configure
+        run: cmake -B build -S tools/sync-test -DCMAKE_BUILD_TYPE=Release -DSTREFLOP_MODE=${{ matrix.mode }}
+
+      - name: Build
+        run: cmake --build build --target streflop-float-test -j"$(nproc)"
+
+      - name: Run (52K tests)
+        run: ./build/streflop-float-test -n 10000 "streflop_results_${{ matrix.mode }}_${{ matrix.arch }}"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: streflop-results-${{ matrix.mode }}-${{ matrix.arch }}
+          path: |
+            streflop_results_${{ matrix.mode }}_${{ matrix.arch }}.bin
+            streflop_results_${{ matrix.mode }}_${{ matrix.arch }}.txt
+          if-no-files-found: error
+          retention-days: 30
+
+  cross-arch-compare:
+    name: Cross-arch (SSE x86_64 == NEON arm64)
+    needs: build-and-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download SSE (x86_64) results
+        uses: actions/download-artifact@v4
+        with:
+          name: streflop-results-SSE-x86_64
+          path: sse
+
+      - name: Download NEON (arm64) results
+        uses: actions/download-artifact@v4
+        with:
+          name: streflop-results-NEON-arm64
+          path: neon
+
+      - name: Compare (fails on any mismatch)
+        run: |
+          python3 tools/sync-test/compare_results.py \
+            "sse/streflop_results_SSE_x86_64.bin" \
+            "neon/streflop_results_NEON_arm64.bin"


### PR DESCRIPTION
## What

Adds a manually-dispatchable CI workflow (`streflop-sync-crossarch.yml`) that asserts the streflop floating-point library produces **bit-identical results on x86_64 (SSE) and arm64 (NEON, via sse2neon)**.

## Why

Multiplayer sync is deterministic and depends on every client computing identical floating-point results. An ARM/Apple-Silicon client runs the streflop **NEON** path (through `sse2neon`); an x86 client runs the **SSE** path. If those two paths ever diverge — through compiler codegen changes, an `sse2neon` update, or a `FastMath.h` change — the result is a cross-architecture desync that only manifests in a live multiplayer game, not in any existing test. Cross-arch FP desyncs are not hypothetical; they have occurred (e.g. float-to-short angle cast UB on arm64). The NEON path is currently not exercised by CI at all.

## Mechanism

Reuses the existing standalone harness in `tools/sync-test/` (already in-tree):

1. Builds `streflop-float-test` on `ubuntu-latest` (SSE) and `ubuntu-24.04-arm` (NEON).
2. Runs the same deterministic input set (`-n 10000`, ~52K tests) on each leg.
3. A third job downloads both artifacts and runs `compare_results.py`, which exits non-zero on any mismatch.

No new test/harness code — only the workflow YAML.

## Scope (and how it differs from the source)

Adapted from the [`ExaDev/RecoilEngine`](https://github.com/ExaDev/RecoilEngine) macOS fork (commit `32d3855`). Deliberately retargeted for upstream:

- **arm64 leg runs on Linux (`ubuntu-24.04-arm`)**, not the fork's `macos-latest`. The runner is already used elsewhere in this repo's CI, and a full macOS engine build currently fails on unmerged portability fixes — but this standalone streflop test doesn't need them, and Linux arm64 keeps the gate clean and free.
- **Manual dispatch only** (`workflow_dispatch`) — see CI cost below. The fork's PR/push path-filter triggers and macOS shipping pins are intentionally omitted.
- **Complements, does not replace** the existing `streflop-float-test.yml`. That one is x86-only and compares against a *checked-in* NEON reference snapshot; this builds and runs both arches **live**, catching drift in the actual NEON output rather than a frozen copy. It also inits the `streflop`/`sse2neon` submodules, which the build requires.

## CI cost

Manual-dispatch only, so **zero automatic cost** — it never runs on a PR unless someone triggers it. Each run is two short builds of a single standalone test (~minutes), not full-engine builds. Happy to wire it to path-filtered PR triggers (streflop / sse2neon / FastMath.h changes) if maintainers prefer it as an automatic gate; that's a one-line change to the `on:` block.

## Testing

- `actionlint`: clean.
- Built and ran the standalone test locally on Apple-Silicon (arm64/NEON): 52,080 tests, **bit-exact** vs the checked-in NEON reference (`compare_results.py` exit 0).
- Verified the gate's actual assertion (`SSE_x86_64` vs `NEON_arm64` references): **bit-exact match** — the workflow goes green on current `master`.
- Not locally verified: the x86/SSE build leg (verifier is on arm64); it is the same known-good CMake project the existing `streflop-float-test.yml` already builds on ubuntu, and will be exercised on CI.

Opened as **draft** so a first CI run can be watched before review.

## AI usage disclosure

This PR was prepared with AI assistance (Claude Code): codebase investigation, adapting the ExaDev workflow to upstream conventions, and local verification. All changes were reviewed and tested by a human (the build/run/compare steps above were run locally). Per `AI_POLICY.md`.
