### PR TITLE
Annotate GetConfig functions so default values produce non-optional return type

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -4783,8 +4783,9 @@ int LuaUnsyncedRead::GetConfigParams(lua_State* L)
  *
  * @function Spring.GetConfigInt
  * @param name string
- * @param default number? (Default: `0`)
- * @return number? configInt
+ * @param default integer Default value if `name` is not found
+ * @return integer
+ * @overload fun(name: string): integer?
  */
 int LuaUnsyncedRead::GetConfigInt(lua_State* L)
 {
@@ -4804,8 +4805,9 @@ int LuaUnsyncedRead::GetConfigInt(lua_State* L)
  *
  * @function Spring.GetConfigFloat
  * @param name string
- * @param default number? (Default: `0`)
- * @return number? configFloat
+ * @param default number Default value if `name` is not found
+ * @return number
+ * @overload fun(name: string): number?
  */
 int LuaUnsyncedRead::GetConfigFloat(lua_State* L)
 {
@@ -4825,8 +4827,9 @@ int LuaUnsyncedRead::GetConfigFloat(lua_State* L)
  *
  * @function Spring.GetConfigString
  * @param name string
- * @param default string? (Default: `""`)
- * @return number? configString
+ * @param default string Default value if `name` is not found
+ * @return string
+ * @overload fun(name: string): string?
  */
 int LuaUnsyncedRead::GetConfigString(lua_State* L)
 {


### PR DESCRIPTION
`GetConfigString` is annotated to return an optional string. However, if the optional second parameter is included then the return type is a non-optional string. Ditto for GetConfigFloat and GetConfigInt.

This PR overloads the functions with two signatures each, with and without a default.

I've also removed the mention of the "Default" from the comments. I think this was a misunderstanding of how `luaL_optstring` etc work; those deeper defaults won't ever be used.