### PR TITLE
after camera panning via middlemouse toggling: position cursor in the center of the screen

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -880,15 +880,21 @@ void CMouseHandler::HideMouse()
 void CMouseHandler::ToggleMiddleClickScroll()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (locked) {
-		ShowMouse();
-	} else {
-		HideMouse();
-	}
-
 	locked = !locked;
 	mmbScroll = !mmbScroll;
 	ignoreMove = mmbScroll;
+
+	if (locked) {
+		HideMouse();
+	} else {
+		ShowMouse();
+
+		const int2 cursorPos = GetViewMouseCenter();
+		lastx = cursorPos.x;
+		lasty = cursorPos.y;
+		mouseInput->SetWarpPos(cursorPos);
+		UpdateCursorCameraDir();
+	}
 }
 
 


### PR DESCRIPTION
fixes: https://github.com/beyond-all-reason/RecoilEngine/issues/219

works and tested with all camera modes

assisted by GPT 5.6 sol