### PR TITLE
CMake: make test setup configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,8 +696,11 @@ add_subdirectory(rts)
 
 # Unit tests
 # this has to be in root CMakeLists.txt
-enable_testing()
-add_subdirectory(test)
+option(BUILD_TESTING "Build engine tests" ON)
+if (BUILD_TESTING)
+	enable_testing()
+	add_subdirectory(test)
+endif ()
 
 if (INSTALL_PORTABLE)
 	install(DIRECTORY DESTINATION games)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,7 +73,9 @@ set(test_common_libraries
 	fmt::fmt
 )
 
-add_custom_target(tests)
+if(NOT TARGET tests)
+	add_custom_target(tests)
+endif()
 add_custom_target(check ${CMAKE_CTEST_COMMAND} --output-on-failure -V
 	DEPENDS engine-headless)
 add_custom_target(install-tests)


### PR DESCRIPTION
The reason for these (two) changes were to prevent (configuration? compilation? I forgot) issues when something else defined "tests" and to make this configurable -> there were some times (CI? local?) where I didn't want them to run, would just be wasteful.

Still defaults to ON so no behavior change, just adds configuration.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Make engine test configuration optional through `BUILD_TESTING`, defaulting to enabled, and avoid redefining the aggregate `tests` target when another dependency already provides it.

## Why

This keeps normal test builds unchanged while allowing test-free configurations and avoids duplicate-target configuration failures.

## Validation

- `git diff --check`