### PR TITLE
MouseHandler: rebind hardware cursor after warp

### DIFF
--- a/doc/pr-changelogs/3216.md
+++ b/doc/pr-changelogs/3216.md
@@ -1,0 +1,1 @@
+ * fixed the cursor sometimes disappearing after being warped (on Linux/Wayland).

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -791,7 +791,8 @@ void CMouseHandler::Update()
 		if (auto& rmlCursor = RmlGui::GetMouseCursor(); !rmlCursor.empty())
 			queuedCursorName = rmlCursor;
 
-	SetCursor(queuedCursorName);
+	SetCursor(queuedCursorName, rebindCursorAfterWarp);
+	rebindCursorAfterWarp = false;
 
 	if (!hideCursor) {
 		mouse->UpdateCursorCameraDir();
@@ -827,7 +828,9 @@ void CMouseHandler::WarpMouse(int x, int y)
 	lastx = x + globalRendering->viewPosX;
 	lasty = y;
 
-	mouseInput->SetWarpPos({lastx, lasty});
+	// WarpPos temporarily hides the SDL cursor on Wayland. Rebind the hardware
+	// cursor during the next update, after SDL has processed the warp.
+	rebindCursorAfterWarp |= mouseInput->SetWarpPos({lastx, lasty});
 }
 
 

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -136,6 +136,7 @@ private:
 	bool hardwareCursor = false;
 	bool invertMouse = false;
 	bool ignoreMove = false;
+	bool rebindCursorAfterWarp = false;
 
 	float cursorScale = 1.0f;
 


### PR DESCRIPTION
  Fixes #3177.

  On Wayland, `WarpPos` temporarily hides the SDL cursor. Reapplying the same cursor from Lua does not restore it because `CMouseHandler::SetCursor` skips unchanged cursor names.

  Remember when a warp requires the workaround and force a hardware-cursor rebind during the next update, after SDL has processed the warp.

  Tested manually on Wayland with `HardwareCursor = 1` using BAR's PIP minimap during start-position selection. The cursor now remains visible after middle-button minimap movement.

  AI disclosure: OpenAI Codex was used to investigate the issue, implement the fix, and prepare this pull request. I reviewed the complete diff and manually reproduced and verified the fix.
