### PR TITLE
Added guideline for documenting function aliases in Lua

### DIFF
--- a/doc/site/content/development/documenting-lua.md
+++ b/doc/site/content/development/documenting-lua.md
@@ -156,6 +156,19 @@ An array type is expressed as `type[]`.
  */
 ````
 
+#### Aliases
+
+If a function is exported to two Lua functions, you can give it two `@function` tags:
+
+```cpp
+/***
+ * @function Spring.GetLocalPlayerID
+ * @function Spring.GetMyPlayerID
+ * @return integer playerID
+ */
+int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
+```
+
 ### Class
 
 Structured data is expressed as a class. This represents a table with expected key/value pairs.


### PR DESCRIPTION
Added guideline for documenting for function aliases in Lua

See:
- https://github.com/beyond-all-reason/RecoilEngine/pull/3184
- https://github.com/rhys-vdw/lua-doc-extractor/issues/78