### PR TITLE
Fix endless loop in demo replay, allow skip before game start

### DIFF
--- a/doc/pr-changelogs/3217.md
+++ b/doc/pr-changelogs/3217.md
@@ -1,0 +1,1 @@
+ * `/skip` now works if called before game start

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -404,7 +404,6 @@ void CGameServer::SkipTo(int targetFrameNum)
 {
 	const bool wasPaused = isPaused;
 
-	if (!gameHasStarted) { return; }
 	if (serverFrameNum >= targetFrameNum) { return; }
 	if (demoReader == nullptr) { return; }
 
@@ -412,13 +411,16 @@ void CGameServer::SkipTo(int targetFrameNum)
 	CommandMessage endMsg("skip end", SERVER_PLAYER);
 	Broadcast(std::shared_ptr<const netcode::RawPacket>(startMsg.Pack()));
 
+	if (!gameHasStarted)
+		StartGame(true); // this skips the countdown
+
 	// fast-read and send demo data
 	//
 	// note that we must maintain <modGameTime> ourselves
 	// since we do we NOT go through ::Update when skipping
 	while (SendDemoData(targetFrameNum)) {
 		gameTime = GetDemoTime();
-		modGameTime = demoReader->GetModGameTime() + 0.001f;
+		modGameTime = demoReader->GetNextDemoReadTime() + 0.001f;
 
 		if (udpListener == nullptr) { continue; }
 		if ((serverFrameNum % 20) != 0) { continue; }


### PR DESCRIPTION
## Summary

1. Allow skipping a demo replay before game start by removing the pregame guard from SkipTo.
2. When skipping during the countdown, start the game immediately after the skip completes so the countdown ends.
3. Fix the endless skip loop by advancing modGameTime with GetNextDemoReadTime instead of GetModGameTime.

## Testing

Manually verified with a forced 10-second countdown and pressing Skip during the countdown (around 8s)

-   without this PR: Skip does not stop countdown, game is paused after countdown
-   with the StartGame(true) change but without GetModGameTime() fix: countdown does not stop, engine freezes
 -  with the GetModGameTime() fix but without StartGame(true): Countdown is no longer shown, but game shows "game paused" until the countdown time is elapsed and then replay resumes normally
 -  with both StartGame(true) and GetModGameTime() fix: Everything works as expected, countdown stops, demo playback starts immediately

Addresses the replay-skip portion of #3209.

## AI disclosure

OpenAI Codex assisted with diagnosing the endless loop, implementing the change, and drafting this pull request. The behavior was manually tested and confirmed by the contributor.