### PR TITLE
unitsync: release Lua memory pool on shutdown

### DIFF
--- a/test/unitsync/testUnitSync.cpp
+++ b/test/unitsync/testUnitSync.cpp
@@ -350,4 +350,12 @@ TEST_CASE("UnitSync")
 	if ((errmsg = us::GetNextError()) == nullptr) {
 		FAIL_CHECK("No error on GetWritableDataDirectory before init"); // there's an error cause we called GetWritableDataDirectory() after UnInit()!
 	}
+
+	// Exercise repeated initialization and shutdown.
+	for (int cycle = 0; cycle < 2; ++cycle) {
+		CHECK(us::Init(false, 0) != 0);
+		CHECK_ERROR_MESSAGE(errmsg);
+		us::UnInit();
+		CHECK_ERROR_MESSAGE(errmsg);
+	}
 }

--- a/tools/unitsync/unitsync.cpp
+++ b/tools/unitsync/unitsync.cpp
@@ -12,6 +12,7 @@
 // shared with spring:
 #include "lib/lua/include/LuaInclude.h"
 #include "Game/GameVersion.h"
+#include "Lua/LuaMemPool.h"
 #include "Lua/LuaParser.h"
 #include "Map/MapParser.h"
 #include "Map/ReadMap.h"
@@ -421,6 +422,7 @@ EXPORT(void) UnInit()
 	try {
 		_Cleanup();
 		FileSystemInitializer::Cleanup();
+		LuaMemPool::KillStatic();
 		ConfigHandler::Deallocate();
 		DataDirLocater::FreeInstance();
 	}
@@ -2371,4 +2373,3 @@ EXPORT(const char*) GetMacAddrHash() {
 	memcpy(macAddrBuf.data(), macAddrHash.data(), std::min(macAddrHash.size(), macAddrBuf.size()));
 	return (macAddrBuf.data());
 }
-


### PR DESCRIPTION
Unfortunately I don't remember what this was anymore but I think it might've caused some ASAN crash due to heavier testing. Could also have caused crashes during Spring.Reload which might've invoked Uninit - honestly, don't remember, but the change itself seems sound to me.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Release the Lua memory pool during unitsync shutdown and exercise repeated initialization and shutdown in the existing unitsync test.

## Why

Repeated unitsync lifecycles can otherwise retain static Lua pool state after shutdown.

## Validation

- `git diff --check`
