### PR TITLE
Fix unbindaction leaving scancode bindings in place

### DIFF
--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -740,7 +740,13 @@ bool CKeyBindings::UnBindAction(const std::string& command)
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (debugEnabled)
 		LOG("[CKeyBindings::%s] command=%s", __func__, command.c_str());
-	return RemoveActionFromKeyMap(command, codeBindings) || RemoveActionFromKeyMap(command, scanBindings);
+
+	// clear both maps; || would short-circuit and leave the scancode binding when
+	// the action is also bound to a keycode
+	const bool removedFromCode = RemoveActionFromKeyMap(command, codeBindings);
+	const bool removedFromScan = RemoveActionFromKeyMap(command, scanBindings);
+
+	return removedFromCode || removedFromScan;
 }
 
 


### PR DESCRIPTION
`unbindaction <action>` doesn't fully unbind - it clears the action from the keycode bindings but leaves the scancode ones. In `UnBindAction` the two removals are joined with `||`, so once `RemoveActionFromKeyMap(..., codeBindings)` returns true the scancode removal is skipped. An action bound to both a key and a scancode ends up half-unbound.

The fix runs both removals and then ORs the results.

I checked it on a headless build: bound a test action to both keycode `a` and scancode `sc_0x04`, ran `unbindaction`, and its hotkey count went from 2 to 0. Without the fix the `||` leaves the scancode binding in place.

Came across this while working in the keybinding code for the input-emulation change.

Written with Claude Code.
