### PR TITLE
Platform: return ExecuteProcess errors consistently

### DIFF
--- a/rts/System/Platform/Misc.cpp
+++ b/rts/System/Platform/Misc.cpp
@@ -649,17 +649,20 @@ namespace Platform
 			if (!CreateProcess(nullptr, flatArgs.str().data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si, &pi))
 				LOG("[%s] error %lu creating subprocess with arguments \"%s\"", __func__, GetLastError(), nowide::narrow(flatArgs.str()).c_str());
 
+			return execError;
+
 			#else
 
-			int pid;
-			if ((pid = fork()) < 0) {
-				LOG("[%s] error forking process", __func__);
-			} else if (pid != 0) {
-				// TODO: Maybe useful to return the subprocess ID (pid)?
-			}
-			#endif
+			const auto pid = fork();
+			if (pid != 0) {
+				if (pid < 0)
+					LOG("[%s] error forking process", __func__);
 
-			return execError;
+				return execError;
+			}
+
+			// The child (pid == 0) falls through to execvp below.
+			#endif
 		}
 
 		#ifdef UNICODE

--- a/test/engine/System/FileSystem/TestFileSystem.cpp
+++ b/test/engine/System/FileSystem/TestFileSystem.cpp
@@ -1,4 +1,7 @@
 #include <algorithm>
+#include <array>
+#include <chrono>
+#include <thread>
 #include <string>
 #include <vector>
 #include <nowide/cstdio.hpp>
@@ -10,6 +13,7 @@
 // needs to be included after catch
 #include "System/FileSystem/FileSystem.h"
 #include "System/FileSystem/FileQueryFlags.h"
+#include "System/Platform/Misc.h"
 
 namespace {
 	struct PrepareFileSystem {
@@ -76,6 +80,31 @@ TEST_CASE("FileExists")
 	CHECK_FALSE(FileSystem::FileExists(u8"testFile99.txt"));
 	CHECK_FALSE(FileSystem::FileExists(u8"testDir"));
 	CHECK_FALSE(FileSystem::FileExists(u8"testDir99"));
+}
+
+
+TEST_CASE("ExecuteProcess executes the subprocess child")
+{
+	const std::string marker = pfs.testCwd + "/execute-process-marker";
+	FileSystem::DeleteFile(marker);
+
+	std::array<std::string, 32> args;
+	#ifdef _WIN32
+	args[0] = "cmd.exe";
+	args[1] = "/C";
+	args[2] = "type nul > \"" + marker + "\"";
+	#else
+	args[0] = "/bin/touch";
+	args[1] = marker;
+	#endif
+
+	CHECK(std::string(Platform::ExecuteProcess(args, true)) == "ExecuteProcess failure");
+
+	for (int i = 0; i < 100 && !FileSystem::FileExists(marker); ++i)
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+	CHECK(FileSystem::FileExists(marker));
+	FileSystem::DeleteFile(marker);
 }
 
 


### PR DESCRIPTION
Don't have much to add on the AI explanation below. Super unimportant change, only ended up using it during some debugging/testing flow.

-- AI below (GPT 5.6 Luna Max) --

## What changed

Return subprocess execution errors from the parent branch on both Windows and Unix while allowing the Unix child to continue into `exec`.

## Why

The previous shared return obscured the platform-specific control flow and made the parent/child behavior harder to verify.

## Validation

- Added cross-platform coverage for successful child execution and the documented error result.
