### PR TITLE
Added configbool "UnitIconsSortedByDepth" (default disabled) + allow for unittype based draw order

### DIFF
--- a/doc/pr-changelogs/3204.md
+++ b/doc/pr-changelogs/3204.md
@@ -1,0 +1,5 @@
+### Unit icon draw ordering
+- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; icons with higher `drawOrder` are drawn on top of lower ones in the world, screen ("icons as UI") and minimap draw paths. Icons sharing a `drawOrder` keep their stable creation order. Games that define no `drawOrder` values skip sorting entirely.
+- add `UnitIconsSortedByDepth` config bool (default false). When enabled, overlapping icons are additionally ordered back-to-front by view depth within equal `drawOrder`; this makes overlap stacking change as units and the camera move, hence optional.
+- add optional 10th parameter `drawOrder` (default 0) to `Spring.AddUnitIcon`.
+- `Spring.GetUnitIconData`, `Spring.GetIconData` and `Spring.GetAllIconDataArray` now include `drawOrder` when called with `fullData`.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -10,7 +10,7 @@ This is the bleeding-edge changelog since version 2026.07, for **pre-release 202
 ## Features
 
 ### Unit icon draw ordering
-- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; when icon sorting is enabled, icons with higher `drawOrder` are drawn on top.
-- add `UnitIconsSorted` config bool (default false). When enabled, unit icons in the world, screen ("icons as UI") and minimap draw paths are sorted by their icon's `drawOrder`, then back-to-front, so overlapping icons resolve in a deterministic, prioritized order instead of unit creation order.
+- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; icons with higher `drawOrder` are drawn on top of lower ones in the world, screen ("icons as UI") and minimap draw paths. Icons sharing a `drawOrder` keep their stable creation order. Games that define no `drawOrder` values skip sorting entirely.
+- add `UnitIconsSortedByDepth` config bool (default false). When enabled, overlapping icons are additionally ordered back-to-front by view depth within equal `drawOrder`; this makes overlap stacking change as units and the camera move, hence optional.
 - add optional 10th parameter `drawOrder` (default 0) to `Spring.AddUnitIcon`.
 - `Spring.GetUnitIconData`, `Spring.GetIconData` and `Spring.GetAllIconDataArray` now include `drawOrder` when called with `fullData`.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,10 +7,4 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-## Features
-
-### Unit icon draw ordering
-- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; icons with higher `drawOrder` are drawn on top of lower ones in the world, screen ("icons as UI") and minimap draw paths. Icons sharing a `drawOrder` keep their stable creation order. Games that define no `drawOrder` values skip sorting entirely.
-- add `UnitIconsSortedByDepth` config bool (default false). When enabled, overlapping icons are additionally ordered back-to-front by view depth within equal `drawOrder`; this makes overlap stacking change as units and the camera move, hence optional.
-- add optional 10th parameter `drawOrder` (default 0) to `Spring.AddUnitIcon`.
-- `Spring.GetUnitIconData`, `Spring.GetIconData` and `Spring.GetAllIconDataArray` now include `drawOrder` when called with `fullData`.
+No changes as of yet.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,4 +7,10 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-No changes as of yet.
+## Features
+
+### Unit icon draw ordering
+- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; when icon sorting is enabled, icons with higher `drawOrder` are drawn on top.
+- add `UnitIconsSorted` config bool (default false). When enabled, unit icons in the world, screen ("icons as UI") and minimap draw paths are sorted by their icon's `drawOrder`, then back-to-front, so overlapping icons resolve in a deterministic, prioritized order instead of unit creation order.
+- add optional 10th parameter `drawOrder` (default 0) to `Spring.AddUnitIcon`.
+- `Spring.GetUnitIconData`, `Spring.GetIconData` and `Spring.GetAllIconDataArray` now include `drawOrder` when called with `fullData`.

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2498,6 +2498,7 @@ int LuaUnsyncedCtrl::SetFeatureSelectionVolumeData(lua_State* L)
  * @param v0 number?
  * @param u1 number?
  * @param v1 number?
+ * @param drawOrder number? (Default: 0) Sort priority used when icon sorting is enabled; higher values are drawn on top.
  *
  * @return boolean added
  */
@@ -2520,7 +2521,9 @@ int LuaUnsyncedCtrl::AddUnitIcon(lua_State* L)
 	const float  u1 = luaL_optnumber(L, 8, 1.0f);
 	const float  v1 = luaL_optnumber(L, 9, 1.0f);
 
-	lua_pushboolean(L, icon::iconHandler.AddIcon(1, iconName, texName, size, dist, radAdjust, u0, v0, u1, v1));
+	const float  drawOrder = luaL_optnumber(L, 10, 0.0f);
+
+	lua_pushboolean(L, icon::iconHandler.AddIcon(1, iconName, texName, size, dist, radAdjust, u0, v0, u1, v1, drawOrder));
 	return 1;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2498,7 +2498,7 @@ int LuaUnsyncedCtrl::SetFeatureSelectionVolumeData(lua_State* L)
  * @param v0 number?
  * @param u1 number?
  * @param v1 number?
- * @param drawOrder number? (Default: 0) Sort priority used when icon sorting is enabled; higher values are drawn on top.
+ * @param drawOrder number? (Default: 0) Sort priority for icon drawing; icons with higher values are drawn on top of lower ones.
  *
  * @return boolean added
  */

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -1472,7 +1472,7 @@ int LuaUnsyncedRead::UnitIconGetDraw(lua_State* L) {
 namespace Impl {
 	template<bool full>
 	void PushIconData(lua_State* L, const icon::IconData& iconData) {
-		lua_createtable(L, 0, 2 + 5 * !full);
+		lua_createtable(L, 0, 2 + 6 * full);
 
 		/*** @field IconData.name string */
 		LuaPushNamedString(L, "name", iconData.GetName());
@@ -1483,6 +1483,8 @@ namespace Impl {
 			LuaPushNamedNumber(L, "size", iconData.GetSize());
 			/*** @field IconData.distance number? When squared used as a icon length multiplier */
 			LuaPushNamedNumber(L, "distance", iconData.GetDistance());
+			/*** @field IconData.drawOrder number? Sort priority used when icon sorting is enabled; higher values are drawn on top */
+			LuaPushNamedNumber(L, "drawOrder", iconData.GetDrawOrder());
 			/*** @field IconData.radiusAdjust boolean? Controls whether the unit radius affects the icon size */
 			LuaPushNamedBool(L, "radiusAdjust", iconData.GetRadiusAdjust());
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -1483,7 +1483,7 @@ namespace Impl {
 			LuaPushNamedNumber(L, "size", iconData.GetSize());
 			/*** @field IconData.distance number? When squared used as a icon length multiplier */
 			LuaPushNamedNumber(L, "distance", iconData.GetDistance());
-			/*** @field IconData.drawOrder number? Sort priority used when icon sorting is enabled; higher values are drawn on top */
+			/*** @field IconData.drawOrder number? Sort priority for icon drawing; icons with higher values are drawn on top of lower ones */
 			LuaPushNamedNumber(L, "drawOrder", iconData.GetDrawOrder());
 			/*** @field IconData.radiusAdjust boolean? Controls whether the unit radius affects the icon size */
 			LuaPushNamedBool(L, "radiusAdjust", iconData.GetRadiusAdjust());

--- a/rts/Rendering/IconHandler.cpp
+++ b/rts/Rendering/IconHandler.cpp
@@ -191,7 +191,8 @@ void CIconHandler::LoadIcons(const std::string& filename)
 			iconTable.GetFloat("u0", 0.0f),
 			iconTable.GetFloat("v0", 0.0f),
 			iconTable.GetFloat("u1", 1.0f),
-			iconTable.GetFloat("v1", 1.0f)
+			iconTable.GetFloat("v1", 1.0f),
+			iconTable.GetFloat("drawOrder", 0.0f)
 		);
 	}
 
@@ -208,7 +209,8 @@ bool CIconHandler::AddIcon(
 	float size,
 	float distance,
 	bool radAdj,
-	float u0, float v0, float u1, float v1
+	float u0, float v0, float u1, float v1,
+	float drawOrder
 ) {
 	auto it = iconsMap.find(iconName);
 	if (it != iconsMap.end()) {
@@ -225,7 +227,8 @@ bool CIconHandler::AddIcon(
 		distance,
 		atlasIndex,
 		radAdj,
-		float4{u0, v0, u1, v1}
+		float4{u0, v0, u1, v1},
+		drawOrder
 	};
 
 	// do basic check instead of the full load procedure

--- a/rts/Rendering/IconHandler.cpp
+++ b/rts/Rendering/IconHandler.cpp
@@ -33,6 +33,7 @@ CIconHandler iconHandler;
 void CIconHandler::Kill()
 {
 	defaultIconIdx = INVALID_ICON_INDEX;
+	drawOrderIconCount = 0;
 
 	glDeleteTextures(2, atlasTextureIDs.data());
 	atlasTextureIDs = { 0 };
@@ -231,6 +232,8 @@ bool CIconHandler::AddIcon(
 		drawOrder
 	};
 
+	drawOrderIconCount += (drawOrder != 0.0f);
+
 	// do basic check instead of the full load procedure
 	return CFileHandler::FileExists(texFileName, SPRING_VFS_ALL);
 }
@@ -249,6 +252,8 @@ bool CIconHandler::FreeIcon(const std::string& iconName)
 	if (const auto& ai = iconsData[it->second].GetAtlasIndex(); ai > 0) {
 		atlasNeedsUpdate.set(ai);
 	}
+
+	drawOrderIconCount -= (iconsData[it->second].GetDrawOrder() != 0.0f);
 
 	iconsData[it->second] = IconData{};
 	it->second = defaultIconIdx;

--- a/rts/Rendering/IconHandler.h
+++ b/rts/Rendering/IconHandler.h
@@ -27,16 +27,18 @@ namespace icon {
 			, size{ 0.0f }
 			, distance{ 1.0f }
 			, distSqr{ 1.0f }
+			, drawOrder{ 0.0f }
 			, radiusAdjust{ false }
 			, srcTexCoords{}
 			, texCoords{}
 		{}
-		explicit IconData(const std::string& name_, const std::string& fileName_, float size_, float distance_, uint32_t atlasIndex_, bool radiusAdjust_, const float4& srcTexCoords_)
+		explicit IconData(const std::string& name_, const std::string& fileName_, float size_, float distance_, uint32_t atlasIndex_, bool radiusAdjust_, const float4& srcTexCoords_, float drawOrder_ = 0.0f)
 			: name{ name_ }
 			, fileName{ fileName_ }
 			, size{ size_ }
 			, distance{ distance_ }
 			, distSqr{ distance_ * distance_ }
+			, drawOrder{ drawOrder_ }
 			, radiusAdjust{ radiusAdjust_ }
 			, srcTexCoords{ srcTexCoords_ }
 			, texCoords{ 0.0f, 0.0f, 1.0f, 1.0f, atlasIndex_ }
@@ -46,6 +48,7 @@ namespace icon {
 		const auto& GetSize() const { return size; }
 		const auto& GetDistance() const { return distance; }
 		const auto& GetDistanceSq() const { return distSqr; }
+		const auto& GetDrawOrder() const { return drawOrder; }
 		const auto& GetRadiusAdjust() const { return radiusAdjust; }
 		const auto& GetSrcTexCoords() const { return srcTexCoords; }
 		const auto& GetTexCoords() const { return texCoords; }
@@ -62,6 +65,7 @@ namespace icon {
 		float size;
 		float distance;
 		float distSqr;
+		float drawOrder;
 
 		bool radiusAdjust;
 		float4 srcTexCoords;
@@ -88,7 +92,8 @@ namespace icon {
 				float size,
 				float distance,
 				bool radAdj,
-				float u0, float v0, float u1, float v1
+				float u0, float v0, float u1, float v1,
+				float drawOrder = 0.0f
 			);
 
 			bool FreeIcon(const std::string& iconName);

--- a/rts/Rendering/IconHandler.h
+++ b/rts/Rendering/IconHandler.h
@@ -108,6 +108,8 @@ namespace icon {
 			size_t GetIconIdxOrDefault(const std::string& iconName) const;
 			std::pair<bool, spring::unordered_map<std::string, size_t>::const_iterator> FindIconIdx(const std::string& iconName) const;
 			size_t GetDefaultIconIdx() const { return defaultIconIdx; }
+			/// true when any icon defines a nonzero drawOrder; sorting is skipped entirely otherwise
+			bool HasDrawOrders() const { return (drawOrderIconCount > 0); }
 
 			const auto& GetAtlasTextureIDs() const { return atlasTextureIDs; }
 			auto GetAtlasTextureID(size_t i) const { return atlasTextureIDs[i]; }
@@ -125,6 +127,7 @@ namespace icon {
 			std::vector<IconData> iconsData;
 
 			size_t defaultIconIdx = INVALID_ICON_INDEX;
+			size_t drawOrderIconCount = 0;
 
 			std::array<uint32_t, 2> atlasTextureIDs = {};
 			std::array<int2, 2> atlasTextureSizes = {};

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -69,7 +69,7 @@ CONFIG(float, UnitTransparency).defaultValue(0.7f);
 CONFIG(bool, UnitIconsAsUI).defaultValue(false).description("Draw unit icons like it is an UI element and not like unit's LOD.");
 CONFIG(bool, UnitIconsHideWithUI).defaultValue(false).description("Hide unit icons when UI is hidden.");
 CONFIG(float, UnitGhostIconsDimming).defaultValue(0.8).minimumValue(0.0f).maximumValue(1.0f).description("Dimming multiplier for out of radar ghost icons. Setting to 0 disables them.");
-CONFIG(bool, UnitIconsSorted).defaultValue(false).description("Sort unit icons (world, screen and minimap) by the drawOrder of their icontypes.lua entry, then back-to-front, so overlapping icons resolve in a deterministic, prioritized order instead of unit creation order.");
+CONFIG(bool, UnitIconsSortedByDepth).defaultValue(false).description("Additionally order overlapping unit icons (world, screen and minimap) back-to-front by view depth. Icons always sort by the drawOrder of their icontypes.lua entry when the game defines one; depth ordering on top of that makes overlap stacking change as units and the camera move, hence optional.");
 
 CONFIG(int, MaxDynamicModelLights)
 	.defaultValue(1)
@@ -345,12 +345,16 @@ void CUnitDrawerGLSL::DrawUnitTrans(const CUnit* unit, uint32_t preList, uint32_
 }
 
 namespace {
-	// icon draw ordering (gated by UnitIconsSorted). The sort runs over flat 8-byte
-	// records instead of the payload entries: the icon's icontypes.lua drawOrder
-	// (higher drawn on top) packs above a path-specific back-to-front depth quantized
-	// to 16 bits, with the payload index in the low 16 bits. Both floats are remapped
-	// to order-preserving unsigned bits, so the whole sort is comparator-free integer
-	// sorting; icons that tie on drawOrder and quantized depth draw in gather order.
+	// icon draw ordering: active whenever the game defines icontypes.lua drawOrder
+	// values (games without them skip sorting entirely). The sort runs over flat 8-byte
+	// records instead of the payload entries: the icon's drawOrder (higher drawn on
+	// top, 16 bits) packs above a path-specific back-to-front depth (full 32 bits),
+	// with the payload index in the low 16 bits. Both floats are remapped to
+	// order-preserving unsigned bits, so the whole sort is comparator-free integer
+	// sorting. The depth field only participates when UnitIconsSortedByDepth is
+	// enabled — it makes overlap stacking change as units and the camera move, so by
+	// default icons that share a drawOrder keep their stable gather (creation) order
+	// via the index tiebreak.
 	inline uint32_t SortableFloatBits(float f) {
 		uint32_t b;
 		std::memcpy(&b, &f, sizeof(b));
@@ -362,9 +366,23 @@ namespace {
 
 	inline uint64_t MakeIconSortRec(float drawOrder, float depth, size_t entryIdx) {
 		assert(entryIdx <= ICON_SORT_IDX_MASK);
-		return (uint64_t{SortableFloatBits(drawOrder)} << 32)
-		     | (SortableFloatBits(depth) & ~ICON_SORT_IDX_MASK)
+		// drawOrder gets 16 bits of float precision (plenty for layer indices); depth
+		// keeps all 32 so overlap order only changes at true depth crossings instead
+		// of jittering at quantization-bucket boundaries as units or the camera move
+		return (uint64_t{SortableFloatBits(drawOrder) >> 16} << 48)
+		     | (uint64_t{SortableFloatBits(depth)} << 16)
 		     | (uint32_t(entryIdx) & ICON_SORT_IDX_MASK);
+	}
+
+	// the minimap can be drawn rotated in 90° steps; sort by the post-rotation screen
+	// vertical so icons lower on the rotated minimap draw on top
+	inline float MiniMapIconSortDepth(const float3& pos, CMiniMap::RotationOptions rotation) {
+		switch (rotation) {
+			case CMiniMap::ROTATION_90:  return -pos.x;
+			case CMiniMap::ROTATION_180: return -pos.z;
+			case CMiniMap::ROTATION_270: return  pos.x;
+			default:                     return  pos.z;
+		}
 	}
 
 	void SortIconRecs(std::vector<uint64_t>& recs) {
@@ -486,7 +504,9 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 	const auto defIconIdx = icon::iconHandler.GetDefaultIconIdx();
 
-	const bool sortIcons = modelDrawerData->sortUnitIcons;
+	const bool sortDepth = modelDrawerData->sortUnitIconsByDepth;
+	const bool sortIcons = sortDepth || icon::iconHandler.HasDrawOrders();
+	const auto mmRotation = minimap->GetRotationOption();
 
 	struct IconDrawEntry {
 		size_t iconIdx;
@@ -556,7 +576,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 			DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
 		} else {
 			entries.push_back({ iconIndex, iconScale, pos, currentColor });
-			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), pos.z, entries.size() - 1));
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), sortDepth ? MiniMapIconSortDepth(pos, mmRotation) : 0.0f, entries.size() - 1));
 		}
 	}
 
@@ -586,7 +606,7 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 				DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
 			} else {
 				entries.push_back({ iconIndex, iconScale, pos, currentColor });
-				sortRecs.push_back(MakeIconSortRec(iconData.GetDrawOrder(), pos.z, entries.size() - 1));
+				sortRecs.push_back(MakeIconSortRec(iconData.GetDrawOrder(), sortDepth ? MiniMapIconSortDepth(pos, mmRotation) : 0.0f, entries.size() - 1));
 			}
 		}
 	}
@@ -686,7 +706,8 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 	static auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_TC3>();
 	rb.AssertSubmission();
 
-	const bool sortIcons = modelDrawerData->sortUnitIcons;
+	const bool sortDepth = modelDrawerData->sortUnitIconsByDepth;
+	const bool sortIcons = sortDepth || icon::iconHandler.HasDrawOrders();
 
 	struct IconDrawEntry {
 		CUnit* unit;
@@ -725,7 +746,7 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 			unit->iconRadius = DrawUnitIcon(rb, unit->currentIconIndex, unit->iconRadius, unit->radius, pos, iconColor);
 		} else {
 			entries.push_back({ unit, pos, iconColor });
-			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), -camera->GetPos().SqDistance(pos), entries.size() - 1));
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), sortDepth ? -camera->GetPos().SqDistance(pos) : 0.0f, entries.size() - 1));
 		}
 	}
 
@@ -831,7 +852,8 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
-	const bool sortIcons = modelDrawerData->sortUnitIcons;
+	const bool sortDepth = modelDrawerData->sortUnitIconsByDepth;
+	const bool sortIcons = sortDepth || icon::iconHandler.HasDrawOrders();
 
 	struct IconDrawEntry {
 		size_t iconIdx;
@@ -865,11 +887,11 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 
 
 		// drawMidPos is auto-calculated now; can wobble on its own as pieces move
-		float3 pos = (!isFullView) ?
+		const float3 worldPos = (!isFullView) ?
 			unit->GetObjDrawErrorPos(myAllyTeam) :
 			unit->GetObjDrawMidPos();
 
-		pos = camera->CalcViewPortCoordinates(pos);
+		float3 pos = camera->CalcViewPortCoordinates(worldPos);
 		if (pos.z > 1.0f || pos.z < 0.0f)
 			continue;
 
@@ -888,20 +910,20 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			}
 		}
 
-		// negated depth: within equal drawOrder farther icons are drawn first (back-to-front)
 		if (!sortIcons) {
 			DrawUnitIconScreen(rb, unit->currentIconIndex, pos, currentColor, unit->radius, unit->GetIsIcon());
 		} else {
 			entries.push_back({ unit->currentIconIndex, pos, currentColor, unit->radius, unit->GetIsIcon() });
-			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), -pos.z, entries.size() - 1));
+			// negated camera distance: farther icons draw first (back-to-front). The
+			// post-projection viewport z is unusable here — it compresses everything
+			// toward 1.0, which the 16-bit key quantization collapses into one value
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), sortDepth ? -camera->GetPos().SqDistance(worldPos) : 0.0f, entries.size() - 1));
 		}
 	}
 
 	if (!isFullView && ghostIconDimming > 0.0f) {
 		for (auto* ghost : modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam)) {
-			float3 pos = ghost->midPos;
-
-			pos = camera->CalcViewPortCoordinates(pos);
+			float3 pos = camera->CalcViewPortCoordinates(ghost->midPos);
 			if (pos.z > 1.0f || pos.z < 0.0f)
 				continue;
 
@@ -920,7 +942,7 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 				DrawUnitIconScreen(rb, iconIndex, pos, currentColor, ghost->radius, false);
 			} else {
 				entries.push_back({ iconIndex, pos, currentColor, ghost->radius, false });
-				sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), -pos.z, entries.size() - 1));
+				sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), sortDepth ? -camera->GetPos().SqDistance(ghost->midPos) : 0.0f, entries.size() - 1));
 			}
 		}
 	}

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -38,6 +38,7 @@
 #include "Rendering/Models/ModelsMemStorage.h"
 
 #include "Sim/Features/Feature.h"
+#include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Projectiles/ExplosionGenerator.h"
@@ -361,8 +362,10 @@ namespace {
 		return b ^ (uint32_t(int32_t(b) >> 31) | 0x80000000u);
 	}
 
-	// 64k icons per path; the sim caps units far below this
+	// 64k icons per path: covers MAX_UNITS with room to spare for dead ghost buildings
+	// (which draw in the same pass); the runtime assert below guards the combined count
 	constexpr uint32_t ICON_SORT_IDX_MASK = (1u << 16) - 1;
+	static_assert(ICON_SORT_IDX_MASK >= uint32_t(MAX_UNITS), "icon sort records cannot index all units");
 
 	inline uint64_t MakeIconSortRec(float drawOrder, float depth, size_t entryIdx) {
 		assert(entryIdx <= ICON_SORT_IDX_MASK);
@@ -374,8 +377,14 @@ namespace {
 		     | (uint32_t(entryIdx) & ICON_SORT_IDX_MASK);
 	}
 
-	// the minimap can be drawn rotated in 90° steps; sort by the post-rotation screen
-	// vertical so icons lower on the rotated minimap draw on top
+	// the minimap can be drawn rotated in 90° steps. Overlaps read naturally when the
+	// icon nearer the viewer's screen bottom draws on top — the same convention the
+	// world view gets from back-to-front depth ordering. Raw pos.z implements that only
+	// for the unrotated minimap: flipped 180° it would stack exactly backwards (icons
+	// visually behind covering the ones in front of them) and sideways at 90°/270°, so
+	// sort by the post-rotation screen vertical instead. A minimap that auto-rotates to
+	// follow the camera thereby also matches the world view's stacking for free, while
+	// a fixed minimap keeps a stable order instead of reshuffling as the camera turns
 	inline float MiniMapIconSortDepth(const float3& pos, CMiniMap::RotationOptions rotation) {
 		switch (rotation) {
 			case CMiniMap::ROTATION_90:  return -pos.x;

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -2,7 +2,11 @@
 
 #include "UnitDrawer.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstring>
 #include <map>
+#include <vector>
 
 #include "Game/Camera.h"
 #include "Game/CameraHandler.h"
@@ -65,6 +69,7 @@ CONFIG(float, UnitTransparency).defaultValue(0.7f);
 CONFIG(bool, UnitIconsAsUI).defaultValue(false).description("Draw unit icons like it is an UI element and not like unit's LOD.");
 CONFIG(bool, UnitIconsHideWithUI).defaultValue(false).description("Hide unit icons when UI is hidden.");
 CONFIG(float, UnitGhostIconsDimming).defaultValue(0.8).minimumValue(0.0f).maximumValue(1.0f).description("Dimming multiplier for out of radar ghost icons. Setting to 0 disables them.");
+CONFIG(bool, UnitIconsSorted).defaultValue(false).description("Sort unit icons (world, screen and minimap) by the drawOrder of their icontypes.lua entry, then back-to-front, so overlapping icons resolve in a deterministic, prioritized order instead of unit creation order.");
 
 CONFIG(int, MaxDynamicModelLights)
 	.defaultValue(1)
@@ -339,6 +344,84 @@ void CUnitDrawerGLSL::DrawUnitTrans(const CUnit* unit, uint32_t preList, uint32_
 	glPopMatrix();
 }
 
+namespace {
+	// icon draw ordering (gated by UnitIconsSorted). The sort runs over flat 8-byte
+	// records instead of the payload entries: the icon's icontypes.lua drawOrder
+	// (higher drawn on top) packs above a path-specific back-to-front depth quantized
+	// to 16 bits, with the payload index in the low 16 bits. Both floats are remapped
+	// to order-preserving unsigned bits, so the whole sort is comparator-free integer
+	// sorting; icons that tie on drawOrder and quantized depth draw in gather order.
+	inline uint32_t SortableFloatBits(float f) {
+		uint32_t b;
+		std::memcpy(&b, &f, sizeof(b));
+		return b ^ (uint32_t(int32_t(b) >> 31) | 0x80000000u);
+	}
+
+	// 64k icons per path; the sim caps units far below this
+	constexpr uint32_t ICON_SORT_IDX_MASK = (1u << 16) - 1;
+
+	inline uint64_t MakeIconSortRec(float drawOrder, float depth, size_t entryIdx) {
+		assert(entryIdx <= ICON_SORT_IDX_MASK);
+		return (uint64_t{SortableFloatBits(drawOrder)} << 32)
+		     | (SortableFloatBits(depth) & ~ICON_SORT_IDX_MASK)
+		     | (uint32_t(entryIdx) & ICON_SORT_IDX_MASK);
+	}
+
+	void SortIconRecs(std::vector<uint64_t>& recs) {
+		// measured crossover: LSD radix beats std::sort ~3x at 20k records but loses
+		// below a few thousand, where its per-pass histogram overhead dominates
+		constexpr size_t RADIX_THRESHOLD = 8192;
+
+		const size_t n = recs.size();
+
+		if (n < RADIX_THRESHOLD) {
+			std::sort(recs.begin(), recs.end());
+			return;
+		}
+
+		static std::vector<uint64_t> tmp;
+		tmp.resize(n);
+
+		uint64_t* a = recs.data();
+		uint64_t* b = tmp.data();
+
+		for (int pass = 0; pass < 8; ++pass) {
+			const int shift = pass * 8;
+
+			uint32_t cnt[256] = {0};
+			for (size_t i = 0; i < n; ++i)
+				++cnt[(a[i] >> shift) & 0xFF];
+
+			// a byte value shared by every key makes this pass an identity permutation;
+			// in practice this skips most of the drawOrder half of the key
+			bool skip = false;
+			for (int d = 0; d < 256; ++d) {
+				if (cnt[d] == uint32_t(n)) {
+					skip = true;
+					break;
+				}
+			}
+			if (skip)
+				continue;
+
+			uint32_t pos[256];
+			uint32_t sum = 0;
+			for (int d = 0; d < 256; ++d) {
+				pos[d] = sum;
+				sum += cnt[d];
+			}
+
+			for (size_t i = 0; i < n; ++i)
+				b[pos[(a[i] >> shift) & 0xFF]++] = a[i];
+
+			std::swap(a, b);
+		}
+
+		if (a != recs.data())
+			std::memcpy(recs.data(), a, n * sizeof(uint64_t));
+	}
+}
+
 void CUnitDrawerGLSL::DrawUnitMiniMapIcon(TypedRenderBuffer<VA_TYPE_2DTC3>& rb, size_t iconIdx, const float iconScale, const float3& pos, const SColor& color) const
 {
 	const float iconSizeX = (iconScale * minimap->GetUnitSizeX());
@@ -403,6 +486,23 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 	const auto defIconIdx = icon::iconHandler.GetDefaultIconIdx();
 
+	const bool sortIcons = modelDrawerData->sortUnitIcons;
+
+	struct IconDrawEntry {
+		size_t iconIdx;
+		float iconScale;
+		float3 pos;
+		SColor color;
+	};
+	static std::vector<IconDrawEntry> entries;
+	static std::vector<uint64_t> sortRecs;
+	entries.clear();
+	sortRecs.clear();
+	if (sortIcons) {
+		entries.reserve(modelDrawerData->GetUnsortedObjects().size());
+		sortRecs.reserve(modelDrawerData->GetUnsortedObjects().size());
+	}
+
 	for (auto* unit : modelDrawerData->GetUnsortedObjects()) {
 		const size_t iconIndex = minimap->UseUnitIcons() ? unit->currentIconIndex : defIconIdx;
 
@@ -452,7 +552,12 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 			unit->GetObjDrawErrorPos(myAllyTeam) :
 			unit->GetObjDrawMidPos();
 
-		DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
+		if (!sortIcons) {
+			DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
+		} else {
+			entries.push_back({ iconIndex, iconScale, pos, currentColor });
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), pos.z, entries.size() - 1));
+		}
 	}
 
 	if (!isFullView && ghostIconDimming > 0.0f) {
@@ -477,7 +582,27 @@ void CUnitDrawerGLSL::DrawUnitMiniMapIcons() const
 			currentColor.g *= ghostIconDimming;
 			currentColor.b *= ghostIconDimming;
 
-			DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
+			if (!sortIcons) {
+				DrawUnitMiniMapIcon(rb, iconIndex, iconScale, pos, currentColor);
+			} else {
+				entries.push_back({ iconIndex, iconScale, pos, currentColor });
+				sortRecs.push_back(MakeIconSortRec(iconData.GetDrawOrder(), pos.z, entries.size() - 1));
+			}
+		}
+	}
+
+	if (sortIcons) {
+		{
+			ZoneScopedN("DrawUnitMiniMapIcons::Sort");
+			ZoneValue(uint64_t(sortRecs.size()));
+			SortIconRecs(sortRecs);
+		}
+
+		ZoneScopedN("DrawUnitMiniMapIcons::Emit");
+
+		for (const uint64_t rec : sortRecs) {
+			const auto& e = entries[uint32_t(rec) & ICON_SORT_IDX_MASK];
+			DrawUnitMiniMapIcon(rb, e.iconIdx, e.iconScale, e.pos, e.color);
 		}
 	}
 
@@ -561,6 +686,22 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 	static auto& rb = RenderBuffer::GetTypedRenderBuffer<VA_TYPE_TC3>();
 	rb.AssertSubmission();
 
+	const bool sortIcons = modelDrawerData->sortUnitIcons;
+
+	struct IconDrawEntry {
+		CUnit* unit;
+		float3 pos;
+		SColor color;
+	};
+	static std::vector<IconDrawEntry> entries;
+	static std::vector<uint64_t> sortRecs;
+	entries.clear();
+	sortRecs.clear();
+	if (sortIcons) {
+		entries.reserve(modelDrawerData->GetUnsortedObjects().size());
+		sortRecs.reserve(modelDrawerData->GetUnsortedObjects().size());
+	}
+
 	for (auto* unit : modelDrawerData->GetUnsortedObjects()) {
 		if (unit->currentIconIndex == icon::INVALID_ICON_INDEX)
 			continue;
@@ -571,8 +712,6 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 		if (!unit->drawIcon)
 			continue;
 
-		const auto& iconData = icon::iconHandler.GetIconData(unit->currentIconIndex);
-
 		// drawMidPos is auto-calculated now; can wobble on its own as pieces move
 		float3 pos = (!gu->spectatingFullView) ?
 			unit->GetObjDrawErrorPos(gu->myAllyTeam) :
@@ -581,7 +720,28 @@ void CUnitDrawerGLSL::DrawUnitIcons() const
 		// use white for selected units
 		const auto& iconColor = unit->isSelected ? color4::white : teamHandler.Team(unit->team)->color;
 
-		unit->iconRadius = DrawUnitIcon(rb, unit->currentIconIndex, unit->iconRadius, unit->radius, pos, iconColor);
+		// negated distance: within equal drawOrder farther icons are drawn first (back-to-front)
+		if (!sortIcons) {
+			unit->iconRadius = DrawUnitIcon(rb, unit->currentIconIndex, unit->iconRadius, unit->radius, pos, iconColor);
+		} else {
+			entries.push_back({ unit, pos, iconColor });
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), -camera->GetPos().SqDistance(pos), entries.size() - 1));
+		}
+	}
+
+	if (sortIcons) {
+		{
+			ZoneScopedN("DrawUnitIcons::Sort");
+			ZoneValue(uint64_t(sortRecs.size()));
+			SortIconRecs(sortRecs);
+		}
+
+		ZoneScopedN("DrawUnitIcons::Emit");
+
+		for (const uint64_t rec : sortRecs) {
+			const auto& e = entries[uint32_t(rec) & ICON_SORT_IDX_MASK];
+			e.unit->iconRadius = DrawUnitIcon(rb, e.unit->currentIconIndex, e.unit->iconRadius, e.unit->radius, e.pos, e.color);
+		}
 	}
 
 	if (!rb.ShouldSubmit())
@@ -671,6 +831,24 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 	const auto isFullView = gu->spectatingFullView;
 	const float ghostIconDimming = modelDrawerData->ghostIconDimming;
 
+	const bool sortIcons = modelDrawerData->sortUnitIcons;
+
+	struct IconDrawEntry {
+		size_t iconIdx;
+		float3 pos;
+		SColor color;
+		float radius;
+		bool isIcon;
+	};
+	static std::vector<IconDrawEntry> entries;
+	static std::vector<uint64_t> sortRecs;
+	entries.clear();
+	sortRecs.clear();
+	if (sortIcons) {
+		entries.reserve(modelDrawerData->GetUnsortedObjects().size());
+		sortRecs.reserve(modelDrawerData->GetUnsortedObjects().size());
+	}
+
 	for (auto* unit : modelDrawerData->GetUnsortedObjects()) {
 		if (unit->currentIconIndex == icon::INVALID_ICON_INDEX)
 			continue;
@@ -710,9 +888,15 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			}
 		}
 
-		DrawUnitIconScreen(rb, unit->currentIconIndex, pos, currentColor, unit->radius, unit->GetIsIcon());
+		// negated depth: within equal drawOrder farther icons are drawn first (back-to-front)
+		if (!sortIcons) {
+			DrawUnitIconScreen(rb, unit->currentIconIndex, pos, currentColor, unit->radius, unit->GetIsIcon());
+		} else {
+			entries.push_back({ unit->currentIconIndex, pos, currentColor, unit->radius, unit->GetIsIcon() });
+			sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(unit->currentIconIndex).GetDrawOrder(), -pos.z, entries.size() - 1));
+		}
 	}
-	
+
 	if (!isFullView && ghostIconDimming > 0.0f) {
 		for (auto* ghost : modelDrawerData->GetDeadGhostBuildings(gu->myAllyTeam)) {
 			float3 pos = ghost->midPos;
@@ -732,7 +916,27 @@ void CUnitDrawerGLSL::DrawUnitIconsScreen() const
 			currentColor.g *= ghostIconDimming;
 			currentColor.b *= ghostIconDimming;
 
-			DrawUnitIconScreen(rb, iconIndex, pos, currentColor, ghost->radius, false);
+			if (!sortIcons) {
+				DrawUnitIconScreen(rb, iconIndex, pos, currentColor, ghost->radius, false);
+			} else {
+				entries.push_back({ iconIndex, pos, currentColor, ghost->radius, false });
+				sortRecs.push_back(MakeIconSortRec(icon::iconHandler.GetIconData(iconIndex).GetDrawOrder(), -pos.z, entries.size() - 1));
+			}
+		}
+	}
+
+	if (sortIcons) {
+		{
+			ZoneScopedN("DrawUnitIconsScreen::Sort");
+			ZoneValue(uint64_t(sortRecs.size()));
+			SortIconRecs(sortRecs);
+		}
+
+		ZoneScopedN("DrawUnitIconsScreen::Emit");
+
+		for (const uint64_t rec : sortRecs) {
+			auto& e = entries[uint32_t(rec) & ICON_SORT_IDX_MASK];
+			DrawUnitIconScreen(rb, e.iconIdx, e.pos, e.color, e.radius, e.isIcon);
 		}
 	}
 

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -156,10 +156,10 @@ CUnitDrawerData::CUnitDrawerData(bool& mtModelDrawer_)
 	iconFadeVanish = configHandler->GetFloat("UnitIconFadeVanish");
 	useScreenIcons = configHandler->GetBool("UnitIconsAsUI");
 	iconHideWithUI = configHandler->GetBool("UnitIconsHideWithUI");
-	sortUnitIcons = configHandler->GetBool("UnitIconsSorted");
+	sortUnitIconsByDepth = configHandler->GetBool("UnitIconsSortedByDepth");
 	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
 
-	configHandler->NotifyOnChange(this, {"UnitGhostIconsDimming", "UnitIconsSorted"});
+	configHandler->NotifyOnChange(this, {"UnitGhostIconsDimming", "UnitIconsSortedByDepth"});
 
 	unitDefImages.clear();
 	unitDefImages.resize(unitDefHandler->NumUnitDefs() + 1);
@@ -208,7 +208,7 @@ CUnitDrawerData::~CUnitDrawerData()
 void CUnitDrawerData::ConfigNotify(const std::string& key, const std::string& value)
 {
 	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
-	sortUnitIcons = configHandler->GetBool("UnitIconsSorted");
+	sortUnitIconsByDepth = configHandler->GetBool("UnitIconsSortedByDepth");
 }
 
 void CUnitDrawerData::Update()

--- a/rts/Rendering/Units/UnitDrawerData.cpp
+++ b/rts/Rendering/Units/UnitDrawerData.cpp
@@ -156,9 +156,10 @@ CUnitDrawerData::CUnitDrawerData(bool& mtModelDrawer_)
 	iconFadeVanish = configHandler->GetFloat("UnitIconFadeVanish");
 	useScreenIcons = configHandler->GetBool("UnitIconsAsUI");
 	iconHideWithUI = configHandler->GetBool("UnitIconsHideWithUI");
+	sortUnitIcons = configHandler->GetBool("UnitIconsSorted");
 	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
 
-	configHandler->NotifyOnChange(this, {"UnitGhostIconsDimming"});
+	configHandler->NotifyOnChange(this, {"UnitGhostIconsDimming", "UnitIconsSorted"});
 
 	unitDefImages.clear();
 	unitDefImages.resize(unitDefHandler->NumUnitDefs() + 1);
@@ -207,6 +208,7 @@ CUnitDrawerData::~CUnitDrawerData()
 void CUnitDrawerData::ConfigNotify(const std::string& key, const std::string& value)
 {
 	ghostIconDimming = configHandler->GetFloat("UnitGhostIconsDimming");
+	sortUnitIcons = configHandler->GetBool("UnitIconsSorted");
 }
 
 void CUnitDrawerData::Update()

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -198,7 +198,7 @@ public:
 
 	//icons
 	bool iconHideWithUI = true;
-	bool sortUnitIcons = false;
+	bool sortUnitIconsByDepth = false;
 	float ghostIconDimming = 0.5f;
 
 	// IconsAsUI

--- a/rts/Rendering/Units/UnitDrawerData.h
+++ b/rts/Rendering/Units/UnitDrawerData.h
@@ -198,6 +198,7 @@ public:
 
 	//icons
 	bool iconHideWithUI = true;
+	bool sortUnitIcons = false;
 	float ghostIconDimming = 0.5f;
 
 	// IconsAsUI


### PR DESCRIPTION
For example allows to show the commander icon always above all others. You can make mobile units render on top of buildings, and more expensive units with preference.

Coded with: Claude Fable

Profiled with Tracy and made it to be as performant as can be

Tested 10 seconds with 10000 units: 
445 ms DrawUnitIconsScreen
- 38 ms DrawUnitIconsScreen::Sort
- 185 ms DrawUnitIconsScreen::Emit

example already implemented in BAR iconytypes.lua:
https://github.com/beyond-all-reason/Beyond-All-Reason/commit/2045e8dec34cedf18352b4d9d12b20d43894b3c2

## noted in doc\site\content\changelogs\_index.markdown

### Unit icon draw ordering
- add optional `drawOrder` number (default 0) to `gamedata/icontypes.lua` entries; icons with higher `drawOrder` are drawn on top of lower ones in the world, screen ("icons as UI") and minimap draw paths. Icons sharing a `drawOrder` keep their stable creation order. Games that define no `drawOrder` values skip sorting entirely.
- add `UnitIconsSortedByDepth` config bool (default false). When enabled, overlapping icons are additionally ordered back-to-front by view depth within equal `drawOrder`; this makes overlap stacking change as units and the camera move, hence optional.
- add optional 10th parameter `drawOrder` (default 0) to `Spring.AddUnitIcon`.
- `Spring.GetUnitIconData`, `Spring.GetIconData` and `Spring.GetAllIconDataArray` now include `drawOrder` when called with `fullData`.