### PR TITLE
fix wide char to utf8 conversions.

### DIFF
--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -286,15 +286,13 @@ std::string windows::GetDisplayString(bool getName, bool getVersion, bool getExt
 		oss << " (build " << osvi.dwBuildNumber;
 
 		if (osvi.szCSDVersion[0] != 0) {
-			static_assert(sizeof(wchar_t) >= sizeof(osvi.szCSDVersion[0]), "");
+			const int utf8Len = WideCharToMultiByte(CP_UTF8, 0, osvi.szCSDVersion, -1, nullptr, 0, nullptr, nullptr);
 
-			// Windows uses UTF16
-			std::wstring_convert<std::codecvt_utf16<wchar_t>, wchar_t> ws2s;
-
-			const std::wstring wstr(osvi.szCSDVersion);
-			const std::string nstr(ws2s.to_bytes(wstr));
-
-			oss << ", " << nstr;
+			if (utf8Len > 1) {
+				std::string nstr(utf8Len - 1, '\0');
+				WideCharToMultiByte(CP_UTF8, 0, osvi.szCSDVersion, -1, nstr.data(), utf8Len, nullptr, nullptr);
+				oss << ", " << nstr;
+			}
 		}
 
 		oss << ")";
@@ -309,14 +307,25 @@ std::string windows::GetHardwareString()
 {
 	std::ostringstream oss;
 
-	unsigned char regbuf[200];
-	DWORD regLength = sizeof(regbuf);
+	wchar_t regbuf[200] = {};
+	DWORD regLength = sizeof(regbuf); // in bytes, not wchar_t units
 	DWORD regType = REG_SZ;
 	HKEY regkey;
 
-	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", 0, KEY_READ, &regkey) == ERROR_SUCCESS) {
-		if (RegQueryValueEx(regkey, L"ProcessorNameString", 0, &regType, regbuf, &regLength) == ERROR_SUCCESS) {
-			oss << regbuf << "; ";
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", 0, KEY_READ, &regkey) == ERROR_SUCCESS) {
+		if (RegQueryValueExW(regkey, L"ProcessorNameString", 0, &regType, reinterpret_cast<LPBYTE>(regbuf), &regLength) == ERROR_SUCCESS) {
+			// REG_SZ values aren't guaranteed to be null-terminated; force it
+			regbuf[(sizeof(regbuf) / sizeof(regbuf[0])) - 1] = L'\0';
+
+			const int utf8Len = WideCharToMultiByte(CP_UTF8, 0, regbuf, -1, nullptr, 0, nullptr, nullptr);
+
+			if (utf8Len > 1) {
+				std::string utf8str(utf8Len - 1, '\0'); // -1: exclude the null terminator WideCharToMultiByte counts
+				WideCharToMultiByte(CP_UTF8, 0, regbuf, -1, utf8str.data(), utf8Len, nullptr, nullptr);
+				oss << utf8str << "; ";
+			} else {
+				oss << "cannot read processor data; ";
+			}
 		} else {
 			oss << "cannot read processor data; ";
 		}

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <array>
 #include <cassert>
 #include <sstream>
 #include <string>
@@ -307,21 +308,21 @@ std::string windows::GetHardwareString()
 {
 	std::ostringstream oss;
 
-	wchar_t regbuf[200] = {};
-	DWORD regLength = sizeof(regbuf); // in bytes, not wchar_t units
+	std::array<wchar_t, 200> regbuf{};
+	DWORD regLength = static_cast<DWORD>(regbuf.size() * sizeof(wchar_t)); // RegQueryValueExW wants bytes
 	DWORD regType = REG_SZ;
 	HKEY regkey;
 
 	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", 0, KEY_READ, &regkey) == ERROR_SUCCESS) {
-		if (RegQueryValueExW(regkey, L"ProcessorNameString", 0, &regType, reinterpret_cast<LPBYTE>(regbuf), &regLength) == ERROR_SUCCESS) {
+		if (RegQueryValueExW(regkey, L"ProcessorNameString", 0, &regType, reinterpret_cast<LPBYTE>(regbuf.data()), &regLength) == ERROR_SUCCESS) {
 			// REG_SZ values aren't guaranteed to be null-terminated; force it
-			regbuf[(sizeof(regbuf) / sizeof(regbuf[0])) - 1] = L'\0';
+			regbuf.back() = L'\0';
 
-			const int utf8Len = WideCharToMultiByte(CP_UTF8, 0, regbuf, -1, nullptr, 0, nullptr, nullptr);
+			const int utf8Len = WideCharToMultiByte(CP_UTF8, 0, regbuf.data(), -1, nullptr, 0, nullptr, nullptr);
 
 			if (utf8Len > 1) {
-				std::string utf8str(utf8Len - 1, '\0'); // -1: exclude the null terminator WideCharToMultiByte counts
-				WideCharToMultiByte(CP_UTF8, 0, regbuf, -1, utf8str.data(), utf8Len, nullptr, nullptr);
+				std::string utf8str(utf8Len - 1, '\0');
+				WideCharToMultiByte(CP_UTF8, 0, regbuf.data(), -1, utf8str.data(), utf8Len, nullptr, nullptr);
 				oss << utf8str << "; ";
 			} else {
 				oss << "cannot read processor data; ";

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -325,7 +325,7 @@ std::string windows::GetHardwareString()
 				WideCharToMultiByte(CP_UTF8, 0, regbuf.data(), -1, utf8str.data(), utf8Len, nullptr, nullptr);
 				oss << utf8str << "; ";
 			} else {
-				oss << "cannot read processor data; ";
+				oss << "cannot convert processor name to UTF-8; ";
 			}
 		} else {
 			oss << "cannot read processor data; ";


### PR DESCRIPTION
Urgent fix that will be cherry-picked into 2026.06 release branch.

I've tested locally on my machine and I get the expect correct values in the info log file.

was

`Hardware Config: A; Hardware Config: A; `

now

`Hardware Config: AMD Ryzen 5 5600X 6-Core Processor             ; 65450MB RAM, 69546MB pagefile`

also fixed the deprecated use of `std::wstring_convert` in the same file because that is closely related to this fix.
