### PR TITLE
CI: add a macOS compile gate for Apple Silicon

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -18,6 +18,7 @@
 name: Build macOS
 
 on:
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - 'doc/**'

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,119 @@
+# Compile-only gate for Apple Silicon.
+#
+# This builds the subset of targets that currently compile on macOS with
+# Homebrew GCC. Its purpose is to stop already-merged portability fixes from
+# silently regressing, not to produce release artifacts.
+#
+# The engine binaries (spring, spring-headless, spring-dedicated) and unitsync
+# are deliberately absent: they still need fixes that are in review. Targets get
+# added to the list below as those land, so the list doubles as a record of how
+# much of the engine builds on macOS.
+#
+# macOS 15 is the floor for the platform because of SDL availability, so the
+# runner is pinned rather than tracking macos-latest.
+#
+# GCC is used rather than Apple Clang for parity with the Linux and Windows
+# toolchains, which matters for simulation consistency.
+
+name: Build macOS
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'doc/**'
+
+jobs:
+  build-macos:
+    name: Build arm64-macos targets
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Engine version naming uses git describe, so it needs full history.
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          brew install \
+            ccache \
+            cmake \
+            devil \
+            freetype \
+            gcc \
+            libvorbis \
+            minizip \
+            pkg-config \
+            sdl2 \
+            sevenzip
+
+      - name: Select Homebrew GCC
+        id: toolchain
+        run: |
+          cc=$(printf '%s\n' "$(brew --prefix)"/bin/gcc-[0-9]* | sort -V | tail -1)
+          cxx=${cc/gcc-/g++-}
+          "$cc" --version | head -1
+          echo "cc=$cc" >> "$GITHUB_OUTPUT"
+          echo "cxx=$cxx" >> "$GITHUB_OUTPUT"
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-arm64-macos-${{ github.sha }}
+          restore-keys: ccache-arm64-macos-
+
+      - name: Configure
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_C_COMPILER="${{ steps.toolchain.outputs.cc }}" \
+            -DCMAKE_CXX_COMPILER="${{ steps.toolchain.outputs.cxx }}" \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        run: |
+          cmake --build build --parallel "$(sysctl -n hw.ncpu)" --target \
+            7zip \
+            CUtils \
+            GameHeadless \
+            IrrXML \
+            TracyClient \
+            assimp \
+            basecontent \
+            dirchange \
+            engineSim \
+            engineSystemNet \
+            fastgltf \
+            fmt \
+            gflags_nothreads_static \
+            glad \
+            headlessStubs \
+            lua \
+            luasocket \
+            lunasvg \
+            mimalloc-static \
+            nowide \
+            plutovg \
+            pr-downloader \
+            pr-downloader_cli \
+            rgetc1 \
+            rmlui_core \
+            simdjson \
+            smiley \
+            smmalloc \
+            squish \
+            streflop \
+            svg2png
+
+      - name: Report ccache statistics
+        if: always()
+        run: ccache --show-stats

--- a/rts/builds/headless/CMakeLists.txt
+++ b/rts/builds/headless/CMakeLists.txt
@@ -60,6 +60,10 @@ target_link_libraries(GameHeadless PRIVATE
 	nowide::nowide
 	fmt::fmt
 )
+# create_headless_target_from() copies sources but not dependencies, so this has
+# to be repeated from Game, which compiles the same GameVersion.cpp.
+add_dependencies(GameHeadless generateVersionFiles)
+
 ### Build the executable
 add_executable(engine-headless ${engineSources} ${ENGINE_ICON})
 target_link_libraries(engine-headless no-sound ${engineHeadlessLibraries} GameHeadless no-sound)


### PR DESCRIPTION
Several macOS portability fixes have merged over the last few weeks (#3034, #3045, #3064, #3065, #3071, #3074, #3076, #3040) and nothing currently stops them regressing.

This adds a job that compiles the subset of targets that already build on Apple Silicon. It also fixes a subtle ordering bug when generating the game version header.