### PR TITLE
fix(GLSL/GL4): draw ghost buildings with the palette they were last seen under

### DIFF
--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -886,7 +886,9 @@ void CUnitDrawerGLSL::DrawGhostedBuildings(int modelType) const
 	}
 
 	// buildings that left LOS but are still alive
-	for (CUnit* unit : liveGhostedBuildings) {
+	for (const auto& lgb : liveGhostedBuildings) {
+		const CUnit* unit = lgb.unit;
+
 		// check for decoy models
 		const UnitDef* decoyDef = unit->unitDef->decoyDef;
 		const S3DModel* model = (decoyDef == nullptr) ? unit->model : decoyDef->LoadModel();
@@ -915,8 +917,9 @@ void CUnitDrawerGLSL::DrawGhostedBuildings(int modelType) const
 		// not actually cloaked
 		CModelDrawerHelper::BindModelTypeTexture(modelType, model->textureType);
 
+		// color with the team the unit was last seen under, not the live unit's current team
 		const float ghostAlpha = (losStatus & LOS_CONTRADAR) ? IModelDrawerState::alphaValues.z : IModelDrawerState::alphaValues.y;
-		SetTeamColor(unit->team, ghostAlpha);
+		SetTeamColor(lgb.team, ghostAlpha);
 		model->DrawStatic();
 		glPopMatrix();
 
@@ -1772,7 +1775,7 @@ void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 			}
 
 			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(dgb->GetModel(), static_cast<uint16_t>(dgb->team)); //need to submit immediately every model because of static per-model matrix
+			smv.SubmitImmediately(dgb->GetModel(), dgb->paletteIndex); //need to submit immediately every model because of static per-model matrix
 		}
 	}
 
@@ -1782,20 +1785,14 @@ void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 
 		int prevModelType = -1;
 		int prevTexType = -1;
-		for (const auto* lgb : liveGhostedBuildings) {
-			if (!camera->InView(lgb->pos, lgb->model->GetDrawRadius()))
+		for (const auto& lgb : liveGhostedBuildings) {
+			const CUnit* u = lgb.unit;
+			if (!camera->InView(u->pos, u->model->GetDrawRadius()))
 				continue;
 
 			// check for decoy models
-			const UnitDef* decoyDef = lgb->unitDef->decoyDef;
-			const S3DModel* model = nullptr;
-
-			if (decoyDef == nullptr) {
-				model = lgb->model;
-			}
-			else {
-				model = decoyDef->LoadModel();
-			}
+			const UnitDef* decoyDef = u->unitDef->decoyDef;
+			const S3DModel* model = (decoyDef == nullptr) ? u->model : decoyDef->LoadModel();
 
 			// FIXME: needs a second pass
 			if (model->type != modelType)
@@ -1804,20 +1801,21 @@ void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 			static CMatrix44f staticWorldMat;
 
 			staticWorldMat.LoadIdentity();
-			staticWorldMat.Translate(lgb->pos);
+			staticWorldMat.Translate(u->pos);
 
-			staticWorldMat.RotateY(-lgb->buildFacing * math::DEG_TO_RAD * 90.0f);
+			staticWorldMat.RotateY(-u->buildFacing * math::DEG_TO_RAD * 90.0f);
 
-			const unsigned short losStatus = lgb->losStatus[gu->myAllyTeam];
+			const unsigned short losStatus = u->losStatus[gu->myAllyTeam];
 
-			// ghosted enemy units
+			// ghosted enemy units; SetTeamColor only gates the alpha here (the per-instance
+			// paletteIndex passed to SubmitImmediately drives the actual color)
 			if (losStatus & LOS_CONTRADAR) {
 				modelDrawerState->SetColorMultiplier(0.9f, 0.9f, 0.9f, IModelDrawerState::alphaValues.z);
-				modelDrawerState->SetTeamColor(lgb->team, IModelDrawerState::alphaValues.z);
+				modelDrawerState->SetTeamColor(lgb.team, IModelDrawerState::alphaValues.z);
 			}
 			else {
 				modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
-				modelDrawerState->SetTeamColor(lgb->team, IModelDrawerState::alphaValues.y);
+				modelDrawerState->SetTeamColor(lgb.team, IModelDrawerState::alphaValues.y);
 			}
 
 			if (prevModelType != modelType || prevTexType != model->textureType) {
@@ -1826,7 +1824,8 @@ void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 			}
 
 			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(model, static_cast<uint16_t>(lgb->team)); //need to submit immediately every model because of static per-model matrix
+			// draw with the palette the unit was last seen under, not the live unit's current one
+			smv.SubmitImmediately(model, lgb.paletteIndex); //need to submit immediately every model because of static per-model matrix
 		}
 	}
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -48,11 +48,19 @@ CR_REG_METADATA(GhostSolidObject, (
 
 	CR_MEMBER(facing),
 	CR_MEMBER(team),
+	CR_MEMBER(paletteIndex),
 	CR_IGNORED(currentIconIndex),
 
 	CR_IGNORED(model),
 
 	CR_POSTLOAD(PostLoad)
+))
+
+CR_BIND(CUnitDrawerData::LiveGhostBuilding, )
+CR_REG_METADATA(CUnitDrawerData::LiveGhostBuilding, (
+	CR_MEMBER(unit),
+	CR_MEMBER(paletteIndex),
+	CR_MEMBER(team)
 ))
 
 CR_BIND(CUnitDrawerData::TempDrawUnit, )
@@ -617,6 +625,7 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 				gso->facing = u->buildFacing;
 				gso->dir = u->frontdir;
 				gso->team = u->team;
+				gso->paletteIndex = u->paletteIndex;
 				gso->radius = u->radius;
 				gso->GetModel();
 
@@ -640,7 +649,8 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 
 		}
 
-		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(u)], u);
+		spring::VectorEraseIf(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(u)],
+			[u](const LiveGhostBuilding& lgb) { return lgb.unit == u; });
 	}
 	return addedOwnAllyTeam;
 }
@@ -674,7 +684,8 @@ void CUnitDrawerData::UnitEnteredLos(const CUnit* unit, int allyTeam)
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
 	if (unit->leavesGhost)
-		spring::VectorErase(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u);
+		spring::VectorEraseIf(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)],
+			[u](const LiveGhostBuilding& lgb) { return lgb.unit == u; });
 
 	if (allyTeam != gu->myAllyTeam)
 		return;
@@ -687,8 +698,15 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	CUnit* u = const_cast<CUnit*>(unit); //cleanup
 
-	if (unit->leavesGhost)
-		spring::VectorInsertUnique(savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)], u, true);
+	if (unit->leavesGhost) {
+		// snapshot the color the unit is last seen under so a later team change (while out of LOS)
+		// does not recolor its ghost. keep the earliest snapshot if it re-fires without re-entering.
+		auto& lgbs = savedData.liveGhostBuildings[allyTeam][MDL_TYPE(unit)];
+		const bool alreadyGhosted = std::any_of(lgbs.begin(), lgbs.end(),
+			[u](const LiveGhostBuilding& lgb) { return lgb.unit == u; });
+		if (!alreadyGhosted)
+			lgbs.push_back({ u, u->paletteIndex, static_cast<uint8_t>(u->team) });
+	}
 
 	if (allyTeam != gu->myAllyTeam)
 		return;

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -34,7 +34,13 @@ public:
 
 	int refCount;
 	int facing; //FIXME replaced with dir-vector just legacy decal drawer uses this
+
+	// color identity captured when the ghost was created; a ghost keeps the color it was last
+	// seen under. team drives the legacy (GLSL) team-color path, paletteIndex drives the GL4
+	// per-instance palette (equal to team unless a custom Lua color palette was assigned).
 	uint8_t team;
+	uint16_t paletteIndex;
+
 	size_t currentIconIndex;
 private:
 	mutable const S3DModel* model;
@@ -86,6 +92,16 @@ public:
 	private:
 		mutable const UnitDef* unitDef;
 	};
+	// a still-alive building that left an observer's LOS. The unit is drawn as a ghost using the
+	// color it was last seen under (snapshotted here), so it does not silently recolor if the live
+	// unit changes team while out of LOS. team feeds the legacy (GLSL) team-color path, paletteIndex
+	// feeds the GL4 per-instance palette (equal to team unless a custom Lua palette was assigned).
+	struct LiveGhostBuilding {
+		CR_DECLARE_STRUCT(LiveGhostBuilding)
+		CUnit* unit = nullptr;
+		uint16_t paletteIndex = 0;
+		uint8_t team = 0;
+	};
 	struct SavedData {
 		CR_DECLARE_STRUCT(SavedData)
 
@@ -97,7 +113,7 @@ public:
 		std::vector<std::array<std::vector<GhostSolidObject*>, MODELTYPE_CNT>> deadGhostBuildings;
 
 		/// buildings that left LOS but are still alive
-		std::vector<std::array<std::vector<CUnit*>, MODELTYPE_CNT>> liveGhostBuildings;
+		std::vector<std::array<std::vector<LiveGhostBuilding>, MODELTYPE_CNT>> liveGhostBuildings;
 	};
 public:
 	CUnitDrawerData(bool& mtModelDrawer_);


### PR DESCRIPTION
### Context
This addresses two bugs:
1. recently we added custom color palette functionality, but that was not extended to ghosts (so they are currently using just the team color).
2. Live ghosts read the color from the live CUnit at draw time, so if a unit changes team while in fog of war (eg. unit gifts), that information would be leaked.

### Work done
So, to fix, we now a) use paletteIndex for ghost color and b) snapshot the last seen paletteIndex for that unit.

### Screenshots
**building units**:
I don't have a way to test this... Not sure if this is a valid codepath (can you palette units before they're built?)

**live ghost buildings**:
Before:
<img width="2560" height="1440" alt="screen_2026-07-15_04-14-05-142" src="https://github.com/user-attachments/assets/2398f464-9299-4afe-9598-e20ed7cad770" />

After:
<img width="2560" height="1440" alt="screen_2026-07-15_04-42-24-791" src="https://github.com/user-attachments/assets/8b82f684-b759-4f5a-91b7-5edbf72cf801" />



**radar'd ghost buildings**:
Before:
<img width="2560" height="1440" alt="screen_2026-07-15_04-13-23-278" src="https://github.com/user-attachments/assets/5bfdaf45-7346-42b1-a6e5-5f30ccc9c6c5" />

After:
<img width="2560" height="1440" alt="screen_2026-07-15_04-41-43-580" src="https://github.com/user-attachments/assets/dd898bba-1fb9-47d0-884e-7561b579fef4" />



**dead ghost buildings**:
Before:
<img width="2560" height="1440" alt="screen_2026-07-15_04-28-20-368" src="https://github.com/user-attachments/assets/c744d709-fe7d-471a-866c-dd7732bbecd0" />

After:
<img width="2560" height="1440" alt="screen_2026-07-15_04-43-33-604" src="https://github.com/user-attachments/assets/d4e186af-db13-445f-8962-f506d4de9170" />

**snapshotting working**: (you can see if we turn player view fog on, the ghosts switch back to the snapshotted color)
<img width="2560" height="1440" alt="screen_2026-07-15_04-49-43-072" src="https://github.com/user-attachments/assets/664e00d2-daef-4f50-91de-ee353cd610d3" />
<img width="2560" height="1440" alt="screen_2026-07-15_04-49-45-269" src="https://github.com/user-attachments/assets/9df7d63c-42e2-47cf-8da6-0b0a9d06a76a" />


### AI Disclosure
Me using claude code do so most of the underlying writing, but with heavy review and iteration by me, a human.