### PR TITLE
Lighting: refresh grass and shaders after Lua sun changes

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4201,6 +4201,8 @@ int LuaUnsyncedCtrl::SetSunDirection(lua_State* L)
 	auto dir = float3(luaL_checkfloat(L, 1), luaL_checkfloat(L, 2), luaL_checkfloat(L, 3));
 	auto intensity = luaL_optfloat(L, 4, 1.0f); // seems broken atm, only toggles shadows off when set to 0
 	ISky::GetSky()->GetLight()->SetLightDir(float4(dir.SafeNormalize(), intensity));
+	sunLighting->SetUpdated();
+	eventHandler.SunChanged();
 	return 0;
 }
 

--- a/rts/Rendering/Env/GrassDrawer.cpp
+++ b/rts/Rendering/Env/GrassDrawer.cpp
@@ -373,7 +373,7 @@ void CGrassDrawer::EnableShader(const GrassShaderProgram type) {
 	grassShader->SetUniform3v("ambientLightColor",  &sunLighting->modelAmbientColor.x);
 	grassShader->SetUniform3v("diffuseLightColor",  &sunLighting->modelDiffuseColor.x);
 	grassShader->SetUniform3v("specularLightColor", &sunLighting->modelSpecularColor.x);
-	grassShader->SetUniform3v("sunDir",             &mapInfo->light.sunDir.x);
+	grassShader->SetUniform3v("sunDir",             &ISky::GetSky()->GetLight()->GetLightDir().x);
 }
 
 
@@ -1062,5 +1062,3 @@ void CGrassDrawer::UnsyncedHeightMapUpdate(const SRectangle& rect)
 		}
 	}
 }
-
-


### PR DESCRIPTION
Again another thing I noticed when I used SpringBoard. Lighting wasn't refreshing right.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Refresh lighting consumers when Lua changes the sun direction, and make grass use the current sky-light direction.

## Why

Changing the sun direction updated the sky light without notifying the dependent lighting paths.

## Validation

- Manual renderer check: call `Spring.SetSunDirection` and verify grass and terrain lighting update immediately.
