### PR TITLE
Build fixes for FreeBSD / OpenBSD

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,15 +3,18 @@ add_definitions(-DCATCH_AMALGAMATED_CUSTOM_MAIN)
 # defines spring_test_compile_fail macro
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/CompileFailTest/CompileFailTest.cmake)
 
-if    (UNIX AND (NOT APPLE) AND (NOT MINGW))
+if    (UNIX AND NOT APPLE AND NOT MINGW AND
+       NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	find_library(REALTIME_LIBRARY rt)
 
 	if    (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")
 		message(FATAL_ERROR "librt.[so|a] not found! Needed by std::chrono when statically linked!")
 	endif (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")
-else  (UNIX AND (NOT APPLE) AND (NOT MINGW))
+else  (UNIX AND NOT APPLE AND NOT MINGW AND
+       NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	set(REALTIME_LIBRARY "")
-endif (UNIX AND (NOT APPLE) AND (NOT MINGW))
+endif (UNIX AND NOT APPLE AND NOT MINGW AND
+       NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 
 ADD_SUBDIRECTORY(lib/catch2)
 # Engine-wide -fsingle-precision-constant (gcc) makes `0.` a float, which
@@ -36,7 +39,7 @@ if (WIN32)
 		RESULT_VARIABLE IPV6_RET
 		ERROR_QUIET)
 else(WIN32)
-	execute_process(COMMAND ping6 ::1 -c 1
+	execute_process(COMMAND ping6 -c 1 ::1
 		RESULT_VARIABLE IPV6_RET
 		ERROR_QUIET)
 endif (WIN32)
@@ -426,7 +429,9 @@ endif()
 	set(test_libs
 			${WINMM_LIBRARY}
 		)
-	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+            NOT (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") AND
+            NOT (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"))
 		list(APPEND test_libs atomic)
 	endif()
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DTHREADPOOL -DUNITSYNC")


### PR DESCRIPTION
- OpenBSD does not use librt
- Fix ping6 detection on OpenBSD
- FreeBSD / OpenBSD use compiler-rt and do not use libatomic

$ ping6 ::1 -c 1
usage: ping6 [-DdEefgHLmnqv] [-c count] [-h hoplimit] [-I sourceaddr]
        [-i interval] [-l preload] [-p pattern] [-s packetsize] [-T toskeyword]
        [-V rtable] [-w maxwait] host
$ ping6 -c 1 ::1
PING ::1 (::1): 56 data bytes
64 bytes from ::1: icmp_seq=0 hlim=64 time=0.071 ms

--- ::1 ping statistics ---
1 packets transmitted, 1 packets received, 0.0% packet loss round-trip min/avg/max/std-dev = 0.071/0.071/0.071/0.000 ms