### PR TITLE
Futex fixes for OpenBSD

### DIFF
--- a/rts/System/Platform/Linux/Futex.cpp
+++ b/rts/System/Platform/Linux/Futex.cpp
@@ -41,7 +41,7 @@ void spring_futex::lock()
 
 	do {
 		if ((c == 2) || __sync_val_compare_and_swap(&mtx, 1, 2) != 0)
-			do_futex(&mtx, FUTEX_WAIT, 2, NULL);
+			do_futex(&mtx, FUTEX_WAIT_PRIVATE, 2, NULL);
 	} while((c = __sync_val_compare_and_swap(&mtx, 0, 2)) != 0);
 }
 
@@ -56,7 +56,7 @@ void spring_futex::unlock()
 {
 	if (__sync_fetch_and_sub(&mtx, 1) != 1) {
 		mtx = 0;
-		do_futex(&mtx, FUTEX_WAKE, 4, NULL);
+		do_futex(&mtx, FUTEX_WAKE_PRIVATE, 4, NULL);
 	}
 }
 
@@ -137,7 +137,7 @@ void linux_signal::wait()
 	const int g = gen.load(); // our gen
 	sleepers++;
 	while ((g - (m = mtx)) >= 0) {
-		do_futex(&mtx, FUTEX_WAIT, m, NULL);
+		do_futex(&mtx, FUTEX_WAIT_PRIVATE, m, NULL);
 	}
 	sleepers--;
 }
@@ -156,7 +156,7 @@ void linux_signal::wait_for(spring_time t)
 	const spring_time endTimer = spring_now() + t;
 
 	while (((g - (m = mtx)) >= 0) && (spring_now() < endTimer)) {
-		do_futex(&mtx, FUTEX_WAIT, m, &linux_t);
+		do_futex(&mtx, FUTEX_WAIT_PRIVATE, m, &linux_t);
 	}
 	sleepers--;
 }
@@ -168,6 +168,6 @@ void linux_signal::notify_all(const int min_sleepers)
 		return;
 
 	mtx = gen++;
-	do_futex(&mtx, FUTEX_WAKE, INT_MAX, NULL);
+	do_futex(&mtx, FUTEX_WAKE_PRIVATE, INT_MAX, NULL);
 }
 

--- a/test/other/testMutex.cpp
+++ b/test/other/testMutex.cpp
@@ -11,9 +11,16 @@
 #include <cstdint>
 #include <functional>
 
-#ifndef _WIN32
+#ifdef __linux__
 	#include <sys/syscall.h>
 	#include <linux/futex.h>
+#endif
+
+#ifdef __OpenBSD__
+	#include <sys/futex.h>
+#endif
+
+#ifndef _WIN32
 	#include <unistd.h>
 #endif
 
@@ -27,6 +34,15 @@ InitSpringTime ist;
 
 #ifndef _WIN32
 	typedef uint32_t futex;
+
+	static inline long do_futex (uint32_t *mtx, int op, uint32_t value, const struct timespec *timeout)
+	{
+#ifdef __OpenBSD__
+		return futex(mtx, op, value, NULL, NULL);
+#else
+		return syscall(SYS_futex, mtx, op, value, NULL, NULL, 0);
+#endif
+	}
 
 	static void futex_init(futex* m)
 	{
@@ -44,7 +60,7 @@ InitSpringTime ist;
 		if ((c = __sync_val_compare_and_swap(m, 0, 1)) != 0)  {
 			do {
 				if ((c == 2) || __sync_val_compare_and_swap(m, 1, 2) != 0)
-					syscall(SYS_futex, m, FUTEX_WAIT_PRIVATE, 2, NULL, NULL, 0);
+					do_futex(m, FUTEX_WAIT_PRIVATE, 2, NULL);
 			} while((c = __sync_val_compare_and_swap(m, 0, 2)) != 0);
 		}
 	}
@@ -53,7 +69,7 @@ InitSpringTime ist;
 	{
 		if (__sync_fetch_and_sub(m, 1) != 1) {
 			*m = 0;
-			syscall(SYS_futex, m, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+			do_futex(m, FUTEX_WAKE_PRIVATE, 1, NULL);
 		}
 	}
 #endif

--- a/test/other/testMutex.cpp
+++ b/test/other/testMutex.cpp
@@ -37,10 +37,10 @@ InitSpringTime ist;
 
 	static inline long do_futex (uint32_t *mtx, int op, uint32_t value, const struct timespec *timeout)
 	{
-#ifdef __OpenBSD__
-		return futex(mtx, op, value, NULL, NULL);
+#ifndef __OpenBSD__
+		return syscall(SYS_futex, mtx, op, value, timeout, NULL, 0);
 #else
-		return syscall(SYS_futex, mtx, op, value, NULL, NULL, 0);
+		return futex(mtx, op, value, timeout, NULL);
 #endif
 	}
 


### PR DESCRIPTION
- Make use of private futexes.
- Fix the futex test to build on OpenBSD. OpenBSD uses a futex()
  libc wrapper and not a syscall.