### PR TITLE
Build Queue: Fix queued build overlap checks for yardmap-compatible placement

### DIFF
--- a/cont/cmdcolors.txt
+++ b/cont/cmdcolors.txt
@@ -6,6 +6,7 @@
 unitBoxLineWidth  1.49
 unitBox           0.0  1.0  0.0  0.6
 buildBox          0.0  1.0  0.0  0.6
+buildBoxOverlap   1.0  0.0  0.0  0.6
 allyBuildBox      0.8  0.8  0.2  0.6
 buildBoxesOnShift 1
 

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -9,6 +9,6 @@ This is the bleeding-edge changelog since version 2026.07, for **pre-release 202
 
 ### Build commands
 
-- queued build cancellation and rejection now apply yardmaps after their existing rectangular checks, allowing the same compatible overlaps as sequential construction. Set `construction.useYardmapsForQueuedBuildOverlap = false` in `gamedata/modrules.lua` to restore the previous rectangle-only queue behavior.
+- queued build cancellation and rejection can apply yardmaps after their existing rectangular checks, allowing the same compatible overlaps as sequential construction. Set `construction.useYardmapsForQueuedBuildOverlap = true` in `gamedata/modrules.lua` to enable yardmap-aware queue overlap; the default remains the previous rectangle-only behavior.
 - queued build outlines that would be removed by the previewed placement use the configurable `buildBoxOverlap` command color, which defaults to red.
 - add `Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild) → boolean overlaps, boolean cancels` to test a queued build against a proposed build. `overlaps` reports any conflict under the queued-build yardmap rules; `cancels` reports that the conflict is also inside the cancellation rectangle. Each build is `{unitDefID, x, y, z, facing}`.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,4 +7,7 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-No changes as of yet.
+### Build commands
+
+- queued build cancellation and rejection now apply yardmaps after their existing rectangular checks, allowing the same compatible overlaps as sequential construction. Set `construction.useYardmapsForQueuedBuildOverlap = false` in `gamedata/modrules.lua` to restore the previous rectangle-only queue behavior.
+- add `Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild) → boolean overlaps, boolean cancels` to test a queued build against a proposed build. `overlaps` reports any conflict under the queued-build yardmap rules; `cancels` reports that the conflict is also inside the cancellation rectangle. Each build is `{unitDefID, x, y, z, facing}`.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -10,4 +10,5 @@ This is the bleeding-edge changelog since version 2026.07, for **pre-release 202
 ### Build commands
 
 - queued build cancellation and rejection now apply yardmaps after their existing rectangular checks, allowing the same compatible overlaps as sequential construction. Set `construction.useYardmapsForQueuedBuildOverlap = false` in `gamedata/modrules.lua` to restore the previous rectangle-only queue behavior.
+- queued build outlines that would be removed by the previewed placement use the configurable `buildBoxOverlap` command color, which defaults to red.
 - add `Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild) → boolean overlaps, boolean cancels` to test a queued build against a proposed build. `overlaps` reports any conflict under the queued-build yardmap rules; `cancels` reports that the conflict is also inside the cancellation rectangle. Each build is `{unitDefID, x, y, z, facing}`.

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -31,6 +31,7 @@
 #include "Sim/Units/CommandAI/MobileCAI.h"
 #include "Sim/Units/UnitTypes/Factory.h"
 #include "Sim/Units/BuildInfo.h"
+#include "Sim/Units/QueuedBuildOverlap.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitHandler.h"
@@ -1019,35 +1020,13 @@ float4 CGameHelper::BuildPosToRect(const float3& midPoint, int facing, int xsize
 int CGameHelper::GetYardMapIndex(int buildFacing, const int2& yardPos, const int2& xrange, const int2& zrange)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	int yardX = yardPos.x - xrange.x;
-	int yardZ = yardPos.y - zrange.x;
-	int yardXR = xrange.y - xrange.x;
-	int yardZR = zrange.y - zrange.x;
+	return QueuedBuildOverlap::GetYardMapIndex(buildFacing, yardPos, xrange, zrange);
+}
 
-	switch (buildFacing) {
-		default: {
-			// FACING_SOUTH don't need to do any remapping
-		} break;
-
-		case FacingMap::FACING_NORTH: {
-			yardX = yardXR - yardX - 1; //mirror yardX
-			yardZ = yardZR - yardZ - 1; //mirror yardZ
-		} break;
-
-		case FacingMap::FACING_EAST: {
-			yardZ = yardZR - yardZ - 1; //mirror yardZ
-			std::swap(yardX , yardZ );  //swap yard{X,Z}
-			std::swap(yardXR, yardZR);  //swap yard{XR,ZR}
-		} break;
-
-		case FacingMap::FACING_WEST: {
-			yardX = yardXR - yardX - 1; //mirror yardX
-			std::swap(yardX , yardZ );  //swap yard{X,Z}
-			std::swap(yardXR, yardZR);  //swap yard{XR,ZR}
-		} break;
-	}
-
-	return yardX + yardXR * yardZ;
+bool CGameHelper::TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	return QueuedBuildOverlap::Test(queuedBuild, buildInfo);
 }
 
 

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1023,10 +1023,10 @@ int CGameHelper::GetYardMapIndex(int buildFacing, const int2& yardPos, const int
 	return QueuedBuildOverlap::GetYardMapIndex(buildFacing, yardPos, xrange, zrange);
 }
 
-bool CGameHelper::TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo)
+QueuedBuildOverlap::Result CGameHelper::TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	return QueuedBuildOverlap::Test(queuedBuild, buildInfo);
+	return QueuedBuildOverlap::Test(queuedBuild, buildInfo, modInfo.useYardmapsForQueuedBuildOverlap);
 }
 
 

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1263,11 +1263,10 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 	const int z1 = int(testPos.z / SQUARE_SIZE) - (zsize >> 1), z2 = z1 + zsize;
 	const int2 xrange = int2(x1, x2);
 	const int2 zrange = int2(z1, z2);
+	const int numCells = (x2 - x1) * (z2 - z1);
 
-	if (statuses != nullptr) {
-		const int numCells = (x2 - x1) * (z2 - z1);
+	if (statuses != nullptr)
 		statuses->assign(numCells, 0);
-	}
 
 	const MoveDef* moveDef = (buildInfo.def->pathType != -1U) ? moveDefHandler.GetMoveDefByPathType(buildInfo.def->pathType) : nullptr;
 
@@ -1329,9 +1328,23 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 
 	if (commands != nullptr) {
 		assert(!synced);
+		std::vector<uint8_t> queuedBuildBlockedCells(numCells, false);
+		size_t queuedBuildOpenCellCount = numCells;
+		for (const Command& command: *commands) {
+			const BuildInfo queuedBuild(command);
+			if (QueuedBuildOverlap::AddBlockedCells(
+				queuedBuild,
+				buildInfo,
+				modInfo.useYardmapsForQueuedBuildOverlap,
+				queuedBuildBlockedCells,
+				queuedBuildOpenCellCount
+			))
+				break;
+		}
 
 		for (int z = z1; z < z2; z++) {
 			for (int x = x1; x < x2; x++) {
+				const int idx = (z - z1) * (x2 - x1) + (x - x1);
 				sqrPos.x = x * SQUARE_SIZE;
 				sqrPos.z = z * SQUARE_SIZE;
 
@@ -1340,27 +1353,11 @@ CGameHelper::BuildSquareStatus CGameHelper::TestUnitBuildSquare(
 				if (sqrPos.IsInBounds())
 					sqrStatus = TestBuildSquare(sqrPos, xrange, zrange, buildInfo, moveDef, feature, gu->myAllyTeam, synced);
 
-				if (sqrStatus != BUILDSQUARE_BLOCKED) {
-					for (const Command& c : *commands) {
-						const BuildInfo bc(c);
+				if (sqrStatus != BUILDSQUARE_BLOCKED && queuedBuildBlockedCells[idx])
+					sqrStatus = BUILDSQUARE_BLOCKED;
 
-						const int cmdSizeX = bc.GetXSize() * SQUARE_SIZE;
-						const int cmdSizeZ = bc.GetZSize() * SQUARE_SIZE;
-
-						const int cmdDistX = std::max(bc.pos.x - sqrPos.x - SQUARE_SIZE, sqrPos.x - bc.pos.x) * 2;
-						const int cmdDistZ = std::max(bc.pos.z - sqrPos.z - SQUARE_SIZE, sqrPos.z - bc.pos.z) * 2;
-
-						if (cmdDistX < cmdSizeX && cmdDistZ < cmdSizeZ) {
-							sqrStatus = BUILDSQUARE_BLOCKED;
-							break;
-						}
-					}
-				}
-
-				if (statuses != nullptr) {
-					const int idx = (z - z1) * (x2 - x1) + (x - x1);
+				if (statuses != nullptr)
 					(*statuses)[idx] = sqrStatus;
-				}
 
 				testStatus = std::min(testStatus, sqrStatus);
 			}

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -154,6 +154,10 @@ public:
 		const int2& zrange
 	);
 
+	/// Test whether an earlier queued build would block a later build if the
+	/// earlier build already existed. The test is directional and yardmap-aware.
+	static bool TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo);
+
 	///< test whether a blocked map square has a build override
 	static bool TestBlockSquareForBuildOnly(
 		const CSolidObject *blockingObject,

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -29,6 +29,10 @@ struct UnitDef;
 struct MoveDef;
 struct BuildInfo;
 
+namespace QueuedBuildOverlap {
+	enum class Result;
+}
+
 class ExplosionHitObject {
 private:
 	using VariantType = std::variant<std::monostate, CUnit*, CFeature*, CWeapon*>;
@@ -154,9 +158,9 @@ public:
 		const int2& zrange
 	);
 
-	/// Test whether an earlier queued build would block a later build if the
-	/// earlier build already existed. The test is directional and yardmap-aware.
-	static bool TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo);
+	/// Classify a queued-build conflict as cancellation, rejected overlap, or
+	/// no conflict. The occupied-cell test is directional and yardmap-aware.
+	static QueuedBuildOverlap::Result TestQueuedBuildOverlap(const BuildInfo& queuedBuild, const BuildInfo& buildInfo);
 
 	///< test whether a blocked map square has a build override
 	static bool TestBlockSquareForBuildOnly(

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -682,40 +682,6 @@ void CSelectedUnitsHandler::Draw()
 		shader.Disable();
 	}
 
-	// highlight queued build sites if we are about to build something
-	// (or old-style, whenever the shift key is being held down)
-	if (cmdColors.buildBox[3] > 0.0f) {
-		if (!selectedUnits.empty() &&
-				((cmdColors.BuildBoxesOnShift() && KeyInput::GetKeyModState(KMOD_SHIFT)) ||
-				 ((guihandler->inCommand >= 0) &&
-					(guihandler->inCommand < int(guihandler->commands.size())) &&
-					(guihandler->commands[guihandler->inCommand].id < 0)))) {
-
-			bool myColor = true;
-			glColor4fv(cmdColors.buildBox);
-
-			for (const auto& [bid, builderCAI] : unitHandler.GetBuilderCAIs()) {
-				const CUnit* builder = builderCAI->owner;
-
-				if (builder->team == gu->myTeam) {
-					if (!myColor) {
-						glColor4fv(cmdColors.buildBox);
-						myColor = true;
-					}
-					commandDrawer->DrawQuedBuildingSquares(builderCAI);
-				}
-
-				else if (teamHandler.AlliedTeams(builder->team, gu->myTeam)) {
-					if (myColor) {
-						glColor4fv(cmdColors.allyBuildBox);
-						myColor = false;
-					}
-					commandDrawer->DrawQuedBuildingSquares(builderCAI);
-				}
-			}
-		}
-	}
-
 	glLineWidth(1.0f);
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 	glDisable(GL_BLEND);
@@ -1155,4 +1121,3 @@ void CSelectedUnitsHandler::SendCommandsToUnits(const std::vector<int>& unitIDs,
 
 	clientNet->Send(std::shared_ptr<netcode::RawPacket>(packet));
 }
-

--- a/rts/Game/UI/CommandColors.cpp
+++ b/rts/Game/UI/CommandColors.cpp
@@ -79,6 +79,7 @@ CCommandColors::CCommandColors()
 	SETUP_COLOR(rangeInterceptorOff, 0.0f, 0.0f, 0.0f, 0.7f);
 	SETUP_COLOR(unitBox,             0.0f, 1.0f, 0.0f, 0.9f);
 	SETUP_COLOR(buildBox,            0.0f, 1.0f, 0.0f, 0.9f);
+	SETUP_COLOR(buildBoxOverlap,     1.0f, 0.0f, 0.0f, 0.9f);
 	SETUP_COLOR(allyBuildBox,        0.8f, 0.8f, 0.2f, 0.9f);
 	SETUP_COLOR(mouseBox,            1.0f, 1.0f, 1.0f, 0.9f);
 }
@@ -332,4 +333,3 @@ bool CCommandColors::LoadConfigFromString(const std::string& cfg)
 
 	return true;
 }
-

--- a/rts/Game/UI/CommandColors.h
+++ b/rts/Game/UI/CommandColors.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef _COMMAND_COLORS_H
-#define _COMMAND_COLORS_H
+#pragma once
 
 #include <string>
 #include "System/UnorderedMap.hpp"
@@ -75,6 +74,7 @@ public:
 	// the colors
 	const float* unitBox;
 	const float* buildBox;
+	const float* buildBoxOverlap;
 	const float* allyBuildBox;
 	const float* mouseBox;
 
@@ -154,6 +154,7 @@ private:
 
 		unitBoxIndex,
 		buildBoxIndex,
+		buildBoxOverlapIndex,
 		allyBuildBoxIndex,
 		mouseBoxIndex,
 
@@ -197,6 +198,3 @@ private:
 
 
 extern CCommandColors cmdColors;
-
-
-#endif // _COMMAND_COLORS_H

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -23,6 +23,7 @@
 #include "Map/MapInfo.h"
 #include "Map/MetalMap.h"
 #include "Map/ReadMap.h"
+#include "Rendering/CommandDrawer.h"
 #include "Rendering/Fonts/glFont.h"
 #include "Rendering/IconHandler.h"
 #include "Rendering/Units/UnitDrawer.h"
@@ -32,8 +33,10 @@
 #include "Rendering/Textures/NamedTextures.h"
 #include "Sim/Features/Feature.h"
 #include "Sim/Misc/LosHandler.h"
+#include "Sim/Misc/TeamHandler.h"
 #include "Sim/Units/CommandAI/CommandAI.h"
 #include "Sim/Units/CommandAI/BuilderCAI.h"
+#include "Sim/Units/QueuedBuildOverlap.h"
 #include "Sim/Units/UnitDefHandler.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitHandler.h"
@@ -2464,22 +2467,68 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 	return Command(CMD_STOP);
 }
 
-
-
-static bool WouldCancelAnyQueued(const BuildInfo& b)
+static bool WouldCancelAnyQueued(const BuildInfo& buildInfo)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	const Command c = b.CreateCommand();
+	const Command command = buildInfo.CreateCommand();
 
 	for (const int unitID: selectedUnitsHandler.selectedUnits) {
-		const CUnit* u = unitHandler.GetUnit(unitID);
+		const CUnit* unit = unitHandler.GetUnit(unitID);
 
-		if (u->commandAI->WillCancelQueued(c))
+		if (unit->commandAI->WillCancelQueued(command))
 			return true;
-
 	}
 
 	return false;
+}
+
+using CancelledBuildCommandTags = spring::unordered_map<int, spring::unordered_set<unsigned int>>;
+
+static void DrawQueuedBuildSquares(const CancelledBuildCommandTags& cancelledCommandTags)
+{
+	if (cmdColors.buildBox[3] <= 0.0f || selectedUnitsHandler.selectedUnits.empty())
+		return;
+
+	const bool drawOnShift = cmdColors.BuildBoxesOnShift() && KeyInput::GetKeyModState(KMOD_SHIFT);
+	const bool activeBuildCommand =
+		guihandler->inCommand >= 0 &&
+		guihandler->inCommand < int(guihandler->commands.size()) &&
+		guihandler->commands[guihandler->inCommand].id < 0;
+
+	if (!drawOnShift && !activeBuildCommand)
+		return;
+
+	glDisable(GL_TEXTURE_2D);
+	glDisable(GL_DEPTH_TEST);
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+	glLineWidth(cmdColors.UnitBoxLineWidth());
+
+	static const spring::unordered_set<unsigned int> noCancelledCommands;
+	for (const auto& [builderID, builderCAI]: unitHandler.GetBuilderCAIs()) {
+		const CUnit* builder = builderCAI->owner;
+		const float* buildColor = nullptr;
+
+		if (builder->team == gu->myTeam) {
+			buildColor = cmdColors.buildBox;
+		} else if (teamHandler.AlliedTeams(builder->team, gu->myTeam)) {
+			buildColor = cmdColors.allyBuildBox;
+		} else {
+			continue;
+		}
+
+		const auto cancelledIt = cancelledCommandTags.find(builderID);
+		const auto& cancelled = (cancelledIt != cancelledCommandTags.end()) ? cancelledIt->second : noCancelledCommands;
+		glColor4fv(buildColor);
+		commandDrawer->DrawQuedBuildingSquares(builderCAI, cancelled, cmdColors.buildBoxOverlap);
+	}
+
+	glLineWidth(1.0f);
+	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+	glDisable(GL_BLEND);
+	glEnable(GL_DEPTH_TEST);
+	glEnable(GL_TEXTURE_2D);
 }
 
 static void FillRowOfBuildPos(const BuildInfo& startInfo, float x, float z, float xstep, float zstep, int n, int facing, bool nocancel, std::vector<BuildInfo>& ret)
@@ -3543,6 +3592,8 @@ static inline void DrawWeaponArc(const CUnit* unit)
 void CGuiHandler::DrawMapStuff(bool onMiniMap)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	CancelledBuildCommandTags cancelledBuildCommandTags;
+
 	if (!onMiniMap) {
 		glEnable(GL_DEPTH_TEST);
 		glDepthMask(GL_FALSE);
@@ -3835,7 +3886,6 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 
 				for (const BuildInfo& bi: buildInfos) {
 					const float3& buildPos = bi.pos;
-
 					DrawUnitDefRanges(nullptr, buildeeDef, buildPos);
 
 					// draw (primary) weapon range
@@ -3864,9 +3914,21 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						for (const int unitID: selectedUnitsHandler.selectedUnits) {
 							const CUnit* su = unitHandler.GetUnit(unitID);
 							const CCommandAI* cai = su->commandAI;
+							const CBuilderCAI* builderCAI = dynamic_cast<const CBuilderCAI*>(cai);
+							const std::vector<Command> overlapCommands = cai->GetOverlapQueued(c);
 
-							for (const Command& cmd: cai->GetOverlapQueued(c)) {
+							for (const Command& cmd: overlapCommands) {
 								buildCommands.push_back(cmd);
+
+								const bool activeBuild =
+									builderCAI != nullptr && builderCAI->HasCurrentBuild() &&
+									!cai->commandQue.empty() && cmd.GetTag() == cai->commandQue.front().GetTag();
+								if (activeBuild)
+									continue;
+
+								const BuildInfo queuedBuild(cmd);
+								if (QueuedBuildOverlap::IsInsideCancellationRectangle(queuedBuild, bi))
+									cancelledBuildCommandTags[unitID].insert(cmd.GetTag());
 							}
 						}
 					}
@@ -3933,6 +3995,8 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 			}
 		}
 	}
+
+	DrawQueuedBuildSquares(cancelledBuildCommandTags);
 
 	glLineWidth(1.0f);
 
@@ -4434,4 +4498,3 @@ void CGuiHandler::DrawSelectCircle(const float3& pos, float radius,
 
 	glEnable(GL_FOG);
 }
-

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3916,15 +3916,15 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 							const CCommandAI* cai = su->commandAI;
 							const CBuilderCAI* builderCAI = dynamic_cast<const CBuilderCAI*>(cai);
 							const std::vector<Command> overlapCommands = cai->GetOverlapQueued(c);
+							unsigned int activeBuildCommandTag = 0;
+							const bool hasActiveBuildCommand =
+								builderCAI != nullptr && builderCAI->GetCurrentBuildCommandTag(activeBuildCommandTag);
 
 							for (const Command& cmd: overlapCommands) {
-								buildCommands.push_back(cmd);
-
-								const bool activeBuild =
-									builderCAI != nullptr && builderCAI->HasCurrentBuild() &&
-									!cai->commandQue.empty() && cmd.GetTag() == cai->commandQue.front().GetTag();
-								if (activeBuild)
+								if (hasActiveBuildCommand && cmd.GetTag() == activeBuildCommandTag)
 									continue;
+
+								buildCommands.push_back(cmd);
 
 								const BuildInfo queuedBuild(cmd);
 								if (QueuedBuildOverlap::IsInsideCancellationRectangle(queuedBuild, bi))

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -74,6 +74,7 @@
  * @field fireAtKilled number
  * @field fireAtCrashing number
  * @field constructionDecay boolean
+ * @field useYardmapsForQueuedBuildOverlap boolean
  * @field reclaimAllowEnemies boolean
  * @field reclaimAllowAllies boolean
  * @field constructionDecayTime number
@@ -193,6 +194,7 @@ bool LuaConstGame::PushEntries(lua_State* L)
 		LuaPushNamedBool  (L, "constructionDecay"     , modInfo.constructionDecay);
 		LuaPushNamedNumber(L, "constructionDecayTime" , modInfo.constructionDecayTime);
 		LuaPushNamedNumber(L, "constructionDecaySpeed", modInfo.constructionDecaySpeed);
+		LuaPushNamedBool  (L, "useYardmapsForQueuedBuildOverlap", modInfo.useYardmapsForQueuedBuildOverlap);
 
 		LuaPushNamedNumber(L, "multiReclaim"                  , modInfo.multiReclaim);
 		LuaPushNamedNumber(L, "reclaimMethod"                 , modInfo.reclaimMethod);
@@ -344,4 +346,3 @@ bool LuaConstGame::PushEntries(lua_State* L)
 
 	return true;
 }
-

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -56,6 +56,7 @@
 #include "Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h"
 #include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/BuildInfo.h"
+#include "Sim/Units/QueuedBuildOverlap.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitHandler.h"
@@ -365,6 +366,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(TestMoveOrder);
 	REGISTER_LUA_CFUNC(TestBuildOrder);
+	REGISTER_LUA_CFUNC(TestBuildOrderOverlap);
 	REGISTER_LUA_CFUNC(Pos2BuildPos);
 	REGISTER_LUA_CFUNC(ClosestBuildPos);
 
@@ -8135,6 +8137,68 @@ int LuaSyncedRead::TestBuildOrder(lua_State* L)
 	return 2;
 }
 
+
+/***
+ * @class BuildOrderSpec
+ * @x_helper
+ * @field [1] integer unitDefID
+ * @field [2] number x
+ * @field [3] number y
+ * @field [4] number z
+ * @field [5] Facing facing
+ */
+
+static BuildInfo ParseBuildOrderSpec(lua_State* L, int tableIndex)
+{
+	luaL_checktype(L, tableIndex, LUA_TTABLE);
+
+	BuildInfo buildInfo;
+
+	lua_rawgeti(L, tableIndex, 1);
+	buildInfo.def = unitDefHandler->GetUnitDefByID(luaL_checkint(L, -1));
+	lua_pop(L, 1);
+
+	float pos[3];
+	for (int i = 0; i < 3; ++i) {
+		lua_rawgeti(L, tableIndex, i + 2);
+		pos[i] = luaL_checkfloat(L, -1);
+		lua_pop(L, 1);
+	}
+	buildInfo.pos = {pos[0], pos[1], pos[2]};
+
+	lua_rawgeti(L, tableIndex, 5);
+	buildInfo.buildFacing = LuaUtils::ParseFacing(L, __func__, -1);
+	lua_pop(L, 1);
+
+	return buildInfo;
+}
+
+/***
+ * @function Spring.TestBuildOrderOverlap
+ * @param queuedBuild BuildOrderSpec
+ * @param proposedBuild BuildOrderSpec
+ * @return boolean overlaps Whether the builds conflict under the queued-build overlap rules.
+ * @return boolean cancels Whether the proposed build would cancel the earlier queued build.
+ */
+int LuaSyncedRead::TestBuildOrderOverlap(lua_State* L)
+{
+	BuildInfo queuedBuild = ParseBuildOrderSpec(L, 1);
+	BuildInfo proposedBuild = ParseBuildOrderSpec(L, 2);
+
+	if (queuedBuild.def == nullptr || proposedBuild.def == nullptr) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	const bool synced = CLuaHandle::GetHandleSynced(L);
+	queuedBuild.pos = CGameHelper::Pos2BuildPos(queuedBuild, synced);
+	proposedBuild.pos = CGameHelper::Pos2BuildPos(proposedBuild, synced);
+
+	const auto result = CGameHelper::TestQueuedBuildOverlap(queuedBuild, proposedBuild);
+	lua_pushboolean(L, result != QueuedBuildOverlap::Result::NONE);
+	lua_pushboolean(L, result == QueuedBuildOverlap::Result::CANCEL);
+	return 2;
+}
 
 /*** Snaps a position to the building grid
  *

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -263,6 +263,7 @@ class LuaSyncedRead {
 
 		static int TestMoveOrder(lua_State* L);
 		static int TestBuildOrder(lua_State* L);
+		static int TestBuildOrderOverlap(lua_State* L);
 		static int Pos2BuildPos(lua_State* L);
 		static int ClosestBuildPos(lua_State* L);
 

--- a/rts/Rendering/CommandDrawer.cpp
+++ b/rts/Rendering/CommandDrawer.cpp
@@ -652,7 +652,11 @@ void CommandDrawer::DrawDefaultCommand(const Command& c, const CUnit* owner) con
 	lineDrawer.DrawLineAndIcon(dd->cmdIconID, unit->GetObjDrawErrorPos(owner->allyteam), dd->color);
 }
 
-void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
+void CommandDrawer::DrawQuedBuildingSquares(
+	const CBuilderCAI* cai,
+	const spring::unordered_set<unsigned int>& cancelledCommandTags,
+	const float* overlapColor
+) const
 {
 	const CCommandQueue& commandQue = cai->commandQue;
 	const auto& buildOptions = cai->buildOptions;
@@ -663,7 +667,6 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 	for (const Command& c: commandQue) {
 		if (buildOptions.find(c.GetID()) == buildOptions.end())
 			continue;
-
 		BuildInfo bi;
 
 		if (!bi.Parse(c))
@@ -677,6 +680,7 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 
 	// worst case - 2 squares per building (when underwater) - 8 vertices * 3 floats
 	std::vector<GLfloat>   quadVerts(buildCommands * 12);
+	std::vector<GLfloat> cancelledQuadVerts(buildCommands * 12);
 	std::vector<GLfloat> uwquadVerts(buildCommands * 12); // underwater
 	// 4 vertical lines
 	std::vector<GLfloat> lineVerts(uwaterCommands * 24);
@@ -684,13 +688,13 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 	std::vector<GLfloat> lineColors(uwaterCommands * 48);
 
 	unsigned int   quadcounter = 0;
+	unsigned int cancelledQuadcounter = 0;
 	unsigned int uwquadcounter = 0;
 	unsigned int   linecounter = 0;
 
 	for (const Command& c: commandQue) {
 		if (buildOptions.find(c.GetID()) == buildOptions.end())
 			continue;
-
 		BuildInfo bi;
 
 		if (!bi.Parse(c))
@@ -707,18 +711,21 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		const float x2 = bi.pos.x + xsize;
 		const float z2 = bi.pos.z + zsize;
 
-		quadVerts[quadcounter++] = x1;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z1;
-		quadVerts[quadcounter++] = x1;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z2;
-		quadVerts[quadcounter++] = x2;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z2;
-		quadVerts[quadcounter++] = x2;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z1;
+		std::vector<GLfloat>& verts = cancelledCommandTags.contains(c.GetTag()) ? cancelledQuadVerts : quadVerts;
+		unsigned int& counter = cancelledCommandTags.contains(c.GetTag()) ? cancelledQuadcounter : quadcounter;
+
+		verts[counter++] = x1;
+		verts[counter++] = h + 1;
+		verts[counter++] = z1;
+		verts[counter++] = x1;
+		verts[counter++] = h + 1;
+		verts[counter++] = z2;
+		verts[counter++] = x2;
+		verts[counter++] = h + 1;
+		verts[counter++] = z2;
+		verts[counter++] = x2;
+		verts[counter++] = h + 1;
+		verts[counter++] = z1;
 
 		if (bi.pos.y >= 0.0f)
 			continue;
@@ -774,11 +781,20 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		lineVerts[linecounter++] = z2;
 	}
 
-	if (quadcounter > 0) {
+	if (quadcounter > 0 || cancelledQuadcounter > 0) {
 		glEnableClientState(GL_VERTEX_ARRAY);
 		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-		glVertexPointer(3, GL_FLOAT, 0, &quadVerts[0]);
-		glDrawArrays(GL_QUADS, 0, quadcounter / 3);
+
+		if (quadcounter > 0) {
+			glVertexPointer(3, GL_FLOAT, 0, &quadVerts[0]);
+			glDrawArrays(GL_QUADS, 0, quadcounter / 3);
+		}
+
+		if (cancelledQuadcounter > 0) {
+			glColor4fv(overlapColor);
+			glVertexPointer(3, GL_FLOAT, 0, &cancelledQuadVerts[0]);
+			glDrawArrays(GL_QUADS, 0, cancelledQuadcounter / 3);
+		}
 
 		if (linecounter > 0) {
 			glPushAttrib(GL_CURRENT_BIT);
@@ -797,4 +813,3 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		glDisableClientState(GL_VERTEX_ARRAY);
 	}
 }
-

--- a/rts/Rendering/CommandDrawer.h
+++ b/rts/Rendering/CommandDrawer.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef COMMAND_DRAWER_H
-#define COMMAND_DRAWER_H
+#pragma once
 
 #include "System/UnorderedSet.hpp"
 
@@ -22,7 +21,11 @@ public:
 
 	void Draw(const CCommandAI*, int queueDrawDepth = -1) const;
 	void DrawLuaQueuedUnitSetCommands() const;
-	void DrawQuedBuildingSquares(const CBuilderCAI*) const;
+	void DrawQuedBuildingSquares(
+		const CBuilderCAI*,
+		const spring::unordered_set<unsigned int>& cancelledCommandTags,
+		const float* overlapColor
+	) const;
 
 	void AddLuaQueuedUnit(const CUnit* unit, int queueDrawDepth = 0);
 
@@ -42,5 +45,3 @@ private:
 };
 
 #define commandDrawer (CommandDrawer::GetInstance())
-
-#endif

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -2111,4 +2111,3 @@ void CUnitDrawerGL4::DrawUnitModelBeingBuiltOpaque(const CUnit* unit, bool noLua
 
 	glPopAttrib();
 }
-

--- a/rts/Sim/CMakeLists.txt
+++ b/rts/Sim/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(engineSim STATIC
 		"${CMAKE_CURRENT_SOURCE_DIR}/Projectiles/WeaponProjectiles/WeaponProjectile.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Projectiles/WeaponProjectiles/WeaponProjectileFactory.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/BuildInfo.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Units/QueuedBuildOverlap.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/AirCAI.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/BuilderCAI.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/Units/CommandAI/Command.cpp"

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -66,7 +66,7 @@ void CModInfo::ResetState()
 		constructionDecayTime  = int(6.66 * GAME_SPEED);
 		constructionDecaySpeed = 0.03f;
 		insertBuiltUnitMoveCommand = true;
-		useYardmapsForQueuedBuildOverlap = true;
+		useYardmapsForQueuedBuildOverlap = false;
 	}
 	{
 		debrisDamage = 50.0f;

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -66,6 +66,7 @@ void CModInfo::ResetState()
 		constructionDecayTime  = int(6.66 * GAME_SPEED);
 		constructionDecaySpeed = 0.03f;
 		insertBuiltUnitMoveCommand = true;
+		useYardmapsForQueuedBuildOverlap = true;
 	}
 	{
 		debrisDamage = 50.0f;
@@ -254,6 +255,7 @@ void CModInfo::Init(const std::string& modFileName)
 		constructionDecayTime = (int)(constructionTbl.GetFloat("constructionDecayTime", (float)constructionDecayTime / GAME_SPEED) * GAME_SPEED);
 		constructionDecaySpeed = constructionTbl.GetFloat("constructionDecaySpeed", constructionDecaySpeed);
 		insertBuiltUnitMoveCommand = constructionTbl.GetBool("insertBuiltUnitMoveCommand", insertBuiltUnitMoveCommand);
+		useYardmapsForQueuedBuildOverlap = constructionTbl.GetBool("useYardmapsForQueuedBuildOverlap", useYardmapsForQueuedBuildOverlap);
 	}
 
 	{
@@ -420,4 +422,3 @@ void CModInfo::Init(const std::string& modFileName)
 	smoothMeshSmoothRadius                   = std::max  (smoothMeshSmoothRadius                  ,    1          );
 	unitQuadPositionUpdateRate               = std::clamp(unitQuadPositionUpdateRate              ,    1    ,   15);
 }
-

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -86,6 +86,8 @@ public:
 	float constructionDecaySpeed;
 	/// When units are created, issue a move command off of the factory pad.
 	bool insertBuiltUnitMoveCommand;
+	/// Whether queued build overlap checks use yardmaps after their rectangular broad phase.
+	bool useYardmapsForQueuedBuildOverlap;
 
 	// Damage behaviour
 	/// unit pieces flying off (usually on death)

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -213,6 +213,12 @@ CBuilderCAI::CBuilderCAI(CUnit* owner):
 	unitHandler.AddBuilderCAI(this);
 }
 
+
+bool CBuilderCAI::HasCurrentBuild() const
+{
+	return (ownerBuilder != nullptr && ownerBuilder->curBuild != nullptr);
+}
+
 CBuilderCAI::~CBuilderCAI()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -1747,4 +1753,3 @@ void CBuilderCAI::BuggerOff(const float3& pos, float radius) {
 
 	CMobileCAI::BuggerOff(pos, radius);
 }
-

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -219,6 +219,31 @@ bool CBuilderCAI::HasCurrentBuild() const
 	return (ownerBuilder != nullptr && ownerBuilder->curBuild != nullptr);
 }
 
+bool CBuilderCAI::GetCurrentBuildCommandTag(unsigned int& commandTag) const
+{
+	if (!HasCurrentBuild())
+		return false;
+
+	const CUnit* currentBuild = ownerBuilder->curBuild;
+
+	for (const Command& queuedCommand: commandQue) {
+		BuildInfo queuedBuild;
+		if (!queuedBuild.Parse(queuedCommand))
+			continue;
+		if (queuedBuild.def != currentBuild->unitDef)
+			continue;
+		if (queuedBuild.buildFacing != currentBuild->buildFacing)
+			continue;
+		if (CSolidObject::GetMapPosStatic(queuedBuild.pos, queuedBuild.GetXSize(), queuedBuild.GetZSize()) != currentBuild->mapPos)
+			continue;
+
+		commandTag = queuedCommand.GetTag();
+		return true;
+	}
+
+	return false;
+}
+
 CBuilderCAI::~CBuilderCAI()
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -55,6 +55,7 @@ public:
 	bool IsInBuildRange(const float3& pos, const float radius) const;
 	float GetBuildRange(const float targetRadius) const;
 	bool HasCurrentBuild() const;
+	bool GetCurrentBuildCommandTag(unsigned int& commandTag) const;
 
 public:
 	spring::unordered_set<int> buildOptions;

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -54,6 +54,7 @@ public:
 	bool IsInBuildRange(const CWorldObject* obj) const;
 	bool IsInBuildRange(const float3& pos, const float radius) const;
 	float GetBuildRange(const float targetRadius) const;
+	bool HasCurrentBuild() const;
 
 public:
 	spring::unordered_set<int> buildOptions;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -8,6 +8,7 @@
 #include "ExternalAI/EngineOutHandler.h"
 #include "ExternalAI/SkirmishAIHandler.h"
 #include "Game/GlobalUnsynced.h"
+#include "Game/GameHelper.h"
 #include "Game/SelectedUnitsHandler.h"
 #include "Game/WaitCommandsAI.h"
 #include "Map/Ground.h"
@@ -20,6 +21,7 @@
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/MoveTypes/MoveType.h"
 #include "Sim/Units/BuildInfo.h"
+#include "Sim/Units/QueuedBuildOverlap.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Units/UnitHandler.h"
@@ -1308,6 +1310,40 @@ bool CCommandAI::WillCancelQueued(const Command& c) const
 	return (GetCancelQueued(c, commandQue) != commandQue.end());
 }
 
+static bool CommandsCancel(const Command& c, const Command& queuedCommand)
+{
+	const int cmdID = c.GetID();
+	const int queuedCmdID = queuedCommand.GetID();
+	const bool attackAndFight = (cmdID == CMD_ATTACK && queuedCmdID == CMD_FIGHT && queuedCommand.GetNumParams() == 1);
+
+	if (queuedCommand.GetNumParams() != c.GetNumParams())
+		return false;
+	if (cmdID != queuedCmdID && (cmdID >= 0 || queuedCmdID >= 0) && !attackAndFight)
+		return false;
+
+	if (c.GetNumParams() == 1)
+		return (queuedCommand.GetParam(0) == c.GetParam(0));
+
+	if (c.GetNumParams() < 3)
+		return false;
+
+	if (cmdID < 0) {
+		const BuildInfo proposedBuild(c);
+		const BuildInfo queuedBuild(queuedCommand);
+
+		if (proposedBuild.def == nullptr || queuedBuild.def == nullptr)
+			return false;
+
+		return (CGameHelper::TestQueuedBuildOverlap(queuedBuild, proposedBuild) == QueuedBuildOverlap::Result::CANCEL);
+	}
+
+	if ((c.GetPos(0) - queuedCommand.GetPos(0)).SqLength2D() >= (COMMAND_CANCEL_DIST * COMMAND_CANCEL_DIST))
+		return false;
+	if ((c.GetOpts() & SHIFT_KEY) != 0 && c.IsInternalOrder())
+		return false;
+
+	return true;
+}
 
 CCommandQueue::const_iterator CCommandAI::GetCancelQueued(const Command& c, const CCommandQueue& q) const
 {
@@ -1316,47 +1352,8 @@ CCommandQueue::const_iterator CCommandAI::GetCancelQueued(const Command& c, cons
 
 	while (ci != q.begin()) {
 		--ci; //iterate from the end and dont check the current order
-		const Command& c2 = *ci;
-		const int cmdID = c.GetID();
-		const int cmd2ID = c2.GetID();
-
-		const bool attackAndFight = (cmdID == CMD_ATTACK && cmd2ID == CMD_FIGHT && c2.GetNumParams() == 1);
-
-		if (c2.GetNumParams() != c.GetNumParams())
-			continue;
-
-		if ((cmdID == cmd2ID) || (cmdID < 0 && cmd2ID < 0) || attackAndFight) {
-			if (c.GetNumParams() == 1) {
-				// assume the param is a unit-ID or feature-ID
-				if (c2.GetParam(0) == c.GetParam(0))
-					return ci;
-			}
-			else if (c.GetNumParams() >= 3) {
-				if (cmdID < 0) {
-					const BuildInfo bc1(c);
-					const BuildInfo bc2(c2);
-
-					if (bc1.def == nullptr) continue;
-					if (bc2.def == nullptr) continue;
-
-					if (math::fabs(bc1.pos.x - bc2.pos.x) * 2 <= std::max(bc1.GetXSize(), bc2.GetXSize()) * SQUARE_SIZE &&
-					    math::fabs(bc1.pos.z - bc2.pos.z) * 2 <= std::max(bc1.GetZSize(), bc2.GetZSize()) * SQUARE_SIZE) {
-						return ci;
-					}
-				} else {
-					// assume c and c2 are positional commands
-					const float3& c1p = c.GetPos(0);
-					const float3& c2p = c2.GetPos(0);
-
-					if ((c1p - c2p).SqLength2D() >= (COMMAND_CANCEL_DIST * COMMAND_CANCEL_DIST))
-						continue;
-					if ((c.GetOpts() & SHIFT_KEY) != 0 && c.IsInternalOrder())
-						continue;
-
-					return ci;
-				}
-			}
-		}
+		if (CommandsCancel(c, *ci))
+			return ci;
 	}
 
 	return q.end();
@@ -1436,18 +1433,10 @@ std::vector<Command> CCommandAI::GetOverlapQueued(const Command& c, const CComma
 					// NOTE: uses a BuildInfo structure, but <t> can be ANY command
 					BuildInfo tbi;
 					if (tbi.Parse(t)) {
-						const float dist2X = 2.0f * math::fabs(cbi.pos.x - tbi.pos.x);
-						const float dist2Z = 2.0f * math::fabs(cbi.pos.z - tbi.pos.z);
-						const float addSizeX = SQUARE_SIZE * (cbi.GetXSize() + tbi.GetXSize());
-						const float addSizeZ = SQUARE_SIZE * (cbi.GetZSize() + tbi.GetZSize());
-						const float maxSizeX = SQUARE_SIZE * std::max(cbi.GetXSize(), tbi.GetXSize());
-						const float maxSizeZ = SQUARE_SIZE * std::max(cbi.GetZSize(), tbi.GetZSize());
-
 						if (cbi.def == NULL) continue;
 						if (tbi.def == NULL) continue;
 
-						if (((dist2X > maxSizeX) || (dist2Z > maxSizeZ)) &&
-						    ((dist2X < addSizeX) && (dist2Z < addSizeZ))) {
+						if (CGameHelper::TestQueuedBuildOverlap(tbi, cbi) != QueuedBuildOverlap::Result::NONE) {
 							v.push_back(t);
 						}
 					} else {
@@ -1861,4 +1850,3 @@ void CCommandAI::StopAttackingAllyTeam(int ally)
 	RECOIL_DETAILED_TRACY_ZONE;
 	StopAttackingTargetIf([&](const CUnit* t) { return (t != nullptr && t->allyteam == ally); });
 }
-

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -64,7 +64,6 @@ public:
 	 * @return true if c will cancel a queued command
 	 */
 	bool WillCancelQueued(const Command& c) const;
-
 	bool HasCommand(int cmdID) const;
 	bool HasMoreMoveCommands(bool skipFirstCmd = true) const;
 
@@ -76,7 +75,7 @@ public:
 	 */
 	CCommandQueue::const_iterator GetCancelQueued(const Command& c, const CCommandQueue& queue) const;
 	/**
-	 * @brief Returns commands that overlap c, but will not be canceled by c
+	 * @brief Returns commands that overlap c, including commands canceled by c
 	 * @return a vector containing commands that overlap c
 	 */
 	std::vector<Command> GetOverlapQueued(const Command& c) const;

--- a/rts/Sim/Units/QueuedBuildOverlap.cpp
+++ b/rts/Sim/Units/QueuedBuildOverlap.cpp
@@ -8,6 +8,7 @@
 #include "Sim/Units/BuildInfo.h"
 #include "Sim/Units/UnitDef.h"
 #include "System/Misc/TracyDefs.h"
+#include "System/SpringMath.h"
 
 namespace QueuedBuildOverlap {
 
@@ -50,12 +51,12 @@ bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& pr
 	);
 }
 
-bool Test(const BuildInfo& earlier, const BuildInfo& proposed)
+Result Test(const BuildInfo& earlier, const BuildInfo& proposed, bool useYardmaps)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 
 	if (earlier.def == nullptr || proposed.def == nullptr)
-		return false;
+		return Result::NONE;
 
 	const int2 earlierSize = {earlier.GetXSize(), earlier.GetZSize()};
 	const int2 proposedSize = {proposed.GetXSize(), proposed.GetZSize()};
@@ -75,13 +76,17 @@ bool Test(const BuildInfo& earlier, const BuildInfo& proposed)
 	const int overlapZ2 = std::min(earlierMaxs.y, proposedMaxs.y);
 
 	if (overlapX1 >= overlapX2 || overlapZ1 >= overlapZ2)
-		return false;
+		return Result::NONE;
+
+	const Result overlapResult = IsInsideCancellationRectangle(earlier, proposed) ? Result::CANCEL : Result::OVERLAP;
+	if (!useYardmaps)
+		return overlapResult;
 
 	const size_t earlierYardMapSize = earlier.def->xsize * earlier.def->zsize;
 	const size_t proposedYardMapSize = proposed.def->xsize * proposed.def->zsize;
 
 	if (earlier.def->yardmap.size() != earlierYardMapSize)
-		return true;
+		return overlapResult;
 
 	const int2 earlierXRange = {earlierMins.x, earlierMaxs.x};
 	const int2 earlierZRange = {earlierMins.y, earlierMaxs.y};
@@ -103,7 +108,7 @@ bool Test(const BuildInfo& earlier, const BuildInfo& proposed)
 
 			if (earlierStatus & (YardmapStates::YARDMAP_EXITONLY | YardmapStates::YARDMAP_UNBUILDABLE)) {
 				if (proposedStatus > YardmapStates::YARDMAP_STACKABLE)
-					return true;
+					return overlapResult;
 				continue;
 			}
 
@@ -114,11 +119,11 @@ bool Test(const BuildInfo& earlier, const BuildInfo& proposed)
 			if (earlierStatus == YardmapStates::YARDMAP_BUILDONLY)
 				continue;
 
-			return true;
+			return overlapResult;
 		}
 	}
 
-	return false;
+	return Result::NONE;
 }
 
 } // namespace QueuedBuildOverlap

--- a/rts/Sim/Units/QueuedBuildOverlap.cpp
+++ b/rts/Sim/Units/QueuedBuildOverlap.cpp
@@ -51,6 +51,147 @@ bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& pr
 	);
 }
 
+namespace {
+
+class CellOverlapTest {
+public:
+	CellOverlapTest(const BuildInfo& earlier, const BuildInfo& proposed, bool useYardmaps)
+		: earlier(earlier)
+		, proposed(proposed)
+		, earlierSize{earlier.GetXSize(), earlier.GetZSize()}
+		, proposedSize{proposed.GetXSize(), proposed.GetZSize()}
+		, earlierMins{
+			int(earlier.pos.x / SQUARE_SIZE) - (earlierSize.x >> 1),
+			int(earlier.pos.z / SQUARE_SIZE) - (earlierSize.y >> 1),
+		}
+		, proposedMins{
+			int(proposed.pos.x / SQUARE_SIZE) - (proposedSize.x >> 1),
+			int(proposed.pos.z / SQUARE_SIZE) - (proposedSize.y >> 1),
+		}
+		, earlierMaxs(earlierMins + earlierSize)
+		, proposedMaxs(proposedMins + proposedSize)
+		, overlapMins{std::max(earlierMins.x, proposedMins.x), std::max(earlierMins.y, proposedMins.y)}
+		, overlapMaxs{std::min(earlierMaxs.x, proposedMaxs.x), std::min(earlierMaxs.y, proposedMaxs.y)}
+		, earlierXRange{earlierMins.x, earlierMaxs.x}
+		, earlierZRange{earlierMins.y, earlierMaxs.y}
+		, proposedXRange{proposedMins.x, proposedMaxs.x}
+		, proposedZRange{proposedMins.y, proposedMaxs.y}
+		, rectangularFallback(
+			!useYardmaps || earlier.def->yardmap.size() != static_cast<size_t>(earlier.def->xsize * earlier.def->zsize)
+		)
+		, proposedHasYardMap(
+			proposed.def->yardmap.size() == static_cast<size_t>(proposed.def->xsize * proposed.def->zsize)
+		)
+	{}
+
+	bool HasFootprintOverlap() const { return (overlapMins.x < overlapMaxs.x && overlapMins.y < overlapMaxs.y); }
+	bool UsesRectangularFallback() const { return rectangularFallback; }
+
+	bool BlocksCell(const int2& mapSquare) const
+	{
+		if (rectangularFallback)
+			return true;
+
+		const int earlierIndex = GetYardMapIndex(earlier.buildFacing, mapSquare, earlierXRange, earlierZRange);
+		const YardMapStatus earlierStatus = earlier.def->yardmap[earlierIndex];
+
+		YardMapStatus proposedStatus = YardmapStates::YARDMAP_BLOCKED;
+		if (proposedHasYardMap) {
+			const int proposedIndex = GetYardMapIndex(proposed.buildFacing, mapSquare, proposedXRange, proposedZRange);
+			proposedStatus = proposed.def->yardmap[proposedIndex];
+		}
+
+		if (earlierStatus & (YardmapStates::YARDMAP_EXITONLY | YardmapStates::YARDMAP_UNBUILDABLE))
+			return (proposedStatus > YardmapStates::YARDMAP_STACKABLE);
+		if ((earlierStatus & YardmapStates::YARDMAP_BLOCKED) == 0)
+			return false;
+		if (proposedStatus <= YardmapStates::YARDMAP_GEOSTACKABLE)
+			return false;
+		if (earlierStatus == YardmapStates::YARDMAP_BUILDONLY)
+			return false;
+
+		return true;
+	}
+
+	int GetProposedCellIndex(const int2& mapSquare) const
+	{
+		return (mapSquare.y - proposedMins.y) * proposedSize.x + mapSquare.x - proposedMins.x;
+	}
+
+	const int2& GetOverlapMins() const { return overlapMins; }
+	const int2& GetOverlapMaxs() const { return overlapMaxs; }
+	int GetProposedCellCount() const { return proposedSize.x * proposedSize.y; }
+
+private:
+	const BuildInfo& earlier;
+	const BuildInfo& proposed;
+	const int2 earlierSize;
+	const int2 proposedSize;
+	const int2 earlierMins;
+	const int2 proposedMins;
+	const int2 earlierMaxs;
+	const int2 proposedMaxs;
+	const int2 overlapMins;
+	const int2 overlapMaxs;
+	const int2 earlierXRange;
+	const int2 earlierZRange;
+	const int2 proposedXRange;
+	const int2 proposedZRange;
+	const bool rectangularFallback;
+	const bool proposedHasYardMap;
+};
+
+} // namespace
+
+bool AddBlockedCells(
+	const BuildInfo& earlier,
+	const BuildInfo& proposed,
+	bool useYardmaps,
+	std::vector<uint8_t>& blockedCells,
+	size_t& openCellCount
+)
+{
+	if (earlier.def == nullptr || proposed.def == nullptr)
+		return false;
+
+	const CellOverlapTest overlapTest(earlier, proposed, useYardmaps);
+	const size_t proposedCellCount = overlapTest.GetProposedCellCount();
+	if (blockedCells.size() != proposedCellCount) {
+		blockedCells.assign(proposedCellCount, false);
+		openCellCount = proposedCellCount;
+	}
+	if (openCellCount == 0)
+		return true;
+	if (!overlapTest.HasFootprintOverlap())
+		return false;
+
+	const int2& overlapMins = overlapTest.GetOverlapMins();
+	const int2& overlapMaxs = overlapTest.GetOverlapMaxs();
+	const bool emptyMask = (openCellCount == proposedCellCount);
+	for (int z = overlapMins.y; z < overlapMaxs.y; ++z) {
+		if (overlapTest.UsesRectangularFallback() && emptyMask) {
+			const int firstIndex = overlapTest.GetProposedCellIndex({overlapMins.x, z});
+			const int rowCellCount = overlapMaxs.x - overlapMins.x;
+			std::fill_n(blockedCells.begin() + firstIndex, rowCellCount, true);
+			openCellCount -= rowCellCount;
+			continue;
+		}
+
+		for (int x = overlapMins.x; x < overlapMaxs.x; ++x) {
+			const int2 mapSquare = {x, z};
+			uint8_t& blockedCell = blockedCells[overlapTest.GetProposedCellIndex(mapSquare)];
+			if (blockedCell || !overlapTest.BlocksCell(mapSquare))
+				continue;
+
+			blockedCell = true;
+			if (--openCellCount == 0)
+				return true;
+		}
+	}
+
+	return (openCellCount == 0);
+}
+
 Result Test(const BuildInfo& earlier, const BuildInfo& proposed, bool useYardmaps)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -58,68 +199,20 @@ Result Test(const BuildInfo& earlier, const BuildInfo& proposed, bool useYardmap
 	if (earlier.def == nullptr || proposed.def == nullptr)
 		return Result::NONE;
 
-	const int2 earlierSize = {earlier.GetXSize(), earlier.GetZSize()};
-	const int2 proposedSize = {proposed.GetXSize(), proposed.GetZSize()};
-	const int2 earlierMins = {
-		int(earlier.pos.x / SQUARE_SIZE) - (earlierSize.x >> 1),
-		int(earlier.pos.z / SQUARE_SIZE) - (earlierSize.y >> 1),
-	};
-	const int2 proposedMins = {
-		int(proposed.pos.x / SQUARE_SIZE) - (proposedSize.x >> 1),
-		int(proposed.pos.z / SQUARE_SIZE) - (proposedSize.y >> 1),
-	};
-	const int2 earlierMaxs = earlierMins + earlierSize;
-	const int2 proposedMaxs = proposedMins + proposedSize;
-	const int overlapX1 = std::max(earlierMins.x, proposedMins.x);
-	const int overlapX2 = std::min(earlierMaxs.x, proposedMaxs.x);
-	const int overlapZ1 = std::max(earlierMins.y, proposedMins.y);
-	const int overlapZ2 = std::min(earlierMaxs.y, proposedMaxs.y);
-
-	if (overlapX1 >= overlapX2 || overlapZ1 >= overlapZ2)
+	const CellOverlapTest overlapTest(earlier, proposed, useYardmaps);
+	if (!overlapTest.HasFootprintOverlap())
 		return Result::NONE;
 
 	const Result overlapResult = IsInsideCancellationRectangle(earlier, proposed) ? Result::CANCEL : Result::OVERLAP;
-	if (!useYardmaps)
+	if (overlapTest.UsesRectangularFallback())
 		return overlapResult;
 
-	const size_t earlierYardMapSize = earlier.def->xsize * earlier.def->zsize;
-	const size_t proposedYardMapSize = proposed.def->xsize * proposed.def->zsize;
-
-	if (earlier.def->yardmap.size() != earlierYardMapSize)
-		return overlapResult;
-
-	const int2 earlierXRange = {earlierMins.x, earlierMaxs.x};
-	const int2 earlierZRange = {earlierMins.y, earlierMaxs.y};
-	const int2 proposedXRange = {proposedMins.x, proposedMaxs.x};
-	const int2 proposedZRange = {proposedMins.y, proposedMaxs.y};
-	const bool proposedHasYardMap = proposed.def->yardmap.size() == proposedYardMapSize;
-
-	for (int z = overlapZ1; z < overlapZ2; ++z) {
-		for (int x = overlapX1; x < overlapX2; ++x) {
-			const int2 yardPos = {x, z};
-			const int earlierIndex = GetYardMapIndex(earlier.buildFacing, yardPos, earlierXRange, earlierZRange);
-			const YardMapStatus earlierStatus = earlier.def->yardmap[earlierIndex];
-
-			YardMapStatus proposedStatus = YardmapStates::YARDMAP_BLOCKED;
-			if (proposedHasYardMap) {
-				const int proposedIndex = GetYardMapIndex(proposed.buildFacing, yardPos, proposedXRange, proposedZRange);
-				proposedStatus = proposed.def->yardmap[proposedIndex];
-			}
-
-			if (earlierStatus & (YardmapStates::YARDMAP_EXITONLY | YardmapStates::YARDMAP_UNBUILDABLE)) {
-				if (proposedStatus > YardmapStates::YARDMAP_STACKABLE)
-					return overlapResult;
-				continue;
-			}
-
-			if ((earlierStatus & YardmapStates::YARDMAP_BLOCKED) == 0)
-				continue;
-			if (proposedStatus <= YardmapStates::YARDMAP_GEOSTACKABLE)
-				continue;
-			if (earlierStatus == YardmapStates::YARDMAP_BUILDONLY)
-				continue;
-
-			return overlapResult;
+	const int2& overlapMins = overlapTest.GetOverlapMins();
+	const int2& overlapMaxs = overlapTest.GetOverlapMaxs();
+	for (int z = overlapMins.y; z < overlapMaxs.y; ++z) {
+		for (int x = overlapMins.x; x < overlapMaxs.x; ++x) {
+			if (overlapTest.BlocksCell({x, z}))
+				return overlapResult;
 		}
 	}
 

--- a/rts/Sim/Units/QueuedBuildOverlap.cpp
+++ b/rts/Sim/Units/QueuedBuildOverlap.cpp
@@ -1,0 +1,124 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "QueuedBuildOverlap.h"
+
+#include <algorithm>
+
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Units/BuildInfo.h"
+#include "Sim/Units/UnitDef.h"
+#include "System/Misc/TracyDefs.h"
+
+namespace QueuedBuildOverlap {
+
+int GetYardMapIndex(int facing, const int2& yardPos, const int2& xrange, const int2& zrange)
+{
+	int yardX = yardPos.x - xrange.x;
+	int yardZ = yardPos.y - zrange.x;
+	int yardXR = xrange.y - xrange.x;
+	int yardZR = zrange.y - zrange.x;
+
+	switch (facing) {
+		default: break;
+		case FACING_NORTH: {
+			yardX = yardXR - yardX - 1;
+			yardZ = yardZR - yardZ - 1;
+		} break;
+		case FACING_EAST: {
+			yardZ = yardZR - yardZ - 1;
+			std::swap(yardX, yardZ);
+			std::swap(yardXR, yardZR);
+		} break;
+		case FACING_WEST: {
+			yardX = yardXR - yardX - 1;
+			std::swap(yardX, yardZ);
+			std::swap(yardXR, yardZR);
+		} break;
+	}
+
+	return yardX + yardXR * yardZ;
+}
+
+bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& proposed)
+{
+	if (earlier.def == nullptr || proposed.def == nullptr)
+		return false;
+
+	return (
+		math::fabs(earlier.pos.x - proposed.pos.x) * 2 <= std::max(earlier.GetXSize(), proposed.GetXSize()) * SQUARE_SIZE &&
+		math::fabs(earlier.pos.z - proposed.pos.z) * 2 <= std::max(earlier.GetZSize(), proposed.GetZSize()) * SQUARE_SIZE
+	);
+}
+
+bool Test(const BuildInfo& earlier, const BuildInfo& proposed)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+
+	if (earlier.def == nullptr || proposed.def == nullptr)
+		return false;
+
+	const int2 earlierSize = {earlier.GetXSize(), earlier.GetZSize()};
+	const int2 proposedSize = {proposed.GetXSize(), proposed.GetZSize()};
+	const int2 earlierMins = {
+		int(earlier.pos.x / SQUARE_SIZE) - (earlierSize.x >> 1),
+		int(earlier.pos.z / SQUARE_SIZE) - (earlierSize.y >> 1),
+	};
+	const int2 proposedMins = {
+		int(proposed.pos.x / SQUARE_SIZE) - (proposedSize.x >> 1),
+		int(proposed.pos.z / SQUARE_SIZE) - (proposedSize.y >> 1),
+	};
+	const int2 earlierMaxs = earlierMins + earlierSize;
+	const int2 proposedMaxs = proposedMins + proposedSize;
+	const int overlapX1 = std::max(earlierMins.x, proposedMins.x);
+	const int overlapX2 = std::min(earlierMaxs.x, proposedMaxs.x);
+	const int overlapZ1 = std::max(earlierMins.y, proposedMins.y);
+	const int overlapZ2 = std::min(earlierMaxs.y, proposedMaxs.y);
+
+	if (overlapX1 >= overlapX2 || overlapZ1 >= overlapZ2)
+		return false;
+
+	const size_t earlierYardMapSize = earlier.def->xsize * earlier.def->zsize;
+	const size_t proposedYardMapSize = proposed.def->xsize * proposed.def->zsize;
+
+	if (earlier.def->yardmap.size() != earlierYardMapSize)
+		return true;
+
+	const int2 earlierXRange = {earlierMins.x, earlierMaxs.x};
+	const int2 earlierZRange = {earlierMins.y, earlierMaxs.y};
+	const int2 proposedXRange = {proposedMins.x, proposedMaxs.x};
+	const int2 proposedZRange = {proposedMins.y, proposedMaxs.y};
+	const bool proposedHasYardMap = proposed.def->yardmap.size() == proposedYardMapSize;
+
+	for (int z = overlapZ1; z < overlapZ2; ++z) {
+		for (int x = overlapX1; x < overlapX2; ++x) {
+			const int2 yardPos = {x, z};
+			const int earlierIndex = GetYardMapIndex(earlier.buildFacing, yardPos, earlierXRange, earlierZRange);
+			const YardMapStatus earlierStatus = earlier.def->yardmap[earlierIndex];
+
+			YardMapStatus proposedStatus = YardmapStates::YARDMAP_BLOCKED;
+			if (proposedHasYardMap) {
+				const int proposedIndex = GetYardMapIndex(proposed.buildFacing, yardPos, proposedXRange, proposedZRange);
+				proposedStatus = proposed.def->yardmap[proposedIndex];
+			}
+
+			if (earlierStatus & (YardmapStates::YARDMAP_EXITONLY | YardmapStates::YARDMAP_UNBUILDABLE)) {
+				if (proposedStatus > YardmapStates::YARDMAP_STACKABLE)
+					return true;
+				continue;
+			}
+
+			if ((earlierStatus & YardmapStates::YARDMAP_BLOCKED) == 0)
+				continue;
+			if (proposedStatus <= YardmapStates::YARDMAP_GEOSTACKABLE)
+				continue;
+			if (earlierStatus == YardmapStates::YARDMAP_BUILDONLY)
+				continue;
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+} // namespace QueuedBuildOverlap

--- a/rts/Sim/Units/QueuedBuildOverlap.h
+++ b/rts/Sim/Units/QueuedBuildOverlap.h
@@ -1,0 +1,18 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include "System/type2.h"
+
+struct BuildInfo;
+
+namespace QueuedBuildOverlap {
+
+int GetYardMapIndex(int facing, const int2& yardPos, const int2& xrange, const int2& zrange);
+bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& proposed);
+
+/// Whether the earlier footprint would block the proposed footprint if it
+/// already existed. This intentionally mirrors built-building yardmap rules.
+bool Test(const BuildInfo& earlier, const BuildInfo& proposed);
+
+} // namespace QueuedBuildOverlap

--- a/rts/Sim/Units/QueuedBuildOverlap.h
+++ b/rts/Sim/Units/QueuedBuildOverlap.h
@@ -8,11 +8,17 @@ struct BuildInfo;
 
 namespace QueuedBuildOverlap {
 
+enum class Result {
+	NONE,
+	CANCEL,
+	OVERLAP,
+};
+
 int GetYardMapIndex(int facing, const int2& yardPos, const int2& xrange, const int2& zrange);
 bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& proposed);
 
-/// Whether the earlier footprint would block the proposed footprint if it
-/// already existed. This intentionally mirrors built-building yardmap rules.
-bool Test(const BuildInfo& earlier, const BuildInfo& proposed);
+/// Whether the earlier build would cancel or block the proposed build. The
+/// occupied-cell test intentionally mirrors built-building yardmap rules.
+Result Test(const BuildInfo& earlier, const BuildInfo& proposed, bool useYardmaps = true);
 
 } // namespace QueuedBuildOverlap

--- a/rts/Sim/Units/QueuedBuildOverlap.h
+++ b/rts/Sim/Units/QueuedBuildOverlap.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 #include "System/type2.h"
 
 struct BuildInfo;
@@ -16,6 +19,18 @@ enum class Result {
 
 int GetYardMapIndex(int facing, const int2& yardPos, const int2& xrange, const int2& zrange);
 bool IsInsideCancellationRectangle(const BuildInfo& earlier, const BuildInfo& proposed);
+
+/// Add cells blocked by earlier to the proposed-build mask. Existing marked
+/// cells are preserved so callers can accumulate multiple queued commands.
+/// openCellCount must describe blockedCells and is updated by this call. Returns
+/// true once every proposed-build cell is blocked.
+bool AddBlockedCells(
+	const BuildInfo& earlier,
+	const BuildInfo& proposed,
+	bool useYardmaps,
+	std::vector<uint8_t>& blockedCells,
+	size_t& openCellCount
+);
 
 /// Whether the earlier build would cancel or block the proposed build. The
 /// occupied-cell test intentionally mirrors built-building yardmap rules.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -453,6 +453,18 @@ endif()
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "${test_flags}")
 
 ################################################################################
+### QueuedBuildOverlap
+	set(test_name QueuedBuildOverlap)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/engine/Sim/Misc/testQueuedBuildOverlap.cpp"
+			"${ENGINE_SOURCE_DIR}/Sim/Units/QueuedBuildOverlap.cpp"
+			${test_Common_sources}
+		)
+
+	set(test_libs "")
+	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DNOT_USING_CREG -DNOT_USING_STREFLOP -DBUILDING_AI")
+
+################################################################################
 ### Ellipsoid
 	set(test_name Ellipsoid)
 	set(test_src

--- a/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
+++ b/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
@@ -86,26 +86,34 @@ TEST_CASE("Queued build overlap follows yardmaps like successive construction")
 	SECTION("diagonally interlocking solars are compatible") {
 		UnitDef secondSolarDef;
 		const auto secondSolar = MakeBuildInfo({6, 6}, {10, 10}, FACING_SOUTH, &secondSolarDef, solarYardMap);
-		CHECK_FALSE(QueuedBuildOverlap::Test(firstSolar, secondSolar));
-		CHECK_FALSE(QueuedBuildOverlap::Test(secondSolar, firstSolar));
+		CHECK(QueuedBuildOverlap::Test(firstSolar, secondSolar) == QueuedBuildOverlap::Result::NONE);
+		CHECK(QueuedBuildOverlap::Test(secondSolar, firstSolar) == QueuedBuildOverlap::Result::NONE);
+		CHECK(QueuedBuildOverlap::Test(firstSolar, secondSolar, false) == QueuedBuildOverlap::Result::OVERLAP);
+		CHECK(QueuedBuildOverlap::Test(secondSolar, firstSolar, false) == QueuedBuildOverlap::Result::OVERLAP);
 	}
 
 	SECTION("occupied yardmap cells still conflict") {
 		UnitDef samePositionDef;
 		const auto samePosition = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &samePositionDef, solarYardMap);
-		CHECK(QueuedBuildOverlap::Test(firstSolar, samePosition));
+		CHECK(QueuedBuildOverlap::Test(firstSolar, samePosition) == QueuedBuildOverlap::Result::CANCEL);
+	}
+
+	SECTION("outer occupied-cell conflicts overlap without cancelling") {
+		UnitDef outerOverlapDef;
+		const auto outerOverlap = MakeBuildInfo({6, 0}, {10, 10}, FACING_SOUTH, &outerOverlapDef, solarYardMap);
+		CHECK(QueuedBuildOverlap::Test(firstSolar, outerOverlap) == QueuedBuildOverlap::Result::OVERLAP);
 	}
 
 	SECTION("non-overlapping footprints are compatible") {
 		UnitDef distantSolarDef;
 		const auto distantSolar = MakeBuildInfo({10, 10}, {10, 10}, FACING_SOUTH, &distantSolarDef, solarYardMap);
-		CHECK_FALSE(QueuedBuildOverlap::Test(firstSolar, distantSolar));
+		CHECK(QueuedBuildOverlap::Test(firstSolar, distantSolar) == QueuedBuildOverlap::Result::NONE);
 	}
 
 	SECTION("missing blocker yardmap keeps rectangular fallback") {
 		UnitDef noYardMapDef;
 		const auto noYardMap = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &noYardMapDef, {});
-		CHECK(QueuedBuildOverlap::Test(noYardMap, firstSolar));
+		CHECK(QueuedBuildOverlap::Test(noYardMap, firstSolar) == QueuedBuildOverlap::Result::CANCEL);
 	}
 }
 
@@ -118,8 +126,8 @@ TEST_CASE("Queued build overlap is directional")
 	const auto buildOnlyFootprint = MakeBuildInfo({0, 0}, {1, 1}, FACING_SOUTH, &buildOnlyDef, buildOnly);
 	const auto blockedFootprint = MakeBuildInfo({0, 0}, {1, 1}, FACING_SOUTH, &blockedDef, blocked);
 
-	CHECK_FALSE(QueuedBuildOverlap::Test(buildOnlyFootprint, blockedFootprint));
-	CHECK(QueuedBuildOverlap::Test(blockedFootprint, buildOnlyFootprint));
+	CHECK(QueuedBuildOverlap::Test(buildOnlyFootprint, blockedFootprint) == QueuedBuildOverlap::Result::NONE);
+	CHECK(QueuedBuildOverlap::Test(blockedFootprint, buildOnlyFootprint) == QueuedBuildOverlap::Result::CANCEL);
 }
 
 TEST_CASE("Queued build yardmap index handles every facing")

--- a/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
+++ b/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
@@ -1,0 +1,140 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <catch_amalgamated.hpp>
+
+#include <string_view>
+#include <vector>
+
+#include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Units/BuildInfo.h"
+#include "Sim/Units/QueuedBuildOverlap.h"
+#include "Sim/Units/UnitDef.h"
+
+// Keep this focused test independent from the full UnitDef parsing and model
+// dependencies while exercising the production BuildInfo overlap interface.
+SolidObjectDecalDef::SolidObjectDecalDef() = default;
+SolidObjectDef::SolidObjectDef() = default;
+UnitDef::UnitDef() = default;
+BuildInfo::BuildInfo() = default;
+
+int BuildInfo::GetXSize() const
+{
+	return ((buildFacing & 1) == 0) ? def->xsize : def->zsize;
+}
+
+int BuildInfo::GetZSize() const
+{
+	return ((buildFacing & 1) == 1) ? def->xsize : def->zsize;
+}
+
+namespace {
+
+std::vector<YardMapStatus> ExpandLowResolutionYardMap(const std::vector<std::string_view>& rows)
+{
+	std::vector<YardMapStatus> yardMap;
+	yardMap.reserve(rows.size() * rows.front().size() * 4);
+
+	for (const std::string_view row: rows) {
+		for (int z = 0; z < 2; ++z) {
+			for (const char cell: row) {
+				for (int x = 0; x < 2; ++x)
+					yardMap.emplace_back(cell == 'y' ? YARDMAP_OPEN : YARDMAP_BLOCKED);
+			}
+		}
+	}
+
+	return yardMap;
+}
+
+BuildInfo MakeBuildInfo(
+	const int2& mins,
+	const int2& yardMapSize,
+	int facing,
+	UnitDef* unitDef,
+	const std::vector<YardMapStatus>& yardMap
+) {
+	const int2 size = ((facing & 1) == 0) ? yardMapSize : int2{yardMapSize.y, yardMapSize.x};
+	unitDef->xsize = yardMapSize.x;
+	unitDef->zsize = yardMapSize.y;
+	unitDef->yardmap = yardMap;
+
+	BuildInfo buildInfo;
+	buildInfo.def = unitDef;
+	buildInfo.pos = {
+		float((mins.x + (size.x >> 1)) * SQUARE_SIZE),
+		0.0f,
+		float((mins.y + (size.y >> 1)) * SQUARE_SIZE),
+	};
+	buildInfo.buildFacing = facing;
+	return buildInfo;
+}
+
+} // namespace
+
+TEST_CASE("Queued build overlap follows yardmaps like successive construction")
+{
+	const auto solarYardMap = ExpandLowResolutionYardMap({
+		"yyoyy",
+		"yoooy",
+		"ooooo",
+		"yoooy",
+		"yyoyy",
+	});
+	UnitDef firstSolarDef;
+	const auto firstSolar = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &firstSolarDef, solarYardMap);
+
+	SECTION("diagonally interlocking solars are compatible") {
+		UnitDef secondSolarDef;
+		const auto secondSolar = MakeBuildInfo({6, 6}, {10, 10}, FACING_SOUTH, &secondSolarDef, solarYardMap);
+		CHECK_FALSE(QueuedBuildOverlap::Test(firstSolar, secondSolar));
+		CHECK_FALSE(QueuedBuildOverlap::Test(secondSolar, firstSolar));
+	}
+
+	SECTION("occupied yardmap cells still conflict") {
+		UnitDef samePositionDef;
+		const auto samePosition = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &samePositionDef, solarYardMap);
+		CHECK(QueuedBuildOverlap::Test(firstSolar, samePosition));
+	}
+
+	SECTION("non-overlapping footprints are compatible") {
+		UnitDef distantSolarDef;
+		const auto distantSolar = MakeBuildInfo({10, 10}, {10, 10}, FACING_SOUTH, &distantSolarDef, solarYardMap);
+		CHECK_FALSE(QueuedBuildOverlap::Test(firstSolar, distantSolar));
+	}
+
+	SECTION("missing blocker yardmap keeps rectangular fallback") {
+		UnitDef noYardMapDef;
+		const auto noYardMap = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &noYardMapDef, {});
+		CHECK(QueuedBuildOverlap::Test(noYardMap, firstSolar));
+	}
+}
+
+TEST_CASE("Queued build overlap is directional")
+{
+	const std::vector<YardMapStatus> buildOnly = {YARDMAP_BUILDONLY};
+	const std::vector<YardMapStatus> blocked = {YARDMAP_BLOCKED};
+	UnitDef buildOnlyDef;
+	UnitDef blockedDef;
+	const auto buildOnlyFootprint = MakeBuildInfo({0, 0}, {1, 1}, FACING_SOUTH, &buildOnlyDef, buildOnly);
+	const auto blockedFootprint = MakeBuildInfo({0, 0}, {1, 1}, FACING_SOUTH, &blockedDef, blocked);
+
+	CHECK_FALSE(QueuedBuildOverlap::Test(buildOnlyFootprint, blockedFootprint));
+	CHECK(QueuedBuildOverlap::Test(blockedFootprint, buildOnlyFootprint));
+}
+
+TEST_CASE("Queued build yardmap index handles every facing")
+{
+	const int2 southXRange = {0, 2};
+	const int2 southZRange = {0, 3};
+	const int2 eastXRange = {0, 3};
+	const int2 eastZRange = {0, 2};
+
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_SOUTH, {0, 0}, southXRange, southZRange) == 0);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_SOUTH, {1, 2}, southXRange, southZRange) == 5);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_NORTH, {0, 0}, southXRange, southZRange) == 5);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_NORTH, {1, 2}, southXRange, southZRange) == 0);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_EAST, {0, 0}, eastXRange, eastZRange) == 1);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_EAST, {2, 1}, eastXRange, eastZRange) == 4);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_WEST, {0, 0}, eastXRange, eastZRange) == 4);
+	CHECK(QueuedBuildOverlap::GetYardMapIndex(FACING_WEST, {2, 1}, eastXRange, eastZRange) == 1);
+}

--- a/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
+++ b/test/engine/Sim/Misc/testQueuedBuildOverlap.cpp
@@ -2,6 +2,7 @@
 
 #include <catch_amalgamated.hpp>
 
+#include <algorithm>
 #include <string_view>
 #include <vector>
 
@@ -96,6 +97,18 @@ TEST_CASE("Queued build overlap follows yardmaps like successive construction")
 		UnitDef samePositionDef;
 		const auto samePosition = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &samePositionDef, solarYardMap);
 		CHECK(QueuedBuildOverlap::Test(firstSolar, samePosition) == QueuedBuildOverlap::Result::CANCEL);
+
+		std::vector<uint8_t> blockedCells;
+		size_t openCellCount = 0;
+		QueuedBuildOverlap::AddBlockedCells(firstSolar, samePosition, true, blockedCells, openCellCount);
+		CHECK_FALSE(blockedCells[0]);
+		CHECK(blockedCells[4]);
+
+		std::fill(blockedCells.begin(), blockedCells.end(), false);
+		openCellCount = blockedCells.size();
+		CHECK(QueuedBuildOverlap::AddBlockedCells(firstSolar, samePosition, false, blockedCells, openCellCount));
+		CHECK(blockedCells[0]);
+		CHECK(openCellCount == 0);
 	}
 
 	SECTION("outer occupied-cell conflicts overlap without cancelling") {
@@ -114,6 +127,23 @@ TEST_CASE("Queued build overlap follows yardmaps like successive construction")
 		UnitDef noYardMapDef;
 		const auto noYardMap = MakeBuildInfo({0, 0}, {10, 10}, FACING_SOUTH, &noYardMapDef, {});
 		CHECK(QueuedBuildOverlap::Test(noYardMap, firstSolar) == QueuedBuildOverlap::Result::CANCEL);
+	}
+
+	SECTION("rectangular blockers accumulate and report a full mask") {
+		UnitDef proposedDef;
+		UnitDef leftDef;
+		UnitDef rightDef;
+		const auto proposed = MakeBuildInfo({0, 0}, {4, 2}, FACING_SOUTH, &proposedDef, {});
+		const auto left = MakeBuildInfo({0, 0}, {2, 2}, FACING_SOUTH, &leftDef, {});
+		const auto right = MakeBuildInfo({2, 0}, {2, 2}, FACING_SOUTH, &rightDef, {});
+
+		std::vector<uint8_t> blockedCells;
+		size_t openCellCount = 0;
+		CHECK_FALSE(QueuedBuildOverlap::AddBlockedCells(left, proposed, true, blockedCells, openCellCount));
+		CHECK(openCellCount == 4);
+		CHECK(QueuedBuildOverlap::AddBlockedCells(right, proposed, true, blockedCells, openCellCount));
+		CHECK(openCellCount == 0);
+		CHECK(std::ranges::all_of(blockedCells, [](uint8_t blocked) { return blocked; }));
 	}
 }
 


### PR DESCRIPTION
## Goal

- Make queued building placement behave like sequential construction, allowing compatible overlap between buildings with non-rectangular yardmaps.
- Clearly indicate which queued buildings would be removed by the previewed placement.
- Use one authoritative engine overlap decision for queue acceptance, cancellation, native rendering, and Lua pregame handling.

## State before this PR

- Queued build commands were compared using rectangular footprints, unlike completed buildings, which use their facing-aware yardmaps.
- Yardmap-compatible buildings such as interlocking Armada solars could be built successively, but the same placement was rejected while the first solar was still queued or under construction.
- If placing a new building would remove an existing queued building, the existing building remained green and the new building showed all green squares. 
- BAR's Lua build-square widget independently approximated queue overlap using rectangles, which could disagree with the engine.

## Implementation

1. Extract a focused queued-build overlap helper and cover its directional and facing-aware yardmap behavior with tests.
2. Keep the existing rectangular comparison as the broad phase, then compare the relevant yardmap cells for overlapping candidates.
3. Use the shared helper in both `GetCancelQueued` and `GetOverlapQueued`, so accepting and removing queued commands follow the same rule.
4. Add `Spring.TestBuildOrderOverlap(queuedBuild, proposedBuild)` so Lua-only pregame queues can use the authoritative engine decision.
5. Keep queued-build rendering in C++. Each queued command uses its normal color or the configurable `buildBoxCancel` color when the previewed placement would remove that command. The default cancel color is red.
6. Keep the existing `DrawBuildSquare` Lua call-in unchanged. Its cell statuses already include conflicting queued commands, so games can derive their existing invalid-placement presentation without another API parameter.

Buildings without a valid yardmap retain conservative rectangular overlap behavior. The new behavior is disabled by default for backward compatibility. Games can set `construction.useYardmapsForQueuedBuildOverlap = true` in `gamedata/modrules.lua` to enable yardmap-aware queued-build overlap.

The implementation is split into five reviewable commits: tested helper extraction, queue behavior (including the backward-compatible modrule default), Lua query API, native rendering with cancellation highlighting, and yardmap-aware preview rendering (including the queued-build preview-state fix).

**Depends on #3296.** This branch is rebased on top of #3296's fix for the build-square preview cache OOB/flicker bug, so its two commits (`Fix build preview cache keys`, `Verify build preview cache UnitDef IDs`) currently appear first in this diff. They are not part of this PR's own change; the diff will shrink to this PR's five commits once #3296 merges to master.

Related to beyond-all-reason/Beyond-All-Reason#8714.

Companion BAR PR: https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8715


## Detailed changes and differences between pregame and ingame

### Build-placement behavior comparison

#### Terminology

- **Queue overlap:** overlap with an earlier queued build.
- **Cancel region:** overlap large enough that clicking removes the earlier queued build.
- **Yardmap overlap:** occupied yardmap cells intersect.
- **Before 🟢 → after:** behavior before and after the yardmap-aware queue change. The green marker highlights changed
  behavior.
- **—:** no earlier queued build is involved.
- 🟡 possible later improvements, see footnotes

The case “inside the cancel region without yardmap overlap” cannot be tested independently as I BAR currently has no unit combination that can overlap inside the cancel region without a yardmap overlap.

#### Pregame

| Placement scenario                            | Earlier queued build   | Non-BuildSquare GL4 preview  | BuildSquare GL4 preview                                   | Click result                                          |
|-----------------------------------------------|------------------------|------------------------------|-----------------------------------------------------------|-------------------------------------------------------|
| Free space                                    | —                      | Green square                 | All cells green                                           | New build is queued                                   |
| Terrain obstruction or invalid slope/other constraints anywhere in the rectangular footprint, including open yardmap cells | — | Red square | All cells red 🟡 1) | New build is not queued |
| Slight queue overlap, with yardmap overlap    | Keeps its green square | Red square                   | All cells red, regardless of which cells overlap     🟡 1)     | Nothing happens                                       |
| Slight queue overlap, without yardmap overlap | Keeps its green square | Red square 🟢 → green square | All cells red 🟢 → all cells green                        | Nothing happens 🟢 → new build is queued              |
| Inside cancel region, with yardmap overlap    | Gets a red square      | Green square                 | Red outline; overlapping cells red; remaining cells green | Earlier build is dequeued                             |
| Over commander/builder                        | —                      | Green square                 | All cells green                                           | A red square appears briefly; new build is not queued 🟢 → new build is queued |

#### In-game

| Placement scenario                                   | Earlier queued build         | Non-BuildSquare GL4 preview                                                                             | BuildSquare GL4 preview                                                                                       | Click result                             |
|------------------------------------------------------|------------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|------------------------------------------|
| Free space                                           | —                            | All cells green                                                                                         | All cells green                                                                                               | New build is queued                      |
| Terrain obstruction or invalid slope/other constraints anywhere in the rectangular footprint, including open yardmap cells | — | Actual obstructed cells red; rest yellow. A slope-only or other non-cell-specific rejection may show no red cells. 🟡 2) | Actual obstructed cells red; rest yellow. A slope-only or other non-cell-specific rejection may show no red cells. 🟡 2) | New build is not queued |
| Completed building, with yardmap overlap             | —                            | Yardmap-conflicting cells red; rest yellow                                                              | Yardmap-conflicting cells red; rest yellow                                                                    | New build is not queued                  |
| Completed building, without yardmap overlap          | —                            | Same as free space                                                                                      | Same as free space                                                                                            | New build is queued                      |
| Slight queue overlap, with yardmap overlap           | Keeps its green square       | Cells intersecting the earlier build’s square outline red; rest yellow 🟢 → overlapping cells red; rest yellow  | Cells intersecting the earlier build’s square outline red; rest yellow 🟢 → overlapping cells red; rest yellow     | Nothing happens                          |
| Slight queue overlap, without yardmap overlap        | Keeps its green square       | Cells intersecting the earlier build’s square outline red; rest yellow 🟢 → all cells green 🟡 3)                    | Cells intersecting the earlier build’s outline red; rest yellow 🟢 → all cells green                          | Nothing happens 🟢 → new build is queued |
| Inside cancel region, with yardmap overlap           | Green square 🟢 → red square | All cells green 🟢 → overlapping cells red; remaining cells green                                       | All cells green 🟢 → overlapping cells red; rest yellow                                                       | Earlier build is dequeued                |
| Building under construction, with yardmap overlap    | —                            | Cells intersecting the square building outline red; rest yellow   🟢 → overlapping cells red; rest yellow    | Red outline; cells intersecting the square building outline red; rest yellow 🟢 → overlapping cells red; rest yellow  | Nothing happens                          |
| Building under construction, without yardmap overlap | —                            | Cells intersecting the building outline red; rest yellow 🟢 → all cells green  🟡 3)                       | Cells intersecting the building outline red; rest yellow 🟢 → all cells green                                 | Nothing happens 🟢 → new build is queued |
| Over commander/builder/unit                          | —                            | Green square; unit-occupied cells yellow                                                                | Free cells green; unit-occupied cells yellow                                                                  | New build is queued                      |

#### Visual verification screenshots

Click a thumbnail to open the full-resolution image.

Notice: The screenshots are with an earlier BAR version, it has been rechecked with current bar (as of 30/8/2026) but screenshots have not been updated.

| Placement scenario | No GL4 — Pregame | With GL4 — Pregame | No GL4 — In-game | With GL4 — In-game |
|---|---|---|---|---|
| Free space | <a href="https://github.com/user-attachments/assets/c89bd5f4-faed-482f-8e11-d704fb443053"><img src="https://github.com/user-attachments/assets/c89bd5f4-faed-482f-8e11-d704fb443053" width="225" alt="Pregame free space without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/021a0ba7-de64-41c0-9142-447279708681"><img src="https://github.com/user-attachments/assets/021a0ba7-de64-41c0-9142-447279708681" width="225" alt="Pregame free space with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/c079e4f6-b62f-46ab-a232-b23caf3bb54f"><img src="https://github.com/user-attachments/assets/c079e4f6-b62f-46ab-a232-b23caf3bb54f" width="225" alt="In-game free space without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/49c1fb4c-85f0-4873-9c55-13666ffba928"><img src="https://github.com/user-attachments/assets/49c1fb4c-85f0-4873-9c55-13666ffba928" width="225" alt="In-game free space with BuildSquare GL4"></a> |
| Terrain obstruction or invalid slope | <a href="https://github.com/user-attachments/assets/a2b7e354-2593-4652-808d-60342487102b"><img src="https://github.com/user-attachments/assets/a2b7e354-2593-4652-808d-60342487102b" width="225" alt="Pregame terrain obstruction without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/c01a3191-41d2-4342-a29a-f837282202a3"><img src="https://github.com/user-attachments/assets/c01a3191-41d2-4342-a29a-f837282202a3" width="225" alt="Pregame terrain obstruction with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/40c0f332-05e5-4f93-9c61-2e754f72bd7b"><img src="https://github.com/user-attachments/assets/40c0f332-05e5-4f93-9c61-2e754f72bd7b" width="225" alt="In-game terrain obstruction without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/d9766520-6f4d-4bbb-a571-a84ec187e52d"><img src="https://github.com/user-attachments/assets/d9766520-6f4d-4bbb-a571-a84ec187e52d" width="225" alt="In-game terrain obstruction with BuildSquare GL4"></a> |
| Slight queue overlap, with yardmap overlap | <a href="https://github.com/user-attachments/assets/ecc41535-6637-475a-96f4-3184ee7915e5"><img src="https://github.com/user-attachments/assets/ecc41535-6637-475a-96f4-3184ee7915e5" width="225" alt="Pregame conflicting queue overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/f4cde157-4f39-467d-bf44-57dd1628dd96"><img src="https://github.com/user-attachments/assets/f4cde157-4f39-467d-bf44-57dd1628dd96" width="225" alt="Pregame conflicting queue overlap with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/f7d974ae-54c3-4f60-a85b-731fd820c732"><img src="https://github.com/user-attachments/assets/f7d974ae-54c3-4f60-a85b-731fd820c732" width="225" alt="In-game conflicting queue overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/29a9ba7c-2f6a-4e78-9f59-639ba300ab52"><img src="https://github.com/user-attachments/assets/29a9ba7c-2f6a-4e78-9f59-639ba300ab52" width="225" alt="In-game conflicting queue overlap with BuildSquare GL4"></a> |
| Slight queue overlap, without yardmap overlap | <a href="https://github.com/user-attachments/assets/570e0bdb-d7fa-45e0-b017-e192a5860fd8"><img src="https://github.com/user-attachments/assets/570e0bdb-d7fa-45e0-b017-e192a5860fd8" width="225" alt="Pregame compatible queue overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/34433b88-dd91-4fbb-b43e-e06d77f5fabc"><img src="https://github.com/user-attachments/assets/34433b88-dd91-4fbb-b43e-e06d77f5fabc" width="225" alt="Pregame compatible queue overlap with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/548b4043-2105-4d09-9856-6a6a255ab986"><img src="https://github.com/user-attachments/assets/548b4043-2105-4d09-9856-6a6a255ab986" width="225" alt="In-game compatible queue overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/e3b2e1d5-04bb-491b-8329-1b5d86aa29e4"><img src="https://github.com/user-attachments/assets/e3b2e1d5-04bb-491b-8329-1b5d86aa29e4" width="225" alt="In-game compatible queue overlap with BuildSquare GL4"></a> |
| Inside cancel region, with yardmap overlap | <a href="https://github.com/user-attachments/assets/91498b91-0ff0-488b-931f-75e03e9faf91"><img src="https://github.com/user-attachments/assets/91498b91-0ff0-488b-931f-75e03e9faf91" width="225" alt="Pregame queue overlap inside the cancel region without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/e07b93f8-3336-466b-af96-1f77cf31c15a"><img src="https://github.com/user-attachments/assets/e07b93f8-3336-466b-af96-1f77cf31c15a" width="225" alt="Pregame queue overlap inside the cancel region with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/cea98bb7-ae41-4548-b5ed-278d03b44744"><img src="https://github.com/user-attachments/assets/cea98bb7-ae41-4548-b5ed-278d03b44744" width="225" alt="In-game queue overlap inside the cancel region without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/14d06cb3-8ccd-4442-8b01-a1eab4a372f2"><img src="https://github.com/user-attachments/assets/14d06cb3-8ccd-4442-8b01-a1eab4a372f2" width="225" alt="In-game queue overlap inside the cancel region with BuildSquare GL4"></a> |
| Completed building, with yardmap overlap | — | — | <a href="https://github.com/user-attachments/assets/e69bd537-6e9b-456c-a3e5-a6711d5c3af5"><img src="https://github.com/user-attachments/assets/e69bd537-6e9b-456c-a3e5-a6711d5c3af5" width="225" alt="In-game completed building with yardmap overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/88181f46-882b-4163-8e61-7a009cd47c07"><img src="https://github.com/user-attachments/assets/88181f46-882b-4163-8e61-7a009cd47c07" width="225" alt="In-game completed building with yardmap overlap with BuildSquare GL4"></a> |
| Completed building, without yardmap overlap | — | — | <a href="https://github.com/user-attachments/assets/fe4de54a-3019-4009-a86b-ddf5f8b28821"><img src="https://github.com/user-attachments/assets/fe4de54a-3019-4009-a86b-ddf5f8b28821" width="225" alt="In-game completed building without yardmap overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/e7bea515-0f7e-4d71-be40-9efc49af4175"><img src="https://github.com/user-attachments/assets/e7bea515-0f7e-4d71-be40-9efc49af4175" width="225" alt="In-game completed building without yardmap overlap with BuildSquare GL4"></a> |
| Building under construction, with yardmap overlap | — | — | <a href="https://github.com/user-attachments/assets/1d0e305e-4eb2-4290-90d0-e46e378c8af4"><img src="https://github.com/user-attachments/assets/1d0e305e-4eb2-4290-90d0-e46e378c8af4" width="225" alt="In-game building under construction with yardmap overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/6d2f37a6-4648-4126-95d7-266bed413e7e"><img src="https://github.com/user-attachments/assets/6d2f37a6-4648-4126-95d7-266bed413e7e" width="225" alt="In-game building under construction with yardmap overlap with BuildSquare GL4"></a> |
| Building under construction, without yardmap overlap | — | — | <a href="https://github.com/user-attachments/assets/759a829c-cdf8-4437-bad7-7673287b5c48"><img src="https://github.com/user-attachments/assets/759a829c-cdf8-4437-bad7-7673287b5c48" width="225" alt="In-game building under construction without yardmap overlap without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/b768ac1d-cf77-40ab-8f24-03502280175e"><img src="https://github.com/user-attachments/assets/b768ac1d-cf77-40ab-8f24-03502280175e" width="225" alt="In-game building under construction without yardmap overlap with BuildSquare GL4"></a> |
| Over commander/builder/unit | <a href="https://github.com/user-attachments/assets/a00ea660-368b-4fa6-b8f2-4c542920d194"><img src="https://github.com/user-attachments/assets/a00ea660-368b-4fa6-b8f2-4c542920d194" width="225" alt="Pregame placement over the commander without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/88d46c92-b6db-4ef2-99af-dca3d19dcba3"><img src="https://github.com/user-attachments/assets/88d46c92-b6db-4ef2-99af-dca3d19dcba3" width="225" alt="Pregame placement over the commander with BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/d4b02c41-c992-429d-961d-3abff0bbd917"><img src="https://github.com/user-attachments/assets/d4b02c41-c992-429d-961d-3abff0bbd917" width="225" alt="In-game placement over the commander without BuildSquare GL4"></a> | <a href="https://github.com/user-attachments/assets/6b8778df-88d5-4a70-90ba-fc3ed3572df9"><img src="https://github.com/user-attachments/assets/6b8778df-88d5-4a70-90ba-fc3ed3572df9" width="225" alt="In-game placement over the commander with BuildSquare GL4"></a> |
Footnotes

🟡 1) Pregame receives only the overall placement result for these cases, so BuildSquare GL4 shows the entire footprint red for terrain obstruction or queued yardmap conflict rather than identifying individual cells. Providing exact per-cell causes would require an interface change and is outside this PR.

🟡 2) Slope and other non-cell-specific placement failures reject the build without identifying individual blocked cells, so the preview may contain no red cells. Actual obstructed cells are painted red. Obstruction anywhere in the rectangular footprint, including open yardmap cells, still rejects the build.

🟡 3) Without BuildSquare GL4 if there is a blocked cell but no yardmap overlap, the preview shows all cells green. It could show the covered but non intersecting cells yellow. BuildSquare GL4 does show only the cells occupied in the yardmap and does not have this issue. This is acceptable for BAR.


#### Pregame vs in-game differences

Cases that were consistent both before and after the change are omitted.

🟢 resolved · 🟡 preview difference only · 🔴 click/behavior difference

| Placement scenario | Before: pregame vs in-game | After: pregame vs in-game | Status |
|---|---|---|---|
| Terrain obstruction or invalid slope/other constraints anywhere in the rectangular footprint, including open yardmap cells | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes actual obstructed cells; slope-only rejection may identify no red cells | Unchanged | 🟡 **Remains:** previews differ |
| Slight queue overlap, with yardmap overlap | Both reject the build, but pregame shows the whole footprint red while in-game distinguishes yardmap-conflicting cells | Both still reject the build; pregame remains entirely red while in-game now marks only yardmap-conflicting cells red | 🟡 **Remains:** previews differ |
| Slight queue overlap, without yardmap overlap | Both reject the build, with different blocked previews | Both show a green preview and queue the new build | 🟢 **Resolved** |
| Inside cancel region, with yardmap overlap | Both dequeue the earlier build, but pregame and in-game highlight the cancellation differently | Both mark the earlier build and overlapping cells red and dequeue it, but outline and remaining-cell colors still differ | 🟡 **Remains:** previews differ |
| Over commander/builder | Pregame rejects the build despite a green preview; in-game marks occupied cells yellow and queues it | Both queue the build; the commander moves out of the footprint before building | 🟢 **Resolved** |

#### Design notes

- The former pregame commander restriction was introduced by [BAR PR #1515](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/1515) to address [issue #803](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/803), where an already-spawned commander could start constructing over itself. That original case no longer reproduces: for a pregame queue, the commander moves out of the footprint at game start before building. The companion BAR PR keeps the restriction configurable and now allows the placement by default.


## Testing

- `test_QueuedBuildOverlap`: 28 assertions in 3 test cases passed.
- `test_EventClient`: 2 assertions passed.
- Built successfully for legacy, headless, dedicated, and unitsync.
- BAR's complete headless integration suite passes with the local engine, including the focused pregame faction-substitution overlap test.
- Verified the engine default remains rectangle-only and BAR explicitly opts into yardmap-aware behavior.
- The rebased BAR headless integration suite passes against the local PR engine.
- Verified compatible and conflicting yardmap overlaps for all four facings.
- Manually verified pregame and in-game behavior on All That Glitters v2.2.3.
- Verified with BuildSquare GL4 enabled and disabled.



## Performance considerations

This is an algorithmic comparison; no frame-time benchmark was performed. Let `P` be the proposed building's footprint-cell count, `Q` the number of queued candidates examined, and `Iᵢ` the footprint-intersection cell count for candidate `i`.

- 🟢 Faster or the same performance as before this PR.
- 🟡 Similar complexity, but potentially slower depending on the input or caller.
- 🔴 Actually slower: necessarily performs additional work compared with before this PR.

| Path | Before this PR | PR with default behavior (`useYardmapsForQueuedBuildOverlap = false`) | PR with yardmap checks enabled |
|---|---|---|---|
| Queue acceptance and cancellation | Rectangle arithmetic per queued candidate: `O(Q)`. | 🟡 Still `O(Q)`. Each candidate computes its footprint intersection and cancellation rectangle, then returns through the rectangular fallback without visiting cells. This has slightly different fixed setup cost but no yardmap-cell loop. | 🔴 The same rectangle broad phase runs first. Only candidates whose footprints intersect enter the facing-aware cell test: `O(Q + ΣIᵢ)` worst case, with an early return on the first blocking cell. An earlier building without a valid yardmap still takes the constant-time rectangular fallback. |
| Per-cell build preview | For every proposed-footprint cell, scan queued candidates until one covers it: `O(P × Q)` worst case. This repeatedly constructed `BuildInfo` and repeated rectangle arithmetic inside the nested loop. | 🟡 Build each queued `BuildInfo` once, rasterize intersecting rectangles into a `P`-byte mask, then read the mask once per preview cell: `O(P + Q + ΣIᵢ)`. Empty masks use row fills; already-blocked cells are skipped; processing stops when all `P` cells are blocked. Sparse or multiple candidates avoid the former repeated queue scan, but one early full-footprint blocker can have somewhat higher constant overhead because the mask is initialized, written, and read. | 🟡 Uses the same mask structure and early exits. For each not-yet-blocked intersection cell it additionally maps one or both facing-aware yardmap indices, reads their statuses, and applies the blocking rules. The worst case remains `O(P × Q)` when many candidates overlap most of the footprint. This can be slower per visited cell, while rectangle rejection, constructing each `BuildInfo` once, and already-blocked-cell skipping can make other queue shapes faster. |
| Lua-side work and API | No engine overlap query. BAR's pregame code performed rectangle geometry itself, while BuildSquare GL4 reconstructed and scanned selected builders' queued footprints for previews. | 🟢 Lua does less work in the companion BAR change: pregame delegates overlap classification to the C++ helper, and BuildSquare GL4 no longer reconstructs or scans the command queue for its own overlap approximation. `Spring.TestBuildOrderOverlap` adds no automatic calls; when BAR invokes it, each comparison replaces Lua geometry with one Lua-to-C++ crossing and receives the rectangular fallback result. | 🟡 Lua still does less work and makes the same number of explicit overlap-query calls as in default mode. Each invoked comparison additionally pays the C++ yardmap narrow-phase cost described above. The native in-game preview adds no Lua-to-C++ calls. |
| Native queued-outline rendering | Traverse queued builds and generate one normal-color vertex buffer. | 🟡 Independent of the modrule: the traversal remains, with command-tag lookups and an additional temporary vertex buffer for cancelled outlines. Rendering still uses one draw call when no outlines are cancelled or when all outlines are cancelled; it uses up to one additional draw call only when normal and cancelled outlines are both visible. Identifying an active nanoframe adds at most one command-queue scan per selected active builder during a preview pass. | 🟡 Same rendering cost as default behavior; the modrule changes overlap classification, not the outline-rendering algorithm. |

The additional preview memory is proportional to the proposed footprint (`P` bytes for the blocked-cell mask), plus the temporary cancelled-outline vertex buffer. Building footprints are small compared with unit counts, and all new yardmap work is unsynced preview work or command-time validation rather than a per-unit simulation update.


## Videos

### Before

https://github.com/user-attachments/assets/3ac1a36b-4e8a-40a0-83d8-9f5145fe214a

### After

https://github.com/user-attachments/assets/014715c5-54b9-425b-a250-9afd8c36b2fa

## AI disclosure

OpenAI Codex was used interactively to trace the relevant engine and Lua paths, draft the implementation and focused tests, and assist with build and test commands. I reviewed the changes and manually verified the behavior in-game.









