### PR TITLE
Fix crash after early game load failures

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -386,35 +386,39 @@ void CGame::Load(const std::string& mapFileName)
 		defsParser = &nullDefsParser;
 		defsParser->Execute();
 
-		// we can not (yet) do a clean early exit here because the dtor assumes
-		// all loading stages proceeded normally; just force automatic shutdown
+		// Skip later loading stages, which depend on the failed stage.
+		// Cleanup routines must tolerate components that were never initialized.
 		forcedQuit = true;
 	}
 
-	try {
-		LOG("[Game::%s][2] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
+	if (!forcedQuit) {
+		try {
+			LOG("[Game::%s][2] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
 
-		PreLoadSimulation(defsParser);
-		Watchdog::ClearTimer(WDT_LOAD);
-		PreLoadRendering();
-		Watchdog::ClearTimer(WDT_LOAD);
-	} catch (const content_error& e) {
-		contentErrors.emplace_back(e.what());
-		LOG_L(L_ERROR, "[Game::%s][2] forced quit with exception \"%s\"", __func__, e.what());
-		forcedQuit = true;
+			PreLoadSimulation(defsParser);
+			Watchdog::ClearTimer(WDT_LOAD);
+			PreLoadRendering();
+			Watchdog::ClearTimer(WDT_LOAD);
+		} catch (const content_error& e) {
+			contentErrors.emplace_back(e.what());
+			LOG_L(L_ERROR, "[Game::%s][2] forced quit with exception \"%s\"", __func__, e.what());
+			forcedQuit = true;
+		}
 	}
 
-	try {
-		LOG("[Game::%s][3] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
+	if (!forcedQuit) {
+		try {
+			LOG("[Game::%s][3] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
 
-		PostLoadSimulation(defsParser);
-		Watchdog::ClearTimer(WDT_LOAD);
-		PostLoadRendering();
-		Watchdog::ClearTimer(WDT_LOAD);
-	} catch (const content_error& e) {
-		contentErrors.emplace_back(e.what());
-		LOG_L(L_ERROR, "[Game::%s][3] forced quit with exception \"%s\"", __func__, e.what());
-		forcedQuit = true;
+			PostLoadSimulation(defsParser);
+			Watchdog::ClearTimer(WDT_LOAD);
+			PostLoadRendering();
+			Watchdog::ClearTimer(WDT_LOAD);
+		} catch (const content_error& e) {
+			contentErrors.emplace_back(e.what());
+			LOG_L(L_ERROR, "[Game::%s][3] forced quit with exception \"%s\"", __func__, e.what());
+			forcedQuit = true;
+		}
 	}
 	if (!forcedQuit) {
 		try {
@@ -455,50 +459,52 @@ void CGame::Load(const std::string& mapFileName)
 		}
 	}
 
-	try {
-		LOG("[Game::%s][7] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
+	if (!forcedQuit) {
+		try {
+			LOG("[Game::%s][7] globalQuit=%d forcedQuit=%d", __func__, globalQuit.load(), forcedQuit);
 
-		if (!globalQuit && saveFileHandler != nullptr) {
-			loadscreen->SetLoadMessage("Loading Saved Game");
-			{
-				auto lock = CLoadLock::GetUniqueLock();
-				saveFileHandler->LoadGame();
+			if (!globalQuit && saveFileHandler != nullptr) {
+				loadscreen->SetLoadMessage("Loading Saved Game");
+				{
+					auto lock = CLoadLock::GetUniqueLock();
+					saveFileHandler->LoadGame();
+					Watchdog::ClearTimer(WDT_LOAD);
+				}
+				LoadLua(false, true);
 				Watchdog::ClearTimer(WDT_LOAD);
+			} else {
+				ENTER_SYNCED_CODE();
+				{
+					auto lock = CLoadLock::GetUniqueLock();
+					eventHandler.GamePreload();
+					Watchdog::ClearTimer(WDT_LOAD);
+					eventHandler.CollectGarbage(true);
+					Watchdog::ClearTimer(WDT_LOAD);
+				}
+				LEAVE_SYNCED_CODE();
 			}
-			LoadLua(false, true);
-			Watchdog::ClearTimer(WDT_LOAD);
-		} else {
-			ENTER_SYNCED_CODE();
+			// Update height bounds and pathing after pregame or a saved game load.
 			{
-				auto lock = CLoadLock::GetUniqueLock();
-				eventHandler.GamePreload();
+				ENTER_SYNCED_CODE();
+				//needed in case pre-game terraform changed the map
+				readMap->UpdateHeightBounds();
 				Watchdog::ClearTimer(WDT_LOAD);
-				eventHandler.CollectGarbage(true);
+				pathManager->PostFinalizeRefresh();
 				Watchdog::ClearTimer(WDT_LOAD);
+				LEAVE_SYNCED_CODE();
 			}
-			LEAVE_SYNCED_CODE();
-		}
-		// Update height bounds and pathing after pregame or a saved game load.
-		{
-			ENTER_SYNCED_CODE();
-			//needed in case pre-game terraform changed the map
-			readMap->UpdateHeightBounds();
-			Watchdog::ClearTimer(WDT_LOAD);
-			pathManager->PostFinalizeRefresh();
-			Watchdog::ClearTimer(WDT_LOAD);
-			LEAVE_SYNCED_CODE();
-		}
 
-		{
-			char msgBuf[512];
+			{
+				char msgBuf[512];
 
-			SNPRINTF(msgBuf, sizeof(msgBuf), "[Game::%s][lua{Rules,Gaia}={%p,%p}][locale=\"%s\"]", __func__, luaRules, luaGaia, setlocale(LC_ALL, nullptr));
-			CLIENT_NETLOG(gu->myPlayerNum, LOG_LEVEL_INFO, msgBuf);
+				SNPRINTF(msgBuf, sizeof(msgBuf), "[Game::%s][lua{Rules,Gaia}={%p,%p}][locale=\"%s\"]", __func__, luaRules, luaGaia, setlocale(LC_ALL, nullptr));
+				CLIENT_NETLOG(gu->myPlayerNum, LOG_LEVEL_INFO, msgBuf);
+			}
+		} catch (const content_error& e) {
+			contentErrors.emplace_back(e.what());
+			LOG_L(L_ERROR, "[Game::%s][7] forced quit with exception \"%s\"", __func__, e.what());
+			forcedQuit = true;
 		}
-	} catch (const content_error& e) {
-		contentErrors.emplace_back(e.what());
-		LOG_L(L_ERROR, "[Game::%s][7] forced quit with exception \"%s\"", __func__, e.what());
-		forcedQuit = true;
 	}
 
 	if (!forcedQuit) {

--- a/rts/Game/LoadScreen.cpp
+++ b/rts/Game/LoadScreen.cpp
@@ -109,7 +109,14 @@ bool CLoadScreen::Init()
 	clientNet->KeepUpdating(true);
 
 	netHeartbeatThread = spring::thread(Threading::CreateNewThread(std::bind(&CNetProtocol::UpdateLoop, clientNet)));
-	game = new CGame(mapFileName, modFileName, saveFile);
+	try {
+		game = new CGame(mapFileName, modFileName, saveFile);
+	} catch (...) {
+		// CGame publishes itself before parsing startup content. Its destructor is
+		// not called when construction fails, so do not leave a dangling global.
+		game = nullptr;
+		throw;
+	}
 
 	CglFont::sync.SetThreadSafety(mtLoading);
 	CLoadLock::SetThreadSafety(mtLoading);
@@ -348,4 +355,3 @@ void CLoadScreen::SetLoadMessage(const std::string& text, bool replaceLast)
 	Update();
 	Draw();
 }
-

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -72,6 +72,9 @@ void CProjectileDrawer::InitStatic() {
 }
 void CProjectileDrawer::KillStatic(bool reload) {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (projectileDrawer == nullptr)
+		return;
+
 	projectileDrawer->Kill();
 
 	if (reload)

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -174,6 +174,9 @@ void CProjectileDrawer::InitStatic() {
 }
 void CProjectileDrawer::KillStatic(bool reload) {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (projectileDrawer == nullptr)
+		return;
+
 	projectileDrawer->Kill();
 
 	if (reload)

--- a/rts/Rendering/WorldDrawer.cpp
+++ b/rts/Rendering/WorldDrawer.cpp
@@ -191,7 +191,8 @@ void CWorldDrawer::Kill()
 	textureHandler3DO.Kill();
 	textureHandlerS3O.Kill();
 
-	readMap->KillGroundDrawer();
+	if (readMap != nullptr)
+		readMap->KillGroundDrawer();
 	IGroundDecalDrawer::FreeInstance();
 	DepthBufferCopy::Kill();
 	LuaObjectDrawer::Kill();

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -695,6 +695,9 @@ void CLosHandler::InitStatic()
 void CLosHandler::KillStatic(bool reload)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (losHandler == nullptr)
+		return;
+
 	losHandler->Kill();
 
 	if (reload)

--- a/rts/Sim/Units/Scripts/UnitScriptEngine.cpp
+++ b/rts/Sim/Units/Scripts/UnitScriptEngine.cpp
@@ -52,6 +52,9 @@ void CUnitScriptEngine::InitStatic() {
 
 void CUnitScriptEngine::KillStatic() {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (unitScriptEngine == nullptr)
+		return;
+
 	cobEngine->Kill();
 	cobFileHandler->Kill();
 	unitScriptEngine->Kill();


### PR DESCRIPTION
Fixes #2486.

## Summary

- stop running dependent game-loading stages after a content error
- make cleanup safe when the projectile drawer, map reader, LOS handler, or unit-script engine was never initialized
- preserve the original content error so startup scripts report what could not be loaded

## Reproduction and validation

The reported failure was reproduced with a valid map archive filename used as `MapName`. `LoadMap` raised `SMFMapFile::Open`, but loading continued into `CLosHandler::InitStatic` and dereferenced an uninitialized heightmap. Following the shutdown path under GDB then exposed the cleanup assumptions fixed here.

- failing script now exits without a signal, with exit code 21 and the original `SMFMapFile::Open` diagnostic
- the same script with the canonical map name completes all eight loading stages and enters the game
- `spring-headless` builds
- legacy `spring` builds
- `git diff --check` passes
- `check` target: 27/29 tests pass; the unrelated existing CREG layout warnings and duplicate build/install base content in `testUnitSync` remain failing
