### PR TITLE
Revert "FindSevenZip: also accept the 7zz binary name"

### DIFF
--- a/rts/build/cmake/FindSevenZip.cmake
+++ b/rts/build/cmake/FindSevenZip.cmake
@@ -23,7 +23,7 @@ ENDIF (SEVENZIP_BIN)
 set(progfilesx86 "ProgramFiles(x86)")
 
 find_program(SEVENZIP_BIN
-	NAMES 7z 7za 7zz
+	NAMES 7z 7za
 	HINTS "${MINGWDIR}" "${MINGWLIBS}/bin" "$ENV{${progfilesx86}}/7-zip" "$ENV{ProgramFiles}/7-zip" "$ENV{ProgramW6432}/7-zip"
 	PATH_SUFFIXES bin
 	DOC "7zip executable"


### PR DESCRIPTION
Reverts beyond-all-reason/RecoilEngine#3039
Apparently breaks some doc generator, see https://github.com/beyond-all-reason/RecoilEngine/actions/runs/29058659522/job/86255545126