### PR TITLE
Make --window turn fullscreen off again

### DIFF
--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -1414,8 +1414,8 @@ void CGlobalRendering::SetFullScreen(bool cliWindowed, bool cliFullScreen)
 {
 	const bool cfgFullScreen = configHandler->GetBool("Fullscreen");
 
-	fullScreen = (cfgFullScreen && !cliWindowed  );
-	fullScreen = (cfgFullScreen ||  cliFullScreen);
+	// --window beats --fullscreen, either beats the config
+	fullScreen = (cfgFullScreen || cliFullScreen) && !cliWindowed;
 
 	configHandler->Set("Fullscreen", fullScreen);
 }


### PR DESCRIPTION
`--window` has done nothing since April 2017 whenever the config said `Fullscreen = 1`. `SetFullScreen` works out the windowed case and then overwrites it on the next line.

d1eec3d177 rewrote a working if/else chain into two plain assignments and dropped the first result. This restores that chain's meaning: `--window` beats `--fullscreen`, either beats the config.

Found while working on macOS, where it is hard to miss: exclusive fullscreen forces a display mode change, so the desktop leaves its 2x scale and every other window's text goes tiny. The bug itself is not platform specific.

One thing worth a second opinion on. The result is written back to the config, so `--window` now persists `Fullscreen = 0` into later runs. `--fullscreen` has always persisted `Fullscreen = 1` the same way, so the two are symmetric, but it is a change from nine years of the flag doing nothing at all.

Tested by hand on macOS: with `Fullscreen = 1` in springsettings.cfg, `--window` gives a decorated window and the log reads `windowed::decorated`.