### PR TITLE
Windows: undefine the MemoryBarrier macro

### DIFF
--- a/rts/System/Platform/Win/win32.h
+++ b/rts/System/Platform/Win/win32.h
@@ -31,6 +31,7 @@
 		#undef DeleteFile
 		#undef SendMessage
 		#undef GetCharWidth
+		#undef MemoryBarrier
 		#undef far
 		#undef near
 		#undef FAR


### PR DESCRIPTION
Probably doesn't matter for current engine, but I found this an issue when I worked on some diff feature. Doesn't hurt to have imo, as you _might_ get conflicts on Windows later down the line.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Undefine the `MemoryBarrier` macro after including the Windows platform header.

## Why

The Windows macro conflicts with the engine symbol of the same name.

## Validation

- Windows build validation.
