### PR TITLE
Add lua annotations for aliased functions

### DIFF
--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -1051,6 +1051,7 @@ int LuaShaders::SetFeatureBufferUniforms(lua_State* L) { return SetObjectBufferU
  * shader. Shader must be activated before setting uniforms.
  *
  * @function gl.Uniform
+ * @function gl.UniformFloat Alias of Uniform
  * @param locationID GL|string uniformName
  * @param f1 number
  * @param f2 number?

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2637,6 +2637,7 @@ int LuaUnsyncedRead::GetFeaturesInScreenRectangle(lua_State* L)
 /***
  *
  * @function Spring.GetLocalPlayerID
+ * @function Spring.GetMyPlayerID Alias of GetLocalPlayerID
  * @return integer playerID
  */
 int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
@@ -2649,6 +2650,7 @@ int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
 /***
  *
  * @function Spring.GetLocalTeamID
+ * @function Spring.GetMyTeamID Alias of GetLocalTeamID
  * @return integer teamID
  */
 int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
@@ -2661,6 +2663,7 @@ int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
 /***
  *
  * @function Spring.GetLocalAllyTeamID
+ * @function Spring.GetMyAllyTeamID Alias of GetLocalAllyTeamID
  * @return integer allyTeamID
  */
 int LuaUnsyncedRead::GetLocalAllyTeamID(lua_State* L)


### PR DESCRIPTION
There are four C++ functions exposed to Lua with aliased names. Those aliased names are not visible to LuaLS. This PR adds those names with an "Alias of" comment to the relevant annotations.

A better solution would be to perform an assignment in the generated lua files, but I don't think lua-doc-extractor can do that. I have opened https://github.com/rhys-vdw/lua-doc-extractor/issues/78 requesting that feature.