### PR TITLE
System: use fmt::format instead of std::format in math vector str()

### DIFF
--- a/AI/Wrappers/Cpp/CMakeLists.txt
+++ b/AI/Wrappers/Cpp/CMakeLists.txt
@@ -258,5 +258,10 @@ if    (BUILD_${myName}_AIWRAPPER)
 	list(APPEND myCompleteSources ${ai_common_SRC})
 	add_library(${myTarget} STATIC ${myCompleteSources})
 	add_dependencies(${myTarget} generateVersionFiles)
+	# AIFloat3.h derives from float3, whose str() helper now calls fmt::format,
+	# pulling in the non-inline fmt::vformat symbol. Skirmish AIs built on this
+	# wrapper (e.g. BARb) link neither the engine nor fmt, so propagate fmt::fmt
+	# to every consumer of the wrapper.
+	target_link_libraries(${myTarget} PUBLIC fmt::fmt)
 	set_target_properties(${myTarget} PROPERTIES OUTPUT_NAME "${myName}")
 endif (BUILD_${myName}_AIWRAPPER)

--- a/AI/Wrappers/LegacyCpp/CMakeLists.txt
+++ b/AI/Wrappers/LegacyCpp/CMakeLists.txt
@@ -61,10 +61,15 @@ if    (BUILD_${myName}_AIWRAPPER)
 	add_library(${myTarget}     STATIC ${mySources})
 	set_target_properties(${myTarget} PROPERTIES OUTPUT_NAME "${myName}")
 	add_dependencies(${myTarget} generateVersionFiles)
+	# float3.cpp pulls in float3.h -> <fmt/format.h> and float3::str() routes
+	# through fmt::vformat, so the wrapper (and any Legacy AI that uses it) must
+	# link fmt. PUBLIC propagates both the include dir and the symbol downstream.
+	target_link_libraries(${myTarget} PUBLIC fmt::fmt)
 
 	# Compile the Legacy C++ AI wrapper static library with creg support
 	add_library(${myCregTarget} STATIC ${mySources} ${sources_engine_System_creg})
 	add_dependencies(${myCregTarget} generateVersionFiles)
+	target_link_libraries(${myCregTarget} PUBLIC fmt::fmt)
 	set_target_properties(${myCregTarget} PROPERTIES OUTPUT_NAME   "${myName}Creg")
 	set_target_properties(${myCregTarget} PROPERTIES COMPILE_FLAGS "-DUSING_CREG")
 endif (BUILD_${myName}_AIWRAPPER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,9 @@ add_dependencies(generateSources generateVersionFiles)
 # As the libs are required by all the other sub-projects, we add them first
 # Options that affect lib selection must be declared here, before rts/lib is processed
 option(USE_MIMALLOC "Use mimalloc memory allocator" TRUE)
+# float3.h (widely included, even by the lua glue in rts/lib) uses fmt::format,
+# so the vendored fmt headers must be on the include path everywhere.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/rts/lib/fmt/include)
 add_subdirectory(rts/lib)
 
 # Fix for MinGW assembler limitations with large object files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,9 +688,6 @@ add_dependencies(generateSources generateVersionFiles)
 # As the libs are required by all the other sub-projects, we add them first
 # Options that affect lib selection must be declared here, before rts/lib is processed
 option(USE_MIMALLOC "Use mimalloc memory allocator" TRUE)
-# float3.h (widely included, even by the lua glue in rts/lib) uses fmt::format,
-# so the vendored fmt headers must be on the include path everywhere.
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/rts/lib/fmt/include)
 add_subdirectory(rts/lib)
 
 # Fix for MinGW assembler limitations with large object files

--- a/rts/Game/UI/TooltipConsole.cpp
+++ b/rts/Game/UI/TooltipConsole.cpp
@@ -26,7 +26,7 @@
 #include "System/StringUtil.h"
 
 #include "System/Misc/TracyDefs.h"
-#include <format>
+#include <fmt/format.h>
 
 
 CONFIG(std::string, TooltipGeometry).defaultValue("0.0 0.125 0.41 0.1");
@@ -207,7 +207,7 @@ std::string CTooltipConsole::MakeUnitStatsString(const SUnitStats& stats)
 	string s;
 	s.reserve(512);
 
-	s += std::format
+	s += fmt::format
 		( "\nHealth {:.0f}/{:.0f}"
 		  "\nExperience {:.2f} Cost {:.0f} Range {:.0f}"
 		, stats.health, stats.maxHealth
@@ -215,11 +215,11 @@ std::string CTooltipConsole::MakeUnitStatsString(const SUnitStats& stats)
 	);
 
 	for (int i = 0; i < SResourcePack::MAX_RESOURCES; ++i) {
-		s += std::format("\n" BLUE "{}: " GREEN "+{:.1f}" GREY "/" RED "-{:.1f}"
+		s += fmt::format("\n" BLUE "{}: " GREEN "+{:.1f}" GREY "/" RED "-{:.1f}"
 			, resourceHandler->GetResource(i)->name, stats.resourceMake[i], stats.resourceUse[i]
 		);
 		if (stats.resourceHarvestMax[i] > 0.0f) {
-			s += std::format(GREY " (" GREEN "{:.1f}" GREY "/" BLUE "{:.1f}" GREY ")"
+			s += fmt::format(GREY " (" GREEN "{:.1f}" GREY "/" BLUE "{:.1f}" GREY ")"
 				, stats.resourceHarvest[i], stats.resourceHarvestMax[i]
 			);
 		}

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -3,6 +3,8 @@
 #include <functional>
 #include <tuple>
 
+#include <fmt/format.h>
+
 #include "UnsyncedGameCommands.h"
 
 #include "UnsyncedActionExecutor.h"
@@ -2262,7 +2264,7 @@ public:
 		if (infoTextureHandler->HasMode(mode))
 			return SetMode(action, mode, args.size() > 1 ? args[1] : "");
 		else
-			return CommandError(std::format("infotex mode does not exist '{}'", mode), false, true);
+			return CommandError(fmt::format("infotex mode does not exist '{}'", mode), false, true);
 	}
 };
 

--- a/rts/System/FileSystem/Archives/PoolArchive.cpp
+++ b/rts/System/FileSystem/Archives/PoolArchive.cpp
@@ -9,7 +9,7 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
-#include <format>
+#include <fmt/format.h>
 
 #include "System/FileSystem/DataDirsAccess.h"
 #include "System/FileSystem/FileSystem.h"
@@ -192,7 +192,7 @@ std::string CPoolArchive::GetPoolFileName(const std::array<uint8_t, 16>& md5Sum)
 
 	const std::string prefix(c_hex    ,  2);
 	const std::string pstfix(c_hex + 2, 30);
-	return std::format("{}/{}.gz", prefix, pstfix);
+	return fmt::format("{}/{}.gz", prefix, pstfix);
 }
 
 std::string CPoolArchive::GetPoolFilePath(const std::string& poolRootDir, const std::string& poolFile)

--- a/rts/System/Matrix44f.h
+++ b/rts/System/Matrix44f.h
@@ -177,7 +177,7 @@ public:
 	};
 
 	std::string str() const {
-		return std::format(
+		return fmt::format(
 			"m44(\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f})",
 			m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7], m[11], m[15]);
 	}

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -3,6 +3,8 @@
 #include "DumpHistory.h"
 #include "SyncChecker.h"
 
+#include <fmt/format.h>
+
 #include "Game/Game.h"
 #include "Game/GlobalUnsynced.h"
 #include "Net/GameServer.h"
@@ -34,13 +36,13 @@ void DumpHistory(nowide::fstream& file, int frameNum, bool serverRequest)
 
 	LOG("[%s] dump history at %d (%d records)", __func__, frameNum, firstRangeSize + secondRangeSize);
 
-	file << std::format("internal frame checksums ({}):\n", frameNum);
+	file << fmt::format("internal frame checksums ({}):\n", frameNum);
 
 	for (int i = startIndex; i < startIndex + firstRangeSize; ++i) {
-		file << std::format("\t{:08x}\n", data[i]);
+		file << fmt::format("\t{:08x}\n", data[i]);
 	}
 	for (int i = 0; i < secondRangeSize; ++i) {
-		file << std::format("\t{:08x}\n", data[i]);
+		file << fmt::format("\t{:08x}\n", data[i]);
 	}
 #endif // SYNC_HISTORY
 }

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <array>
 #include <utility>
-#include <format>
+#include <fmt/format.h>
 
 #include "System/BranchPrediction.h"
 #include "System/creg/creg_cond.h"
@@ -839,7 +839,7 @@ public:
 	static constexpr float nrm_eps() { return 1e-12f; }
 
 	std::string str() const {
-		return std::format("float3({:.3f}, {:.3f}, {:.3f})", x, y, z);
+		return fmt::format("float3({:.3f}, {:.3f}, {:.3f})", x, y, z);
 	}
 
 	/**

--- a/rts/System/float4.h
+++ b/rts/System/float4.h
@@ -109,7 +109,7 @@ struct float4 : public float3
 	}
 
 	std::string str() const {
-		return std::format("float4({:.3f}, {:.3f}, {:.3f}, {:.3f})", x, y, z, w);
+		return fmt::format("float4({:.3f}, {:.3f}, {:.3f}, {:.3f})", x, y, z, w);
 	}
 
 


### PR DESCRIPTION
Standalone cleanup requested by @sprunk during review of the macOS renderer PRs (on `rts/System/float3.h`): *"try fmt::format. if that helps, make a small standalone PR that converts existing std::formats to fmt::format."*

## Changes
- `rts/System/float3.h`, `rts/System/float4.h`, `rts/System/Matrix44f.h`: `std::format` → `fmt::format` in the `str()` helpers.
- `rts/System/float3.h`: swap the direct `#include <format>` for `#include <fmt/format.h>`. Where `<format>` was a standard-library header available unconditionally, `<fmt/format.h>` only resolves where fmt's include dir is on the path - which is handled by linking `fmt::fmt` on the consuming targets (see AI wrappers below), not a global include.

### Remaining call sites (follow-up to @sprunk's "what about the others?" review)
Converts the rest of the engine's `std::format` usage for the same cross-toolchain consistency reason:
- `rts/System/Sync/DumpHistory.cpp`
- `rts/System/FileSystem/Archives/PoolArchive.cpp`
- `rts/Game/UnsyncedGameCommands.cpp`
- `rts/Game/UI/TooltipConsole.cpp`

`PoolArchive.cpp` and `TooltipConsole.cpp` had a direct `#include <format>` (swapped for `#include <fmt/format.h>`); `DumpHistory.cpp` and `UnsyncedGameCommands.cpp` relied on a transitive `<format>` and now include `<fmt/format.h>` explicitly. The only other match in the tree is a commented-out line in `rts/Rml/SolLua/plugin/SolLuaEventListener.cpp` (dead code, left untouched).

### AI wrappers: link `fmt::fmt` (usage requirements, not a global include)
`fmt::format` routes through the non-inline `fmt::vformat` symbol in the compiled `libfmt`, so a target that uses `float3::str()` must *link* `fmt`, not just see its headers. Auditing every target that compiles a `float3`/`float4`/`Matrix44f` translation unit, all already link `fmt::fmt` - the engine binaries, `unitsync`, `System/FileSystem/Archives`, and the tests (via `test_common_libraries`) - **except the two native AI wrappers**, which compile `float3.cpp` but linked nothing:

- `AI/Wrappers/Cpp` exposes `float3` via `AIFloat3 : public float3`; the Skirmish AIs built on it (BARb, CircuitAI, CppTestAI) link neither the engine nor `fmt`, so the `BARb` `SkirmishAI.dll` link failed with an undefined reference to `fmt::vformat` on the mingw `amd64-windows` build.
- `AI/Wrappers/LegacyCpp` compiles `float3.cpp` directly and also linked nothing.

Both wrappers now propagate `fmt::fmt` (PUBLIC), which resolves `<fmt/format.h>` for their own sources and makes downstream consumers link the already-compiled `libfmt`, matching how the engine and `unitsync` already link it. With those link edges in place the vendored fmt headers no longer need a global `include_directories(rts/lib/fmt/include)` entry, so it was removed (per @sprunk's review comment). An earlier version of this PR justified that global include with "the lua glue in rts/lib" - that was a misdiagnosis; nothing under `rts/lib/lua*` includes `float3`.

`fmt` is already a vendored/linked dependency and shares the same format-spec mini-language as `std::format` (`std::format` was standardised from `fmt`), so output is **byte-identical** and there is no behavioural change.

## Testing
Built `engine-headless` locally (macOS, arm64) - compiles and links cleanly. The four follow-up files were additionally syntax-checked (`-fsyntax-only`) with their exact build flags from the headless `compile_commands.json`; all compile clean.

The CMake rework (dropping the global include, linking `fmt::fmt` into both AI wrappers) still needs verification against a build that exercises the native AI wrappers - in particular the mingw `amd64-windows` AI build that originally surfaced the `fmt::vformat` link error - which can't be reproduced on the macOS dev machine (no mingw cross-toolchain). CI on this PR covers it.

## AI disclosure
Prepared with AI assistance (Claude Code). Changes were reviewed by a human; the macOS headless build is verified locally, the native-AI/mingw build verification is outstanding (see Testing).
