### PR TITLE
CMake: treat the minizip include dir as a system include

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -41,7 +41,7 @@ find_package_static(DevIL REQUIRED)
 include_directories(BEFORE lib)
 include_directories(BEFORE lib/lua/include)
 include_directories(${CMAKE_SOURCE_DIR}/include/AL)
-include_directories(${SPRING_MINIZIP_INCLUDE_DIR})
+include_directories(SYSTEM ${SPRING_MINIZIP_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib/cereal/include)
 

--- a/rts/System/FileSystem/Archives/CMakeLists.txt
+++ b/rts/System/FileSystem/Archives/CMakeLists.txt
@@ -40,13 +40,17 @@ if (THREADPOOL)
 	target_compile_definitions(archives PRIVATE -DTHREADPOOL)
 endif()
 target_include_directories(archives
-	PRIVATE ${SOURCE_ROOT} ${SPRING_MINIZIP_INCLUDE_DIR} ${NOWIDE_INCLUDE_DIR})
+	PRIVATE ${SOURCE_ROOT} ${NOWIDE_INCLUDE_DIR})
+target_include_directories(archives SYSTEM
+	PRIVATE ${SPRING_MINIZIP_INCLUDE_DIR})
 target_link_libraries(archives
 	PRIVATE 7zip ${SPRING_MINIZIP_LIBRARY} Tracy::TracyClient nowide::nowide fmt::fmt)
 
 add_library(archives_nothreadpool STATIC ${archives_sources})
 target_compile_options(archives_nothreadpool PRIVATE ${PIC_FLAG})
 target_include_directories(archives_nothreadpool
-	PRIVATE ${SOURCE_ROOT} ${SPRING_MINIZIP_INCLUDE_DIR} ${NOWIDE_INCLUDE_DIR})
+	PRIVATE ${SOURCE_ROOT} ${NOWIDE_INCLUDE_DIR})
+target_include_directories(archives_nothreadpool SYSTEM
+	PRIVATE ${SPRING_MINIZIP_INCLUDE_DIR})
 target_link_libraries(archives_nothreadpool
 	PRIVATE 7zip ${SPRING_MINIZIP_LIBRARY} nowide::nowide fmt::fmt)

--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -46,7 +46,7 @@ remove_definitions(-DTHREADPOOL)
 
 set(ENGINE_SRC_ROOT "../../rts")
 
-include_directories(${SPRING_MINIZIP_INCLUDE_DIR})
+include_directories(SYSTEM ${SPRING_MINIZIP_INCLUDE_DIR})
 include_directories(${ENGINE_SRC_ROOT}/lib)
 include_directories(${ENGINE_SRC_ROOT}/lib/lua/include)
 include_directories(${ENGINE_SRC_ROOT}/lib/7zip)


### PR DESCRIPTION
On macOS the minizip headers live in a subdirectory of the Homebrew prefix, so MINIZIP_INCLUDE_DIR is /opt/homebrew/include. Adding that with -I puts every installed Homebrew header ahead of the engine's own vendored libraries in the search order.

The concrete failure: a system fmt 12.2.0 shadowed the vendored fmt 12.1.0 while the link still used the vendored static lib. unitsync failed to link on `fmt::v12::detail::allocate`, and the engine binaries linked anyway, silently mixing headers from one version with code from the other.

-isystem is searched after every -I, so vendored headers win regardless of the order CMake appends them in. This is latent on any platform where a system package ships a newer copy of something the repo also vendors.