### PR TITLE
perf(GL4): batch ghost-building rendering

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -262,7 +262,7 @@ Transform Lerp(Transform t0, Transform t1, float a) {
 
 void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 {
-	bool staticModel = (matrixMode == MATMODE_STATIC);
+	bool staticModel = (matrixMode == MATMODE_STATIC || matrixMode == MATMODE_ARRAY);
 
 	vec4 piecePos = vec4(pos, 1.0);
 	vec4 normal4 = vec4(normal, 0.0);
@@ -271,7 +271,10 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 	
 	Transform tx;
 	if (staticModel) {
-		tx = transforms[instData.x + bID0];
+		// pieces always come from the bind-pose block (instData.w). In ARRAY_MATMODE
+		// instData.x is the per-instance world transform, not the bind pose; for static
+		// model submits instData.x == instData.w anyway, so instData.w is correct for both.
+		tx = transforms[instData.w + bID0];
 	} else {
 		// do interpolation
 		tx = Lerp(
@@ -327,16 +330,20 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 
 void main(void)
 {
-	bool staticModel = (matrixMode == MATMODE_STATIC);
-
 	vec4 modelPos;
 	vec3 modelNormal;
 	GetModelSpaceVertex(modelPos, modelNormal);
 
-	if (staticModel) {
+	if (matrixMode == MATMODE_ARRAY) {
+		// static instanced: per-instance world transform read from the SSBO (no interpolation)
+		Transform wtx = transforms[instData.x + 0u];
+		worldPos = ApplyTransform(wtx, modelPos);
+		wtx.trSc = vec4(0, 0, 0, 1); //nullify the translation part for the normal
+		worldNormal = ApplyTransform(wtx, modelNormal);
+	} else if (matrixMode == MATMODE_STATIC) {
 		worldPos = staticModelMatrix * modelPos;
 		worldNormal = mat3(staticModelMatrix) * modelNormal;
-	} else {
+	} else { // MATMODE_NORMAL
 		// do interpolation
 		Transform tx = Lerp(
 			transforms[instData.x + 0u],

--- a/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ModelVertProgGL4.glsl
@@ -262,7 +262,7 @@ Transform Lerp(Transform t0, Transform t1, float a) {
 
 void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 {
-	bool staticModel = (matrixMode > 0);
+	bool staticModel = (matrixMode == MATMODE_STATIC);
 
 	vec4 piecePos = vec4(pos, 1.0);
 	vec4 normal4 = vec4(normal, 0.0);
@@ -327,7 +327,7 @@ void GetModelSpaceVertex(out vec4 msPosition, out vec3 msNormal)
 
 void main(void)
 {
-	bool staticModel = (matrixMode > 0);
+	bool staticModel = (matrixMode == MATMODE_STATIC);
 
 	vec4 modelPos;
 	vec3 modelNormal;

--- a/rts/Rendering/Common/ModelDrawerState.cpp
+++ b/rts/Rendering/Common/ModelDrawerState.cpp
@@ -263,6 +263,9 @@ CModelDrawerStateGL4::CModelDrawerStateGL4()
 		modelShaders[n]->SetFlag("GBUFFER_MISCTEX_IDX", GL::GeometryBuffer::ATTACHMENT_MISCTEX);
 		modelShaders[n]->SetFlag("GBUFFER_ZVALTEX_IDX", GL::GeometryBuffer::ATTACHMENT_ZVALTEX);
 
+		// name the matrix-mode value the shader compares against, so it reads the mode by name
+		modelShaders[n]->SetFlag("MATMODE_STATIC", static_cast<int>(ShaderMatrixModes::STATIC_MATMODE));
+
 		modelShaders[n]->Link();
 		modelShaders[n]->Enable();
 		modelShaders[n]->Disable();

--- a/rts/Rendering/Common/ModelDrawerState.cpp
+++ b/rts/Rendering/Common/ModelDrawerState.cpp
@@ -263,8 +263,9 @@ CModelDrawerStateGL4::CModelDrawerStateGL4()
 		modelShaders[n]->SetFlag("GBUFFER_MISCTEX_IDX", GL::GeometryBuffer::ATTACHMENT_MISCTEX);
 		modelShaders[n]->SetFlag("GBUFFER_ZVALTEX_IDX", GL::GeometryBuffer::ATTACHMENT_ZVALTEX);
 
-		// name the matrix-mode value the shader compares against, so it reads the mode by name
+		// name the matrix-mode values the shader compares against, so it reads modes by name
 		modelShaders[n]->SetFlag("MATMODE_STATIC", static_cast<int>(ShaderMatrixModes::STATIC_MATMODE));
+		modelShaders[n]->SetFlag("MATMODE_ARRAY",  static_cast<int>(ShaderMatrixModes::ARRAY_MATMODE));
 
 		modelShaders[n]->Link();
 		modelShaders[n]->Enable();

--- a/rts/Rendering/Models/3DModelVAO.cpp
+++ b/rts/Rendering/Models/3DModelVAO.cpp
@@ -372,6 +372,22 @@ bool S3DModelVAO::AddToSubmission(const UnitDef* unitDef, uint16_t paletteIndex)
 	return AddToSubmissionImpl(unitDef, model->indxStart, model->indxCount, paletteIndex);
 }
 
+bool S3DModelVAO::AddStaticInstance(const S3DModel* model, uint32_t worldTransformOffset, uint16_t paletteIndex)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(model);
+
+	// the world transform is the caller-supplied slot; pieces are read from the model bind pose
+	return EmplaceInstance(
+		model->indxStart, model->indxCount,
+		worldTransformOffset,
+		paletteIndex,
+		static_cast<uint16_t>(model->numPieces),
+		static_cast<uint32_t>(modelUniformsStorage.GetObjOffset(model)),
+		static_cast<uint32_t>(transformsUploader.GetElemOffset(model))
+	);
+}
+
 
 void S3DModelVAO::Submit(GLenum mode, bool bindUnbind)
 {

--- a/rts/Rendering/Models/3DModelVAO.hpp
+++ b/rts/Rendering/Models/3DModelVAO.hpp
@@ -71,6 +71,9 @@ public:
 	bool AddToSubmission(const CFeature* feature);
 
 	bool AddToSubmission(const UnitDef* unitDef, uint16_t paletteIndex);
+
+	bool AddStaticInstance(const S3DModel* model, uint32_t worldTransformOffset, uint16_t paletteIndex);
+
 	void Submit(GLenum mode = GL_TRIANGLES, bool bindUnbind = false);
 
 	bool SubmitImmediately(const S3DModel* model, uint16_t paletteIndex, GLenum mode = GL_TRIANGLES, bool bindUnbind = false);

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -2,6 +2,8 @@
 
 #include "UnitDrawer.h"
 
+#include <map>
+
 #include "Game/Camera.h"
 #include "Game/CameraHandler.h"
 #include "Game/Game.h"
@@ -1745,46 +1747,75 @@ void CUnitDrawerGL4::DrawAlphaObjects(int modelType, bool drawReflection, bool d
 void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const auto& deadGhostBuildings = modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam, modelType);
 
 	auto& smv = S3DModelVAO::GetInstance();
 	smv.Bind();
 
-	const auto oldMM = modelDrawerState->SetMatrixMode(ShaderMatrixModes::STATIC_MATMODE);
-	// deadGhostedBuildings
-	{
-		modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
-		modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y); //teamID doesn't matter here
+	// Ghost buildings are static (no animation, never move), so each gets a single world-transform
+	// slot in the transforms SSBO and is drawn batched through ARRAY_MATMODE - one multidraw per
+	// (color bucket x texture type) instead of one immediate draw per ghost.
+	const auto oldMM = modelDrawerState->SetMatrixMode(ShaderMatrixModes::ARRAY_MATMODE);
 
-		int prevModelType = -1;
-		int prevTexType = -1;
+	struct GhostInstance {
+		const S3DModel* model;
+		uint32_t worldTransformOffset;
+		uint16_t paletteIndex; // color the ghost was last seen under (see LiveGhostBuilding / GhostSolidObject)
+	};
+	// bind the texture once per group, accumulate, then one Submit (=one multidraw) per texture type.
+	// buckets are reused across frames (see clearBuckets) so a screen full of ghosts does not realloc
+	// its per-texture vectors every frame; empty buckets (a texture no longer on screen) are skipped.
+	const auto flushGhosts = [&](const std::map<int, std::vector<GhostInstance>>& byTex) {
+		for (const auto& [texType, instances] : byTex) {
+			if (instances.empty())
+				continue;
+			CModelDrawerHelper::BindModelTypeTexture(modelType, texType);
+			for (const auto& gi : instances)
+				smv.AddStaticInstance(gi.model, gi.worldTransformOffset, gi.paletteIndex);
+			smv.Submit(GL_TRIANGLES, false);
+		}
+	};
+	// clear the mapped vectors (keeping their capacity) instead of clearing the map (which would free them)
+	const auto clearBuckets = [](std::map<int, std::vector<GhostInstance>>& byTex) {
+		for (auto& [texType, instances] : byTex)
+			instances.clear();
+	};
+
+	// deadGhostedBuildings (single color state)
+	{
+		const auto& deadGhostBuildings = modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam, modelType);
+
+		static std::map<int, std::vector<GhostInstance>> byTex;
+		clearBuckets(byTex);
+		bool any = false;
 		for (const auto* dgb : deadGhostBuildings) {
-			if (!camera->InView(dgb->pos, dgb->GetModel()->GetDrawRadius()))
+			const S3DModel* model = dgb->GetModel();
+			if (!camera->InView(dgb->pos, model->GetDrawRadius()))
+				continue;
+			if (!dgb->worldTransformAlloc.Valid())
 				continue;
 
-			static CMatrix44f staticWorldMat;
+			byTex[model->textureType].push_back({ model, static_cast<uint32_t>(dgb->worldTransformAlloc.GetOffset()), dgb->paletteIndex });
+			any = true;
+		}
 
-			staticWorldMat.LoadIdentity();
-			staticWorldMat.Translate(dgb->pos);
-
-			staticWorldMat.RotateY(-dgb->facing * math::DEG_TO_RAD * 90.0f);
-
-			if (prevModelType != modelType || prevTexType != dgb->GetModel()->textureType) {
-				prevModelType = modelType; prevTexType = dgb->GetModel()->textureType;
-				CModelDrawerHelper::BindModelTypeTexture(modelType, dgb->GetModel()->textureType); //inefficient rendering, but w/e
-			}
-
-			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			smv.SubmitImmediately(dgb->GetModel(), dgb->paletteIndex); //need to submit immediately every model because of static per-model matrix
+		if (any) {
+			modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y); //teamID is per-instance
+			flushGhosts(byTex);
 		}
 	}
 
-	// liveGhostedBuildings
+	// liveGhostedBuildings (two color states: normal and CONTRADAR)
 	{
 		const auto& liveGhostedBuildings = modelDrawerData->GetLiveGhostBuildings(gu->myAllyTeam, modelType);
 
-		int prevModelType = -1;
-		int prevTexType = -1;
+		static std::map<int, std::vector<GhostInstance>> byTexNormal;
+		static std::map<int, std::vector<GhostInstance>> byTexContradar;
+		clearBuckets(byTexNormal);
+		clearBuckets(byTexContradar);
+		bool anyNormal = false;
+		bool anyContradar = false;
+
 		for (const auto& lgb : liveGhostedBuildings) {
 			const CUnit* u = lgb.unit;
 			if (!camera->InView(u->pos, u->model->GetDrawRadius()))
@@ -1798,34 +1829,27 @@ void CUnitDrawerGL4::DrawGhostedBuildings(int modelType) const
 			if (model->type != modelType)
 				continue;
 
-			static CMatrix44f staticWorldMat;
-
-			staticWorldMat.LoadIdentity();
-			staticWorldMat.Translate(u->pos);
-
-			staticWorldMat.RotateY(-u->buildFacing * math::DEG_TO_RAD * 90.0f);
+			const size_t xfOffset = modelDrawerData->GetLiveGhostTransform(u);
+			if (xfOffset == TransformsMemStorage::INVALID_INDEX)
+				continue;
 
 			const unsigned short losStatus = u->losStatus[gu->myAllyTeam];
+			const bool contradar = (losStatus & LOS_CONTRADAR);
+			// bucket with the palette the unit was last seen under, not the live unit's current one
+			(contradar ? byTexContradar : byTexNormal)[model->textureType]
+				.push_back({ model, static_cast<uint32_t>(xfOffset), lgb.paletteIndex });
+			(contradar ? anyContradar : anyNormal) = true;
+		}
 
-			// ghosted enemy units; SetTeamColor only gates the alpha here (the per-instance
-			// paletteIndex passed to SubmitImmediately drives the actual color)
-			if (losStatus & LOS_CONTRADAR) {
-				modelDrawerState->SetColorMultiplier(0.9f, 0.9f, 0.9f, IModelDrawerState::alphaValues.z);
-				modelDrawerState->SetTeamColor(lgb.team, IModelDrawerState::alphaValues.z);
-			}
-			else {
-				modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
-				modelDrawerState->SetTeamColor(lgb.team, IModelDrawerState::alphaValues.y);
-			}
-
-			if (prevModelType != modelType || prevTexType != model->textureType) {
-				prevModelType = modelType; prevTexType = model->textureType;
-				CModelDrawerHelper::BindModelTypeTexture(modelType, model->textureType); //inefficient rendering, but w/e
-			}
-
-			modelDrawerState->SetStaticModelMatrix(staticWorldMat);
-			// draw with the palette the unit was last seen under, not the live unit's current one
-			smv.SubmitImmediately(model, lgb.paletteIndex); //need to submit immediately every model because of static per-model matrix
+		if (anyNormal) {
+			modelDrawerState->SetColorMultiplier(0.6f, 0.6f, 0.6f, IModelDrawerState::alphaValues.y);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.y);
+			flushGhosts(byTexNormal);
+		}
+		if (anyContradar) {
+			modelDrawerState->SetColorMultiplier(0.9f, 0.9f, 0.9f, IModelDrawerState::alphaValues.z);
+			modelDrawerState->SetTeamColor(0, IModelDrawerState::alphaValues.z);
+			flushGhosts(byTexContradar);
 		}
 	}
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -29,8 +29,21 @@
 #include "Map/ReadMap.h"
 
 #include "System/Misc/TracyDefs.h"
+#include "System/Matrix44f.h"
+#include "System/MathConstants.h"
+#include "System/Transform.hpp"
+#include "Rendering/Models/ModelsMemStorage.h"
 
 static FixedDynMemPoolT<MAX_UNITS / 1000, MAX_UNITS / 32, GhostSolidObject> ghostMemPool;
+
+// world transform of a (static) ghost building, matching the legacy staticModelMatrix construction
+static Transform MakeGhostWorldTransform(const float3& pos, int facing)
+{
+	CMatrix44f m;
+	m.Translate(pos);
+	m.RotateY(-facing * math::HALFPI);
+	return Transform::FromMatrix(m);
+}
 
 ///////////////////////////
 
@@ -51,6 +64,7 @@ CR_REG_METADATA(GhostSolidObject, (
 	CR_MEMBER(paletteIndex),
 	CR_IGNORED(currentIconIndex),
 
+	CR_IGNORED(worldTransformAlloc),
 	CR_IGNORED(model),
 
 	CR_POSTLOAD(PostLoad)
@@ -96,6 +110,15 @@ void GhostSolidObject::PostLoad()
 	RECOIL_DETAILED_TRACY_ZONE;
 	model = nullptr;
 	GetModel();
+
+	// the GPU world transform slot is render-only state; re-create it from the saved pos/facing
+	InitWorldTransform();
+}
+
+void GhostSolidObject::InitWorldTransform()
+{
+	worldTransformAlloc = ScopedTransformMemAlloc(1);
+	worldTransformAlloc.UpdateForced(0, MakeGhostWorldTransform(pos, facing));
 }
 
 const S3DModel* GhostSolidObject::GetModel() const
@@ -165,6 +188,7 @@ CUnitDrawerData::~CUnitDrawerData()
 				if (tmpGso->DecRef())
 					continue;
 
+				// worldTransformAlloc frees its slot in ~GhostSolidObject (ghostMemPool.free below)
 				// <ghost> might be the gbOwner of a decal; groundDecals is deleted after us
 				groundDecals->GhostDestroyed(tmpGso);
 				ghostMemPool.free(tmpGso);
@@ -173,6 +197,7 @@ CUnitDrawerData::~CUnitDrawerData()
 			lgb.clear();
 		}
 	}
+	liveGhostTransforms.clear(); // each entry's ScopedTransformMemAlloc frees its slot on erase
 	assert(ghostMemPool.allocs() == 0);
 	ghostMemPool.clear();
 
@@ -223,6 +248,8 @@ void CUnitDrawerData::Update()
 		for (CUnit* unit : unsortedObjects)
 			updateBody(unit);
 	}
+
+	UpdateLiveGhostTransforms();
 
 	if ((useDistToGroundForIcons = (camHandler->GetCurrentController()).GetUseDistToGroundForIcons())) {
 		const float3& camPos = camera->GetPos();
@@ -634,6 +661,8 @@ bool CUnitDrawerData::UpdateUnitGhosts(const CUnit* unit, const bool addNewGhost
 
 				gso->iconRadius = u->iconRadius;
 
+				gso->InitWorldTransform();
+
 				groundDecals->GhostCreated(u, gso);
 
 			}
@@ -714,6 +743,37 @@ void CUnitDrawerData::UnitLeftLos(const CUnit* unit, int allyTeam)
 	UpdateCurrentUnitIcon(unit);
 }
 
+void CUnitDrawerData::UpdateLiveGhostTransforms()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	// Maintain one world-transform slot per live ghost building drawn for the local allyTeam.
+	// Ghosts are static, so each slot is filled once on first sight; entries not seen this sweep
+	// (units that regained LOS, died, or belong to a different allyTeam now) are freed.
+	const int stamp = ++liveGhostSweepStamp;
+
+	for (int modelType = MODELTYPE_3DO; modelType < MODELTYPE_CNT; modelType++) {
+		for (const auto& lgb : savedData.liveGhostBuildings[gu->myAllyTeam][modelType]) {
+			const CUnit* u = lgb.unit;
+			const auto it = liveGhostTransforms.find(u);
+			if (it == liveGhostTransforms.end()) {
+				ScopedTransformMemAlloc alloc(1);
+				alloc.UpdateForced(0, MakeGhostWorldTransform(u->pos, u->buildFacing));
+				liveGhostTransforms.emplace(u, std::make_pair(std::move(alloc), stamp));
+			}
+			else {
+				it->second.second = stamp;
+			}
+		}
+	}
+
+	for (auto it = liveGhostTransforms.begin(); it != liveGhostTransforms.end(); ) {
+		if (it->second.second != stamp)
+			it = liveGhostTransforms.erase(it); // ScopedTransformMemAlloc frees the slot on erase
+		else
+			++it;
+	}
+}
+
 void CUnitDrawerData::UnitLeavesGhostChanged(const CUnit* unit, const bool leaveDeadGhost)
 {
 	if (unit->leavesGhost) {
@@ -750,6 +810,7 @@ void CUnitDrawerData::PlayerChanged(int playerID)
 void CUnitDrawerData::RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index)
 {
 	if (!gso->DecRef()) {
+		// worldTransformAlloc frees its slot in ~GhostSolidObject (ghostMemPool.free)
 		groundDecals->GhostDestroyed(gso);
 		ghostMemPool.free(gso);
 	}

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -23,6 +23,8 @@ public:
 	bool DecRef() { return ((refCount--) > 1); }
 	const S3DModel* GetModel() const;
 	void PostLoad();
+	// (re)allocate and fill the batched-draw world transform slot from pos/facing
+	void InitWorldTransform();
 public:
 	std::string modelName;
 
@@ -42,6 +44,8 @@ public:
 	uint16_t paletteIndex;
 
 	size_t currentIconIndex;
+
+	ScopedTransformMemAlloc worldTransformAlloc;
 private:
 	mutable const S3DModel* model;
 };
@@ -167,6 +171,12 @@ public:
 		return savedData.liveGhostBuildings[allyTeam][modelType];
 	}
 
+	// world transform slot (in transformsMemStorage) for a live ghost building; INVALID_INDEX if none
+	size_t GetLiveGhostTransform(const CUnit* unit) const {
+		const auto it = liveGhostTransforms.find(unit);
+		return (it != liveGhostTransforms.end()) ? it->second.first.GetOffset(false) : TransformsMemStorage::INVALID_INDEX;
+	}
+
 	auto*       GetSavedData()       { return &savedData; }
 	const auto* GetSavedData() const { return &savedData; }
 protected:
@@ -206,6 +216,13 @@ private:
 
 	S3DModel* GetUnitModel(const CUnit* unit) const;
 	void RemoveDeadGhost(GhostSolidObject* gso, std::vector<GhostSolidObject*>& dgb, int index);
+
+	// rebuilds the per-unit world transform slots for live ghost buildings of the local allyTeam.
+	// scan-based so it self-heals across savegame load, allyTeam/spectator changes and leavesGhost toggles.
+	void UpdateLiveGhostTransforms();
+	// maps unit -> { RAII-owned world transform slot, last sweep stamp seen }
+	spring::unordered_map<const CUnit*, std::pair<ScopedTransformMemAlloc, int>> liveGhostTransforms;
+	int liveGhostSweepStamp = 0;
 
 	// icons
 	bool useDistToGroundForIcons;


### PR DESCRIPTION
### Context
POC here: https://github.com/beyond-all-reason/RecoilEngine/pull/3001
When looking at large numbers of ghost buildings, performance massively drops waiting on the GPU.

eg. I spawn 600 winds, those 600 ghosts take me from 500 fps -> 120 fps. In other cases we saw dropping from ~100+fps -> 20fps in a real game/replay.

### Work done

Ghost buildings are drawn batched through a new draw mode ARRAY_MATMODE. One multidraw per (color bucket x texture type) instead of one immediate draw per ghost.

### Screenshots
**Performance**:
Before:
<img width="309" height="145" alt="image" src="https://github.com/user-attachments/assets/3b8f8af7-710f-4168-afb0-9fb0d9eac508" />
After:
<img width="405" height="171" alt="image" src="https://github.com/user-attachments/assets/e4761070-ebc8-46b2-8775-93a4f012a932" />


**building ghosts**:
Before:
<img width="2560" height="1440" alt="screen_2026-07-15_05-10-34-222" src="https://github.com/user-attachments/assets/dc5a0532-972d-455e-a261-84773f7ea25d" />

After:
<img width="2560" height="1440" alt="screen_2026-07-15_05-11-50-567" src="https://github.com/user-attachments/assets/2b3e299b-bd84-4c45-bc34-c816de31b182" />

**radar'd + live ghost buildings**:
Before:
After:
<img width="2560" height="1440" alt="screen_2026-07-15_05-03-56-567" src="https://github.com/user-attachments/assets/6d0ee3ef-4588-4587-adcc-5768fec8954e" />

**dead ghost buildings**:
Before:
After:
<img width="2560" height="1440" alt="screen_2026-07-15_05-05-16-943" src="https://github.com/user-attachments/assets/c7794e8b-9eef-4405-966b-3d1f5ace763b" />



### AI Disclosure
Claude code. Claude did most of the code writing but I iterated a lot to get somewhere that's easy to review and easy to maintain.