### PR TITLE
AIFloat3: Remove non-trivial copy constructor

### DIFF
--- a/AI/Wrappers/Cpp/src/AIFloat3.cpp
+++ b/AI/Wrappers/Cpp/src/AIFloat3.cpp
@@ -16,10 +16,6 @@ springai::AIFloat3::AIFloat3(float* xyz)
 	: float3(xyz)
 {
 }
-springai::AIFloat3::AIFloat3(const springai::AIFloat3& other)
-	: float3(other)
-{
-}
 springai::AIFloat3::AIFloat3(const float3& f3)
 	: float3(f3)
 {

--- a/AI/Wrappers/Cpp/src/AIFloat3.h
+++ b/AI/Wrappers/Cpp/src/AIFloat3.h
@@ -18,7 +18,8 @@ public:
 	AIFloat3();
 	AIFloat3(float x, float y, float z);
 	AIFloat3(float* xyz);
-	AIFloat3(const AIFloat3& other);
+	// must be trivial - same as float3, otherwise it ruins bindings
+	AIFloat3(const AIFloat3& other) = default;
 	AIFloat3(const float3& f3);
 
 	void LoadInto(float* xyz) const;


### PR DESCRIPTION
When `AIFloat3` had virtual methods - it required non-trivial copy constructor.
It is a leftover that spoils AngelScript bindings to `float3` math methods that return `float3` as result.

Insinuations: while AngelScript expects copying through registers (`this==nullptr`) non-trivial copy constructor makes it in memory trying to dereference nullptr.

This is the 1st part of planned `AIFloat3` refactor. In 2nd part (as separate PR) `AIFloat3` will become a copy of `float3` interface and implementation with inheritance removed.