### PR TITLE
rendering: work around drivers that mis-render batched immediate mode

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -2707,7 +2707,7 @@ bool CGuiHandler::DrawUnitBuildIcon(const IconInfo& icon, int unitDefID)
 	glEnable(GL_TEXTURE_2D);
 	glColor4f(1.0f, 1.0f, 1.0f, textureAlpha);
 	glBindTexture(GL_TEXTURE_2D, CUnitDrawer::GetUnitDefImage(ud));
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 		glTexCoord2f(0.0f, 0.0f); glVertex2f(b.x1, b.y1);
 		glTexCoord2f(1.0f, 0.0f); glVertex2f(b.x2, b.y1);
 		glTexCoord2f(1.0f, 1.0f); glVertex2f(b.x2, b.y2);
@@ -2893,7 +2893,7 @@ bool CGuiHandler::DrawTexture(const IconInfo& icon, const std::string& texName)
 
 	// draw the full size quad
 	const Box& b = icon.visual;
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(0.0f, 0.0f); glVertex2f(b.x1, b.y1);
 	glTexCoord2f(1.0f, 0.0f); glVertex2f(b.x2, b.y1);
 	glTexCoord2f(1.0f, 1.0f); glVertex2f(b.x2, b.y2);
@@ -2917,7 +2917,7 @@ bool CGuiHandler::DrawTexture(const IconInfo& icon, const std::string& texName)
 	const float y2 = b.y2 + (yIconSize * yscale);
 
 	// draw the scaled quad
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(0.0f, 0.0f); glVertex2f(x1, y1);
 	glTexCoord2f(1.0f, 0.0f); glVertex2f(x2, y1);
 	glTexCoord2f(1.0f, 1.0f); glVertex2f(x2, y2);
@@ -2933,7 +2933,7 @@ void CGuiHandler::DrawIconFrame(const IconInfo& icon)
 	RECOIL_DETAILED_TRACY_ZONE;
 	const Box& b = icon.visual;
 	glDisable(GL_TEXTURE_2D);
-	glBegin(GL_LINE_LOOP);
+	glBeginBatch(GL_LINE_LOOP);
 	constexpr float fudge = 0.001f; // avoids getting creamed if iconBorder == 0.0
 	glVertex2f(b.x1 + fudge, b.y1 - fudge);
 	glVertex2f(b.x2 - fudge, b.y1 - fudge);
@@ -3045,7 +3045,7 @@ void CGuiHandler::DrawHilightQuad(const IconInfo& icon)
 	const Box& b = icon.visual;
 	glDisable(GL_TEXTURE_2D);
 	glBlendFunc(GL_ONE, GL_ONE); // additive blending
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 		glVertex2f(b.x1, b.y1);
 		glVertex2f(b.x2, b.y1);
 		glVertex2f(b.x2, b.y2);
@@ -3065,7 +3065,7 @@ void CGuiHandler::DrawButtons() // Only called by Draw
 	const float alpha = (frameAlpha < 0.0f) ? guiAlpha : frameAlpha;
 	if (alpha > 0.0f) {
 		glColor4f(0.2f, 0.2f, 0.2f, alpha);
-		glBegin(GL_QUADS);
+		glBeginBatch(GL_QUADS);
 			glVertex2f(buttonBox.x1, buttonBox.y1);
 			glVertex2f(buttonBox.x1, buttonBox.y2);
 			glVertex2f(buttonBox.x2, buttonBox.y2);
@@ -3299,7 +3299,7 @@ void CGuiHandler::DrawNumberInput() // Only called by drawbuttons
 			glRectf(0.75f, 0.45f, 0.765f, 0.55f);
 			glColor4f(0.0f, 0.0f, 1.0f, 0.8f);
 			glRectf(0.25f, 0.49f, 0.75f, 0.51f);
-			glBegin(GL_TRIANGLES);
+			glBeginBatch(GL_TRIANGLES);
 				glColor4f(1.0f, 0.0f, 0.0f, 1.0f);
 				glVertex2f(slideX + 0.015f, 0.55f);
 				glVertex2f(slideX - 0.015f, 0.55f);
@@ -3324,7 +3324,7 @@ void CGuiHandler::DrawPrevArrow(const IconInfo& icon)
 	const float ySize = 0.125f * math::fabs(b.y2 - b.y1);
 	const float xSiz2 = 2.0f * xSize;
 	glDisable(GL_TEXTURE_2D);
-	glBegin(GL_POLYGON);
+	glBeginBatch(GL_POLYGON);
 		glVertex2f(b.x2 - xSize, yCenter - ySize);
 		glVertex2f(b.x1 + xSiz2, yCenter - ySize);
 		glVertex2f(b.x1 + xSize, yCenter);
@@ -3343,7 +3343,7 @@ void CGuiHandler::DrawNextArrow(const IconInfo& icon)
 	const float ySize = 0.125f * math::fabs(b.y2 - b.y1);
 	const float xSiz2 = 2.0f * xSize;
 	glDisable(GL_TEXTURE_2D);
-	glBegin(GL_POLYGON);
+	glBeginBatch(GL_POLYGON);
 		glVertex2f(b.x1 + xSize, yCenter - ySize);
 		glVertex2f(b.x2 - xSiz2, yCenter - ySize);
 		glVertex2f(b.x2 - xSize, yCenter);
@@ -3477,7 +3477,7 @@ static inline GLuint GetConeList()
 
 	list = glGenLists(1);
 	glNewList(list, GL_COMPILE); {
-		glBegin(GL_TRIANGLE_FAN);
+		glBeginBatch(GL_TRIANGLE_FAN);
 		const int divs = 64;
 		glVertex3f(0.0f, 0.0f, 0.0f);
 		for (int i = 0; i <= divs; i++) {
@@ -3663,7 +3663,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 							DrawArea(innerPos, radius, color);
 						} else {
 							glColor4f(color[0], color[1], color[2], 0.5f);
-							glBegin(GL_TRIANGLE_FAN);
+							glBeginBatch(GL_TRIANGLE_FAN);
 
 							constexpr int divs = 256;
 							for (int i = 0; i <= divs; ++i) {
@@ -3700,7 +3700,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 							DrawSelectBox(innerPos, outerPos, tracePos);
 						} else {
 							glColor4f(1.0f, 0.0f, 0.0f, 0.5f);
-							glBegin(GL_QUADS);
+							glBeginBatch(GL_QUADS);
 							glVertex3f(innerPos.x, 0.0f, innerPos.z);
 							glVertex3f(outerPos.x, 0.0f, innerPos.z);
 							glVertex3f(outerPos.x, 0.0f, outerPos.z);
@@ -3974,7 +3974,7 @@ void CGuiHandler::DrawMiniMapMarker(const float3& cameraPos)
 	glEnable(GL_BLEND);
 	glShadeModel(GL_FLAT);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-	glBegin(GL_TRIANGLE_FAN);
+	glBeginBatch(GL_TRIANGLE_FAN);
 		                       glVertex3f(0.0f, 0.0f, 0.0f);
 		                       glVertex3f(  +w,   +h, 0.0f);
 		glColor4fv(colors[4]); glVertex3f(0.0f,   +h,   +w);
@@ -3982,7 +3982,7 @@ void CGuiHandler::DrawMiniMapMarker(const float3& cameraPos)
 		glColor4fv(colors[6]); glVertex3f(0.0f,   +h,   -w);
 		glColor4fv(colors[7]); glVertex3f(  +w,   +h, 0.0f);
 	glEnd();
-	glBegin(GL_TRIANGLE_FAN);
+	glBeginBatch(GL_TRIANGLE_FAN);
 		                       glVertex3f(0.0f, h * 2.0f, 0.0f);
 		                       glVertex3f(  +w,   +h, 0.0f);
 		glColor4fv(colors[3]); glVertex3f(0.0f,   +h,   -w);
@@ -4065,7 +4065,7 @@ void CGuiHandler::DrawArea(float3 pos, float radius, const float* color)
 
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_FOG);
-	glBegin(GL_TRIANGLE_FAN);
+	glBeginBatch(GL_TRIANGLE_FAN);
 		glVertexf3(pos);
 		for(int a=0;a<=40;++a){
 			float3 p(fastmath::cos(a * math::TWOPI / 40.0f) * radius, 0.0f, fastmath::sin(a * math::TWOPI / 40.0f) * radius);
@@ -4118,7 +4118,7 @@ void CGuiHandler::DrawFormationFrontOrder(
 	if (onMinimap) {
 		pos1 += (pos1 - pos2);
 		glLineWidth(2.0f);
-		glBegin(GL_LINES);
+		glBeginBatch(GL_LINES);
 		glVertexf3(pos1);
 		glVertexf3(pos2);
 		glEnd();
@@ -4132,7 +4132,7 @@ void CGuiHandler::DrawFormationFrontOrder(
 	{
 		// direction arrow
 		glDisable(GL_DEPTH_TEST);
-		glBegin(GL_QUADS);
+		glBeginBatch(GL_QUADS);
 			glVertexf3(pos1 + side * 25.0f                   );
 			glVertexf3(pos1 - side * 25.0f                   );
 			glVertexf3(pos1 - side * 25.0f + forward *  50.0f);
@@ -4156,7 +4156,7 @@ void CGuiHandler::DrawFormationFrontOrder(
 	{
 		// vertical quad
 		glDisable(GL_FOG);
-		glBegin(GL_QUAD_STRIP);
+		glBeginBatch(GL_QUAD_STRIP);
 		const float3 delta = (pos2 - pos1) / (float)steps;
 		for (int i = 0; i <= steps; i++) {
 			float3 p;
@@ -4188,7 +4188,7 @@ static void DrawBoxShape(const void* data)
 	const BoxData* boxData = static_cast<const BoxData*>(data);
 	const float3& mins = boxData->mins;
 	const float3& maxs = boxData->maxs;
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 		// the top
 		glVertex3f(mins.x, maxs.y, mins.z);
 		glVertex3f(mins.x, maxs.y, maxs.z);
@@ -4200,7 +4200,7 @@ static void DrawBoxShape(const void* data)
 		glVertex3f(maxs.x, mins.y, maxs.z);
 		glVertex3f(mins.x, mins.y, maxs.z);
 	glEnd();
-	glBegin(GL_QUAD_STRIP);
+	glBeginBatch(GL_QUAD_STRIP);
 		// the sides
 		glVertex3f(mins.x, maxs.y, mins.z);
 		glVertex3f(mins.x, mins.y, mins.z);
@@ -4227,7 +4227,7 @@ static void DrawCornerPosts(const float3& pos0, const float3& pos1)
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glLineWidth(2.0f);
-	glBegin(GL_LINES);
+	glBeginBatch(GL_LINES);
 		glColor4f(1.0f, 1.0f, 0.0f, 0.9f);
 		glVertexf3(corner0); glVertexf3(corner0 + lineVector);
 		glColor4f(0.0f, 1.0f, 0.0f, 0.9f);
@@ -4288,14 +4288,14 @@ static void FullScreenDraw()
 static void DrawMinMaxBox(const float3& mins, const float3& maxs)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 		// the top
 		glVertex3f(mins.x, maxs.y, mins.z);
 		glVertex3f(maxs.x, maxs.y, mins.z);
 		glVertex3f(maxs.x, maxs.y, maxs.z);
 		glVertex3f(mins.x, maxs.y, maxs.z);
 	glEnd();
-	glBegin(GL_QUAD_STRIP);
+	glBeginBatch(GL_QUAD_STRIP);
 		// the sides
 		glVertex3f(mins.x, mins.y, mins.z);
 		glVertex3f(mins.x, maxs.y, mins.z);
@@ -4373,7 +4373,7 @@ static void DrawCylinderShape(const void* data)
 	const CylinderData& cyl = *static_cast<const CylinderData*>(data);
 	const float step = math::TWOPI / cyl.divs;
 	int i;
-	glBegin(GL_QUAD_STRIP); // the sides
+	glBeginBatch(GL_QUAD_STRIP); // the sides
 	for (i = 0; i <= cyl.divs; i++) {
 		const float radians = step * float(i % cyl.divs);
 		const float x = cyl.xc + (cyl.radius * fastmath::sin(radians));
@@ -4382,7 +4382,7 @@ static void DrawCylinderShape(const void* data)
 		glVertex3f(x, cyl.yn, z);
 	}
 	glEnd();
-	glBegin(GL_TRIANGLE_FAN); // the top
+	glBeginBatch(GL_TRIANGLE_FAN); // the top
 	for (i = 0; i < cyl.divs; i++) {
 		const float radians = step * float(i);
 		const float x = cyl.xc + (cyl.radius * fastmath::sin(radians));
@@ -4390,7 +4390,7 @@ static void DrawCylinderShape(const void* data)
 		glVertex3f(x, cyl.yp, z);
 	}
 	glEnd();
-	glBegin(GL_TRIANGLE_FAN); // the bottom
+	glBeginBatch(GL_TRIANGLE_FAN); // the bottom
 	for (i = (cyl.divs - 1); i >= 0; i--) {
 		const float radians = step * float(i);
 		const float x = cyl.xc + (cyl.radius * fastmath::sin(radians));
@@ -4426,7 +4426,7 @@ void CGuiHandler::DrawSelectCircle(const float3& pos, float radius,
 	glColor4f(color[0], color[1], color[2], 0.9f);
 	glLineWidth(2.0f);
 	const float3 base(pos.x, CGround::GetHeightAboveWater(pos.x, pos.z, false), pos.z);
-	glBegin(GL_LINES);
+	glBeginBatch(GL_LINES);
 		glVertexf3(base);
 		glVertexf3(base + float3(0.0f, 128.0f, 0.0f));
 	glEnd();

--- a/rts/Lua/LuaDisplayLists.h
+++ b/rts/Lua/LuaDisplayLists.h
@@ -45,6 +45,19 @@ class CLuaDisplayLists {
 			return SMatrixStateData();
 		}
 
+		/**
+		 * Lua registry reference to the recording function and its arguments,
+		 * or 0 when this entry is a real GL display list. luaL_ref never
+		 * returns 0 for a live value, so 0 is unambiguous.
+		 */
+		int GetFuncRef(unsigned int index) const
+		{
+			if (index < active.size())
+				return active[index].funcRef;
+
+			return 0;
+		}
+
 		unsigned int NewDList(GLuint dlist, SMatrixStateData& m)
 		{
 			if (dlist == 0)
@@ -59,10 +72,34 @@ class CLuaDisplayLists {
 			active.push_back(DLdata(dlist, m));
 			return active.size() - 1;
 		}
+
+		/**
+		 * A list that is replayed by re-running its recording function rather
+		 * than by glCallList. Used where the driver mis-renders immediate-mode
+		 * batches: glFlush is executed during compilation and never recorded
+		 * into the list, so the corrupted batches are baked in and no flush at
+		 * replay time can reach them.
+		 */
+		unsigned int NewDeferredDList(int funcRef)
+		{
+			if (funcRef == 0)
+				return 0;
+
+			if (!unused.empty()) {
+				const unsigned int index = unused[unused.size() - 1];
+				active[index] = DLdata(0);
+				active[index].funcRef = funcRef;
+				unused.pop_back();
+				return index;
+			}
+			active.push_back(DLdata(0));
+			active.back().funcRef = funcRef;
+			return active.size() - 1;
+		}
 				
 		void FreeDList(unsigned int index)
 		{
-			if ((index < active.size()) && (active[index].id != 0)) {
+			if ((index < active.size()) && ((active[index].id != 0) || (active[index].funcRef != 0))) {
 				active[index] = DLdata(0);
 				unused.push_back(index);
 			}
@@ -74,6 +111,7 @@ class CLuaDisplayLists {
 			DLdata(int i, SMatrixStateData &m): id(i), matData(m) {}
 			GLuint id;
 			SMatrixStateData matData;
+			int funcRef = 0;
 		};
 		std::vector<DLdata> active;
 		std::vector<unsigned int> unused; // references slots in active

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -2186,7 +2186,7 @@ int LuaOpenGL::DrawGroundQuad(lua_State* L)
 			const int xit = xib + 1;
 			const float xb = xib * SQUARE_SIZE;
 			const float xt = xb + SQUARE_SIZE;
-			glBegin(GL_TRIANGLE_STRIP);
+			glBeginBatch(GL_TRIANGLE_STRIP);
 			for (int zi = zis; zi <= zie; zi++) {
 				const int ziOff = zi * mapxi;
 				const float yb = heightmap[ziOff + xib];
@@ -2209,7 +2209,7 @@ int LuaOpenGL::DrawGroundQuad(lua_State* L)
 			const float xt = xb + SQUARE_SIZE;
 			const float tut = tub + tuStep;
 			float tv = tv0;
-			glBegin(GL_TRIANGLE_STRIP);
+			glBeginBatch(GL_TRIANGLE_STRIP);
 			for (int zi = zis; zi <= zie; zi++) {
 				const int ziOff = zi * mapxi;
 				const float yb = heightmap[ziOff + xib];
@@ -2334,7 +2334,7 @@ int LuaOpenGL::Shape(lua_State* L)
 
 	const GLuint type = (GLuint)luaL_checkint(L, 1);
 
-	glBegin(type);
+	glBeginBatch(type);
 
 	const int table = 2;
 	int i = 1;
@@ -2386,7 +2386,7 @@ int LuaOpenGL::BeginEnd(lua_State* L)
 	}
 
 	// call the function
-	glBegin(primMode);
+	glBeginBatch(primMode);
 	const int error = lua_pcall(L, (args - 2), 0, 0);
 	glEnd();
 
@@ -2874,7 +2874,7 @@ int LuaOpenGL::TexRect(lua_State* L)
 			t1 = 0.0f;
 			t2 = 1.0f;
 		}
-		glBegin(GL_QUADS); {
+		glBeginBatch(GL_QUADS); {
 			glTexCoord2f(s1, t1); glVertex2f(x1, y1);
 			glTexCoord2f(s2, t1); glVertex2f(x2, y1);
 			glTexCoord2f(s2, t2); glVertex2f(x2, y2);
@@ -2888,7 +2888,7 @@ int LuaOpenGL::TexRect(lua_State* L)
 	const float t1 = luaL_checkfloat(L, 6);
 	const float s2 = luaL_checkfloat(L, 7);
 	const float t2 = luaL_checkfloat(L, 8);
-	glBegin(GL_QUADS); {
+	glBeginBatch(GL_QUADS); {
 		glTexCoord2f(s1, t1); glVertex2f(x1, y1);
 		glTexCoord2f(s2, t1); glVertex2f(x2, y1);
 		glTexCoord2f(s2, t2); glVertex2f(x2, y2);

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -6133,6 +6133,46 @@ int LuaOpenGL::CreateList(lua_State* L)
 			"Incorrect arguments to gl.CreateList(func [, arg1, arg2, etc ...])");
 	}
 
+	// Where the driver mis-renders immediate-mode batches, do not compile at
+	// all. glFlush is executed during compilation and is never recorded into
+	// the list, so glBeginBatch cannot help a batch that is baked into one, and
+	// neither can any flush at replay time. Keep the function instead and run it
+	// live on every gl.CallList, which is the path the mitigation does reach.
+	if (!globalRendering->supportImmediateModeBatching) {
+		CLuaDisplayLists& displayLists = CLuaHandle::GetActiveDisplayLists(L);
+
+		// A deferred list holds a Lua closure and its upvalues, not a GL name.
+		// A gl.CreateList reached from inside another list's recording function
+		// therefore allocates once per frame forever and retains everything the
+		// closure captured. Unguarded, that took a machine to 54 GB and froze it.
+		// Refuse rather than grow without bound.
+		static constexpr unsigned int MAX_DEFERRED_LISTS = 8192;
+
+		if (displayLists.GetCount() >= MAX_DEFERRED_LISTS) {
+			static bool loggedCap = false;
+			if (!loggedCap) {
+				loggedCap = true;
+				LOG_L(L_ERROR, "gl.CreateList: refusing to create more than %u lists. "
+					"Something is creating lists every frame without deleting them.",
+					MAX_DEFERRED_LISTS);
+			}
+			lua_pushnumber(L, 0);
+			return 1;
+		}
+
+		lua_createtable(L, args, 0);
+		for (int i = 1; i <= args; i++) {
+			lua_pushvalue(L, i);
+			lua_rawseti(L, -2, i);
+		}
+
+		const int funcRef = luaL_ref(L, LUA_REGISTRYINDEX);
+		const unsigned int index = displayLists.NewDeferredDList(funcRef);
+
+		lua_pushnumber(L, index);
+		return 1;
+	}
+
 	// generate the list id
 	const GLuint list = glGenLists(1);
 	if (list == 0) {
@@ -6180,7 +6220,36 @@ int LuaOpenGL::CallList(lua_State* L)
 	CheckDrawingEnabled(L, __func__);
 	CondWarnDeprecatedGL(L, __func__);
 	const unsigned int listIndex = luaL_checkint(L, 1);
-	const CLuaDisplayLists& displayLists = CLuaHandle::GetActiveDisplayLists(L);
+	CLuaDisplayLists& displayLists = CLuaHandle::GetActiveDisplayLists(L);
+
+	// a deferred list holds its recording function rather than a GL list, and
+	// is replayed by running it. Its own matrix calls execute live, so there is
+	// no captured matrix state to reapply.
+	if (const int funcRef = displayLists.GetFuncRef(listIndex); funcRef != 0) {
+		lua_rawgeti(L, LUA_REGISTRYINDEX, funcRef);
+
+		const int tableIdx = lua_gettop(L);
+		const int numVals = lua_objlen(L, tableIdx);
+
+		for (int i = 1; i <= numVals; i++)
+			lua_rawgeti(L, tableIdx, i);
+
+		const int error = lua_pcall(L, numVals - 1, 0, 0);
+		lua_remove(L, tableIdx);
+
+		if (error != 0) {
+			// drop the list rather than repeat the error every frame. A list
+			// whose function fails at compile time is discarded the same way.
+			LOG_L(L_ERROR, "gl.CallList: error(%i) = %s", error, lua_tostring(L, -1));
+			lua_pop(L, 1);
+
+			displayLists.FreeDList(listIndex);
+			luaL_unref(L, LUA_REGISTRYINDEX, funcRef);
+		}
+
+		return 0;
+	}
+
 	const unsigned int dlist = displayLists.GetDList(listIndex);
 	if (dlist) {
 		SMatrixStateData matrixStateData = displayLists.GetMatrixState(listIndex);
@@ -6208,9 +6277,13 @@ int LuaOpenGL::DeleteList(lua_State* L)
 	const unsigned int listIndex = (unsigned int)luaL_checkint(L, 1);
 	CLuaDisplayLists& displayLists = CLuaHandle::GetActiveDisplayLists(L);
 	const unsigned int dlist = displayLists.GetDList(listIndex);
+	const int funcRef = displayLists.GetFuncRef(listIndex);
 	displayLists.FreeDList(listIndex);
 	if (dlist != 0) {
 		glDeleteLists(dlist, 1);
+	}
+	if (funcRef != 0) {
+		luaL_unref(L, LUA_REGISTRYINDEX, funcRef);
 	}
 	return 0;
 }

--- a/rts/Rendering/Env/DynWater.cpp
+++ b/rts/Rendering/Env/DynWater.cpp
@@ -678,7 +678,7 @@ void CDynWater::DrawWaves()
 	glProgramEnvParameter4fARB(GL_FRAGMENT_PROGRAM_ARB,1, W_SIZE*2, 0, 0, 0);
 
 	//update normals pass
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(start, start); glVertexf3(ZeroVector);
 	glTexCoord2f(start, end);   glVertexf3(  UpVector);
 	glTexCoord2f(end,   end);   glVertexf3(  XYVector);
@@ -745,7 +745,7 @@ void CDynWater::DrawHeightTex()
 	float startv = 8.0f / 256;
 	float endv   = 248.0f / 256;
 	//update 32 bit height map
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(startx, startz); glVertex3f(startv, startv, 0);
 	glTexCoord2f(startx, endz);   glVertex3f(startv, endv,   0);
 	glTexCoord2f(endx,   endz);   glVertex3f(endv,   endv,   0);
@@ -999,7 +999,7 @@ void CDynWater::DrawDetailNormalTex()
 	glProgramEnvParameter4fARB(GL_FRAGMENT_PROGRAM_ARB,7, 0.08f*swh, 0.2f*swh, 0.7f*lwh, 0);
 
 	//update detail normals
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(0, 0); glVertexf3(ZeroVector);
 	glTexCoord2f(0, 1); glVertexf3(  UpVector);
 	glTexCoord2f(1, 1); glVertexf3(  XYVector);

--- a/rts/Rendering/GL/GeometryBuffer.cpp
+++ b/rts/Rendering/GL/GeometryBuffer.cpp
@@ -100,7 +100,7 @@ void GL::GeometryBuffer::DrawDebug(const unsigned int texID, const float2 texMin
 	glActiveTexture(GL_TEXTURE0);
 	glEnable(GetTextureTarget());
 	glBindTexture(GetTextureTarget(), texID);
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 	glTexCoord2f(texMins.x, texMins.y); glNormal3fv(&UpVector.x); glVertex2f(texMins.x, texMins.y);
 	glTexCoord2f(texMaxs.x, texMins.y); glNormal3fv(&UpVector.x); glVertex2f(texMaxs.x, texMins.y);
 	glTexCoord2f(texMaxs.x, texMaxs.y); glNormal3fv(&UpVector.x); glVertex2f(texMaxs.x, texMaxs.y);

--- a/rts/Rendering/GL/myGL.cpp
+++ b/rts/Rendering/GL/myGL.cpp
@@ -545,6 +545,18 @@ bool glSpringBlitImages(
 
 /******************************************************************************/
 
+void glBeginBatch(GLenum mode)
+{
+	// the pending batches have to reach the GPU before the next one starts
+	// writing into the same buffer. Issuing them without submitting, which any
+	// state change does, is not enough: measured on Zink over KosmicKrisp the
+	// draws Mesa emits are then byte for byte identical and still come out wrong.
+	if (!globalRendering->supportImmediateModeBatching)
+		glFlush();
+
+	glBegin(mode);
+}
+
 void ClearScreen()
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Rendering/GL/myGL.h
+++ b/rts/Rendering/GL/myGL.h
@@ -106,6 +106,15 @@ bool glSpringBlitImages(
 	GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth
 );
 
+/**
+ * Starts an immediate-mode batch.
+ *
+ * Identical to glBegin() except where the driver mis-renders batches that
+ * accumulate in Mesa's begin/end buffer, in which case whatever is already
+ * queued is submitted first. See CGlobalRendering::ProbeImmediateModeBatching.
+ */
+void glBeginBatch(GLenum mode);
+
 void ClearScreen();
 
 bool ProgramStringIsNative(GLenum target, const char* filename);

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -55,6 +55,8 @@ CONFIG(float, MinSampleShadingRate).defaultValue(0.0f).minimumValue(0.0f).maximu
 CONFIG(int, ForceDisablePersistentMapping).defaultValue(0).minimumValue(0).maximumValue(1);
 CONFIG(int, ForceDisableExplicitAttribLocs).defaultValue(0).minimumValue(0).maximumValue(1);
 CONFIG(int, ForceDisableClipCtrl).defaultValue(0).minimumValue(0).maximumValue(1);
+CONFIG(int, ForceImmediateModeFlush).defaultValue(-1).minimumValue(-1).maximumValue(1)
+	.description("Overrides the immediate-mode batching probe. -1 measures the driver, 0 never submits before a batch, 1 always does.");
 //CONFIG(int, ForceDisableShaders).defaultValue(0).minimumValue(0).maximumValue(1);
 CONFIG(int, ForceDisableGL4).defaultValue(0).safemodeValue(1).minimumValue(0).maximumValue(1);
 
@@ -194,6 +196,7 @@ CR_REG_METADATA(CGlobalRendering, (
 	CR_IGNORED(supportClipSpaceControl),
 	CR_IGNORED(supportSeamlessCubeMaps),
 	CR_IGNORED(supportFragDepthLayout),
+	CR_IGNORED(supportImmediateModeBatching),
 	CR_IGNORED(haveGL4),
 	CR_IGNORED(glslMaxVaryings),
 	CR_IGNORED(glslMaxAttributes),
@@ -324,6 +327,7 @@ CGlobalRendering::CGlobalRendering()
 	, supportClipSpaceControl(false)
 	, supportSeamlessCubeMaps(false)
 	, supportFragDepthLayout(false)
+	, supportImmediateModeBatching(true)
 	, haveGL4(false)
 
 	, glslMaxVaryings(0)
@@ -931,6 +935,11 @@ void CGlobalRendering::SetGLSupportFlags()
 	if (globalRendering->amdHacks) {
 		supportDepthBufferBitDepth = 24;
 	}
+
+	{
+		const int forceFlush = configHandler->GetInt("ForceImmediateModeFlush");
+		supportImmediateModeBatching = (forceFlush < 0) ? ProbeImmediateModeBatching() : (forceFlush == 0);
+	}
 }
 
 void CGlobalRendering::QueryGLMaxVals()
@@ -1039,6 +1048,7 @@ void CGlobalRendering::LogVersionInfo(const char* sdlVersionStr, const char* glV
 	LOG("\tclip-space control support: %i (%i)", supportClipSpaceControl, IsExtensionSupported("GL_ARB_clip_control"));
 	LOG("\tseamless cube-map support : %i (%i)", supportSeamlessCubeMaps, IsExtensionSupported("GL_ARB_seamless_cube_map"));
 	LOG("\tfrag-depth layout support : %i (%i)", supportFragDepthLayout, IsExtensionSupported("GL_ARB_conservative_depth"));
+	LOG("\timmediate-mode batching   : %i (-)" , supportImmediateModeBatching);
 	LOG("\tpersistent maps support   : %i (%i)", supportPersistentMapping, IsExtensionSupported("GL_ARB_buffer_storage"));
 	LOG("\texplicit attribs location : %i (%i)", supportExplicitAttribLoc, IsExtensionSupported("GL_ARB_explicit_attrib_location"));
 	LOG("\tmulti draw indirect       : %i (-)" , IsExtensionSupported("GL_ARB_multi_draw_indirect"));
@@ -1791,6 +1801,130 @@ void main()
 	return testShader.IsValid();
 #else
 	return false;
+#endif
+}
+
+
+bool CGlobalRendering::ProbeImmediateModeBatching() const
+{
+#ifndef HEADLESS
+	// Mesa accumulates consecutive glBegin/glEnd batches into one buffer and
+	// issues them as one draw. Zink on KosmicKrisp renders that wrongly, but
+	// only once the buffer already holds another batch and a later batch widens
+	// its vertex format part way through. Draw exactly that: two batches that
+	// cover nothing, then a grid of cells whose batches add a colour, then a
+	// texture coordinate, then a third vertex component as they go.
+	//
+	// Every cell should be lit inside its margin and nothing outside it.
+	if (!FBO::IsSupported())
+		return true;
+
+	constexpr int probeSize = 256;
+	constexpr int probeCells = 6;
+	constexpr int probeMargin = 6;
+	constexpr int cellSize = probeSize / probeCells;
+
+	FBO fbo;
+	fbo.Bind();
+	fbo.CreateRenderBuffer(GL_COLOR_ATTACHMENT0_EXT, GL_RGBA8, probeSize, probeSize);
+
+	bool wrong = false;
+
+	if (fbo.GetStatus() == GL_FRAMEBUFFER_COMPLETE_EXT) {
+		glUseProgram(0);
+
+		glViewport(0, 0, probeSize, probeSize);
+		glDisable(GL_DEPTH_TEST);
+		glDisable(GL_BLEND);
+		glDisable(GL_CULL_FACE);
+		glDisable(GL_TEXTURE_2D);
+
+		glMatrixMode(GL_PROJECTION);
+		glPushMatrix();
+		glLoadIdentity();
+		glMatrixMode(GL_MODELVIEW);
+		glPushMatrix();
+		glLoadIdentity();
+
+		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+
+		// batches that write vertices but light nothing, so the begin/end buffer
+		// is not empty when the grid starts. One is not enough to trigger it.
+		for (int i = 0; i < 2; ++i) {
+			glColor3f(1.0f, 1.0f, 1.0f);
+			glBegin(GL_QUADS);
+			for (int v = 0; v < 4; ++v)
+				glVertex2f(-1.0f, -1.0f);
+			glEnd();
+		}
+
+		for (int cy = 0; cy < probeCells; ++cy) {
+			for (int cx = 0; cx < probeCells; ++cx) {
+				const float x0 = ((cx * cellSize + probeMargin) / float(probeSize)) * 2.0f - 1.0f;
+				const float y0 = ((cy * cellSize + probeMargin) / float(probeSize)) * 2.0f - 1.0f;
+				const float x1 = (((cx + 1) * cellSize - probeMargin) / float(probeSize)) * 2.0f - 1.0f;
+				const float y1 = (((cy + 1) * cellSize - probeMargin) / float(probeSize)) * 2.0f - 1.0f;
+
+				const float xs[4] = { x0, x1, x1, x0 };
+				const float ys[4] = { y0, y0, y1, y1 };
+
+				glColor3f(1.0f, 1.0f, 1.0f);
+				glBegin(GL_QUADS);
+
+				for (int v = 0; v < 4; ++v) {
+					if (v & 1)
+						glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+					if (v == 2)
+						glTexCoord2f(0.0f, 0.0f);
+
+					if (v == 3) {
+						glVertex3f(xs[v], ys[v], 0.0f);
+					} else {
+						glVertex2f(xs[v], ys[v]);
+					}
+				}
+
+				glEnd();
+			}
+		}
+
+		static std::vector<uint8_t> pixels;
+		pixels.resize(probeSize * probeSize * 4);
+		glReadPixels(0, 0, probeSize, probeSize, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+
+		glMatrixMode(GL_PROJECTION);
+		glPopMatrix();
+		glMatrixMode(GL_MODELVIEW);
+		glPopMatrix();
+
+		size_t strayPixels = 0;
+		size_t unlitPixels = 0;
+
+		for (int y = 0; y < probeSize; ++y) {
+			for (int x = 0; x < probeSize; ++x) {
+				const bool lit = pixels[(y * probeSize + x) * 4] > 32;
+				const bool inCellX = (x % cellSize) >= probeMargin && (x % cellSize) < (cellSize - probeMargin);
+				const bool inCellY = (y % cellSize) >= probeMargin && (y % cellSize) < (cellSize - probeMargin);
+				const bool expected = inCellX && inCellY;
+
+				strayPixels += (lit && !expected);
+				unlitPixels += (!lit && expected);
+			}
+		}
+
+		// a driver that gets this right leaves no pixel of either kind
+		wrong = (strayPixels + unlitPixels) > 0;
+
+		if (wrong)
+			LOG_L(L_WARNING, "[GR::%s] immediate-mode batches render wrongly (%u stray, %u unlit of %u)", __func__, uint32_t(strayPixels), uint32_t(unlitPixels), uint32_t(probeSize * probeSize));
+	}
+
+	fbo.Unbind();
+
+	return !wrong;
+#else
+	return true;
 #endif
 }
 

--- a/rts/Rendering/GlobalRendering.h
+++ b/rts/Rendering/GlobalRendering.h
@@ -117,6 +117,7 @@ public:
 	void ToggleMultisampling() const;
 
 	bool CheckShaderGL4() const;
+	bool ProbeImmediateModeBatching() const;
 public:
 	//helper function
 	static int DepthBitsToFormat(int bits);
@@ -329,6 +330,20 @@ public:
 	bool supportClipSpaceControl;
 	bool supportSeamlessCubeMaps;
 	bool supportFragDepthLayout;
+
+	/**
+	 * @brief whether consecutive glBegin/glEnd batches render correctly
+	 *
+	 * Mesa accumulates immediate-mode batches into one buffer and issues them
+	 * together. Some drivers render the result wrongly once more than one batch
+	 * is in that buffer and a later batch widens its vertex format part way
+	 * through, which is what gl.Shape and gl.BeginEnd produce. No GL query
+	 * reports it and no GL error is raised, so it is measured by
+	 * ProbeImmediateModeBatching().
+	 *
+	 * When false, glBeginBatch() submits the pending work before each batch.
+	 */
+	bool supportImmediateModeBatching;
 
 	/**
 	 * Shader capabilities

--- a/rts/Rendering/HAPFSPathDrawer.cpp
+++ b/rts/Rendering/HAPFSPathDrawer.cpp
@@ -299,7 +299,7 @@ void HAPFSPathDrawer::Draw() const {
 	for (const auto& p: pm->GetPathMap()) {
 		const HAPFS::CPathManager::MultiPath& multiPath = p.second;
 
-		glBegin(GL_LINE_STRIP);
+		glBeginBatch(GL_LINE_STRIP);
 
 			// draw low-res segments of <path> (blue)
 			glColor4f(0.0f, 0.0f, 1.0f, 1.0f);
@@ -402,7 +402,7 @@ void HAPFSPathDrawer::Draw(const HAPFS::CPathEstimator* pe) const {
 	if (drawLowResPE || drawMedResPE) {
 
 		// Draw the block positions
-		glBegin(GL_LINES);
+		glBeginBatch(GL_LINES);
 
 		const int2 peNumBlocks = ps->GetNumBlocks();
 		const int vertexBaseNr = md->pathType * peNumBlocks.x * peNumBlocks.y * PATH_DIRECTION_VERTICES;

--- a/rts/Rendering/HUDDrawer.cpp
+++ b/rts/Rendering/HUDDrawer.cpp
@@ -86,7 +86,7 @@ void HUDDrawer::DrawUnitDirectionArrow(const CUnit* unit)
 			glRotatef(unit->heading * 180.0f / 32768 + 180, 0.0f, 0.0f, 1.0f);
 
 			glColor4f(0.3f, 0.9f, 0.3f, 0.4f);
-			glBegin(GL_TRIANGLE_FAN);
+			glBeginBatch(GL_TRIANGLE_FAN);
 				glVertex2f(-0.2f, -0.3f);
 				glVertex2f(-0.2f,  0.3f);
 				glVertex2f( 0.0f,  0.4f);
@@ -113,7 +113,7 @@ void HUDDrawer::DrawCameraDirectionArrow(const CUnit* unit)
 			glScalef(0.4f, 0.4f, 0.3f);
 
 			glColor4f(0.4f, 0.4f, 1.0f, 0.6f);
-			glBegin(GL_TRIANGLE_FAN);
+			glBeginBatch(GL_TRIANGLE_FAN);
 				glVertex2f(-0.2f, -0.3f);
 				glVertex2f(-0.2f,  0.3f);
 				glVertex2f( 0.0f,  0.5f);
@@ -229,7 +229,7 @@ void HUDDrawer::DrawTargetReticle(const CUnit* unit)
 					radius = w->GetCurrentTarget().unit->radius;
 
 				// draw the reticle
-				glBegin(GL_LINE_STRIP);
+				glBeginBatch(GL_LINE_STRIP);
 				for (int b = 0; b <= 80; ++b) {
 					glVertexf3(pos + (v2 * fastmath::sin(b * math::TWOPI / 80) + v3 * fastmath::cos(b * math::TWOPI / 80)) * radius);
 				}
@@ -246,14 +246,14 @@ void HUDDrawer::DrawTargetReticle(const CUnit* unit)
 					v3 = (v2.cross(v1)).ANormalize();
 					radius = dist / 100.0f;
 
-					glBegin(GL_LINE_STRIP);
+					glBeginBatch(GL_LINE_STRIP);
 					for (int b = 0; b <= 80; ++b) {
 						glVertexf3(pos + (v2 * fastmath::sin(b * math::TWOPI / 80) + v3 * fastmath::cos(b *math::TWOPI / 80)) * radius);
 					}
 					glEnd();
 				}
 
-				glBegin(GL_LINES);
+				glBeginBatch(GL_LINES);
 				if (!w->onlyForward) {
 					glVertexf3(pos);
 					glVertexf3(w->GetCurrentTargetPos());

--- a/rts/Rendering/Map/InfoTexture/Modern/Combiner.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Combiner.cpp
@@ -131,7 +131,7 @@ void CInfoTextureCombiner::Update()
 	const float isy = 2.0f * (mapDims.mapy / float(mapDims.pwr2mapy)) - 1.0f;
 
 	// need to keep this old nonsence intact to keep Lua shaders compatible
-	glBegin(GL_QUADS);
+	glBeginBatch(GL_QUADS);
 		glTexCoord2f(0.f, 0.f); glVertex2f(-1.f, -1.f);
 		glTexCoord2f(0.f, 1.f); glVertex2f(-1.f, +isy);
 		glTexCoord2f(1.f, 1.f); glVertex2f(+isx, +isy);


### PR DESCRIPTION
Some drivers render consecutive `glBegin`/`glEnd` batches wrongly once Mesa has accumulated more than one batch into its immediate-mode buffer and a later batch widens its vertex format part way through, which is the shape `gl.Shape` and `gl.BeginEnd` produce. No GL query reports it and no GL error is raised. In game it shows up as skewed hatched geometry smeared across the UI, and as UI elements that silently vanish.

Found on Zink over KosmicKrisp on Apple Silicon, but nothing here is platform specific. The capability is measured at startup and every path is inert on a driver that renders these batches correctly.

Three parts:

- `ProbeImmediateModeBatching` reproduces the triggering shape in an FBO and counts stray pixels, because there is nothing to query.
- `glBeginBatch` submits pending work before a batch when the probe found the driver broken. All `glBegin` call sites outside `rts/lib` go through it.
- `gl.CreateList` keeps its recording function instead of compiling, and `gl.CallList` runs it. A display list compiled from immediate mode cannot be repaired at replay time. `glFlush` executes during compilation and is never recorded into the list, so the corrupted batches are baked in permanently. Two captures a hundred frames apart are pixel identical, and rebuilding the list reproduces the same corruption exactly.

On why it has to be a submission rather than something cheaper: making Mesa issue the accumulated batches without submitting, which any state change does, produces a byte-identical stream of draws and still renders wrongly. Instrumenting Mesa's `vbo_exec_draw.c` and running the same binary on Zink and on llvmpipe gives identical draw streams, and llvmpipe renders them correctly.

Two behaviour changes worth knowing, both only on an affected driver. A Lua display list is no longer a snapshot, since its recording function runs every frame, so side effects inside one now repeat. And because a `gl.CreateList` reached from inside another list's function would then allocate every frame forever, the list count is capped at 8192 and refused past that.

`ForceImmediateModeFlush` overrides the probe, -1 measures, 0 never submits, 1 always does, so both sides can be compared on one binary.

## Testing

Measured on SplinterFaction at 1280x720, scoring phase dumps for saturated red, magenta and lavender pixels, on Zink over KosmicKrisp:

| | frames | peak stray pixels | corrupted frames |
|---|---|---|---|
| workaround active | 31 | 706 | 0 |
| probe forced off | 89 | 160284 | 11, 12.4% |

Seeing zero in 31 frames at the unmitigated rate has p around 0.02, and the peak never leaves the clean baseline.

**Not tested on hardware where the probe returns true.** On such a driver every path here is inert by construction, but I have only run this on macOS, so the startup probe itself is unexercised elsewhere. That is the main thing worth a second pair of eyes.

There is no existing issue covering this. I searched and found none, and am happy to open one first if that is preferred.

## AI usage

Written with Claude Code. The diagnosis, the probes and the measurements were driven by me and verified against captured frames and a standalone reproducer. The code was drafted with AI assistance and reviewed by hand.