### PR TITLE
fix(Lua): GetProfilerTimeRecord argument handling

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -616,8 +616,6 @@ int LuaUnsyncedRead::GetProfilerTimeRecord(lua_State* L)
 {
 	const CTimeProfiler::TimeRecord& record = CTimeProfiler::GetInstance().GetTimeRecord(lua_tostring(L, 1));
 
-	// read before pushing anything: the results land on indices 2 upwards, so
-	// reading the argument afterwards inspects record.total instead
 	const bool wantFrameData = luaL_optboolean(L, 2, false);
 
 	lua_pushnumber(L, record.total.toMilliSecsf());

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -616,23 +616,28 @@ int LuaUnsyncedRead::GetProfilerTimeRecord(lua_State* L)
 {
 	const CTimeProfiler::TimeRecord& record = CTimeProfiler::GetInstance().GetTimeRecord(lua_tostring(L, 1));
 
-	int numRet = 5;
+	// read before pushing anything: the results land on indices 2 upwards, so
+	// reading the argument afterwards inspects record.total instead
+	const bool wantFrameData = luaL_optboolean(L, 2, false);
+
 	lua_pushnumber(L, record.total.toMilliSecsf());
 	lua_pushnumber(L, record.current.toMilliSecsf());
 	lua_pushnumber(L, record.stats.x); // max-dt
 	lua_pushnumber(L, record.stats.y); // time-%
 	lua_pushnumber(L, record.stats.z); // peak-%
 
-	if (luaL_optboolean(L, 2, false)) {
-		for (size_t i = 0; i < record.frames.size(); i++) {
-			lua_pushnumber(L, i + 1); // key
-			lua_pushnumber(L, record.frames[i].toMilliSecsf()); // val
-			lua_rawset(L, -3);
-		}
-		++numRet;
+	if (!wantFrameData)
+		return 5;
+
+	lua_createtable(L, record.frames.size(), 0);
+
+	for (size_t i = 0; i < record.frames.size(); i++) {
+		lua_pushnumber(L, i + 1); // key
+		lua_pushnumber(L, record.frames[i].toMilliSecsf()); // val
+		lua_rawset(L, -3);
 	}
 
-	return numRet;
+	return 6;
 }
 
 /***


### PR DESCRIPTION
Spring.GetProfilerTimeRecord read its optional frameData argument after pushing its five results, so stack index 2 held the pushed total rather than the caller's argument. Every call with fewer than two arguments raised "bad argument #2 to 'GetProfilerTimeRecord' (boolean expected, got number)", which is the call form the documentation gives.

The frameData branch was separately broken: it rawset into index -3 without creating a table, so the documented sixth return value could not have worked either.

Found while writing a widget to dump the profiler breakdown to the infolog. Nothing here is platform specific.

AI disclosure: written by Claude Code under my direction.