### PR TITLE
rendering: avoid primitive restart for Lua VAO model submissions

### DIFF
--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -534,12 +534,8 @@ void LuaVAOImpl::RemoveFromSubmission(int idx)
  */
 void LuaVAOImpl::Submit()
 {
-	glEnable(GL_PRIMITIVE_RESTART);
-	glPrimitiveRestartIndex(indxLuaVBO->primitiveRestartIndex);
-
+	// model index buffers use triangle lists, so restart only adds driver overhead
 	vao->Bind();
 	glMultiDrawElementsIndirect(GL_TRIANGLES, GL_UNSIGNED_INT, submitCmds.data(), submitCmds.size(), sizeof(SDrawElementsIndirectCommand));
 	vao->Unbind();
-
-	glDisable(GL_PRIMITIVE_RESTART);
 }


### PR DESCRIPTION
What changed:

`LuaVAOImpl::Submit()` no longer enables primitive restart around model multi draw submissions.

The regular `LuaVAOImpl::DrawElements()` path is unchanged and continues to support the primitive restart.


Why: 

Lua VAO model submissions use ordinary triangle lists and dont contain primitive restart indices. 

Enabling primitive restart caused Zink to enter an extremely slow path when BARS custom unit shaders were active. Model rendering dropped the game to roughly 2-4 fps.

Removing the unnecessary state avoids that bottleneck without disabling CUS, changing any shaders, or introducing a zink specific fallback.


Tested:


- Zink: BAR loaded with CUS enabled and full shaders, then rendered models without the previous severe framerate hit.

- Native OpenGL on NVIDIA: CUS initialized, compiled, and rendered successfully.

- RelWithDebInfo engine build completed
