### PR TITLE
fix: link test_DemoFileExtension against ZLIB::ZLIB for windows build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -349,8 +349,6 @@ endif()
 			${test_Common_sources}
 		)
 
-	# plain `z` resolves to `-lz`, which the mingw cross-linker cannot find:
-	# on Windows zlib comes from mingwlibs64, so go through the imported target
 	find_package_static(ZLIB 1.2.7 REQUIRED)
 
 	set(test_libs

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -349,8 +349,12 @@ endif()
 			${test_Common_sources}
 		)
 
+	# plain `z` resolves to `-lz`, which the mingw cross-linker cannot find:
+	# on Windows zlib comes from mingwlibs64, so go through the imported target
+	find_package_static(ZLIB 1.2.7 REQUIRED)
+
 	set(test_libs
-			z
+			ZLIB::ZLIB
 		)
 
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "")


### PR DESCRIPTION
The DemoFileExtension test target linked the bare library name `z`, which expands to `-lz`. That works on Linux where zlib sits in the default library search path, but the mingw cross-linker fails with "cannot find -lz" because on Windows zlib is supplied by mingwlibs64.

Use the ZLIB::ZLIB imported target instead, matching how the engine, unitsync and DemoTool link zlib. find_package is needed here because imported targets are directory-scoped and test/ is a sibling of rts/.


### 
AI Disclosure: 100% claude code, pointed it at the failing action and asked it to fix.