### PR TITLE
CI: grant release workflow contents permission

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -50,6 +50,8 @@ jobs:
     secrets: inherit
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build-engine, build-engine-tracy, get-tag]
     steps:
       - name: Download All Artifacts


### PR DESCRIPTION
I think the BAR repo has this as default but forks might not have it. It doesn't hurt BAR to make forks work by default.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Grant the release job `contents: write` permission.

## Why

The job creates a GitHub release after downloading the build artifacts and needs explicit permission to do so.

## Validation

- Reviewed the workflow permissions and release-job steps.
