### PR TITLE
LuaParser: run Spring.TimeCheck's callback under unitsync/dedicated

### DIFF
--- a/rts/Lua/LuaParser.cpp
+++ b/rts/Lua/LuaParser.cpp
@@ -501,12 +501,13 @@ void LuaParser::AddString(int key, const std::string& value)
 
 int LuaParser::TimeCheck(lua_State* L)
 {
-	#if (!defined(UNITSYNC) && !defined(DEDICATED))
 	if (!lua_isstring(L, 1) || !lua_isfunction(L, 2))
 		luaL_error(L, "Invalid arguments to TimeCheck('string', func, ...)");
 
 	{
+		#if (!defined(UNITSYNC) && !defined(DEDICATED))
 		ScopedOnceTimer timer(lua_tostring(L, 1));
+		#endif
 
 		lua_remove(L, 1);
 
@@ -519,9 +520,6 @@ int LuaParser::TimeCheck(lua_State* L)
 	}
 
 	return lua_gettop(L);
-	#else
-	return 0;
-	#endif
 }
 
 


### PR DESCRIPTION
Under `UNITSYNC` and `DEDICATED`, `TimeCheck` compiled to `return 0`, silently dropping the function it was handed. The shipped `gamedata/defs.lua` wraps all unitdef/weapondef/etc. loading in `Spring.TimeCheck(...)`, so `ProcessUnits()` ends up with an empty root and throws `root unitdef table invalid` — unitsync reports zero units for every game whose `defs.lua` uses `TimeCheck` (i.e. the standard springcontent path). Only the profiling timer needs to be excluded from those builds, not the call itself.

Surfaced by a lobby that enumerates units via unitsync; most consumers only read checksums/options, so it went unnoticed.

This also enables the callback under `DEDICATED` — that seems correct (the function shouldn't discard its argument), but flagging in case that build skips it deliberately.