### PR TITLE
Add a bindable cancelcommand action

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1851,16 +1851,19 @@ int CGuiHandler::GetIconPosCommand(int slot) const // only called by SetActiveCo
 }
 
 
+void CGuiHandler::CancelActiveCommand()
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	activeMousePress = false;
+	SetActiveCommandIndex(-1);
+}
+
+
 bool CGuiHandler::KeyPressed(int keyCode, int scanCode, bool isRepeat)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (keyCode == SDLK_ESCAPE && activeMousePress) {
-		activeMousePress = false;
-		SetActiveCommandIndex(-1);
-		return true;
-	}
-	if (keyCode == SDLK_ESCAPE && inCommand >= 0) {
-		SetActiveCommandIndex(-1);
+	if (keyCode == SDLK_ESCAPE && (activeMousePress || inCommand >= 0)) {
+		CancelActiveCommand();
 		return true;
 	}
 

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -1853,7 +1853,6 @@ int CGuiHandler::GetIconPosCommand(int slot) const // only called by SetActiveCo
 
 void CGuiHandler::CancelActiveCommand()
 {
-	RECOIL_DETAILED_TRACY_ZONE;
 	activeMousePress = false;
 	SetActiveCommandIndex(-1);
 }

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -99,6 +99,7 @@ public:
 	bool SetActiveCommand(int cmdIndex, bool rightMouseButton);
 	bool SetActiveCommand(int cmdIndex, int button, bool leftMouseButton, bool rightMouseButton, bool alt, bool ctrl, bool meta, bool shift);
 	bool SetActiveCommand(const Action& action, const CKeySet& ks, int actionIndex);
+	void CancelActiveCommand();
 
 	void SetDrawSelectionInfo(bool dsi) { drawSelectionInfo = dsi; }
 	bool GetDrawSelectionInfo() const { return drawSelectionInfo; }

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -254,6 +254,20 @@ public:
 
 
 
+class CancelCommandActionExecutor : public IUnsyncedActionExecutor {
+public:
+	CancelCommandActionExecutor() : IUnsyncedActionExecutor("CancelCommand", "Cancels the active command (build/order mode)") {
+	}
+
+	bool Execute(const UnsyncedAction& action) const final {
+		if (guihandler != nullptr)
+			guihandler->CancelActiveCommand();
+		return true;
+	}
+};
+
+
+
 class MapMeshDrawerActionExecutor : public IUnsyncedActionExecutor {
 public:
 	MapMeshDrawerActionExecutor() : IUnsyncedActionExecutor("mapmeshdrawer", "Switch map-mesh rendering modes: 0=GCM, 1=HLOD, 2=ROAM") {
@@ -4038,6 +4052,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<SelectUnitsActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<SelectCycleActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DeselectActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<CancelCommandActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<ShadowsActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DumpShadowsActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<MapShadowPolyOffsetActionExecutor>());

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -260,8 +260,10 @@ public:
 	}
 
 	bool Execute(const UnsyncedAction& action) const final {
-		if (guihandler != nullptr)
-			guihandler->CancelActiveCommand();
+		if (guihandler == nullptr)
+			return false;
+
+		guihandler->CancelActiveCommand();
 		return true;
 	}
 };


### PR DESCRIPTION
Another small piece of #377. Adds a `cancelcommand` action that cancels the active command (the build/order cursor) - the same thing ESCAPE already does - so a game or player can bind it to another key.

Purely additive. I pulled the cancel logic (clear the active command and the mid-press flag) into a public `CancelActiveCommand()` on the gui handler, pointed the existing ESCAPE handler at it, and added the action calling the same thing. So ESCAPE and the action do the same thing, and ESCAPE behaves exactly as before.

It doesn't make ESCAPE itself rebindable - left out on purpose, since ESCAPE is bound by default and its cancel depends on context, so making it yield to a binding would break that.

Checked on a headless build: boots clean, the action runs the cancel path without crashing, and it does nothing when there's no active command. I didn't exercise canceling a live command there (that needs selected units), but it goes through the same clear-the-command call ESCAPE already used.

Implemented and tested with Claude Code.