### PR TITLE
RmlUi Lua: expose version as a string field

### DIFF
--- a/rts/Rml/SolLua/bind/Global.cpp
+++ b/rts/Rml/SolLua/bind/Global.cpp
@@ -290,7 +290,7 @@
 			 "contexts", sol::readonly_property(&getIndexedTable<Rml::Context, &functions::getContext, &functions::getMaxContexts>),
 			 //--
 			 /*** @field RmlUi.version string RmlUi version */
-			 "version", sol::readonly_property(&Rml::GetVersion)
+			 "version", Rml::GetVersion()
 		 );
 		namespace_table.set_function(
 			/***

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -526,6 +526,48 @@ endif()
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "")
 
 ################################################################################
+### RmlSolLuaPublicBindings
+	find_package(PNG QUIET)
+
+	set(test_name RmlSolLuaPublicBindings)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/engine/Rml/TestSolLuaPublicBindings.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/bind.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Colour.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Convert.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Context.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/DataModel.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Document.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Element.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/ElementDerived.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/ElementForm.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Event.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/bind/Global.cpp"
+			"${ENGINE_SOURCE_DIR}/Lua/LuaMemPool.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/plugin/SolLuaDocument.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/plugin/SolLuaEventListener.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/plugin/SolLuaInstancer.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/plugin/SolLuaDataModel.cpp"
+			"${ENGINE_SOURCE_DIR}/Rml/SolLua/plugin/SolLuaPlugin.cpp"
+			"${ENGINE_SOURCE_DIR}/System/Misc/SpringTime.cpp"
+			${sources_engine_System_Threading}
+			${test_Common_sources}
+		)
+	set(test_libs
+			rmlui_core
+			lua
+			smmalloc
+		)
+	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DNOT_USING_CREG -DBUILDING_AI")
+	target_link_libraries(test_${test_name} ${FREETYPE_LIBRARY_RELEASE} ZLIB::ZLIB SDL2::SDL2)
+	if (TARGET PNG::PNG)
+		target_link_libraries(test_${test_name} PNG::PNG)
+	endif ()
+	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/)
+	target_include_directories(test_${test_name} PRIVATE ${ENGINE_SOURCE_DIR}/lib/lua/include)
+	target_include_directories(test_${test_name} PRIVATE ${SDL2_INCLUDE_DIRS})
+
+################################################################################
 ### SerializeLuaState
 	set(test_name SerializeLuaState)
 	set(test_src

--- a/test/engine/Rml/TestSolLuaPublicBindings.cpp
+++ b/test/engine/Rml/TestSolLuaPublicBindings.cpp
@@ -1,0 +1,122 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <catch_amalgamated.hpp>
+
+#include "Rml/SolLua/bind/bind.h"
+#include "Rml/Backends/RmlUi_SystemInterface.h"
+#include "Rml/SolLua/plugin/SolLuaPlugin.h"
+
+#include <RmlUi/Core.h>
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/RenderInterface.h>
+
+#include <sol2/sol.hpp>
+
+namespace
+{
+class NullRenderInterface final : public Rml::RenderInterface
+{
+public:
+	Rml::CompiledGeometryHandle CompileGeometry(Rml::Span<const Rml::Vertex>, Rml::Span<const int>) override { return {}; }
+	void RenderGeometry(Rml::CompiledGeometryHandle, Rml::Vector2f, Rml::TextureHandle) override {}
+	void ReleaseGeometry(Rml::CompiledGeometryHandle) override {}
+
+	Rml::TextureHandle LoadTexture(Rml::Vector2i& textureDimensions, const Rml::String&) override
+	{
+		textureDimensions = {};
+		return {};
+	}
+
+	Rml::TextureHandle GenerateTexture(Rml::Span<const Rml::byte>, Rml::Vector2i) override { return {}; }
+	void ReleaseTexture(Rml::TextureHandle) override {}
+	void EnableScissorRegion(bool) override {}
+	void SetScissorRegion(Rml::Rectanglei) override {}
+};
+
+struct BindingFixture
+{
+	BindingFixture(const char* contextName)
+		: renderInterface()
+		, lua()
+	{
+		Rml::SetRenderInterface(&renderInterface);
+		REQUIRE(Rml::Initialise());
+
+		lua.open_libraries(sol::lib::base);
+		plugin = new Rml::SolLua::SolLuaPlugin(lua, "rmlPublicBindings");
+		Rml::RegisterPlugin(plugin);
+
+		namespaceTable = lua.create_named_table("RmlUi");
+		Rml::SolLua::bind_global(namespaceTable, plugin);
+		Rml::SolLua::bind_context(namespaceTable, plugin);
+		Rml::SolLua::bind_document(namespaceTable);
+		Rml::SolLua::bind_element(namespaceTable);
+		Rml::SolLua::bind_element_derived(namespaceTable);
+		Rml::SolLua::bind_element_form(namespaceTable);
+		Rml::SolLua::bind_event(namespaceTable);
+
+		context = Rml::CreateContext(contextName, {1024, 768});
+		REQUIRE(context != nullptr);
+		lua["context"] = context;
+	}
+
+	~BindingFixture()
+	{
+		if (context != nullptr)
+			Rml::RemoveContext(context->GetName());
+		Rml::UnregisterPlugin(plugin);
+		Rml::Shutdown();
+	}
+
+	NullRenderInterface renderInterface;
+	sol::state lua;
+	sol::table namespaceTable;
+	Rml::SolLua::SolLuaPlugin* plugin = nullptr;
+	Rml::Context* context = nullptr;
+};
+
+void requireLuaSuccess(const sol::protected_function_result& result)
+{
+	REQUIRE(result.valid());
+}
+} // namespace
+
+namespace RmlGui
+{
+void MarkContextForRemoval(Rml::Context*) {}
+void SetDebugContext(Rml::Context*) {}
+bool ClearDebugContext(Rml::Context*) { return true; }
+Rml::Context* GetOrCreateContext(const std::string& name)
+{
+	if (auto* context = Rml::GetContext(name); context != nullptr)
+		return context;
+	return Rml::CreateContext(name, {1024, 768});
+}
+Rml::Context* GetContext(const std::string& name) { return Rml::GetContext(name); }
+void BeginFrame() {}
+void PresentFrame() {}
+void SetMouseCursorAlias(std::string, std::string) {}
+} // namespace RmlGui
+
+void AddPendingDelete(Rml::ElementPtr) {}
+
+std::vector<std::string> RmlSystemInterface::GetDocumentPathRequests(const Rml::String&)
+{
+	return {};
+}
+
+void RmlSystemInterface::ClearDocumentPathRequests(const Rml::String&)
+{
+}
+
+TEST_CASE("RmlUi.version is exposed as a string")
+{
+	BindingFixture fixture("sol-lua-version");
+
+	auto result = fixture.lua.safe_script(
+		"assert(type(RmlUi.version) == 'string')\n"
+		"assert(#RmlUi.version > 0)"
+	);
+	requireLuaSuccess(result);
+}


### PR DESCRIPTION
I think the original intention (per original docstring) here was to make it a property rather than the function, so fixing it like so. Also adding a test setup that will be used in other places, so these errors / crashes can be asserted.

Test setup is a bit of an overkill for this one thing 

-- AI below (GPT 5.6 Luna Max) --

## What changed

Expose `RmlUi.version` as the evaluated version string.

## Why

The binding currently installs a callable property, while the documented API is a string field.

## Validation

- ASAN `test_RmlSolLuaPublicBindings "RmlUi.version is exposed as a string"` — 3 assertions passed.
