### PR TITLE
Make Spring.SetMapShader work reliably

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -28,6 +28,7 @@
  * @field noHandicapForReclaim boolean Whether handicap is applied to income from reclaim
  * @field groupAddDoesntSelect boolean Whether 'group add' also selects the group (does both if false)
  * @field deadTeamsKeepUnitLimit boolean Whether engine redistributes dead team unitlimit to allies (false) or keeps it as-is (true)
+ * @field reliableLuaMapShaders boolean Whether forward-only Lua map shaders activate without a deferred draw and Spring.SetMapShader program swaps refresh cached uniform locations
  */
 
 /***
@@ -83,6 +84,7 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 		LuaPushNamedBool(L, "noHandicapForReclaim", true);
 		LuaPushNamedBool(L, "groupAddDoesntSelect", true);
 		LuaPushNamedBool(L, "deadTeamsKeepUnitLimit", false);
+		LuaPushNamedBool(L, "reliableLuaMapShaders", true);
 	lua_rawset(L, -3);
 
 	lua_pushliteral(L, "textColorCodes");

--- a/rts/Map/SMF/SMFRenderState.cpp
+++ b/rts/Map/SMF/SMFRenderState.cpp
@@ -94,6 +94,12 @@ void SMFRenderStateGLSL::Update(
 		for (uint32_t n = GLSL_SHADER_FWD_ADV; n <= GLSL_SHADER_DFR_ADV; n++) {
 			glslShaders[n]->LoadFromID(luaMapShaderData->shaderIDs[n - 1]);
 		}
+
+		// currShader is null from Init() (GLSL_SHADER_FWD_STD is never created for
+		// the Lua state), so re-evaluate it now that program IDs changed; otherwise
+		// HasValidShader(Normal) stays false and a forward-only Lua map shader is
+		// never selected until a deferred Lua draw happens to run first
+		SetCurrentShader(smfGroundDrawer, DrawPass::Normal);
 	} else {
 		assert(luaMapShaderData == nullptr);
 

--- a/rts/Rendering/Shaders/Shader.h
+++ b/rts/Rendering/Shaders/Shader.h
@@ -131,6 +131,10 @@ namespace Shader {
 
 			// not needed for pre-compiled programs
 			shaderObjs.clear();
+			// cached locations/values belong to the previous program; without this,
+			// uniforms set by name (e.g. texSquare) target stale locations after a
+			// Spring.SetMapShader program swap
+			uniformStates.clear();
 		}
 
 		/// create the whole shader from a lua file


### PR DESCRIPTION
### Summary

Two small fixes that make `Spring.SetMapShader` usable, plus a `FeatureSupport` entry so games can detect them. No ticket exists for this; the PR doubles as the report. Found while developing a Lua map shader (game-agnostic fixes, nothing game-specific in them).

### Bug 1: forward-only Lua map shaders never activate (`SMFRenderState.cpp`)

The Lua render state's `currShader` starts null (`GLSL_SHADER_FWD_STD` is never created for it) and `Update()` only did `LoadFromID`, so `HasValidShader(DrawPass::Normal)` stayed false and `SelectRenderState` skipped the Lua state entirely.
The state only started working after a deferred Lua map draw repaired `currShader` as a side effect, so a game that sets only a forward shader (or runs with `AllowDeferredMapRendering=0`, the default) gets nothing, silently.
Regression traceable to the FWD_STD/FWD_ADV split in 984e1d8ebc.
Fix: select the current shader for the normal draw pass when Lua map shader programs load.

### Bug 2: stale uniform cache when a program is loaded from ID (`Shader.h`)

`LoadFromID` swaps the GL program but kept the previous program's `uniformStates`, and `GetNewUniformState` resolves each uniform's location only once.
After a `Spring.SetMapShader` program swap (second widget setting a shader, or a widget reload creating a new program), name-based engine uniforms like `texSquare` targeted stale locations and the value cache skipped redundant-looking updates — visible result: all terrain big squares collapse onto square (0,0).
Fix: clear the cached uniform states in `LoadFromID`.

### `Engine.FeatureSupport.reliableLuaMapShaders`

Both fixes are behavioral, so Lua cannot feature-detect them: on an unfixed engine `Spring.SetMapShader` "succeeds" and then either does nothing or corrupts terrain.
The new flag lets games hard-gate their map shader paths; it resolves to a falsy `nil` on all older engines, per the table's convention.

### How to test

Manual procedure, using the test wupget below (drop into `LuaUI/Widgets`, enable "Map Shader Smoke Test"):

1. **Forward activation**: set `TEST_DEFERRED = false` in the widget. Before: terrain stays completely stock — the forward shader never takes effect and `DrawGroundPreForward` never fires. After: terrain immediately turns green with diagonal stripes and the widget echoes that the forward render state is active.
2. **Uniform cache**: with the shader active, `/luaui reload` (or toggle the widget off and on) so `SetMapShader` receives a fresh program id. Before: terrain textures collapse to the (0,0) big-square tile repeated across the map (stale `texSquare` location). After: terrain renders correctly through any number of swaps.
3. **Deferred still fine**: set `TEST_DEFERRED = true` with `AllowDeferredMapRendering=1`; both passes echo active and terrain shows the deferred magenta tint where deferred output is consumed.
4. **Flag**: `/luaui echo` or any widget: `Engine.FeatureSupport.reliableLuaMapShaders` is `true`; on current master it is `nil`.

Tested this way in BAR, including a full forward+deferred tileset terrain shader prototype on top of these fixes: forward state activates from frame 0 and repeated program swaps across widget reloads no longer collapse terrain.

Note: the widget binds `$heightmap` from `DrawGroundPreForward`/`PreDeferred`, so the game's widget handler must dispatch those callins (they exist engine-side; some game handlers don't forward them yet).

<details>
<summary><code>dev_map_shader_smoke.lua</code> — self-contained test wupget</summary>

```lua
-- Proves Spring.SetMapShader activation.
-- Expected result on a fixed engine: terrain turns green with diagonal dark stripes.
-- On a stock engine with TEST_DEFERRED=false this silently does nothing (the forward-activation bug).

function widget:GetInfo()
	return {
		name    = "Map Shader Smoke Test",
		desc    = "Trivial Lua map shader via Spring.SetMapShader",
		author  = "PtaQ",
		date    = "2026-07-14",
		license = "GNU GPL, v2 or later",
		layer   = 0,
		enabled = false,
	}
end

-- false = forward-only (the pure activation-bug test), true = also install a deferred G-buffer shader
local TEST_DEFERRED = true

local fwdShader = nil
local dfrShader = nil
local echoedFwd = false
local echoedDfr = false

local vertSrc = [[
#version 130
in vec3 vertexPos;

uniform ivec2 texSquare;      // set by the engine per big square, must be ivec2
uniform vec2 specularTexGen;  // 1/mapSize in elmos, set from Lua
uniform sampler2D heightMapTex;

out vec4 vertexWorldPos;
out vec2 diffuseTexCoords;
out float fogFactor;

const float SMF_TEXSQR_SIZE = 1024.0;

float HeightAtWorldPos(vec2 wxz) {
	// texel alignment magic copied from engine SMFVertProg.glsl
	const vec2 HM_TEXEL = vec2(8.0, 8.0);
	vec2 mapSize = vec2(1.0) / specularTexGen;
	wxz += -HM_TEXEL * (wxz * specularTexGen) + 0.5 * HM_TEXEL;
	vec2 uvhm = clamp(wxz, HM_TEXEL, mapSize - HM_TEXEL);
	uvhm *= specularTexGen;
	return textureLod(heightMapTex, uvhm, 0.0).x;
}

void main() {
	vertexWorldPos = vec4(vertexPos, 1.0);
	vertexWorldPos.xz += vec2(texSquare) * SMF_TEXSQR_SIZE;
	vertexWorldPos.y = HeightAtWorldPos(vertexWorldPos.xz);

	diffuseTexCoords = (vertexWorldPos.xz / SMF_TEXSQR_SIZE) - vec2(texSquare);

	gl_Position = gl_ModelViewProjectionMatrix * vertexWorldPos;
	gl_ClipVertex = gl_ModelViewMatrix * vertexWorldPos;

	float fogCoord = length(gl_ClipVertex.xyz);
	fogFactor = clamp((gl_Fog.end - fogCoord) * gl_Fog.scale, 0.0, 1.0);
}
]]

local fragSrcForward = [[
#version 130
uniform sampler2D diffuseTex; // TU0, engine-bound SMT tile

in vec4 vertexWorldPos;
in vec2 diffuseTexCoords;
in float fogFactor;

out vec4 fragColor;

void main() {
	vec4 diffuse = texture(diffuseTex, diffuseTexCoords);
	// unmistakable: green tint + world-space diagonal stripes
	float stripe = step(0.5, fract((vertexWorldPos.x + vertexWorldPos.z) / 256.0));
	vec3 tinted = mix(diffuse.rgb * vec3(0.3, 1.2, 0.3), diffuse.rgb * 0.25, stripe * 0.5);
	fragColor = vec4(mix(gl_Fog.color.rgb, tinted, fogFactor), 1.0);
}
]]

local fragSrcDeferred = [[
#version 130
uniform sampler2D diffuseTex;

in vec4 vertexWorldPos;
in vec2 diffuseTexCoords;
in float fogFactor;

out vec4 fragData[5];

void main() {
	vec4 diffuse = texture(diffuseTex, diffuseTexCoords);
	// magenta-tinted diffuse in the G-buffer so deferred output is distinguishable
	fragData[0] = vec4(0.5, 1.0, 0.5, 1.0);            // NORMTEX: flat up, encoded (n+1)*0.5
	fragData[1] = vec4(diffuse.rgb * vec3(1.2, 0.3, 1.2), 1.0); // DIFFTEX
	fragData[2] = vec4(0.0);                            // SPECTEX
	fragData[3] = vec4(0.0);                            // EMITTEX
	fragData[4] = vec4(0.0);                            // MISCTEX
}
]]

local function makeShader(fragSrc, label)
	local shader = gl.CreateShader({
		vertex   = vertSrc,
		fragment = fragSrc,
		uniformInt = {
			diffuseTex   = 0,
			heightMapTex = 1,
		},
		uniformFloat = {
			specularTexGen = { 1.0 / Game.mapSizeX, 1.0 / Game.mapSizeZ },
		},
	})
	if not shader then
		Spring.Echo("[MapShaderSmoke] " .. label .. " shader compile FAILED:")
		Spring.Echo(gl.GetShaderLog())
	end
	return shader
end

function widget:Initialize()
	if not gl.CreateShader then
		Spring.Echo("[MapShaderSmoke] GLSL not supported, removing")
		widgetHandler:RemoveWidget(self)
		return
	end

	local advMapShading = Spring.GetConfigInt("AdvMapShading", 1)
	local allowDeferred = Spring.GetConfigInt("AllowDeferredMapRendering", 0)
	Spring.Echo("[MapShaderSmoke] AdvMapShading=" .. advMapShading .. " AllowDeferredMapRendering=" .. allowDeferred)
	if advMapShading == 0 then
		Spring.Echo("[MapShaderSmoke] WARNING: AdvMapShading=0 blocks Lua map shaders entirely (needs restart after change)")
	end
	if TEST_DEFERRED and allowDeferred == 0 then
		Spring.Echo("[MapShaderSmoke] WARNING: deferred test requested but AllowDeferredMapRendering=0 (needs restart after change)")
	end

	fwdShader = makeShader(fragSrcForward, "forward")
	if TEST_DEFERRED then
		dfrShader = makeShader(fragSrcDeferred, "deferred")
	end

	if not fwdShader then
		widgetHandler:RemoveWidget(self)
		return
	end

	Spring.SetMapShader(fwdShader, dfrShader or 0)
	Spring.Echo("[MapShaderSmoke] map shader installed (fwd=" .. tostring(fwdShader) .. " dfr=" .. tostring(dfrShader) .. ")")
	Spring.Echo("[MapShaderSmoke] expected: green striped terrain. If unchanged, forward activation failed.")
end

function widget:DrawGroundPreForward()
	if not echoedFwd then
		echoedFwd = true
		Spring.Echo("[MapShaderSmoke] DrawGroundPreForward fired -> forward Lua render state IS active")
	end
	gl.Texture(1, "$heightmap")
end

function widget:DrawGroundPostForward()
	gl.Texture(1, false)
end

function widget:DrawGroundPreDeferred()
	if not echoedDfr then
		echoedDfr = true
		Spring.Echo("[MapShaderSmoke] DrawGroundPreDeferred fired -> deferred Lua render state IS active")
	end
	gl.Texture(1, "$heightmap")
end

function widget:DrawGroundPostDeferred()
	gl.Texture(1, false)
end

function widget:Shutdown()
	-- must reset before LuaShaders programs are destroyed, else the engine render
	-- state keeps dangling GL program ids after /luaui reload
	Spring.SetMapShader(0, 0)
	if fwdShader then gl.DeleteShader(fwdShader) end
	if dfrShader then gl.DeleteShader(dfrShader) end
	Spring.Echo("[MapShaderSmoke] map shader reset to engine default")
end
```

</details>

Happy to add a running-changelog entry (`doc/site/content/changelogs/_index.markdown`) if you'd like it in this PR rather than a batch update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
