### PR TITLE
Let unbind target one action argument variant

### DIFF
--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -800,20 +800,20 @@ bool CKeyBindings::AddKeySymbol(const std::string& keysym, const std::string& co
 bool CKeyBindings::RemoveCommandFromList(ActionList& al, const std::string& command)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	bool success = false;
+	/* parse through Action so the name and the arguments get split and
+	 * normalized the same way Bind did when it stored them */
+	const Action target(command);
 
-	auto it = al.begin();
+	const auto removedCount = std::erase_if(al, [&target](const auto& x) {
+		if (x.command != target.command)
+			return false;
 
-	while (it != al.end()) {
-		if (it->command == command) {
-			it = al.erase(it);
-			success = true;
-		} else {
-			++it;
-		}
-	}
+		/* naming arguments removes only that one variant, naming
+		 * the action on its own still removes all of them */
+		return target.extra.empty() || x.extra == target.extra;
+	});
 
-	return success;
+	return removedCount > 0;
 }
 
 
@@ -931,7 +931,9 @@ bool CKeyBindings::ExecuteCommandInternal(const std::string& line)
 		if (!UnBind(words[1], words[2])) { return false; }
 	}
 	else if ((command == "unbindaction") && (words.size() > 1)) {
-		if (!UnBindAction(words[1])) { return false; }
+		/* the action name lands in words[1] and its arguments in
+		 * words[2], so rejoin them to keep the arguments addressable */
+		if (!UnBindAction(words.size() > 2 ? (words[1] + " " + words[2]) : words[1])) { return false; }
 	}
 	else if ((command == "unbindkeyset") && (words.size() > 1)) {
 		if (!UnBindKeyset(words[1])) { return false; }

--- a/rts/Game/UI/KeyBindings.cpp
+++ b/rts/Game/UI/KeyBindings.cpp
@@ -725,10 +725,18 @@ bool CKeyBindings::RemoveActionFromKeyMap(const std::string& command, KeyMap& bi
 
 	auto it = bindings.begin();
 
+	/* unbindaction takes no keyset, so it is not the inverse of a bind:
+	 * naming an action without arguments clears every variant of it */
+	const Action target(command);
+
 	while (it != bindings.end()) {
 		ActionList& al = it->second;
 
-		if (RemoveCommandFromList(al, command))
+		const auto removedCount = std::erase_if(al, [&target](const auto& x) {
+			return x.command == target.command && (target.extra.empty() || x.extra == target.extra);
+		});
+
+		if (removedCount > 0)
 			success = true;
 
 		if (al.empty()) {
@@ -805,12 +813,9 @@ bool CKeyBindings::RemoveCommandFromList(ActionList& al, const std::string& comm
 	const Action target(command);
 
 	const auto removedCount = std::erase_if(al, [&target](const auto& x) {
-		if (x.command != target.command)
-			return false;
-
-		/* naming arguments removes only that one variant, naming
-		 * the action on its own still removes all of them */
-		return target.extra.empty() || x.extra == target.extra;
+		/* unbind is the inverse of bind, so the arguments have to line up
+		 * too; naming none means the binding must not carry any either */
+		return x.command == target.command && x.extra == target.extra;
 	});
 
 	return removedCount > 0;


### PR DESCRIPTION
Fixes #3140. `unbind` compared the action name against the whole "name plus arguments" string, so `unbind a firestate 2` matched nothing while `unbind a firestate` removed every variant on the key. It now parses what you typed through Action, like Bind does when storing, and compares name and arguments separately - so after `bind sc_a firestate 2`, `unbind sc_a firestate` deliberately removes nothing.

unbindaction keeps sweeping on a bare name, since it takes no keyset and so isn't the inverse of a bind. BAR's 60% presets depend on that. Naming arguments narrows it now, which also needed the dispatch fixed - it was forwarding the action and dropping the arguments.

Wants #3136 first, which adds a chain-aware overload to UnBind that the argument check has to be carried into.

Round-tripped headless from zero to twelve arguments and a 239 character selectkey argument, with near misses correctly left alone.

Used Claude to help investigate and write this.

