### PR TITLE
Particles performance enhancements

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
@@ -232,6 +232,9 @@ ShieldSegmentProjectile::ShieldSegmentProjectile(
 	useAirLos     = true;
 	drawRadius    = shieldWeaponDef->shieldRadius * 0.4f;
 	mygravity     = 0.0f;
+	// Draw() mutates the shared segment collection and can fire the DrawShield
+	// Lua callin, neither of which may run off the main thread
+	mtDrawSafe    = false;
 
 	vertices = GetSegmentVertices(xpart, ypart);
 	texCoors = GetSegmentTexCoords(collection->GetShieldTexture(), xpart, ypart);

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -159,16 +159,16 @@ void CSimpleParticleSystem::Draw()
 	}
 
 	// !directional
+	zdir = camera->GetForward();
+	xdir = camera->GetRight();
+	ydir = camera->GetUp();
+
 	for (int i = 0; i < numParticles; i++) {
 		const Particle* p = &particles[i];
 
 		if (p->life >= 1.0f)
 			continue;
 
-		zdir = camera->GetForward();
-		xdir = camera->GetRight();
-		ydir = camera->GetUp();
-		
 		DoParticleDraw(xdir, ydir, zdir, p);
 	}
 }

--- a/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
@@ -26,6 +26,7 @@ CTracerProjectile::CTracerProjectile()
 	, drawLength(0.0f)
 {
 	checkCol = false;
+	mtDrawSafe = false; // Draw() issues immediate GL calls on its own buffer
 }
 
 CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const float3& spd, const float range)
@@ -36,6 +37,7 @@ CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const floa
 	SetRadiusAndHeight(1.0f, 0.0f);
 
 	checkCol = false;
+	mtDrawSafe = false; // Draw() issues immediate GL calls on its own buffer
 	// Projectile::Init has been called by base ctor, so .w is defined
 	// FIXME: constant, assumes |speed| never changes after creation
 	speedf = this->speed.w;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -45,15 +45,93 @@
 #include "System/Misc/TracyDefs.h"
 
 CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften up CEG particles on clipping edges");
+CONFIG(float, ProjectileReflectionMinRadius).defaultValue(0.0f).minimumValue(0.0f).description("Alpha particles with a draw radius (in elmos) smaller than this are skipped in water reflection passes; 0 draws all of them. Small particles are barely visible in reflections, so culling them there is cheap visually and saves a large part of the reflection pass on effect-heavy frames.");
+CONFIG(int, ProjectileDrawThreadedFill).defaultValue(1).safemodeValue(0).description("Generate alpha-particle geometry on the ThreadPool workers instead of the render thread. Draw order is preserved; the few particle types whose Draw is not thread-safe stay on the render thread.");
 
-static uint32_t sortCamType = 0;
-static bool CProjectileDrawOrderSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::forward_as_tuple(p2->drawOrder, p1->GetSortDist(sortCamType), p1) > std::forward_as_tuple(p1->drawOrder, p2->GetSortDist(sortCamType), p2);
+// sort keys are snapshotted into SortableParticle at fill time, so the
+// comparators run on a contiguous array instead of dereferencing two
+// CProjectile pointers (= two likely cache misses) per comparison
+using SortableParticle = CProjectileDrawer::SortableParticle;
+
+static bool CProjectileDrawOrderSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
+	return std::forward_as_tuple(b.drawOrder, a.sortDist, a.proj) > std::forward_as_tuple(a.drawOrder, b.sortDist, b.proj);
 }
 
-static bool CProjectileSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::forward_as_tuple(p1->GetSortDist(sortCamType), p1) > std::forward_as_tuple(p2->GetSortDist(sortCamType), p2);
+static bool CProjectileSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
+	return std::forward_as_tuple(a.sortDist, a.proj) > std::forward_as_tuple(b.sortDist, b.proj);
 };
+
+// with fewer particles per chunk the for_mt dispatch overhead exceeds the
+// quad-generation work being distributed
+static constexpr size_t MT_FILL_MIN_CHUNK_SIZE = 96;
+
+// Runs p->Draw() over a particle list, generating quads on the ThreadPool
+// workers: the list is split into contiguous chunks, each chunk fills its own
+// scratch buffer, and the scratch buffers are merged into the primary buffer
+// in chunk order, so the emitted geometry is byte-identical to a serial fill.
+// Particles with mtDrawSafe == false (immediate GL calls, Lua callins) split
+// the list into segments and are drawn serially, in their exact position.
+template<typename GetParticle>
+static void FillParticleGeometry(std::vector<TypedRenderBuffer<VA_TYPE_PROJ>>& scratchBufs, size_t count, bool threaded, GetParticle&& getParticle)
+{
+	auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
+
+	size_t segStart = 0;
+	for (size_t i = 0; i <= count; ++i) {
+		CProjectile* boundaryProj = (i < count) ? getParticle(i) : nullptr;
+		if (boundaryProj != nullptr && boundaryProj->mtDrawSafe)
+			continue;
+
+		// [segStart, i) is a contiguous run of MT-safe particles
+		const size_t segLen = i - segStart;
+		const size_t numChunks = threaded ? std::min<size_t>(ThreadPool::GetNumThreads(), segLen / MT_FILL_MIN_CHUNK_SIZE) : 1;
+
+		if (numChunks < 2) {
+			for (size_t j = segStart; j < i; ++j)
+				getParticle(j)->Draw();
+		} else {
+			// main thread only: buffer (de)registration is not thread-safe
+			if (scratchBufs.size() < numChunks)
+				scratchBufs.resize(numChunks);
+
+			const size_t chunkSize = (segLen + numChunks - 1) / numChunks;
+			const size_t segEnd = i;
+
+			for_mt(0, static_cast<int>(numChunks), [&scratchBufs, &getParticle, segStart, segEnd, chunkSize](int ci) {
+				auto& scratch = scratchBufs[ci];
+				scratch.Clear();
+
+				CExpGenSpawnable::SetGeomFillTarget(&scratch);
+				const size_t jb = segStart + ci * chunkSize;
+				const size_t je = std::min(jb + chunkSize, segEnd);
+				for (size_t j = jb; j < je; ++j)
+					getParticle(j)->Draw();
+				CExpGenSpawnable::SetGeomFillTarget(nullptr);
+			});
+
+			// merge in chunk order to preserve the back-to-front particle order
+			for (size_t ci = 0; ci < numChunks; ++ci) {
+				auto& scratch = scratchBufs[ci];
+				const auto& verts = scratch.GetElems();
+				const auto& indcs = scratch.GetIndcs();
+
+				if (verts.empty())
+					continue;
+
+				const auto vertBias = static_cast<int32_t>(rb.GetBaseVertex());
+				rb.AddVertices(verts.begin(), verts.end());
+				rb.AddIndices(indcs.begin(), indcs.end(), vertBias);
+			}
+		}
+
+		// the boundary particle itself is not MT-safe; draw it serially in its
+		// exact sorted position
+		if (boundaryProj != nullptr)
+			boundaryProj->Draw();
+
+		segStart = i + 1;
+	}
+}
 
 CProjectileDrawer* projectileDrawer = nullptr;
 
@@ -350,8 +428,9 @@ void CProjectileDrawer::Kill() {
 
 	renderProjectiles.clear();
 
-	for (auto& dp : drawParticles)
-		dp.clear();
+	sortedParticles.clear();
+	unsortedParticles.clear();
+	mtFillBuffers.clear();
 
 	perlinFB.Kill();
 
@@ -372,7 +451,12 @@ void CProjectileDrawer::UpdateDrawFlags()
 {
 	ZoneScopedN("ProjectileDrawer::UpdateDrawFlags");
 
-	for_mt(0, renderProjectiles.size(), [this](int i) {
+	// water reflections are distorted enough that small particles contribute
+	// next to nothing visually; skipping them avoids most of the reflection
+	// pass' fill/sort/quad-generation cost on effect-heavy frames
+	const float reflMinRadius = configHandler->GetFloat("ProjectileReflectionMinRadius");
+
+	for_mt(0, renderProjectiles.size(), [this, reflMinRadius](int i) {
 		CProjectile* p = renderProjectiles[i];
 		const bool hasModel = (p->model != nullptr);
 
@@ -388,6 +472,9 @@ void CProjectileDrawer::UpdateDrawFlags()
 
 		for (uint32_t camType = CCamera::CAMTYPE_PLAYER; camType < CCamera::CAMTYPE_ENVMAP; ++camType) {
 			if (camType == CCamera::CAMTYPE_UWREFL && !IWater::GetWater()->CanDrawReflectionPass())
+				continue;
+
+			if (camType == CCamera::CAMTYPE_UWREFL && !hasModel && p->GetDrawRadius() < reflMinRadius)
 				continue;
 
 			if (camType == CCamera::CAMTYPE_SHADOW && !p->castShadow)
@@ -770,8 +857,10 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 			(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
 			(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
 
-		for (auto& dp : drawParticles)
-			dp.clear();
+		sortedParticles.clear();
+		unsortedParticles.clear();
+
+		const uint32_t sortCamType = camera->GetCamType();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
@@ -779,32 +868,30 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 				if (!ShouldDrawProjectile(p, thisPassMask))
 					continue;
 
-				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+				if (drawSorted && p->drawSorted)
+					sortedParticles.emplace_back(SortableParticle{ p->drawOrder, p->GetSortDist(sortCamType), p });
+				else
+					unsortedParticles.emplace_back(p);
 			}
 		}
-
-		// set static variable to facilite sorting
-		sortCamType = camera->GetCamType();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
 			if (wantDrawOrder)
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
+				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileDrawOrderSortingPredicate);
 			else
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
+				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileSortingPredicate);
 		}
+
+		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-			for (auto p : drawParticles[ true]) {
-				p->Draw();
-			}
+			FillParticleGeometry(mtFillBuffers, sortedParticles.size(), threadedFill, [this](size_t j) { return sortedParticles[j].proj; });
 		}
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-			for (auto p : drawParticles[false]) {
-				p->Draw();
-			}
+			FillParticleGeometry(mtFillBuffers, unsortedParticles.size(), threadedFill, [this](size_t j) { return unsortedParticles[j]; });
 		}
 	}
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -753,45 +753,58 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	};
 	const auto& clipPlane = clipPlanes[1U * drawBelowWater + 2U * drawAboveWater];
 
-	const uint8_t thisPassMask =
-		(1 - (drawReflection || drawRefraction)) * DrawFlags::SO_ALPHAF_FLAG +
-		(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
-		(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
+	// The main view draws alpha particles twice per frame when water is
+	// visible: a below-water pass, then an above-water pass once the water
+	// surface has been drawn. Both passes contain the same particles viewed
+	// from the same camera; only the clip plane differs. Fill and upload the
+	// geometry once in the below-water pass and re-submit the saved range in
+	// the above-water pass. The water reflection/refraction passes that run
+	// in between fill the buffer for their own camera/mask and consume their
+	// own ranges, so the saved range stays valid for the whole frame.
+	const bool mainPass = !drawReflection && !drawRefraction;
+	const bool reusePass = mainPass && drawAboveWater && !drawBelowWater && (alphaRangeDrawFrame == globalRendering->drawFrame);
 
-	for (auto& dp : drawParticles)
-		dp.clear();
+	if (!reusePass) {
+		const uint8_t thisPassMask =
+			(1 - (drawReflection || drawRefraction)) * DrawFlags::SO_ALPHAF_FLAG +
+			(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
+			(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
-		for (CProjectile* p : renderProjectiles) {
-			if (!ShouldDrawProjectile(p, thisPassMask))
-				continue;
+		for (auto& dp : drawParticles)
+			dp.clear();
 
-			drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
+			for (CProjectile* p : renderProjectiles) {
+				if (!ShouldDrawProjectile(p, thisPassMask))
+					continue;
+
+				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+			}
 		}
-	}
 
-	// set static variable to facilite sorting
-	sortCamType = camera->GetCamType();
+		// set static variable to facilite sorting
+		sortCamType = camera->GetCamType();
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-		if (wantDrawOrder)
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
-		else
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
-	}
-
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-		for (auto p : drawParticles[ true]) {
-			p->Draw();
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
+			if (wantDrawOrder)
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
+			else
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
 		}
-	}
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-		for (auto p : drawParticles[false]) {
-			p->Draw();
+
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
+			for (auto p : drawParticles[ true]) {
+				p->Draw();
+			}
+		}
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
+			for (auto p : drawParticles[false]) {
+				p->Draw();
+			}
 		}
 	}
 
@@ -810,7 +823,18 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		eventHandler.DrawWorldPreParticles(drawAboveWater, drawBelowWater, drawReflection, drawRefraction);
 
 		auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
-		if (!rb.ShouldSubmit())
+
+		if (mainPass && drawBelowWater && !drawAboveWater) {
+			// an above-water pass will follow this frame; remember what to re-draw
+			const auto pendingRange = rb.GetPendingElemsRange();
+			alphaRangeStart = pendingRange.first;
+			alphaRangeCount = pendingRange.second;
+			alphaRangeDrawFrame = globalRendering->drawFrame;
+		}
+
+		const bool haveRangeToRedraw = (reusePass && alphaRangeCount > 0);
+
+		if (!haveRangeToRedraw && !rb.ShouldSubmit())
 			return;
 
 		const bool needSoften = (wantSoften > 0) && !drawReflection && !drawRefraction;
@@ -835,7 +859,16 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		fxShader->SetUniform("fogColor", sky->fogColor.x, sky->fogColor.y, sky->fogColor.z);
 		fxShader->SetUniform("fogParams", sky->fogStart * camPlayer->GetFarPlaneDist(), sky->fogEnd * camPlayer->GetFarPlaneDist());
 
-		rb.DrawElements(GL_TRIANGLES);
+		if (reusePass) {
+			rb.DrawElementsRange(GL_TRIANGLES, alphaRangeStart, alphaRangeCount);
+			// consume anything appended since the range was saved (e.g. by the
+			// DrawWorldPreParticles handlers above), so it cannot leak into a
+			// later submit running a different shader
+			if (rb.ShouldSubmit())
+				rb.DrawElements(GL_TRIANGLES);
+		} else {
+			rb.DrawElements(GL_TRIANGLES);
+		}
 
 		fxShader->Disable();
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -170,6 +170,12 @@ private:
 	/// used to render particle effects in back-to-front order. {unsorted, sorted}
 	std::array<std::vector<CProjectile*>, 2> drawParticles;
 
+	/// geometry range submitted by the below-water alpha pass, re-drawn by the
+	/// above-water pass of the same frame instead of refilling the buffer
+	size_t alphaRangeStart = 0;
+	size_t alphaRangeCount = 0;
+	unsigned int alphaRangeDrawFrame = 0;
+
 	bool drawSorted = true;
 
 	Shader::IProgramObject* fxShader = nullptr;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -167,8 +167,26 @@ private:
 	/// projectiles with a model, binned by model type and textures
 	std::array<ModelRenderContainer<CProjectile>, MODELTYPE_CNT> modelRenderers;
 
-	/// used to render particle effects in back-to-front order. {unsorted, sorted}
-	std::array<std::vector<CProjectile*>, 2> drawParticles;
+public:
+	struct SortableParticle {
+		int drawOrder;
+		float sortDist;
+		CProjectile* proj;
+	};
+
+private:
+	/// alpha particles drawn back-to-front; sort keys are snapshotted at fill
+	/// time so sorting compares a contiguous 16-byte array instead of chasing
+	/// projectile pointers
+	std::vector<SortableParticle> sortedParticles;
+	/// alpha particles that opt out of sorting, drawn after the sorted ones
+	std::vector<CProjectile*> unsortedParticles;
+
+	/// per-chunk scratch buffers for the multithreaded alpha-pass geometry
+	/// fill; only their CPU-side arrays are ever used (no GL objects). Grown
+	/// on the main thread only, since (de)registration in the RenderBuffer
+	/// registry is not thread-safe.
+	std::vector<TypedRenderBuffer<VA_TYPE_PROJ>> mtFillBuffers;
 
 	/// geometry range submitted by the below-water alpha pass, re-drawn by the
 	/// above-water pass of the same frame instead of refilling the buffer

--- a/rts/Rendering/GL/RenderBuffers.h
+++ b/rts/Rendering/GL/RenderBuffers.h
@@ -587,7 +587,15 @@ public:
 	void AssertBoundShader() const;
 	void DrawArrays(uint32_t mode, bool rewind = true);
 	void DrawElements(uint32_t mode, bool rewind = true);
+	void DrawElementsRange(uint32_t mode, size_t eboRangeStart, size_t eboRangeCount);
 	void DropCurrent();
+
+	// the index range the next DrawElements() call would submit; capture before
+	// submitting to later re-draw the same geometry via DrawElementsRange()
+	// (valid until the next SwapBuffer(), i.e. within the current draw frame)
+	std::pair<size_t, size_t> GetPendingElemsRange() const {
+		return { eboStartIndex, indcs.size() - eboStartIndex };
+	}
 
 	TypedRenderBuffer<T> CopyCurrent(bool readOnly) const;
 
@@ -907,6 +915,29 @@ inline void TypedRenderBuffer<T>::DrawElements(uint32_t mode, bool rewind)
 	}
 
 	vboStartIndex = verts.size();
+
+	numSubmits[1] += 1;
+}
+
+// re-draws an already uploaded and submitted index range of the current frame,
+// without touching the consume/rewind bookkeeping. The range must come from
+// GetPendingElemsRange() captured earlier in the same draw frame.
+template<typename T>
+inline void TypedRenderBuffer<T>::DrawElementsRange(uint32_t mode, size_t eboRangeStart, size_t eboRangeCount)
+{
+	AssertBoundShader();
+
+	if (eboRangeCount == 0)
+		return;
+
+	assert(eboRangeStart + eboRangeCount <= indcs.size());
+	assert(eboRangeStart + eboRangeCount <= eboUploadIndex);
+#ifndef HEADLESS
+	assert(vao.GetIdRaw() > 0);
+#endif
+	vao.Bind();
+	glDrawElements(mode, static_cast<GLsizei>(eboRangeCount), GL_UNSIGNED_INT, reinterpret_cast<void*>(sizeof(uint32_t) * (ebo->BufferElemOffset() + eboRangeStart)));
+	vao.Unbind();
 
 	numSubmits[1] += 1;
 }

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -138,9 +138,21 @@ bool CExpGenSpawnable::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	return false;
 }
 
+// per-thread geometry destination override for the multithreaded alpha-pass
+// fill; null (the default) routes everything to the shared primary buffer
+static thread_local TypedRenderBuffer<VA_TYPE_PROJ>* geomFillTarget = nullptr;
+
+void CExpGenSpawnable::SetGeomFillTarget(TypedRenderBuffer<VA_TYPE_PROJ>* target)
+{
+	geomFillTarget = target;
+}
+
 TypedRenderBuffer<VA_TYPE_PROJ>& CExpGenSpawnable::GetPrimaryRenderBuffer()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (geomFillTarget != nullptr)
+		return *geomFillTarget;
+
 	return RenderBuffer::GetTypedRenderBuffer<VA_TYPE_PROJ>();
 }
 

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -35,6 +35,11 @@ public:
 	//Memory handled in projectileHandler
 	static CExpGenSpawnable* CreateSpawnable(int spawnableID);
 	static TypedRenderBuffer<VA_TYPE_PROJ>& GetPrimaryRenderBuffer();
+
+	// while set (per thread), AddEffectsQuad geometry lands in the given
+	// buffer instead of the shared primary one; used by the multithreaded
+	// alpha-pass fill in CProjectileDrawer. Pass nullptr to restore.
+	static void SetGeomFillTarget(TypedRenderBuffer<VA_TYPE_PROJ>* target);
 protected:
 	CExpGenSpawnable();
 

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -116,6 +116,10 @@ public:
 
 	bool castShadow = false;
 	bool drawSorted = true;
+	// false for the few classes whose Draw() touches shared state (immediate
+	// GL calls, Lua callins); they are drawn serially by the alpha pass while
+	// everything else fills geometry multithreaded
+	bool mtDrawSafe = true;
 
 	bool blockPreciseCol = false;
 


### PR DESCRIPTION
On water maps the main view fills the alpha-particle stream buffer up to four times per frame (below-water, reflection, refraction, above-water), each time re-filtering, re-sorting, re-running every particle's Draw() and re-uploading the result. At battle-level particle counts this makes ProjectileDrawer::DrawAlpha one of the largest CPU blocks in the frame. This PR removes the fully redundant pass and parallelizes/speeds up what remains, without changing a single rendered pixel: every optimization here is geometry-byte-identical by construction.

# Measurement
Numbers come from a deterministic benchmark: a synced gadget that spawns a fixed, seeded, map-wide mix of CEGs, weapon explosions, in-flight projectiles and beams (≈6k visible alpha particles, ~1.7k spawns/s at the tested intensity), so back-to-back runs draw identical scenes. Measured with Tracy on a water map (Tabula), same session A/B via the config toggles where applicable.  executed in BAR with: /luarules particlebench mix 300 3

Metric (mean)	before	after
Frame average	7.51 ms (133 fps)	5.22 ms (192 fps)
Particles pass, below water	1.15 ms	0.66 ms
Particles pass, above water	1.16 ms	65 µs
DrawAlpha(DS) quad generation	~390 µs	~130 µs
DrawAlpha(SO) sorting	~209 µs	small

# Commits
1. Water-pass geometry reuse. The below/above-water passes contain the same particles from the same camera at the same interpolation time — only the shader clip plane differs. The below-water pass now records its submitted index range (TypedRenderBuffer::GetPendingElemsRange) and the above-water pass of the same draw frame re-issues it via the new DrawElementsRange (draws an uploaded range without touching consume/rewind state). Reflection/refraction passes in between consume their own ranges, so the saved range stays valid until the end-of-frame buffer swap. The reuse pass still fires DrawWorldPreParticles and flushes anything appended during it.

2. Sorting + threaded quad generation.

Sort predicates no longer dereference two CProjectile* per comparison; keys (drawOrder, sortDist) are snapshotted into a contiguous array at filter time. Ordering semantics unchanged.
The Draw() loops fan out over the ThreadPool in contiguous chunks, each filling a per-chunk scratch buffer via a thread_local redirect of CExpGenSpawnable::GetPrimaryRenderBuffer(); scratches merge back in chunk order, preserving exact back-to-front order. Every Draw() override reachable from the alpha pass was audited: none touch RNG, statics, or lazily-initialized caches. The two exceptions are flagged mtDrawSafe = false and drawn serially at their exact sorted position: CTracerProjectile (immediate GL inside Draw()) and ShieldSegmentProjectile (shared collection latch + DrawShield Lua callin). Configbool ProjectileDrawThreadedFill (default 1, safemode 0); segments below 96 particles/chunk stay serial so small fills skip dispatch overhead.
ProjectileReflectionMinRadius (default 0 = off): opt-in culling of small non-model particles from the reflection pass, for games that want the reflection fill cheaper.
Review notes
The reuse in commit 1 is keyed on mainPass && drawAboveWater && !drawBelowWater && same drawFrame, so reflection/refraction (drawReflection/drawRefraction set) can never hit it, and no-water frames (single combined pass) are untouched.
Scratch buffers are grown on the main thread only — RenderBuffer's registry registration isn't thread-safe.
mtDrawSafe is not creg-serialized; it's a render-side constant established in ctors.
Safemode disables the threaded fill; ProjectileDrawThreadedFill 0 restores the exact serial path at runtime.

before:
<img width="2270" height="796" alt="2026-08-15 20_53_25-NVIDIA GeForce Overlay" src="https://github.com/user-attachments/assets/7c13fc84-1f39-4108-9002-4750c23e7bee" />
after:
<img width="1936" height="921" alt="2026-08-15 22_22_26-spring exe @ 2026-08-15 22_18_52 - Tracy Profiler 0 11 1" src="https://github.com/user-attachments/assets/b4bb1223-fbf9-49ff-839c-559fb50b33d7" />

# Possible future endevours (not in this PR)
GPU quad expansion (per-quad SSBO records, corner expansion in the vertex shader) would cut the remaining fill cost and upload volume ~3–4× across all passes including shadows, at the cost of touching VA_TYPE_PROJ and the FX shaders. The shadow-transparent pass could also adopt the threaded fill helper.

Code written by: Claude Fable 5
