### PR TITLE
DemoTool: fix the build after the alternate replay extension change

### DIFF
--- a/rts/System/LoadSave/DemoFileExtension.cpp
+++ b/rts/System/LoadSave/DemoFileExtension.cpp
@@ -10,8 +10,11 @@
 #include <zlib.h>
 
 #include "demofile.h"
-#include "System/Config/ConfigHandler.h"
 #include "System/StringUtil.h"
+
+// Tools do not link the config subsystem, and accept any extension anyway.
+#ifndef TOOLS
+#include "System/Config/ConfigHandler.h"
 
 CONFIG(std::string, DemoFileExtension).defaultValue("sdfz").description("Comma-separated list of replay file extensions. The first entry is used when recording; all entries are accepted when loading. Set by the lobby (e.g. 'barreplay,sdfz' for BAR).");
 
@@ -32,6 +35,7 @@ std::vector<std::string> GetDemoFileExtensions()
 		extensions.emplace_back("sdfz");
 	return extensions;
 }
+#endif
 
 bool IsDemoExtension(const std::string& ext)
 {

--- a/rts/System/LoadSave/DemoReader.cpp
+++ b/rts/System/LoadSave/DemoReader.cpp
@@ -5,8 +5,9 @@
 #include "Game/GameVersion.h"
 #include "Sim/Misc/GlobalConstants.h"
 
-#ifndef TOOLS
 #include "DemoFileExtension.h"
+
+#ifndef TOOLS
 #include "System/Config/ConfigHandler.h"
 CONFIG(bool, DisableDemoVersionCheck).defaultValue(false).description("Allow to play every replay file (may crash / cause undefined behaviour in replays)");
 #endif

--- a/tools/DemoTool/CMakeLists.txt
+++ b/tools/DemoTool/CMakeLists.txt
@@ -42,6 +42,7 @@ set(demoToolSpringSources
 	${ENGINE_SRC_ROOT_DIR}/System/Sync/SHA512.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/StringUtil.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Net/RawPacket.cpp
+	${ENGINE_SRC_ROOT_DIR}/System/LoadSave/DemoFileExtension.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/LoadSave/DemoReader.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/LoadSave/Demo.cpp
 	${ENGINE_SRC_ROOT_DIR}/System/Log/Backend.cpp


### PR DESCRIPTION
DemoReader.cpp calls IsDemoExtension unconditionally but includes its header inside #ifndef TOOLS, and demotool never compiled DemoFileExtension.cpp. The tools build has been broken on every platform since alternate replay extensions landed in #2975. demotool is EXCLUDE_FROM_ALL, so CI does not build it.

IsDemoExtension already had a TOOLS branch, so the intent was there. Only the config-backed extension list needs excluding, since tools do not link the config subsystem.