### PR TITLE
Speed up locally loaded replay startup

### DIFF
--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -205,6 +205,8 @@ void CGameServer::Initialize()
 		if (demoReader != nullptr) {
 			const size_t demoPlayers = demoReader->GetFileHeader().numPlayers;
 			players.resize(std::max(demoPlayers, playerStartData.size()));
+			for (size_t n = 0; n < demoPlayers; ++n)
+				players[n].isFromDemo = true;
 			if (players.size() >= MAX_PLAYERS)
 				Message(spring::format("Too many Players (%d) in the demo", players.size()));
 		}
@@ -2194,6 +2196,9 @@ void CGameServer::CheckForGameStart(bool forced)
 	bool anyReady = false;
 
 	for (size_t a = static_cast<size_t>(myGameSetup->numDemoPlayers); a < players.size(); a++) {
+		if (players[a].isFromDemo)
+			continue;
+
 		if (players[a].myState == GameParticipant::UNCONNECTED && serverStartTime + spring_secs(30) < spring_gettime()) {
 			// autostart the game when 30 seconds have passed and everyone who managed to connect is ready
 			continue;

--- a/‎doc/pr-changelogs/3210.md
+++ b/‎doc/pr-changelogs/3210.md
@@ -1,0 +1,1 @@
+ * fixed replays waiting for connections from some of the original participants at start (affected replays which contained mid-joining specs)


### PR DESCRIPTION
## Summary

- mark player slots reserved by the replay header as demo participants
- exclude all demo participants from startup readiness
- continue waiting for actual local or remote replay spectators

Locally loaded replays can spend about 30 seconds waiting for player slots that
will never connect. The tested replay has 18 players in its start script but 33
player-statistic slots in its replay header. The server reserves all 33 slots, so
the 15 header-only slots were treated as disconnected clients.

Marking every header-reserved slot as `isFromDemo` lets the readiness check ignore
replay participants while retaining the normal checks for spectators who connect
locally or over the network.

Countdown Skip behavior is moved to https://github.com/beyond-all-reason/RecoilEngine/pull/3217

## Testing

- built and installed the legacy, headless, and dedicated engine targets
- loaded an 18-player, 33-slot local BAR replay with the patched engine
- confirmed startup no longer waits approximately 30 seconds for header-only
  replay slots
- confirmed the actual local replay spectator is still awaited

Hosted replay startup was not manually tested.

## AI assistance

OpenAI Codex assisted with diagnosis, implementation, build verification, test
setup, and drafting. The changes were reviewed and the local replay behavior was
manually exercised by the author.

Addresses the startup-wait portion of #3209.
