### PR TITLE
refactor: replace ARRAY_MATMODE magic number with a named define

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -262,7 +262,7 @@ Transform Lerp(Transform t0, Transform t1, float a) {
 
 void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 {
-	bool staticModel = (matrixMode > 0);
+	bool staticModel = (matrixMode == MATMODE_STATIC);
 
 	vec4 piecePos = vec4(pos, 1.0);
 	vec4 normal4 = vec4(normal, 0.0);
@@ -327,7 +327,7 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 
 void main(void)
 {
-	bool staticModel = (matrixMode > 0);
+	bool staticModel = (matrixMode == MATMODE_STATIC);
 
 	vec4 modelPos;
 	vec3 modelNormal;

--- a/rts/Rendering/Common/ModelDrawerState.cpp
+++ b/rts/Rendering/Common/ModelDrawerState.cpp
@@ -263,6 +263,9 @@ CModelDrawerStateGL4::CModelDrawerStateGL4()
 		modelShaders[n]->SetFlag("GBUFFER_MISCTEX_IDX", GL::GeometryBuffer::ATTACHMENT_MISCTEX);
 		modelShaders[n]->SetFlag("GBUFFER_ZVALTEX_IDX", GL::GeometryBuffer::ATTACHMENT_ZVALTEX);
 
+		// name the matrix-mode value the shader compares against, so it reads the mode by name
+		modelShaders[n]->SetFlag("MATMODE_STATIC", static_cast<int>(ShaderMatrixModes::STATIC_MATMODE));
+
 		modelShaders[n]->Link();
 		modelShaders[n]->Enable();
 		modelShaders[n]->Disable();


### PR DESCRIPTION
Add SetFlag("MATMODE_ARRAY", ...) alongside the existing GBUFFER_*_IDX flags so the GL4 model shaders can reference the matrix-mode enum value by name instead of hardcoding a literal.

Intended as a precursor for the ghost draw perf fixes, which add a third mode in the shader.