### PR TITLE
Add debug.emulateMouseWheel input emulation

### DIFF
--- a/rts/Lua/LuaDebugExtra.cpp
+++ b/rts/Lua/LuaDebugExtra.cpp
@@ -45,6 +45,7 @@ bool LuaDebugExtra::PushEntries(lua_State* L)
 	LuaPushNamedCFunc(L, "emulateMousePress",   EmulateMousePress);
 	LuaPushNamedCFunc(L, "emulateMouseRelease", EmulateMouseRelease);
 	LuaPushNamedCFunc(L, "emulateMouseMove",    EmulateMouseMove);
+	LuaPushNamedCFunc(L, "emulateMouseWheel",   EmulateMouseWheel);
 	LuaPushNamedCFunc(L, "clearEmulatedInput",  ClearEmulatedInputLua);
 
 	return true;
@@ -135,6 +136,16 @@ int LuaDebugExtra::EmulateMousePress(lua_State* L)
 		return 0;
 
 	mouse->SetButtonEmulated(button, true);
+	return 0;
+}
+
+int LuaDebugExtra::EmulateMouseWheel(lua_State* L)
+{
+	if (mouse == nullptr)
+		return 0;
+
+	// momentary tick, no persistent state to track; fire directly like a real wheel event
+	mouse->MouseWheel((float)luaL_checknumber(L, 1));
 	return 0;
 }
 

--- a/rts/Lua/LuaDebugExtra.h
+++ b/rts/Lua/LuaDebugExtra.h
@@ -21,6 +21,7 @@ class LuaDebugExtra {
 		static int EmulateMousePress(lua_State* L);
 		static int EmulateMouseRelease(lua_State* L);
 		static int EmulateMouseMove(lua_State* L);
+		static int EmulateMouseWheel(lua_State* L);
 		static int ClearEmulatedInputLua(lua_State* L);
 };
 


### PR DESCRIPTION
Split out of #3112 so this uncontroversial piece can be reviewed and merged on its own.

Adds `debug.emulateMouseWheel`, alongside the existing `debug.emulate*` calls from #3097, so mouse-wheel input can be driven from Lua (mainly for headless tests). It just hands the given delta to the existing `MouseWheel` handler.

Implemented and tested with Claude Code.