### PR TITLE
Fix incorrectly copied annotation comment for SolveNURBSCurve

### DIFF
--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -5334,8 +5334,11 @@ int LuaUnsyncedRead::GetSyncedGCInfo(lua_State* L) {
 /***
  *
  * @function Spring.SolveNURBSCurve
- * @param groupID integer
- * @return number[]? unitIDs
+ * @param degree integer Degree of the curve.
+ * @param controlPoints number[] Flat array of `x, y, z, weight` quadruples; its length must be a multiple of 4.
+ * @param knots number[] Knot vector.
+ * @param segments integer Number of segments to evaluate.
+ * @return number[] points Flat array of `x, y, z` triples along the curve.
  */
 int LuaUnsyncedRead::SolveNURBSCurve(lua_State* L)
 {


### PR DESCRIPTION
The annotation for `SolveNURBSCurve` was inappropriately copied from `GetGroupUnits` and is entirely wrong.

The corrected annotation in this PR was written by Claude Opus 5. I have reviewed it fully. I am only slightly unclear on the internal functioning of `LuaUtils::ParseFloat4Vector`, but otherwise I understand and agree with this change.

There is no open issue for this problem. I encountered it while pursuing #2438