### PR TITLE
System: move float3/float4/Matrix44f str() out of line

### DIFF
--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 #include <array>
+#include <format>
 #include <functional>
 #include <tuple>
 

--- a/rts/System/Matrix44f.cpp
+++ b/rts/System/Matrix44f.cpp
@@ -10,6 +10,7 @@
 #include <memory.h>
 #include <algorithm>
 #include <cstring>
+#include <format>
 
 #include "System/simd_compat.h"
 
@@ -18,6 +19,13 @@ CR_BIND(CMatrix44f, )
 CR_REG_METADATA(CMatrix44f, CR_MEMBER(m))
 
 static_assert(alignof(CMatrix44f) == 64);
+
+std::string CMatrix44f::str() const
+{
+	return std::format(
+		"m44(\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f})",
+		m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7], m[11], m[15]);
+}
 CMatrix44f::CMatrix44f(const CMatrix44f& mat)
 {
 	memcpy(&m[0], &mat.m[0], sizeof(CMatrix44f));

--- a/rts/System/Matrix44f.h
+++ b/rts/System/Matrix44f.h
@@ -176,11 +176,7 @@ public:
 		float4 col[4];
 	};
 
-	std::string str() const {
-		return std::format(
-			"m44(\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f}\n{:.3f} {:.3f} {:.3f} {:.3f})",
-			m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7], m[11], m[15]);
-	}
+	std::string str() const;
 };
 
 

--- a/rts/System/Sync/DumpHistory.cpp
+++ b/rts/System/Sync/DumpHistory.cpp
@@ -1,5 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <format>
+
 #include "DumpHistory.h"
 #include "SyncChecker.h"
 

--- a/rts/System/float3.cpp
+++ b/rts/System/float3.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <format>
 
 #include "System/creg/creg_cond.h"
 #include "System/SpringMath.h"
@@ -14,6 +15,11 @@ CR_REG_METADATA(float3, (CR_MEMBER(x), CR_MEMBER(y), CR_MEMBER(z)))
 //! gets initialized later when the map is loaded
 float float3::maxxpos = -1.0f;
 float float3::maxzpos = -1.0f;
+
+std::string float3::str() const
+{
+	return std::format("float3({:.3f}, {:.3f}, {:.3f})", x, y, z);
+}
 
 float3 float3::PickNonParallel() const
 {

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <array>
 #include <utility>
-#include <format>
+#include <string>
 
 #include "System/BranchPrediction.h"
 #include "System/creg/creg_cond.h"
@@ -838,9 +838,7 @@ public:
 	static constexpr float cmp_eps() { return 1e-04f; }
 	static constexpr float nrm_eps() { return 1e-12f; }
 
-	std::string str() const {
-		return std::format("float3({:.3f}, {:.3f}, {:.3f})", x, y, z);
-	}
+	std::string str() const;
 
 	/**
 	 * @brief max x pos

--- a/rts/System/float4.cpp
+++ b/rts/System/float4.cpp
@@ -4,8 +4,15 @@
 #include "System/creg/creg_cond.h"
 #include "System/SpringMath.h"
 
+#include <format>
+
 CR_BIND(float4, )
 CR_REG_METADATA(float4, (CR_MEMBER(x), CR_MEMBER(y), CR_MEMBER(z), CR_MEMBER(w)))
+
+std::string float4::str() const
+{
+	return std::format("float4({:.3f}, {:.3f}, {:.3f}, {:.3f})", x, y, z, w);
+}
 
 // ensure that we use a continuous block of memory
 // (required for passing to gl functions)

--- a/rts/System/float4.h
+++ b/rts/System/float4.h
@@ -108,9 +108,7 @@ struct float4 : public float3
 		return (x * f.x) + (y * f.y) + (z * f.z) + (w * f.w);
 	}
 
-	std::string str() const {
-		return std::format("float4({:.3f}, {:.3f}, {:.3f}, {:.3f})", x, y, z, w);
-	}
+	std::string str() const;
 
 
 	/// Allows implicit conversion to float* (for passing to gl functions)


### PR DESCRIPTION
## What
Moves the `str()` bodies of `float3`, `float4`, and `CMatrix44f` out of their headers into the corresponding `.cpp` files, and drops `#include <format>` from the headers (`float3.h` keeps `<string>` for the declaration). Adds a direct `#include <format>` to the two other live `std::format` users that were relying on the transitive include (`UnsyncedGameCommands.cpp`, `DumpHistory.cpp`).

## Why
`str()` was defined inline in the headers, so `float3.h` had to `#include <format>` at the top. Because `float3.h` is included across most of the engine (and transitively by vendored targets like `lua`/`luasocket`), every one of those translation units paid to parse `<format>` for a debug-only helper, and any target touching `float3.h` had to have the formatting library's headers on its path. Moving `str()` out of line removes that header dependency entirely: only the three math `.cpp` files need `<format>` now.

This also resolves, structurally, the transitive-include problem the macOS work surfaced in #3080 - without converting anything to `fmt::format` or adding global includes / extra link edges. It keeps `std::format` (available under the gcc/libstdc++ toolchain the engine builds with) and is a strict compile-time improvement for a ubiquitous header. It's an alternative to #3080.

## Performance
`str()` is a debug/logging helper - the only two call sites in the engine are commented-out `LOG` lines. It is never on a hot path, so losing header inlining has no measurable cost; the win is faster compilation of every TU that includes `float3.h`.

## Testing
Compiled the affected TUs with the macOS Homebrew gcc-16 (libstdc++) toolchain: `float4.cpp`, `Matrix44f.cpp`, and `DumpHistory.cpp` compile clean. `float3.cpp` and `UnsyncedGameCommands.cpp` fail only on pre-existing macOS-on-master issues unrelated to this change (the `streflop`/`FastMath` `math::sqrtf` error and the `MemPoolTypes.h` `pthread_t`->`uint32_t` cast), verified identical against pristine master. On Linux those don't occur. Opened as a draft so CI covers the authoritative Linux/Windows builds.

## AI disclosure
Analysis and patch prepared with AI assistance (Claude Code); reviewed and locally compile-checked by a human.
