### PR TITLE
Fix units having the wrong path id after loading a save game.

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -146,8 +146,11 @@ CR_REG_METADATA(CGroundMoveType, (
 	CR_MEMBER(forceFromStaticCollidees),
 
 	CR_MEMBER(pathID),
-	CR_MEMBER(nextPathId),
-	CR_MEMBER(deletePathId),
+	// The ECS registry is not persisted across save/load, so a saved entity ID will collide with
+	// a newly-allocated entity in the fresh registry, causing FollowPath to destroy the wrong path
+	// or swap to an invalid one.
+	CR_IGNORED(nextPathId),
+	CR_IGNORED(deletePathId),
 
 	CR_MEMBER(numIdlingUpdates),
 	CR_MEMBER(numIdlingSlowUpdates),


### PR DESCRIPTION
This is intended to fix github.com/beyond-all-reason/RecoilEngine/issues/3119.

I tried a couple different saved games and it seems to work.