### PR TITLE
fix(LuaVBO): CopyTo() now properly manages cpu-side copies of the data

### DIFF
--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -1493,6 +1493,17 @@ bool LuaVBOImpl::CopyTo(const std::shared_ptr<LuaVBOImpl>& destVBO, int copySize
 
 	auto result = vbo->CopyTo(*destVBO->vbo, static_cast<GLsizeiptr>(copySizeInBytes));
 
+	// VBO::CopyTo only moves GPU->GPU. We need to also copy over the CPU-side bufferData.
+	if (result && bufferData != nullptr && destVBO->bufferData != nullptr && copySizeInBytes > 0) {
+		const auto n = std::min({
+			static_cast<uint32_t>(copySizeInBytes),
+			bufferSizeInBytes,
+			destVBO->bufferSizeInBytes
+		});
+		if (n > 0)
+			memcpy(destVBO->bufferData, bufferData, n);
+	}
+
 	if (!wasBound)
 		vbo->Unbind();
 


### PR DESCRIPTION
### Context
Prior to this change, LuaVBOImpl::CopyTo would copy data on the GPU side but then the CPU side would remain uncopied (and therefore as uninitialized data).

Then something could take the uninitialized cpu side data, and push some or all of it to the GPU, leading to garbage memory. We see this with BAR with these weird floating, miscolored buildings https://discord.com/channels/549281623154229250/724924957074915358/1533558143538298890

Exists since initial implementation in #2356 https://github.com/beyond-all-reason/RecoilEngine/commit/70fe169d78098e465b2b89fc9c4f08ca95adefbc#diff-ca3039d532bd05f71823bcf7375169238d8bb4d01eabb19b16aa46125a8cb3d0R1484-R1499

### Testing
Tested against the aforementioned floating buildings in BAR.
Before:
<img width="2560" height="1440" alt="screen_2026-08-03_09-52-32-704" src="https://github.com/user-attachments/assets/5482295c-a0dc-4774-9c03-8f6242ef07f3" />
<img width="2560" height="1440" alt="screen_2026-08-03_09-52-25-062" src="https://github.com/user-attachments/assets/cbb3ef93-0a35-4e64-986d-b25517dca8a9" />

After:
<img width="2560" height="1440" alt="screen_2026-08-03_09-50-17-011" src="https://github.com/user-attachments/assets/97be8d2c-5461-449e-8ecf-9b9b8aab3298" />


### AI Disclosure
Bug hunt and fix claude code _assisted_, and has been tested by human.