### PR TITLE
Add missing names to lua return values. Additional return description and overload cleanup.

### DIFF
--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2646,7 +2646,7 @@ void CLuaHandle::SunChanged()
  * @param type "unit"|"feature" The type of the object pointed at.
  * @param id ObjectID The `unitID` or `featureID`.
  * @param cmd integer The current command ID.
- * @return integer The command ID to use as the default, or nil to keep the current ID.
+ * @return integer cmdID The command ID to use as the default, or nil to keep the current ID.
  */
 bool CLuaHandle::DefaultCommand(const CUnit* unit,
                                 const CFeature* feature, int& cmd)
@@ -3700,7 +3700,7 @@ void CLuaHandle::MiniMapGeometryChanged(const int2 newPos, const int2 newDim, co
  * @param cmdID integer
  * @param cmdParams table
  * @param options CommandOptions
- * @return boolean Returning true deletes the command and does not send it through the network.
+ * @return boolean delete Returning true deletes the command and does not send it through the network.
  */
 bool CLuaHandle::CommandNotify(const Command& cmd)
 {

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -580,7 +580,7 @@ bool CSyncedLuaHandle::SyncedActionFallback(const std::string& msg, int playerID
  * @param cmdParams number[]
  * @param cmdOptions CommandOptions
  * @param cmdTag integer
- * @return boolean whether to remove the command from the queue
+ * @return boolean removeCmd whether to remove the command from the queue
  */
 bool CSyncedLuaHandle::CommandFallback(const CUnit* unit, const Command& cmd)
 {
@@ -618,7 +618,7 @@ bool CSyncedLuaHandle::CommandFallback(const CUnit* unit, const Command& cmd)
  * @param cmdTag integer
  * @param synced boolean
  * @param fromLua boolean
- * @return boolean whether it should be let into the queue.
+ * @return boolean allowCmd whether it should be let into the queue.
  */
 bool CSyncedLuaHandle::AllowCommand(const CUnit* unit, const Command& cmd, int playerNum, bool fromSynced, bool fromLua)
 {
@@ -657,7 +657,8 @@ bool CSyncedLuaHandle::AllowCommand(const CUnit* unit, const Command& cmd, int p
  * @param y number
  * @param z number
  * @param facing FacingInteger
- * @return boolean allow, boolean dropOrder
+ * @return boolean allow
+ * @return boolean dropOrder
  */
 std::pair <bool, bool> CSyncedLuaHandle::AllowUnitCreation(
 	const UnitDef* unitDef,
@@ -702,7 +703,7 @@ std::pair <bool, bool> CSyncedLuaHandle::AllowUnitCreation(
  * @param oldTeam TeamID
  * @param newTeam TeamID
  * @param capture boolean
- * @return boolean whether or not the transfer is permitted.
+ * @return boolean allow whether or not the transfer is permitted.
  */
 bool CSyncedLuaHandle::AllowUnitTransfer(const CUnit* unit, int newTeam, bool capture)
 {
@@ -739,7 +740,7 @@ bool CSyncedLuaHandle::AllowUnitTransfer(const CUnit* unit, int newTeam, bool ca
  * @param unitID UnitID
  * @param unitDefID UnitDefID
  * @param part number
- * @return boolean whether or not the build makes progress.
+ * @return boolean allow whether or not the build makes progress.
  */
 bool CSyncedLuaHandle::AllowUnitBuildStep(const CUnit* builder, const CUnit* unit, float part)
 {
@@ -776,7 +777,7 @@ bool CSyncedLuaHandle::AllowUnitBuildStep(const CUnit* builder, const CUnit* uni
  * @param unitID UnitID
  * @param unitDefID UnitDefID
  * @param part number
- * @return boolean whether or not the capture makes progress.
+ * @return boolean allow whether or not the capture makes progress.
  */
 bool CSyncedLuaHandle::AllowUnitCaptureStep(const CUnit* builder, const CUnit* unit, float part)
 {
@@ -814,7 +815,7 @@ bool CSyncedLuaHandle::AllowUnitCaptureStep(const CUnit* builder, const CUnit* u
  * @param transporteeID UnitID
  * @param transporteeUnitDefID UnitDefID
  * @param transporteeTeam TeamID
- * @return boolean whether or not the transport is allowed
+ * @return boolean allow whether or not the transport is allowed
  */
 bool CSyncedLuaHandle::AllowUnitTransport(const CUnit* transporter, const CUnit* transportee)
 {
@@ -855,7 +856,7 @@ bool CSyncedLuaHandle::AllowUnitTransport(const CUnit* transporter, const CUnit*
  * @param x number
  * @param y number
  * @param z number
- * @return boolean whether or not the transport load is allowed
+ * @return boolean allow whether or not the transport load is allowed
  */
 bool CSyncedLuaHandle::AllowUnitTransportLoad(
 	const CUnit* transporter,
@@ -905,7 +906,7 @@ bool CSyncedLuaHandle::AllowUnitTransportLoad(
  * @param x number
  * @param y number
  * @param z number
- * @return boolean whether or not the transport unload is allowed
+ * @return boolean allow whether or not the transport unload is allowed
  */
 bool CSyncedLuaHandle::AllowUnitTransportUnload(
 	const CUnit* transporter,
@@ -946,7 +947,7 @@ bool CSyncedLuaHandle::AllowUnitTransportUnload(
  * @function SyncedCallins:AllowUnitCloak
  * @param unitID UnitID
  * @param enemyID UnitID?
- * @return boolean whether unit is allowed to cloak
+ * @return boolean allow whether unit is allowed to cloak
  */
 bool CSyncedLuaHandle::AllowUnitCloak(const CUnit* unit, const CUnit* enemy)
 {
@@ -983,7 +984,7 @@ bool CSyncedLuaHandle::AllowUnitCloak(const CUnit* unit, const CUnit* enemy)
  * @param unitID UnitID
  * @param objectID ObjectID?
  * @param weaponNum integer?
- * @return boolean whether unit is allowed to decloak
+ * @return boolean allow whether unit is allowed to decloak
  */
 bool CSyncedLuaHandle::AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon)
 {
@@ -1026,7 +1027,7 @@ bool CSyncedLuaHandle::AllowUnitDecloak(const CUnit* unit, const CSolidObject* o
  * @function SyncedCallins:AllowUnitKamikaze
  * @param unitID UnitID
  * @param targetID UnitID
- * @return boolean whether unit is allowed to selfd
+ * @return boolean allow whether unit is allowed to selfd
  */
 bool CSyncedLuaHandle::AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed)
 {
@@ -1059,7 +1060,7 @@ bool CSyncedLuaHandle::AllowUnitKamikaze(const CUnit* unit, const CUnit* target,
  * @param x number
  * @param y number
  * @param z number
- * @return boolean whether or not the creation is permitted
+ * @return boolean allow whether or not the creation is permitted
  */
 bool CSyncedLuaHandle::AllowFeatureCreation(const FeatureDef* featureDef, int teamID, const float3& pos)
 {
@@ -1104,7 +1105,7 @@ bool CSyncedLuaHandle::AllowFeatureCreation(const FeatureDef* featureDef, int te
  * @param featureDefID FeatureDefID
  * @param part number
  *
- * @return boolean whether or not the change is permitted
+ * @return boolean allow whether or not the change is permitted
  */
 bool CSyncedLuaHandle::AllowFeatureBuildStep(const CUnit* builder, const CFeature* feature, float part)
 {
@@ -1139,7 +1140,7 @@ bool CSyncedLuaHandle::AllowFeatureBuildStep(const CUnit* builder, const CFeatur
  * @param teamID TeamID
  * @param res string
  * @param level number
- * @return boolean whether or not the sharing level is permitted
+ * @return boolean allow whether or not the sharing level is permitted
  */
 bool CSyncedLuaHandle::AllowResourceLevel(int teamID, const std::string& type, float level)
 {
@@ -1173,7 +1174,7 @@ bool CSyncedLuaHandle::AllowResourceLevel(int teamID, const std::string& type, f
  * @param newTeamID TeamID
  * @param res string
  * @param amount number
- * @return boolean whether or not the transfer is permitted.
+ * @return boolean allow whether or not the transfer is permitted.
  */
 bool CSyncedLuaHandle::AllowResourceTransfer(int oldTeam, int newTeam, const char* type, float amount)
 {
@@ -1205,7 +1206,7 @@ bool CSyncedLuaHandle::AllowResourceTransfer(int oldTeam, int newTeam, const cha
  *
  * @function SyncedCallins:ResourceExcess
  * @param excesses table
- * @return boolean whether or not Lua handled the event
+ * @return boolean handled whether or not Lua handled the event
  */
 bool CSyncedLuaHandle::ResourceExcess(const std::map <int, SResourcePack>& excesses)
 {
@@ -1382,7 +1383,7 @@ bool CSyncedLuaHandle::AllowStartPosition(int playerID, int teamID, unsigned cha
  * @param unitTeam TeamID
  * @param data integer was supposed to indicate the type of notification but currently never has a value other than 1 ("unit hit the ground").
  *
- * @return boolean whether or not the unit should remain script-controlled (false) or return to engine controlled movement (true).
+ * @return boolean engineControl whether or not the unit should remain script-controlled (false) or return to engine controlled movement (true).
  */
 bool CSyncedLuaHandle::MoveCtrlNotify(const CUnit* unit, int data)
 {
@@ -1420,7 +1421,7 @@ bool CSyncedLuaHandle::MoveCtrlNotify(const CUnit* unit, int data)
  * @param buildUnitID UnitID
  * @param buildUnitDefID UnitDefID
  * @param buildUnitTeam TeamID
- * @return boolean if true the current build order is terminated
+ * @return boolean stop if true the current build order is terminated
  */
 bool CSyncedLuaHandle::TerraformComplete(const CUnit* unit, const CUnit* build)
 {
@@ -1490,7 +1491,8 @@ bool CSyncedLuaHandle::TerraformComplete(const CUnit* unit, const CUnit* build)
  * @param attackerDefID UnitDefID? Synced Only
  * @param attackerTeam TeamID? Synced Only
  *
- * @return number newDamage, number impulseMult
+ * @return number newDamage
+ * @return number impulseMult
  */
 bool CSyncedLuaHandle::UnitPreDamaged(
 	const CUnit* unit,
@@ -1666,7 +1668,7 @@ bool CSyncedLuaHandle::FeaturePreDamaged(
  * @param hitY number
  * @param hitZ number
  *
- * @return boolean if true the gadget handles the collision event and the engine does not remove the projectile
+ * @return boolean handle if true the gadget handles the collision event and the engine does not remove the projectile
  */
 bool CSyncedLuaHandle::ShieldPreDamaged(
 	const CProjectile* projectile,
@@ -1788,7 +1790,7 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  * @param defPriority number
  *
  * @return boolean allowed
- * @return number the new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.
+ * @return number newPriority The new priority for this target (if you don't want to change it, return defPriority). Lower priority targets are targeted first.
  *
  * @see Script.SetWatchAllowTarget
  * @see Script.SetWatchWeapon
@@ -2223,7 +2225,7 @@ GetWatchDef(Synced, Feature)
  * ```
  *
  * @param weaponDefID WeaponDefID
- * @return boolean watched True if watch is enabled for any weaponDefID callins.
+ * @return boolean watched `true` if watch is enabled for any weaponDefID callins.
  *
  * @see Script.SetWatchWeapon
  */

--- a/rts/Lua/LuaMathExtra.cpp
+++ b/rts/Lua/LuaMathExtra.cpp
@@ -64,7 +64,7 @@ bool LuaMathExtra::PushEntries(lua_State* L)
  * @function math.hypot
  * @param x number
  * @param y number
- * @return number `sqrt(x*x+y*y)`
+ * @return number hypotenuse `sqrt(x*x+y*y)`
  */
 int LuaMathExtra::hypot(lua_State* L) {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -146,7 +146,7 @@ int LuaMathExtra::sgn(lua_State* L) {
  * @param x number
  * @param y number
  * @param a number
- * @return number (x+(y-x)*a)
+ * @return number mixed (x+(y-x)*a)
  */
 int LuaMathExtra::mix(lua_State* L) {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -5815,22 +5815,22 @@ int LuaOpenGL::PushPopMatrix(lua_State* L)
  * @function gl.GetMatrixData
  * @param type GL Matrix type (`GL.PROJECTION`, `GL.MODELVIEW`, `GL.TEXTURE`).
  * @param index integer Matrix index in range `[1, 16]`.
- * @return number The value.
+ * @return number value The value at the given index.
  */
 /***
  * @function gl.GetMatrixData
  * @param type GL Matrix type (`GL.PROJECTION`, `GL.MODELVIEW`, `GL.TEXTURE`).
- * @return Matrix4x4 The matrix.
+ * @return Matrix4x4
  */
 /***
  * @function gl.GetMatrixData
  * @param index integer Matrix index in range `[1, 16]`.
- * @return number The value.
+ * @return number value The value at the given index.
  */
 /***
  * @function gl.GetMatrixData
- * @param name MatrixName The matrix name.
- * @return Matrix4x4 The matrix.
+ * @param name MatrixName
+ * @return Matrix4x4
  */
 int LuaOpenGL::GetMatrixData(lua_State* L)
 {
@@ -6426,7 +6426,7 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
  * @param w 1
  * @param h 1
  * @param format GL? (Default: `GL.RGBA`)
- * @return number ... Color values (color size based on format).
+ * @return number ... Color value (color size based on format).
  */
 /***
  * Get column of pixels.
@@ -6436,7 +6436,7 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
  * @param w 1
  * @param h integer
  * @param format GL? (Default: `GL.RGBA`)
- * @return number[][] Column of color values (color size based on format).
+ * @return number[][] colors Column of color values (color size based on format).
  */
 /***
  * Get row of pixels.
@@ -6446,17 +6446,17 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
  * @param w integer
  * @param h 1
  * @param format GL? (Default: `GL.RGBA`)
- * @return number[][] Row of color values (color size based on format).
+ * @return number[][] colors Row of color values (color size based on format).
  */
 /***
- * Get row of pixels.
+ * Get columns of pixels.
  * @function gl.ReadPixels
  * @param x integer
  * @param y integer
  * @param w integer
  * @param h integer
  * @param format GL? (Default: `GL.RGBA`)
- * @return number[][][] Array of columns of color values (color size based on format).
+ * @return number[][][] colors Array of columns of color values (color size based on format).
  */
 int LuaOpenGL::ReadPixels(lua_State* L)
 {
@@ -6741,7 +6741,7 @@ int LuaOpenGL::GetQuery(lua_State* L)
 
 /***
  * @function gl.GetGlobalTexNames
- * @return string[] List of texture names.
+ * @return string[] texNames List of texture names.
  */
 int LuaOpenGL::GetGlobalTexNames(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -975,7 +975,7 @@ int LuaSyncedCtrl::AssignPlayerToTeam(lua_State* L)
  * @param x number left position (elmos)
  * @param y number vertical position (elmos)
  * @param z number top position (elmos)
- * @return boolean true if the position was set, false if the teamID is invalid
+ * @return boolean success true if the position was set, false if the teamID is invalid
  */
 int LuaSyncedCtrl::SetTeamStartPosition(lua_State* L)
 {
@@ -1006,7 +1006,7 @@ int LuaSyncedCtrl::SetTeamStartPosition(lua_State* L)
  * @function Spring.SetPlayerReadyState
  * @param playerID PlayerID
  * @param ready boolean
- * @return boolean true if the state was set, false if the playerID was invalid
+ * @return boolean success true if the state was set, false if the playerID was invalid
  */
 int LuaSyncedCtrl::SetPlayerReadyState(lua_State* L)
 {
@@ -1121,7 +1121,7 @@ int LuaSyncedCtrl::KillTeam(lua_State* L)
  * Pass multiple winners to declare a draw.
  * Pass no arguments if undecided (e.g. when dropped from the host).
  *
- * @return integer Number of accepted (valid) ally teams.
+ * @return integer teams Number of accepted (valid) ally teams.
  */
 int LuaSyncedCtrl::GameOver(lua_State* L)
 {
@@ -3546,7 +3546,7 @@ int LuaSyncedCtrl::SetUnitPhysicalStateBit(lua_State* L)
 /***
  * @function Spring.GetUnitPhysicalState
  * @param unitID UnitID
- * @return integer Unit's PhysicalState bitmask
+ * @return integer physicalState Unit's PhysicalState bitmask
  */
 int LuaSyncedCtrl::GetUnitPhysicalState(lua_State* L)
 {
@@ -3822,7 +3822,7 @@ int LuaSyncedCtrl::SetUnitPieceParent(lua_State* L)
  * @param unitID UnitID
  * @param pieceNum integer
  * @param matrix number[] an array of 16 floats
- * @return boolean? valid - if the matrix can be used for the purpose of defining the piece spatial transformation. Blocks the piece animation, if true.
+ * @return boolean? valid whether the matrix can be used for the purpose of defining the piece spatial transformation. Blocks the piece animation, if true.
  */
 int LuaSyncedCtrl::SetUnitPieceMatrix(lua_State* L)
 {
@@ -3911,7 +3911,7 @@ int LuaSyncedCtrl::SetUnitPieceVisible(lua_State* L)
  * @param unitID UnitID
  * @param type "los"|"airLos"|"radar"|"sonar"|"seismic"|"radarJammer"|"sonarJammer"
  * @param radius integer
- * @return integer? New radius, or `nil` if unit is invalid.
+ * @return integer? newRadius New radius, or `nil` if unit is invalid.
  */
 int LuaSyncedCtrl::SetUnitSensorRadius(lua_State* L)
 {
@@ -5377,7 +5377,7 @@ int LuaSyncedCtrl::SetFeaturePieceVisible(lua_State* L)
  * @param featureID FeatureID
  * @param pieceIndex integer
  * @param matrix number[] an array of 16 floats
- * @return boolean? valid - if the matrix can be used for the purpose of defining the piece spatial transformation
+ * @return boolean? valid whether the matrix can be used for the purpose of defining the piece spatial transformation
  */
 int LuaSyncedCtrl::SetFeaturePieceMatrix(lua_State* L)
 {
@@ -7031,7 +7031,7 @@ int LuaSyncedCtrl::AddSmoothMesh(lua_State* L)
  * @param z number
  * @param height number
  * @param terraform number? (Default: `1`)
- * @return number? The absolute height difference, or `nil` if coordinates are invalid.
+ * @return number? heightDifference The absolute height difference, or `nil` if coordinates are invalid.
  */
 int LuaSyncedCtrl::SetSmoothMesh(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1607,7 +1607,7 @@ int LuaSyncedRead::GetTeamStartPosition(lua_State* L)
 /***
  *
  * @function Spring.GetMapStartPositions
- * @return float3[] array of positions indexed by teamID
+ * @return float3[] startPositions array of positions indexed by teamID
  */
 int LuaSyncedRead::GetMapStartPositions(lua_State* L)
 {
@@ -1702,7 +1702,7 @@ int LuaSyncedRead::GetTeamList(lua_State* L)
  * @function Spring.GetPlayerList
  * @param teamID TeamID? (Default: `-1`) to filter by when >= 0
  * @param active boolean? (Default: `false`) whether to filter only active teams
- * @return PlayerID[]? list of playerIDs
+ * @return PlayerID[]? playerIDs List of playerIDs.
  */
 int LuaSyncedRead::GetPlayerList(lua_State* L)
 {
@@ -2034,7 +2034,7 @@ int LuaSyncedRead::GetTeamDamageStats(lua_State* L)
  * @param teamID TeamID
  * @param startIndex integer
  * @param endIndex integer? (Default: startIndex)
- * @return TeamStats[] The team stats history, or `nil` if unable to resolve team.
+ * @return TeamStats[] teamStatsHistory The team stats history, or `nil` if unable to resolve team.
  */
 int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 {
@@ -4279,8 +4279,8 @@ int LuaSyncedRead::GetUnitResources(lua_State* L)
 /***
  * @function Spring.GetUnitStorage
  * @param unitID UnitID
- * @return number Unit's metal storage
- * @return number Unit's energy storage
+ * @return number metalStorage Unit's metal storage
+ * @return number energyStorage Unit's energy storage
  */
 int LuaSyncedRead::GetUnitStorage(lua_State* L)
 {
@@ -6413,7 +6413,7 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
  *
  * @param unitID UnitID
  * @param count 0 Returns the number of commands in the units queue.
- * @return integer The number of commands in the unit queue.
+ * @return integer cmdCount The number of commands in the unit queue.
  */
 int LuaSyncedRead::GetUnitCommands(lua_State* L)
 {
@@ -6461,7 +6461,7 @@ int LuaSyncedRead::GetUnitCommands(lua_State* L)
  *
  * @param unitID UnitID
  * @param count 0 Returns the number of commands in the factory queue.
- * @return integer The number of commands in the factory queue.
+ * @return integer cmdCount The number of commands in the factory queue.
  *
  * @see Spring.GetFactoryCommandCount for replacement function.
  */
@@ -6498,7 +6498,7 @@ int LuaSyncedRead::GetFactoryCommands(lua_State* L)
  *
  * @function Spring.GetUnitCommandCount
  * @param unitID UnitID
- * @return integer The number of commands in the unit's queue.
+ * @return integer cmdCount The number of commands in the unit's queue.
  */
 int LuaSyncedRead::GetUnitCommandCount(lua_State* L)
 {
@@ -6521,7 +6521,7 @@ int LuaSyncedRead::GetUnitCommandCount(lua_State* L)
  *
  * @function Spring.GetFactoryCommandCount
  * @param unitID UnitID
- * @return integer The number of commands in the factory queue.
+ * @return integer cmdCount The number of commands in the factory queue.
  *
  * @see Spring.GetFactoryCommands to get the factory commands.
  * @see Spring.GetFactoryCounts to get command counts grouped by cmdID.
@@ -7261,8 +7261,8 @@ int LuaSyncedRead::GetFeatureResurrect(lua_State* L)
  *
  * @function Spring.GetFeatureLastAttackedPiece
  * @param featureID FeatureID
- * @return string|""|nil Last hit piece name
- * @return integer? frame it was last hit on, nil when featureID is not valid
+ * @return string|""|nil pieceName Last hit piece name
+ * @return integer? frame frame it was last hit on, `nil` when featureID is not valid
  */
 int LuaSyncedRead::GetFeatureLastAttackedPiece(lua_State* L)
 {
@@ -9157,7 +9157,7 @@ int LuaSyncedRead::GetUnitScriptPiece(lua_State* L)
  *
  * @param unitID UnitID
  *
- * @return table<string,integer> where keys are piece names and values are piece indices
+ * @return table<string,integer> pieceInfos where keys are piece names and values are piece indices
  */
 int LuaSyncedRead::GetUnitScriptNames(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -5579,7 +5579,7 @@ int LuaUnsyncedCtrl::SetClipboard(lua_State* L)
  *   wantYield = wantYield and Spring.Yield()
  * end
  *
- * @return boolean when true caller should continue calling `Spring.Yield` during the widgets/gadgets load, when false it shouldn't call it any longer.
+ * @return boolean continueYielding when true caller should continue calling `Spring.Yield` during the widgets/gadgets load, when false it shouldn't call it any longer.
  */
 int LuaUnsyncedCtrl::Yield(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -1058,7 +1058,7 @@ int LuaUnsyncedRead::GetMiniMapGeometry(lua_State* L)
 /*** Get minimap rotation
  *
  * @function Spring.GetMiniMapRotation
- * @return number amount in radians
+ * @return number rotation in radians
  */
 int LuaUnsyncedRead::GetMiniMapRotation(lua_State* L)
 {
@@ -1210,7 +1210,7 @@ int LuaUnsyncedRead::GetFrameTimeOffset(lua_State* L)
  *
  * Returns the game time, taking the interpolated draw frame into account.
  *
- * @return number game time in seconds
+ * @return number time in seconds
  */
 int LuaUnsyncedRead::GetGameSecondsInterpolated(lua_State* L)
 {
@@ -1336,7 +1336,7 @@ int LuaUnsyncedRead::GetUnitLuaDraw(lua_State* L)
  *
  * @function Spring.GetUnitNoDraw
  * @param unitID UnitID
- * @return boolean? nil when unitID cannot be parsed
+ * @return boolean? noDraw `nil` when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitNoDraw(lua_State* L)
 {
@@ -1347,7 +1347,7 @@ int LuaUnsyncedRead::GetUnitNoDraw(lua_State* L)
  *
  * @function Spring.GetUnitEngineDrawMask
  * @param unitID UnitID
- * @return boolean? nil when unitID cannot be parsed
+ * @return boolean? drawMask `nil` when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitEngineDrawMask(lua_State* L)
 {
@@ -1358,7 +1358,7 @@ int LuaUnsyncedRead::GetUnitEngineDrawMask(lua_State* L)
  *
  * @function Spring.GetUnitAlwaysUpdateMatrix
  * @param unitID UnitID
- * @return boolean? nil when unitID cannot be parsed
+ * @return boolean? alwaysUpdateMatrix `nil` when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitAlwaysUpdateMatrix(lua_State* L)
 {
@@ -1375,7 +1375,7 @@ int LuaUnsyncedRead::GetUnitAlwaysUpdateMatrix(lua_State* L)
  *
  * @function Spring.GetUnitDrawFlag
  * @param unitID UnitID
- * @return number? nil when unitID cannot be parsed
+ * @return number? drawFlag `nil` when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitDrawFlag(lua_State* L)
 {
@@ -1392,7 +1392,7 @@ int LuaUnsyncedRead::GetUnitDrawFlag(lua_State* L)
  *
  * @function Spring.GetUnitNoMinimap
  * @param unitID UnitID
- * @return boolean? nil when unitID cannot be parsed
+ * @return boolean? noMinimap `nil` when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitNoMinimap(lua_State* L)
 {
@@ -1656,7 +1656,7 @@ int LuaUnsyncedRead::GetUnitSelectionVolumeData(lua_State* L)
  *
  * @function Spring.GetFeatureLuaDraw
  * @param featureID FeatureID
- * @return boolean? nil when featureID cannot be parsed
+ * @return boolean? luaDraw `nil` when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureLuaDraw(lua_State* L)
 {
@@ -1667,7 +1667,7 @@ int LuaUnsyncedRead::GetFeatureLuaDraw(lua_State* L)
  *
  * @function Spring.GetFeatureNoDraw
  * @param featureID FeatureID
- * @return boolean? nil when featureID cannot be parsed
+ * @return boolean? noDraw `nil` when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureNoDraw(lua_State* L)
 {
@@ -1678,7 +1678,7 @@ int LuaUnsyncedRead::GetFeatureNoDraw(lua_State* L)
  *
  * @function Spring.GetFeatureEngineDrawMask
  * @param featureID FeatureID
- * @return boolean? nil when featureID cannot be parsed
+ * @return boolean? drawMask `nil` when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureEngineDrawMask(lua_State* L)
 {
@@ -1689,7 +1689,7 @@ int LuaUnsyncedRead::GetFeatureEngineDrawMask(lua_State* L)
  *
  * @function Spring.GetFeatureAlwaysUpdateMatrix
  * @param featureID FeatureID
- * @return boolean? nil when featureID cannot be parsed
+ * @return boolean? alwaysUpdateMatrix `nil` when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureAlwaysUpdateMatrix(lua_State* L)
 {
@@ -1706,7 +1706,7 @@ int LuaUnsyncedRead::GetFeatureAlwaysUpdateMatrix(lua_State* L)
  *
  * @function Spring.GetFeatureDrawFlag
  * @param featureID FeatureID
- * @return number? nil when featureID cannot be parsed
+ * @return number? drawFlag `nil` when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureDrawFlag(lua_State* L)
 {
@@ -1772,7 +1772,13 @@ static int GetObjectTransformMatrix(const CSolidObject* o, lua_State* L)
  *
  * @function Spring.GetUnitTransformMatrix
  * @param unitID UnitID
- * @return number? m11 nil when unitID cannot be parsed
+ * @return nil # when unitID cannot be parsed
+ */
+/***
+ *
+ * @function Spring.GetUnitTransformMatrix
+ * @param unitID UnitID
+ * @return number m11
  * @return number m12
  * @return number m13
  * @return number m14
@@ -1796,7 +1802,13 @@ int LuaUnsyncedRead::GetUnitTransformMatrix(lua_State* L) { return (GetObjectTra
  *
  * @function Spring.GetFeatureTransformMatrix
  * @param featureID FeatureID
- * @return number? m11 nil when featureID cannot be parsed
+ * @return nil # when featureID cannot be parsed
+ */
+/***
+ *
+ * @function Spring.GetFeatureTransformMatrix
+ * @param featureID FeatureID
+ * @return number m11
  * @return number m12
  * @return number m13
  * @return number m14
@@ -2711,8 +2723,8 @@ int LuaUnsyncedRead::GetSelectedUnits(lua_State* L)
 /*** Get selected units aggregated by unitDefID
  *
  * @function Spring.GetSelectedUnitsSorted
- * @return table<UnitDefID,UnitID[]> where keys are unitDefIDs and values are unitIDs
- * @return integer the number of unitDefIDs
+ * @return table<UnitDefID,UnitID[]> unitsIDs
+ * @return integer countDefs the number of unitDefIDs
  */
 int LuaUnsyncedRead::GetSelectedUnitsSorted(lua_State* L)
 {
@@ -2727,8 +2739,8 @@ int LuaUnsyncedRead::GetSelectedUnitsSorted(lua_State* L)
  *
  * @function Spring.GetSelectedUnitsCounts
  *
- * @return table<UnitDefID,integer> unitsCounts where keys are unitDefIDs and values are counts
- * @return integer the number of unitDefIDs
+ * @return table<UnitDefID,integer> unitsCounts
+ * @return integer countDefs the number of unitDefIDs
  */
 int LuaUnsyncedRead::GetSelectedUnitsCounts(lua_State* L)
 {
@@ -4198,7 +4210,7 @@ int LuaUnsyncedRead::GetModKeyState(lua_State* L)
 /***
  *
  * @function Spring.GetPressedKeys
- * @return table<integer|string,true> where keys are keyCodes or key names
+ * @return table<integer|string,true> keys where keys are keyCodes or key names
  */
 int LuaUnsyncedRead::GetPressedKeys(lua_State* L)
 {
@@ -4229,7 +4241,7 @@ int LuaUnsyncedRead::GetPressedKeys(lua_State* L)
 /***
  *
  * @function Spring.GetPressedScans
- * @return table<integer|string,true> where keys are scanCodes or scan names
+ * @return table<integer|string,true> scans where keys are scanCodes or scan names
  */
 int LuaUnsyncedRead::GetPressedScans(lua_State* L)
 {
@@ -4409,7 +4421,7 @@ int LuaUnsyncedRead::GetActionHotKeys(lua_State* L)
 /***
  *
  * @function Spring.GetGroupList
- * @return table<GroupID,integer>? where keys are groupIDs and values are counts
+ * @return table<GroupID,integer>? groupCounts
  */
 int LuaUnsyncedRead::GetGroupList(lua_State* L)
 {
@@ -4502,7 +4514,7 @@ int LuaUnsyncedRead::GetGroupUnits(lua_State* L)
  *
  * @function Spring.GetGroupUnitsSorted
  * @param groupID GroupID
- * @return table<UnitDefID,UnitID[]>? where keys are unitDefIDs and values are unitIDs
+ * @return table<UnitDefID,UnitID[]>? unitsIDs
  */
 int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
 {
@@ -4519,7 +4531,7 @@ int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
  *
  * @function Spring.GetGroupUnitsCounts
  * @param groupID GroupID
- * @return table<UnitDefID,integer>? where keys are unitDefIDs and values are counts
+ * @return table<UnitDefID,integer>? unitsCounts
  */
 int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
 {

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -1176,7 +1176,7 @@ size_t LuaVBOImpl::UploadImpl(const std::vector<TIn>& dataVec, uint32_t elemOffs
  *
  * Also fills in VBO definition data as they're set for engine models (no need to do VBO:Define()).
  *
- * @return integer? buffer size in bytes
+ * @return integer? size buffer size in bytes
  */
 size_t LuaVBOImpl::ModelsVBO()
 {
@@ -1340,7 +1340,7 @@ size_t LuaVBOImpl::InstanceDataFromFeatureIDs(const sol::stack_table& ids, int a
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
- * @return number[] matDataVec 4x4 matrix
+ * @return number[] matDataVec Flattened 4x4 matrix(es)
  * @return integer elemOffset
  * @return integer|[integer,integer,integer,integer] attrID
  */


### PR DESCRIPTION
The generated Lua types have a lot of `@return` comments with descriptions but no names. EmmyLua/LuaLS/LuaCATS requires either a name or a `#` before the description. I opted to add names and attempted to follow the existing naming conventions. While I was there (read: looking at search results for `@return` in `Lua*.cpp`) I also made what I think are a few other improvements to typings and overloads.

https://luals.github.io/wiki/annotations/#return is the relevant documentation for the type annotations.

I discussed this a little on the Beyond All Reason Discord, starting around https://discord.com/channels/549281623154229250/549282166543089674/1533836286358458428. I tried to find the right channel on the Recoil Engine Discord but haven't had much success yet.

Screenshot of VSCode Lua extension (which uses LuaLS) interpreting the first word of the description as the name of the return value: <img width="1483" height="321" alt="image" src="https://github.com/user-attachments/assets/0e7d0c7f-27a1-44c9-9215-34117833417e" />
After:<img width="1563" height="300" alt="image" src="https://github.com/user-attachments/assets/49486c4f-7b4a-448e-a133-168070436115" />
