### PR TITLE
Make /take overridable by a game gadget

### DIFF
--- a/rts/Game/SyncedGameCommands.cpp
+++ b/rts/Game/SyncedGameCommands.cpp
@@ -510,6 +510,18 @@ public:
 	}
 
 	bool Execute(const SyncedAction& action) const final {
+		if (luaRules != nullptr) {
+			std::string line = action.GetCmd();
+			if (!action.GetArgs().empty())
+				line += " " + action.GetArgs();
+
+			if (luaRules->GotChatMsg(line, action.GetPlayerID()))
+				return true;
+		}
+
+		if (!modInfo.allowTake)
+			return false;
+
 		const CPlayer* actionPlayer = playerHandler.Player(action.GetPlayerID());
 
 		if (actionPlayer->spectator && !gs->cheatEnabled)
@@ -595,8 +607,7 @@ void SyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<LuaGaiaActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<DesyncActionExecutor>());
 	AddActionExecutor(AllocActionExecutor<AtmActionExecutor>());
-	if (modInfo.allowTake)
-		AddActionExecutor(AllocActionExecutor<TakeActionExecutor>());
+	AddActionExecutor(AllocActionExecutor<TakeActionExecutor>());
 
 	AddActionExecutor(AllocActionExecutor<SkipActionExecutor>());
 }

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -4254,8 +4254,7 @@ void UnsyncedGameCommands::AddDefaultActionExecutors()
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Desync"));
 #endif
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Resync"));
-	if (modInfo.allowTake)
-		AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Take"));
+	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("Take"));
 
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaRules"));
 	AddActionExecutor(AllocActionExecutor<RedirectToSyncedActionExecutor>("LuaGaia"));


### PR DESCRIPTION
/take now hands the command to Lua before doing its built-in transfer, the same way /luarules does. A gadget that handles the "take" chat action and returns true consumes it and the built-in is skipped; if nothing handles it, the engine does its built-in transfer.

allowTake now gates only that built-in transfer, and the command is always registered, so a game can take over /take regardless of the allowTake setting.

Implemented with Claude Code.