### PR TITLE
Handle mixed toggle states on the command card

### DIFF
--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -40,6 +40,9 @@
 #include "System/Sound/ISound.h"
 #include "System/Sound/ISoundChannels.h"
 
+#include <cstdlib>
+#include <set>
+
 #include <SDL_mouse.h>
 #include <SDL_keycode.h>
 
@@ -108,6 +111,9 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 				states[cmdDesc->id] = 0;
 			else
 				states[cmdDesc->id] = cmdDesc->disabled ? 2 : 1;
+
+			if (cmdDesc->type == CMDTYPE_ICON_MODE && !cmdDesc->params.empty())
+				ac.presentModes[cmdDesc->id].insert(atoi(cmdDesc->params[0].c_str()));
 		}
 
 		if (cai->lastSelectedCommandPage < ac.commandPage)

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -120,6 +120,25 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 			ac.commandPage = cai->lastSelectedCommandPage;
 	}
 
+	/* selectedUnits is unordered, so taking any one unit's value would let the
+	 * same selection answer differently between rebuilds; the lowest is stable */
+	const auto PushCommand = [&](const SCommandDescription* cmdDesc) {
+		ac.commands.push_back(*cmdDesc);
+		states[cmdDesc->id] = 0;
+
+		const auto it = ac.presentModes.find(cmdDesc->id);
+
+		if (it == ac.presentModes.end() || it->second.empty())
+			return;
+
+		SCommandDescription& cd = ac.commands.back();
+
+		if (cd.type != CMDTYPE_ICON_MODE || cd.params.empty())
+			return;
+
+		cd.params[0] = IntToString(*it->second.begin());
+	};
+
 	// load the first set (separating build and non-build commands)
 	for (const int unitID: selectedUnits) {
 		const CUnit* u = unitHandler.GetUnit(unitID);
@@ -131,10 +150,8 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 				continue;
 
 			// Prevent duplicates across different units.
-			if (states[cmdDesc->id] > 0) {
-				ac.commands.push_back(*cmdDesc);
-				states[cmdDesc->id] = 0;
-			}
+			if (states[cmdDesc->id] > 0)
+				PushCommand(cmdDesc);
 		}
 	}
 
@@ -147,10 +164,8 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 			if (buildIconsFirst != (cmdDesc->id >= 0))
 				continue;
 
-			if (states[cmdDesc->id] > 0) {
-				ac.commands.push_back(*cmdDesc);
-				states[cmdDesc->id] = 0;
-			}
+			if (states[cmdDesc->id] > 0)
+				PushCommand(cmdDesc);
 		}
 	}
 

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -93,10 +93,10 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 	RECOIL_DETAILED_TRACY_ZONE;
 	possibleCommandsChanged = false;
 
-	int commandPage = 1000;
+	AvailableCommandsStruct ac;
+	ac.commandPage = 1000;
 
 	spring::unordered_map<int, int> states;
-	std::vector<SCommandDescription> commands;
 
 	for (const int unitID: selectedUnits) {
 		const CUnit* u = unitHandler.GetUnit(unitID);
@@ -110,8 +110,8 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 				states[cmdDesc->id] = cmdDesc->disabled ? 2 : 1;
 		}
 
-		if (cai->lastSelectedCommandPage < commandPage)
-			commandPage = cai->lastSelectedCommandPage;
+		if (cai->lastSelectedCommandPage < ac.commandPage)
+			ac.commandPage = cai->lastSelectedCommandPage;
 	}
 
 	// load the first set (separating build and non-build commands)
@@ -126,7 +126,7 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 
 			// Prevent duplicates across different units.
 			if (states[cmdDesc->id] > 0) {
-				commands.push_back(*cmdDesc);
+				ac.commands.push_back(*cmdDesc);
 				states[cmdDesc->id] = 0;
 			}
 		}
@@ -142,15 +142,12 @@ CSelectedUnitsHandler::AvailableCommandsStruct CSelectedUnitsHandler::GetAvailab
 				continue;
 
 			if (states[cmdDesc->id] > 0) {
-				commands.push_back(*cmdDesc);
+				ac.commands.push_back(*cmdDesc);
 				states[cmdDesc->id] = 0;
 			}
 		}
 	}
 
-	AvailableCommandsStruct ac;
-	ac.commandPage = commandPage;
-	ac.commands = commands;
 	return ac;
 }
 

--- a/rts/Game/SelectedUnitsHandler.h
+++ b/rts/Game/SelectedUnitsHandler.h
@@ -3,6 +3,7 @@
 #ifndef SELECTED_UNITS_H
 #define SELECTED_UNITS_H
 
+#include <set>
 #include <vector>
 #include <string>
 
@@ -34,6 +35,8 @@ public:
 
 	struct AvailableCommandsStruct {
 		std::vector<SCommandDescription> commands;
+		/// per command id, the params[0] modes the selection holds
+		spring::unordered_map<int, std::set<int>> presentModes;
 		int commandPage;
 	};
 	AvailableCommandsStruct GetAvailableCommands();

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -601,6 +601,7 @@ void CGuiHandler::LayoutIcons(bool useSelectionPage)
 		forceLayoutUpdate = false;
 
 		commands.clear();
+		presentModes.clear();
 	}
 
 	if (luaUI != nullptr && luaUI->WantsEvent("LayoutButtons")) {
@@ -632,6 +633,8 @@ void CGuiHandler::LayoutIcons(bool useSelectionPage)
 	// get the commands to process
 	CSelectedUnitsHandler::AvailableCommandsStruct ac = selectedUnitsHandler.GetAvailableCommands();
 	ConvertCommands(ac.commands);
+
+	presentModes = std::move(ac.presentModes);
 
 	std::vector<SCommandDescription> hidden;
 
@@ -745,6 +748,8 @@ bool CGuiHandler::LayoutCustomIcons(bool useSelectionPage)
 	// get the commands to process
 	CSelectedUnitsHandler::AvailableCommandsStruct ac = selectedUnitsHandler.GetAvailableCommands();
 	std::vector<SCommandDescription> cmds = ac.commands;
+
+	presentModes = std::move(ac.presentModes);
 
 	if (!cmds.empty()) {
 		ConvertCommands(cmds);

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -3,6 +3,7 @@
 #ifndef GUI_HANDLER_H
 #define GUI_HANDLER_H
 
+#include <set>
 #include <vector>
 
 #include "KeySet.h"
@@ -12,6 +13,7 @@
 #include "Sim/Units/BuildInfo.h"
 #include "Sim/Units/CommandAI/Command.h"
 #include "System/SpringMath.h" // FACING
+#include "System/UnorderedMap.hpp"
 
 #define DEFAULT_GUI_CONFIG "ctrlpanel.txt"
 
@@ -267,6 +269,9 @@ private:
 
 public:
 	std::vector<SCommandDescription> commands;
+	/// per command id, the sorted modes the selection holds; keyed by id so it
+	/// survives the icon filtering and any list a game supplies via LayoutButtons
+	spring::unordered_map<int, std::set<int>> presentModes;
 };
 
 extern CGuiHandler* guihandler;

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -3735,6 +3735,9 @@ int LuaUnsyncedRead::GetDefaultCommand(lua_State* L)
  *
  * @function Spring.GetActiveCmdDescs
  * @return CommandDescription[] cmdDescs
+ * @return integer[][] presentModes keyed as cmdDescs; for a CMDTYPE_ICON_MODE
+ * command, the sorted modes the selection holds, so more than one entry means
+ * the selected units disagree
  */
 int LuaUnsyncedRead::GetActiveCmdDescs(lua_State* L)
 {
@@ -3756,7 +3759,23 @@ int LuaUnsyncedRead::GetActiveCmdDescs(lua_State* L)
 		LuaUtils::PushCommandDesc(L, cmdDescs[i]);
 		lua_rawseti(L, -2, i + CMD_INDEX_OFFSET);
 	}
-	return 1;
+
+	lua_createtable(L,
+			CMD_INDEX_OFFSET == 1 ? cmdDescCount : 0,
+			CMD_INDEX_OFFSET == 1 ? 0 : cmdDescCount);
+
+	static const std::set<int> noModes;
+
+	for (int i = 0; i < cmdDescCount; i++) {
+		const SCommandDescription& cd = cmdDescs[i];
+		const auto it = guihandler->presentModes.find(cd.id);
+		// the winning descriptor for an id decides whether modes mean anything
+		const bool haveModes = (cd.type == CMDTYPE_ICON_MODE) && (it != guihandler->presentModes.end());
+
+		LuaUtils::PushPresentModes(L, haveModes ? it->second : noModes);
+		lua_rawseti(L, -2, i + CMD_INDEX_OFFSET);
+	}
+	return 2;
 }
 
 

--- a/rts/Lua/LuaUtils.cpp
+++ b/rts/Lua/LuaUtils.cpp
@@ -1624,6 +1624,20 @@ void LuaUtils::PushCommandDesc(lua_State* L, const SCommandDescription& cd)
 	lua_settable(L, -3);
 }
 
+
+void LuaUtils::PushPresentModes(lua_State* L, const std::set<int>& modes)
+{
+	lua_checkstack(L, 1 + 1);
+	lua_createtable(L, modes.size(), 0);
+
+	int index = 1;
+
+	for (const int mode: modes) {
+		lua_pushnumber(L, mode);
+		lua_rawseti(L, -2, index++);
+	}
+}
+
 void LuaUtils::LuaStackDumper::PrintStack(lua_State* L, int parseDepth)
 {
 	currPtr = &root;

--- a/rts/Lua/LuaUtils.h
+++ b/rts/Lua/LuaUtils.h
@@ -4,6 +4,7 @@
 #define LUA_UTILS_H
 
 #include <cstdint>
+#include <set>
 #include <string>
 
 #include <fmt/printf.h>
@@ -177,6 +178,7 @@ class LuaUtils {
 		static void PushStringVector(lua_State* L, const vector<string>& vec);
 
 		static void PushCommandDesc(lua_State* L, const SCommandDescription& cd);
+		static void PushPresentModes(lua_State* L, const std::set<int>& modes);
 #if !defined UNITSYNC && !defined DEDICATED && !defined BUILDING_AI
 		static int ParseAllegiance(lua_State* L, const char* caller, int index);
 


### PR DESCRIPTION
Fixes #3212 - on a mixed selection the command card shows one arbitrary unit's fire state, and not the same one each time.

Which unit wins falls out of hash order, so there's no rule here worth keeping. Showing the lowest isn't meant as "safest" - that only lines up for fire state and move state - it's just a stable pick. It's also the one part that changes a value games already read, and the issue thread didn't cover it, so it's worth a separate look from the rest.

The modes come back as a second return value from GetActiveCmdDescs rather than a field on the descriptor, which leaves the descriptor shape alone so reading one and handing it straight back still works. They sit on the guihandler keyed by command id, so filtering the icons or a game supplying its own list through LayoutButtons can't pull them out of step. GetAvailableCommands also fills the struct it returns directly now instead of building locals and copying them in at the end, which drops a copy of the whole descriptor list - a bit wider than this fix strictly needs, so say if you'd rather that went separately.

Checked headless across mixed, uniform and single-unit selections, and in a local game against BAR's command card with fire state, move state, repeat and fly/land.

AI disclosure: written with assistance from Claude Code.
