### PR TITLE
Enforce alignment for std::aligned_alloc

### DIFF
--- a/rts/System/MemoryOverride.cpp
+++ b/rts/System/MemoryOverride.cpp
@@ -70,6 +70,7 @@ void* aligned_alloc(size_t alignment, size_t size)
 	#else
 		// std::aligned_alloc requires size to be a multiple of alignment (C11/C++17);
 		// unlike posix_memalign, passing a non-multiple is undefined behaviour
+		size = (size + alignment - 1) & ~(alignment - 1);  // bitwise round-up
 		assert(size % alignment == 0);
 		return std::aligned_alloc(alignment, size);
 	#endif

--- a/rts/System/MemoryOverride.cpp
+++ b/rts/System/MemoryOverride.cpp
@@ -71,7 +71,8 @@ void* aligned_alloc(size_t alignment, size_t size)
 		// std::aligned_alloc requires size to be a multiple of alignment (C11/C++17);
 		// unlike posix_memalign, passing a non-multiple is undefined behaviour
 		size = (size + alignment - 1) & ~(alignment - 1);  // bitwise round-up
-		assert(size % alignment == 0);
+		assert(std::has_single_bit(alignment)); // assumption
+		assert(size % alignment == 0); // intention
 		return std::aligned_alloc(alignment, size);
 	#endif
 #endif


### PR DESCRIPTION
ASan doesn't work with `mimalloc`. Despite  already having `MI_TRACK_ASAN=1` when `USE_ASAN=1`
the result is:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==10007==ERROR: AddressSanitizer: SEGV on unknown address 0x7fbc0000002a (pc 0x56369a915eba bp 0x7fff07b29140 sp 0x7fff07b29130 T0)
==10007==The signal is caused by a READ memory access.
AddressSanitizer:DEADLYSIGNAL
AddressSanitizer: nested bug in the same thread, aborting.
```

With `USE_ASAN=1 and USE_MIMALLOC=0` it fails with next error:
```
[t=00:01:08.917682][f=-000001] Loaded unsynced gadget:  PBR enabler         <api_pbr_enabler.lua>
=================================================================
==86580==ERROR: AddressSanitizer: invalid alignment requested in aligned_alloc: 32, alignment must be a power of two and the requested size 0x2208 must be a multiple of alignment (thread T0 (recoil-main))
    #0 0x7f392392b731 in aligned_alloc (/usr/lib/libasan.so.8+0x12b731) (BuildId: b28f87d70f4aadfdfe6abce3776c226f5569bd6a)
    #1 0x55c0cdbbd1e8 in recoil::aligned_alloc(unsigned long, unsigned long) recoil/rts/System/MemoryOverride.cpp:74
    #2 0x55c0cc579e72 in LuaVBOImpl::AllocGLBuffer(unsigned long) recoil/rts/Lua/LuaVBOImpl.cpp:1544
    #3 0x55c0cc57a65a in LuaVBOImpl::Define(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >) recoil/rts/Lua/LuaVBOImpl.cpp:582
    #4 0x55c0cc4edb2b in void sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::call<void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >(void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&, int&&, sol::optional<sol::basic_object<sol::basic_reference<false> > >&&) recoil/rts/lib/sol2/sol.hpp:17338
    #5 0x55c0cc4edb2b in decltype(auto) sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller::operator()<void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >(void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&, int&&, sol::optional<sol::basic_object<sol::basic_reference<false> > >&&) const recoil/rts/lib/sol2/sol.hpp:17344
    #6 0x55c0cc4edb2b in eval<true, sol::argument_handler<sol::types<void, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > > >&, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > > recoil/rts/lib/sol2/sol.hpp:16078
    #7 0x55c0cc4edb2b in eval<true, sol::optional<sol::basic_object<sol::basic_reference<false> > >, 1, sol::argument_handler<sol::types<void, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > > >&, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&, int> recoil/rts/lib/sol2/sol.hpp:16101
    #8 0x55c0cc54ba19 in eval<true, int, sol::optional<sol::basic_object<sol::basic_reference<false> > >, 0, 1, sol::argument_handler<sol::types<void, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > > >&, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&> recoil/rts/lib/sol2/sol.hpp:16101
    #9 0x55c0cc54ba19 in decltype(auto) sol::stack::stack_detail::call<true, 0ul, 1ul, void, int, sol::optional<sol::basic_object<sol::basic_reference<false> > >, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&>(sol::types<void>, sol::types<int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >, std::integer_sequence<unsigned long, 0ul, 1ul>, lua_State*, int, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller&&, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&) recoil/rts/lib/sol2/sol.hpp:16127
    #10 0x55c0cc54ba19 in decltype(auto) sol::stack::call<true, void, int, sol::optional<sol::basic_object<sol::basic_reference<false> > >, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&>(sol::types<void>, sol::types<int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >, lua_State*, int, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller&&, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&) recoil/rts/lib/sol2/sol.hpp:16147
    #11 0x55c0cc54ba19 in int sol::stack::call_into_lua<true, true, void, , int, sol::optional<sol::basic_object<sol::basic_reference<false> > >, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&>(sol::types<void>, sol::types<int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >, lua_State*, int, sol::member_function_wrapper<void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), void, LuaVBOImpl, int, sol::optional<sol::basic_object<sol::basic_reference<false> > > >::caller&&, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&) recoil/rts/lib/sol2/sol.hpp:16189
    #12 0x55c0cc54ba19 in int sol::call_detail::lua_call_wrapper<LuaVBOImpl, void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), false, false, true, 0, true, void>::call<void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&>(lua_State*, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl&) recoil/rts/lib/sol2/sol.hpp:18103
    #13 0x55c0cc54ba19 in int sol::call_detail::lua_call_wrapper<LuaVBOImpl, void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), false, false, true, 0, true, void>::call<void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >)>(lua_State*, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >)) recoil/rts/lib/sol2/sol.hpp:18093
    #14 0x55c0cc54ba19 in int sol::call_detail::call_wrapped<LuaVBOImpl, false, false, 0, true, true, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >)>(lua_State*, void (LuaVBOImpl::*&)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >)) recoil/rts/lib/sol2/sol.hpp:18506
    #15 0x55c0cc54ba19 in int sol::u_detail::binding<char [7], void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl>::call_with_<false, false>(lua_State*, void*) recoil/rts/lib/sol2/sol.hpp:23023
    #16 0x55c0cc54ba19 in int sol::u_detail::binding<char [7], void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl>::call_<false, false>(lua_State*) recoil/rts/lib/sol2/sol.hpp:23029
    #17 0x55c0cc54ba19 in sol::detail::lua_cfunction_trampoline(lua_State*, int (*)(lua_State*)) recoil/rts/lib/sol2/sol.hpp:8398
    #18 0x55c0cc54ba19 in int sol::detail::static_trampoline<&(int sol::u_detail::binding<char [7], void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl>::call_<false, false>(lua_State*))>(lua_State*) recoil/rts/lib/sol2/sol.hpp:8423
    #19 0x55c0cc54ba19 in int sol::detail::typed_static_trampoline<int (*)(lua_State*), &(int sol::u_detail::binding<char [7], void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl>::call_<false, false>(lua_State*))>(lua_State*) recoil/rts/lib/sol2/sol.hpp:8490
    #20 0x55c0cc54ba19 in int sol::u_detail::binding<char [7], void (LuaVBOImpl::*)(int, sol::optional<sol::basic_object<sol::basic_reference<false> > >), LuaVBOImpl>::call<false, false>(lua_State*) recoil/rts/lib/sol2/sol.hpp:23034
    #21 0x55c0ce016749 in luaD_precall(lua_State*, lua_TValue*, int) recoil/rts/lib/lua/src/ldo.cpp:320
    #22 0x55c0ce045fb2 in luaV_execute(lua_State*, int) recoil/rts/lib/lua/src/lvm.cpp:620
    #23 0x55c0ce01767c in luaD_call(lua_State*, lua_TValue*, int) recoil/rts/lib/lua/src/ldo.cpp:378
    #24 0x55c0ce0006ce in f_call recoil/rts/lib/lua/src/lapi.cpp:812
    #25 0x55c0ce01484c in luaD_rawrunprotected(lua_State*, void (*)(lua_State*, void*), void*) recoil/rts/lib/lua/src/ldo.cpp:116
    #26 0x55c0ce017f99 in luaD_pcall(lua_State*, void (*)(lua_State*, void*), void*, long, long) recoil/rts/lib/lua/src/ldo.cpp:464
    #27 0x55c0ce008496 in lua_pcall(lua_State*, int, int, int) recoil/rts/lib/lua/src/lapi.cpp:833
    #28 0x55c0cc43651d in LuaVFS::Include(lua_State*, bool) recoil/rts/Lua/LuaVFS.cpp:370
    #29 0x55c0cc4378da in LuaVFS::UnsyncInclude(lua_State*) recoil/rts/Lua/LuaVFS.cpp:389
    #30 0x55c0ce016749 in luaD_precall(lua_State*, lua_TValue*, int) recoil/rts/lib/lua/src/ldo.cpp:320
    #31 0x55c0ce045fb2 in luaV_execute(lua_State*, int) recoil/rts/lib/lua/src/lvm.cpp:620
    #32 0x55c0ce01767c in luaD_call(lua_State*, lua_TValue*, int) recoil/rts/lib/lua/src/ldo.cpp:378
    #33 0x55c0ce0006ce in f_call recoil/rts/lib/lua/src/lapi.cpp:812
    #34 0x55c0ce01484c in luaD_rawrunprotected(lua_State*, void (*)(lua_State*, void*), void*) recoil/rts/lib/lua/src/ldo.cpp:116
    #35 0x55c0ce017f99 in luaD_pcall(lua_State*, void (*)(lua_State*, void*), void*, long, long) recoil/rts/lib/lua/src/ldo.cpp:464
    #36 0x55c0ce008496 in lua_pcall(lua_State*, int, int, int) recoil/rts/lib/lua/src/lapi.cpp:833
    #37 0x55c0cc08a952 in ScopedLuaCall recoil/rts/Lua/LuaHandle.cpp:401
    #38 0x55c0cc08a952 in CLuaHandle::RunCallInTraceback(lua_State*, LuaHashString const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, int, int, int, bool) recoil/rts/Lua/LuaHandle.cpp:487
    #39 0x55c0cc08c0a9 in CLuaHandle::RunCallInTraceback(lua_State*, LuaHashString const&, int, int, int, bool) recoil/rts/Lua/LuaHandle.cpp:498
    #40 0x55c0cc09fdb6 in CLuaHandle::LoadCode(lua_State*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) recoil/rts/Lua/LuaHandle.cpp:552
    #41 0x55c0cc0e192a in CUnsyncedLuaHandle::Init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) recoil/rts/Lua/LuaHandleSynced.cpp:156
    #42 0x55c0cc0e224d in CSplitLuaHandle::InitUnsynced() recoil/rts/Lua/LuaHandleSynced.cpp:2443
    #43 0x55c0cc0e58c7 in CSplitLuaHandle::Init(bool) recoil/rts/Lua/LuaHandleSynced.cpp:2465
    #44 0x55c0cc20d18b in CLuaRules::CLuaRules(bool) recoil/rts/Lua/LuaRules.cpp:43
    #45 0x55c0cc20d423 in CLuaRules::LoadHandler(bool) recoil/rts/Lua/LuaRules.cpp:31

==86580==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: invalid-aligned-alloc-alignment recoil/rts/System/MemoryOverride.cpp:74 in recoil::aligned_alloc(unsigned long, unsigned long)
==86580==ABORTING
```

Hence enforce similar behaviour to `mi_aligned_alloc` (manual alignment).

Alternative code would be:
```
if (size % alignment != 0)
    size = ((size + alignment - 1) / alignment) * alignment;
```
But google AI suggested bitwise round-up and i made it branchless. **The alignment must be a power of 2** in bitwise round-up.