### PR TITLE
prevent underwater projectiles/particles from being visible if you dont have underwater vision there

### DIFF
--- a/doc/pr-changelogs/3185.md
+++ b/doc/pr-changelogs/3185.md
@@ -1,0 +1,1 @@
+- Added weapondef: 'requireSonarUnderWater' (default false): Require sonar before drawing this weapon's projectile while it is underwater. (Only relevant when modrules.requireSonarUnderWater is true)

--- a/rts/Lua/LuaWeaponDefs.cpp
+++ b/rts/Lua/LuaWeaponDefs.cpp
@@ -519,6 +519,7 @@ static bool InitParamMap()
 	ADD_BOOL("turret", wd.turret);
 	ADD_BOOL("onlyForward", wd.onlyForward);
 	ADD_BOOL("waterWeapon", wd.waterweapon);
+	ADD_BOOL("requireSonarUnderWater", wd.requireSonarUnderWater);
 	ADD_BOOL("tracks", wd.tracks);
 	ADD_BOOL("paralyzer", wd.paralyzer);
 

--- a/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
@@ -50,6 +50,7 @@ CNanoProjectile::CNanoProjectile(float3 pos, float3 speed, int lifeTime, SColor 
 	checkCol = false;
 	drawSorted = false;
 	drawRadius = 3;
+	useAirLos = true;
 
 	projectileHandler.currentNanoParticles += 1;
 

--- a/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/NanoProjectile.cpp
@@ -50,7 +50,6 @@ CNanoProjectile::CNanoProjectile(float3 pos, float3 speed, int lifeTime, SColor 
 	checkCol = false;
 	drawSorted = false;
 	drawRadius = 3;
-	useAirLos = true;
 
 	projectileHandler.currentNanoParticles += 1;
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -27,6 +27,7 @@
 #include "Rendering/Common/ModelDrawerHelpers.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/LosHandler.h"
+#include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
 #include "Sim/Projectiles/ProjectileHandler.h"

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -611,7 +611,7 @@ bool CProjectileDrawer::CanDrawProjectile(const CProjectile* pro, int allyTeam)
 	if (pro->pos.y > CGround::GetWaterLevel(pro->pos.x, pro->pos.z))
 		return true;
 
-	if (!modInfo.requireSonarUnderWater)
+	if (!modInfo.requireSonarUnderWater || (pro->weapon && !static_cast<const CWeaponProjectile*>(pro)->GetWeaponDef()->requireSonarUnderWater))
 		return true;
 
 	return lh->sonar.InSight(pro->pos, gu->myAllyTeam);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -598,13 +598,22 @@ bool CProjectileDrawer::CanDrawProjectile(const CProjectile* pro, int allyTeam)
 	auto& th = teamHandler;
 	auto& lh = losHandler;
 
-	if (gu->spectatingFullView || (th.IsValidAllyTeam(allyTeam) && th.Ally(allyTeam, gu->myAllyTeam)))
+	if (gu->spectatingFullView || lh->GetGlobalLOS(gu->myAllyTeam))
 		return true;
 
-	if (pro->pos.y <= CGround::GetWaterLevel(pro->pos.x, pro->pos.z))
-		return (lh->GetGlobalLOS(gu->myAllyTeam) || lh->sonar.InSight(pro->pos, gu->myAllyTeam));
+	if (th.IsValidAllyTeam(allyTeam) && th.Ally(allyTeam, gu->myAllyTeam))
+		return true;
 
-	return lh->InLos(pro, gu->myAllyTeam);
+	if (!lh->InLos(pro, gu->myAllyTeam))
+		return false;
+	
+	if (pro->pos.y > CGround::GetWaterLevel(pro->pos.x, pro->pos.z))
+		return true;
+
+	if (!modInfo.requireSonarUnderWater)
+		return true;
+
+	return lh->sonar.InSight(pro->pos, gu->myAllyTeam);
 }
 
 bool CProjectileDrawer::ShouldDrawProjectile(const CProjectile* p, uint8_t thisPassMask)

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -10,6 +10,7 @@
 #include "Game/CameraHandler.h"
 #include "Game/GlobalUnsynced.h"
 #include "Game/LoadScreen.h"
+#include "Map/Ground.h"
 #include "Lua/LuaParser.h"
 #include "Rendering/GroundFlash.h"
 #include "Rendering/GlobalRendering.h"
@@ -596,7 +597,14 @@ bool CProjectileDrawer::CanDrawProjectile(const CProjectile* pro, int allyTeam)
 	RECOIL_DETAILED_TRACY_ZONE;
 	auto& th = teamHandler;
 	auto& lh = losHandler;
-	return (gu->spectatingFullView || (th.IsValidAllyTeam(allyTeam) && th.Ally(allyTeam, gu->myAllyTeam)) || lh->InLos(pro, gu->myAllyTeam));
+
+	if (gu->spectatingFullView || (th.IsValidAllyTeam(allyTeam) && th.Ally(allyTeam, gu->myAllyTeam)))
+		return true;
+
+	if (pro->pos.y <= CGround::GetWaterLevel(pro->pos.x, pro->pos.z))
+		return (lh->GetGlobalLOS(gu->myAllyTeam) || lh->sonar.InSight(pro->pos, gu->myAllyTeam));
+
+	return lh->InLos(pro, gu->myAllyTeam);
 }
 
 bool CProjectileDrawer::ShouldDrawProjectile(const CProjectile* p, uint8_t thisPassMask)

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -100,6 +100,7 @@ WEAPONTAG(float, craterAreaOfEffect, damages.craterAreaOfEffect).fallbackName("a
 WEAPONTAG(bool, waterweapon).defaultValue(false).description("Can the projectile travel underwater? Ability to fire underwater controlled separately via `fireSubmersed`");
 WEAPONTAG(bool, submissile).defaultValue(false).description("Torpedo only. Lets torpedoes exit the water and be a missile. Lets underwater launchers shoot out-of-water targets (out-of-water launchers still cannot - use Missile instead of Torpedo for that).");
 WEAPONTAG(bool, fireSubmersed).fallbackName("waterweapon").defaultValue(false).description("Can the weapon fire underwater? Requires `waterweapon`.");
+WEAPONTAG(bool, requireSonarUnderWater).defaultValue(false).description("Require sonar before drawing this weapon's projectile while it is underwater. Only applies when modrules.requireSonarUnderWater is enabled.");
 
 // Targeting
 WEAPONTAG(bool, manualfire).externalName("commandfire").defaultValue(false).description("Does the weapon respond to the manual fire command instead of regular attack?");

--- a/rts/Sim/Weapons/WeaponDef.h
+++ b/rts/Sim/Weapons/WeaponDef.h
@@ -113,6 +113,7 @@ public:
 	bool waterweapon;           ///< can target underwater objects/positions if true
 	bool fireSubmersed;         ///< can fire even when underwater if true
 	bool submissile;            ///< Lets a torpedo travel above water like it does below water
+	bool requireSonarUnderWater; ///< only draw underwater projectiles when sonar is available
 	bool tracks;
 	bool paralyzer;             ///< weapon will only paralyze not do real damage
 	bool impactOnly;            ///< The weapon damages by impacting, not by exploding


### PR DESCRIPTION
fixes: https://github.com/beyond-all-reason/RecoilEngine/issues/3157
and: https://github.com/beyond-all-reason/RecoilEngine/issues/3158

assisted with GTP 5.6 Terra, compiled and tested ingame

globallos:
<img width="720" height="392" alt="image" src="https://github.com/user-attachments/assets/9fd83707-035e-4407-847e-27fc4c39946e" />
no globallos:
<img width="766" height="372" alt="image" src="https://github.com/user-attachments/assets/fc36e589-81fd-4e8e-8fbb-3751e88c9c1f" />
