### PR TITLE
chore: bump BAR game version in synctest.yml

### DIFF
--- a/.github/workflows/synctest.yml
+++ b/.github/workflows/synctest.yml
@@ -33,7 +33,7 @@ defaults:
 
 env:
   MAP: "Jade Empress 1.41"
-  GAME: "Beyond All Reason test-30212-63c6ded"
+  GAME: "Beyond All Reason test-30707-55e3a1"
   HASH_FILE: "synctest_synchash.json"
 
 jobs:

--- a/.github/workflows/synctest.yml
+++ b/.github/workflows/synctest.yml
@@ -33,7 +33,7 @@ defaults:
 
 env:
   MAP: "Jade Empress 1.41"
-  GAME: "Beyond All Reason test-30707-55e3a1"
+  GAME: "Beyond All Reason test-30707-555e3a1"
   HASH_FILE: "synctest_synchash.json"
 
 jobs:


### PR DESCRIPTION
Since we moved the const from Engine -> Platform, the BAR side needed to update. This bumps to a version that uses `Platform.` for the synctest const