### PR TITLE
Base content: reference the available scar textures

### DIFF
--- a/cont/base/springcontent/gamedata/resources.lua
+++ b/cont/base/springcontent/gamedata/resources.lua
@@ -71,10 +71,8 @@ if (resources == nil) then
 				'smoke/smoke11.tga',
 			},
 			scars = {
-				'scars/scar1.bmp',
-				'scars/scar2.bmp',
-				'scars/scar3.bmp',
-				'scars/scar4.bmp',
+				'scars/scar1.tga',
+				'scars/scar2.tga',
 			},
 			trees = {
 				bark		=	'Bark.bmp',


### PR DESCRIPTION
Just kills a bunch of annoying warnings I see whenever I open SpringBoard. AI wrote up a test for this originally (checking whether all scars exist) but I didn't like it, so it's gone. 
I think a better test would be to make sure an empty archive loads without warnings, but I think I'll skip the scope creep here.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Update the base resource manifest to reference the two shipped TGA scar textures.

## Why

The manifest listed four obsolete BMP paths that are not packaged.

## Validation

- Confirmed both referenced TGA files are included by `cont/base/bitmaps/CMakeLists.txt`.
