### PR TITLE
Add ViewDataFileOrDir so Lua can open config files

### DIFF
--- a/rts/Lua/LuaIntro.cpp
+++ b/rts/Lua/LuaIntro.cpp
@@ -180,6 +180,7 @@ bool CLuaIntro::LoadUnsyncedCtrlFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetConfigString);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, CreateDir);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, ViewDataFileOrDir);
 
 	//REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetMouseCursor);
 	//REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, WarpMouse);

--- a/rts/Lua/LuaMenu.cpp
+++ b/rts/Lua/LuaMenu.cpp
@@ -189,6 +189,7 @@ bool CLuaMenu::LoadUnsyncedCtrlFunctions(lua_State* L)
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetConfigString);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, CreateDir);
+	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, ViewDataFileOrDir);
 
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetWMIcon);
 	REGISTER_SCOPED_LUA_CFUNC(LuaUnsyncedCtrl, SetWMCaption);

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -99,6 +99,11 @@
 #include "System/Sound/OpenAL/EFXPresets.h"
 #endif
 
+#ifdef _WIN32
+#include <shellapi.h>
+#endif
+
+#include <algorithm>
 #include <cctype>
 #include <cfloat>
 #include <cinttypes>
@@ -241,6 +246,7 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetConfigString);
 
 	REGISTER_LUA_CFUNC(CreateDir);
+	REGISTER_LUA_CFUNC(ViewDataFileOrDir);
 
 	REGISTER_LUA_CFUNC(SendCommands);
 	REGISTER_LUA_CFUNC(GiveOrder);
@@ -2797,6 +2803,111 @@ int LuaUnsyncedCtrl::CreateDir(lua_State* L)
 		luaL_error(L, "[%s][4] invalid access: %s", __func__, dir.c_str());
 
 	lua_pushboolean(L, FileSystem::CreateDirectory(dir));
+	return 1;
+}
+
+
+/***
+ * Opens the Spring user data directory in the native file explorer.
+ * If filename is given, attempts to open the file with the default app.
+ *
+ * @function Spring.ViewDataFileOrDir
+ * @param filename string? (Default: `nil` — opens directory only)
+ * @return boolean success
+ * @return string? errorMessage Present only when `success` is `false`
+ */
+int LuaUnsyncedCtrl::ViewDataFileOrDir(lua_State* L)
+{
+	const std::string writeDir = dataDirLocater.GetWriteDirPath();
+	if (writeDir.empty())
+	{
+		LOG_L(L_WARNING, "[%s] write directory not available", __func__);
+		lua_pushboolean(L, false);
+		lua_pushstring(L, "write directory not available");
+		return 2;
+	}
+
+	std::string filePath;
+	const bool openFile = (lua_gettop(L) >= 1);
+
+	if (openFile)
+	{
+		const std::string filename = luaL_checkstring(L, 1);
+
+		// Security: reject path traversal, absolute paths, and shell metacharacters
+		if (filename.find("..") != std::string::npos ||
+			std::any_of(filename.begin(), filename.end(), [](unsigned char c) {
+				return strchr("/\\\"`$;|&<>()*?[]", c) != nullptr;
+			}))
+		{
+			lua_pushboolean(L, false);
+			lua_pushstring(L, "invalid filename");
+			return 2;
+		}
+
+		filePath = FileSystem::EnsurePathSepAtEnd(writeDir) + filename;
+	}
+
+#ifdef _WIN32
+	// Windows: convert forward slashes to backslashes
+	std::string winPath = (openFile ? filePath : writeDir);
+	std::replace(winPath.begin(), winPath.end(), '/', '\\');
+
+	HINSTANCE result = nullptr;
+
+	if (openFile)
+	{
+		// Try opening the file with its associated app
+		result = ShellExecuteA(nullptr, "open", winPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+	}
+
+	// ShellExecute returns >32 on success, an error code (≤32) on failure.
+	// See SE_ERR_* constants in shellapi.h.
+	bool shellExecuteSucceeded = reinterpret_cast<UINT_PTR>(result) > 32;
+	
+	if (!openFile || !shellExecuteSucceeded)
+	{
+		// No file specified or opening file failed, open the directory
+		result = ShellExecuteA(nullptr, "explorer.exe", winPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+	}
+
+	lua_pushboolean(L, shellExecuteSucceeded);
+#elif defined(__APPLE__)
+	// macOS
+	int ret = -1;
+
+	if (openFile)
+	{
+		// Try opening the file with its associated app
+		ret = system(("open \"" + filePath + "\"").c_str());
+	}
+
+	if (!openFile || ret != 0)
+	{
+		// No file specified or opening file failed, open the directory
+		ret = system(("open -R \"" + writeDir + "\"").c_str());
+	}
+
+	lua_pushboolean(L, (ret == 0));
+#else
+	// Linux
+	int ret = -1;
+
+	if (openFile)
+	{
+		// Try opening the file with its associated app
+		ret = system(("xdg-open \"" + filePath + "\"").c_str());
+	}
+
+	if (!openFile || ret != 0)
+	{
+		// No file specified or opening file failed, open the directory
+		ret = system(("xdg-open \"" + writeDir + "\"").c_str());
+	}
+
+	lua_pushboolean(L, (ret == 0));
+#endif
+
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2849,26 +2849,32 @@ int LuaUnsyncedCtrl::ViewDataFileOrDir(lua_State* L)
 	}
 
 #ifdef _WIN32
-	// Windows: convert forward slashes to backslashes
-	std::string winPath = (openFile ? filePath : writeDir);
-	std::replace(winPath.begin(), winPath.end(), '/', '\\');
-
-	HINSTANCE result = nullptr;
-
+	// Windows
+	HINSTANCE ret = nullptr;
+	
 	if (openFile)
 	{
+		// Convert forward slashes to backslashes
+		std::string winPath = filePath;
+		std::replace(winPath.begin(), winPath.end(), '/', '\\');
+
 		// Try opening the file with its associated app
-		result = ShellExecuteA(nullptr, "open", winPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+		ret = ShellExecuteA(nullptr, "open", winPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 	}
 
 	// ShellExecute returns >32 on success, an error code (≤32) on failure.
 	// See SE_ERR_* constants in shellapi.h.
-	bool shellExecuteSucceeded = reinterpret_cast<UINT_PTR>(result) > 32;
+	bool shellExecuteSucceeded = reinterpret_cast<UINT_PTR>(ret) > 32;
 	
 	if (!openFile || !shellExecuteSucceeded)
 	{
+		// Convert forward slashes to backslashes
+		std::string winDir = writeDir;
+		std::replace(winDir.begin(), winDir.end(), '/', '\\');
+
 		// No file specified or opening file failed, open the directory
-		result = ShellExecuteA(nullptr, "explorer.exe", winPath.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+		ret = ShellExecuteA(nullptr, "open", winDir.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+		shellExecuteSucceeded = reinterpret_cast<UINT_PTR>(ret) > 32;
 	}
 
 	lua_pushboolean(L, shellExecuteSucceeded);

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -134,6 +134,7 @@ class LuaUnsyncedCtrl {
 		static int SetConfigString(lua_State* L);
 
 		static int CreateDir(lua_State* L);
+		static int ViewDataFileOrDir(lua_State* L);
 
 		static int Reload(lua_State* L);
 		static int Restart(lua_State* L);


### PR DESCRIPTION
This is my first contribution here so any feedback is more than welcome!

The intention is to serve the need mentioned in https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3369: allowing users to open `uikeys.txt` without digging around in the game files. I explained my rationale for why an engine update is necessary [here](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/3369#issuecomment-5014728914).

The feature is pretty straightforward:
1. Check the current data dir with `dataDirLocater.GetWriteDirPath()`
2. If Lua passed a `filePath`, attempt to open the file with the OS's default app
    1. Be somewhat defensive about what is allowed in `filePath`
3. If no `filePath` was provided or opening failed, just open the data dir in the relevant file explorer
4. Let Lua know if we succeeded

Tested and working with the Lua changes here in engine version 2026.06.12

Implemented and tested with help from OpenCode running Qwen 3.6 🤖 