### PR TITLE
Update lua number to integer, and integer to ID aliases, where appropriate

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -43,8 +43,8 @@
  * @field commitsNumber string Number of commits after the latest named release, non-zero indicates a "dev" build
  * @field buildFlags string Gets additional engine buildflags, e.g. "Debug" or "Sync-Debug"
  * @field featureSupport FeatureSupport Table containing various engine features as keys; use for cross-version compat
- * @field wordSize number Indicates the build type always 64 these days
- * @field gameSpeed number Number of simulation gameframes per second
+ * @field wordSize integer Indicates the build type always 64 these days
+ * @field gameSpeed integer Number of simulation gameframes per second
  * @field textColorCodes TextColorCode Table containing keys that represent the color code operations during font rendering
  */
 

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -36,13 +36,13 @@
 /*** Game specific information
  *
  * @table Game
- * @field maxUnits number
- * @field maxTeams number
- * @field maxPlayers number
- * @field squareSize number Divide Game.mapSizeX or Game.mapSizeZ by this to get engine's "mapDims" coordinates. The resolution of height, yard and type maps.
- * @field metalMapSquareSize number The resolution of metalmap (for use in API such as Spring.GetMetalAmount etc.)
- * @field gameSpeed number Number of simulation gameframes per second
- * @field startPosType number
+ * @field maxUnits integer
+ * @field maxTeams integer
+ * @field maxPlayers integer
+ * @field squareSize integer Divide Game.mapSizeX or Game.mapSizeZ by this to get engine's "mapDims" coordinates. The resolution of height, yard and type maps.
+ * @field metalMapSquareSize integer The resolution of metalmap (for use in API such as Spring.GetMetalAmount etc.)
+ * @field gameSpeed integer Number of simulation gameframes per second
+ * @field startPosType integer
  * @field ghostedBuildings boolean
  * @field mapChecksum string
  * @field modChecksum string
@@ -50,10 +50,10 @@
  * @field mapName string
  * @field mapDescription string = string Game.mapHumanName
  * @field mapHardness number
- * @field mapX number
- * @field mapY number
- * @field mapSizeX number in worldspace/opengl coords. Divide by Game.squareSize to get engine's "mapDims" coordinates
- * @field mapSizeZ number in worldspace/opengl coords. Divide by Game.squareSize to get engine's "mapDims" coordinates
+ * @field mapX integer
+ * @field mapY integer
+ * @field mapSizeX integer in worldspace/opengl coords. Divide by Game.squareSize to get engine's "mapDims" coordinates
+ * @field mapSizeZ integer in worldspace/opengl coords. Divide by Game.squareSize to get engine's "mapDims" coordinates
  * @field gravity number
  * @field tidal number
  * @field windMin number
@@ -67,20 +67,20 @@
  * @field gameMutator string
  * @field gameDesc string
  * @field requireSonarUnderWater boolean
- * @field transportAir number
- * @field transportShip number
- * @field transportHover number
- * @field transportGround number
- * @field fireAtKilled number
- * @field fireAtCrashing number
+ * @field transportAir integer
+ * @field transportShip integer
+ * @field transportHover integer
+ * @field transportGround integer
+ * @field fireAtKilled integer
+ * @field fireAtCrashing integer
  * @field constructionDecay boolean
  * @field reclaimAllowEnemies boolean
  * @field reclaimAllowAllies boolean
- * @field constructionDecayTime number
+ * @field constructionDecayTime integer
  * @field constructionDecaySpeed number
- * @field multiReclaim number
- * @field reclaimMethod number
- * @field reclaimUnitMethod number
+ * @field multiReclaim integer
+ * @field reclaimMethod integer
+ * @field reclaimUnitMethod integer
  * @field reclaimUnitEnergyCostFactor number
  * @field reclaimUnitEfficiency number
  * @field reclaimFeatureEnergyCostFactor number

--- a/rts/Lua/LuaConstPlatform.cpp
+++ b/rts/Lua/LuaConstPlatform.cpp
@@ -24,7 +24,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	LuaPushNamedString(L, "gpu", globalRenderingInfo.gpuName);
 	/*** @field Platform.gpuVendor "Nvidia"|"Intel"|"ATI"|"Mesa"|"Unknown" */
 	LuaPushNamedString(L, "gpuVendor", globalRenderingInfo.gpuVendor);
-	/*** @field Platform.gpuMemorySize number Size of total GPU memory in MBs; only available for "Nvidia", (rest are 0) */
+	/*** @field Platform.gpuMemorySize integer Size of total GPU memory in MBs; only available for "Nvidia", (rest are 0) */
 	LuaPushNamedNumber(L, "gpuMemorySize", globalRenderingInfo.gpuMemorySize.x);
 	/*** @field Platform.glVersionShort string `major.minor.buildNumber` */
 	LuaPushNamedString(L, "glVersionShort", globalRenderingInfo.glVersionShort.data());
@@ -48,17 +48,17 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	/*** @field Platform.glewVersion string */
 	LuaPushNamedString(L, "glewVersion", globalRenderingInfo.gladVersion);
 
-	/*** @field Platform.sdlVersionCompiledMajor number */
+	/*** @field Platform.sdlVersionCompiledMajor integer */
 	LuaPushNamedNumber(L, "sdlVersionCompiledMajor", globalRenderingInfo.sdlVersionCompiled.major);
-	/*** @field Platform.sdlVersionCompiledMinor number */
+	/*** @field Platform.sdlVersionCompiledMinor integer */
 	LuaPushNamedNumber(L, "sdlVersionCompiledMinor", globalRenderingInfo.sdlVersionCompiled.minor);
-	/*** @field Platform.sdlVersionCompiledPatch number */
+	/*** @field Platform.sdlVersionCompiledPatch integer */
 	LuaPushNamedNumber(L, "sdlVersionCompiledPatch", globalRenderingInfo.sdlVersionCompiled.patch);
-	/*** @field Platform.sdlVersionLinkedMajor number */
+	/*** @field Platform.sdlVersionLinkedMajor integer */
 	LuaPushNamedNumber(L, "sdlVersionLinkedMajor", globalRenderingInfo.sdlVersionLinked.major);
-	/*** @field Platform.sdlVersionLinkedMinor number */
+	/*** @field Platform.sdlVersionLinkedMinor integer */
 	LuaPushNamedNumber(L, "sdlVersionLinkedMinor", globalRenderingInfo.sdlVersionLinked.minor);
-	/*** @field Platform.sdlVersionLinkedPatch number */
+	/*** @field Platform.sdlVersionLinkedPatch integer */
 	LuaPushNamedNumber(L, "sdlVersionLinkedPatch", globalRenderingInfo.sdlVersionLinked.patch);
 
 	/*** @field Platform.availableVideoModes PlatformVideoMode[] */
@@ -77,13 +77,13 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 		LuaPushNamedNumber(L, "display", avm.displayIndex);
 		/*** @field PlatformVideoMode.displayName string */
 		LuaPushNamedString(L, "displayName", avm.displayName);
-		/*** @field PlatformVideoMode.w number */
+		/*** @field PlatformVideoMode.w integer */
 		LuaPushNamedNumber(L, "w", avm.width);
-		/*** @field PlatformVideoMode.h number */
+		/*** @field PlatformVideoMode.h integer */
 		LuaPushNamedNumber(L, "h", avm.height);
 		/*** @field PlatformVideoMode.bpp integer */
 		LuaPushNamedNumber(L, "bpp", avm.bpp);
-		/*** @field PlatformVideoMode.hz number */
+		/*** @field PlatformVideoMode.hz integer */
 		LuaPushNamedNumber(L, "hz", avm.refreshRate);
 
 		lua_rawset(L, -3);
@@ -112,7 +112,7 @@ bool LuaConstPlatform::PushEntries(lua_State* L)
 	/*** @field Platform.glHaveGL4 boolean */
 	LuaPushNamedBool(L, "glHaveGL4", globalRendering->haveGL4);
 
-	/*** @field Platform.glSupportDepthBufferBitDepth number */
+	/*** @field Platform.glSupportDepthBufferBitDepth integer */
 	LuaPushNamedNumber(L, "glSupportDepthBufferBitDepth", globalRendering->supportDepthBufferBitDepth);
 
 	/*** @field Platform.glSupportRestartPrimitive boolean */

--- a/rts/Lua/LuaFBOs.cpp
+++ b/rts/Lua/LuaFBOs.cpp
@@ -563,7 +563,7 @@ int LuaFBOs::DeleteFBO(lua_State* L)
  * @param fbo FBO
  * @param target GL?
  * @return boolean valid
- * @return number? status
+ * @return GL? status
  */
 int LuaFBOs::IsValidFBO(lua_State* L)
 {
@@ -688,7 +688,7 @@ int LuaFBOs::ActiveFBO(lua_State* L)
  * @function gl.RawBindFBO
  * @param fbo FBO
  * @param target GL? (Default: `fbo.target`)
- * @return number previouslyBoundRawFboId
+ * @return integer previouslyBoundRawFboId
  */
 int LuaFBOs::RawBindFBO(lua_State* L)
 {
@@ -720,32 +720,32 @@ int LuaFBOs::RawBindFBO(lua_State* L)
 /*** needs `GLAD_GL_EXT_framebuffer_blit`
  *
  * @function gl.BlitFBO
- * @param x0Src number
- * @param y0Src number
- * @param x1Src number
- * @param y1Src number
- * @param x0Dst number
- * @param y0Dst number
- * @param x1Dst number
- * @param y1Dst number
- * @param mask number? (Default: GL_COLOR_BUFFER_BIT)
- * @param filter number? (Default: GL_NEAREST)
+ * @param x0Src integer
+ * @param y0Src integer
+ * @param x1Src integer
+ * @param y1Src integer
+ * @param x0Dst integer
+ * @param y0Dst integer
+ * @param x1Dst integer
+ * @param y1Dst integer
+ * @param mask GL? (Default: GL_COLOR_BUFFER_BIT)
+ * @param filter GL? (Default: GL_NEAREST)
  */
 /*** needs `GLAD_GL_EXT_framebuffer_blit`
  *
  * @function gl.BlitFBO
  * @param fboSrc FBO
- * @param x0Src number
- * @param y0Src number
- * @param x1Src number
- * @param y1Src number
+ * @param x0Src integer
+ * @param y0Src integer
+ * @param x1Src integer
+ * @param y1Src integer
  * @param fboDst FBO
- * @param x0Dst number
- * @param y0Dst number
- * @param x1Dst number
- * @param y1Dst number
- * @param mask number? (Default: GL_COLOR_BUFFER_BIT)
- * @param filter number? (Default: GL_NEAREST)
+ * @param x0Dst integer
+ * @param y0Dst integer
+ * @param x1Dst integer
+ * @param y1Dst integer
+ * @param mask GL? (Default: GL_COLOR_BUFFER_BIT)
+ * @param filter GL? (Default: GL_NEAREST)
  */
 int LuaFBOs::BlitFBO(lua_State* L)
 {
@@ -820,7 +820,7 @@ namespace Impl {
  * Clears the "attachment" of the currently bound FBO type "target" with "clearValues"
  * 
  * @function gl.ClearAttachmentFBO
- * @param target number? (Default: `GL.FRAMEBUFFER`)
+ * @param target GL? (Default: `GL.FRAMEBUFFER`)
  * @param attachment GL|Attachment (e.g. `"color0"` or `GL.COLOR_ATTACHMENT0`)
  * @param clearValue0 number? (Default: `0`)
  * @param clearValue1 number? (Default: `0`)

--- a/rts/Lua/LuaFonts.cpp
+++ b/rts/Lua/LuaFonts.cpp
@@ -471,7 +471,7 @@ int LuaFonts::SubmitBuffered(lua_State* L)
  * @param maxHeight number? Defaults to an engine-defined maximum height.
  * @param size number? Defaults to the font's point size.
  * @return string wrappedText
- * @return number lineCount
+ * @return integer lineCount
  */
 int LuaFonts::WrapText(lua_State* L)
 {
@@ -516,7 +516,7 @@ int LuaFonts::GetTextWidth(lua_State* L)
  * @param text string
  * @return number height
  * @return number descender
- * @return number lines
+ * @return integer lines
  */
 int LuaFonts::GetTextHeight(lua_State* L)
 {

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -630,7 +630,7 @@ void CLuaHandle::Shutdown()
  *
  * @function Callins:GotChatMsg
  * @param msg string
- * @param playerID integer
+ * @param playerID PlayerID
  */
 bool CLuaHandle::GotChatMsg(const string& msg, int playerID)
 {
@@ -769,7 +769,7 @@ void CLuaHandle::GameStart()
 /*** Called when the game ends
  *
  * @function Callins:GameOver
- * @param winningAllyTeams number[] list of winning allyTeams, if empty the game result was undecided (like when dropping from an host).
+ * @param winningAllyTeams AllyTeamID[] list of winning allyTeams, if empty the game result was undecided (like when dropping from an host).
  */
 void CLuaHandle::GameOver(const std::vector<unsigned char>& winningAllyTeams)
 {
@@ -796,7 +796,7 @@ void CLuaHandle::GameOver(const std::vector<unsigned char>& winningAllyTeams)
 /*** Called when the game is paused.
  *
  * @function Callins:GamePaused
- * @param playerID integer
+ * @param playerID PlayerID
  * @param paused boolean
  */
 void CLuaHandle::GamePaused(int playerID, bool paused)
@@ -846,7 +846,7 @@ void CLuaHandle::RunDelayedFunctions(int frameNum)
 /*** Called for every game simulation frame (30 per second).
  *
  * @function Callins:GameFrame
- * @param frame number Starts at frame 1
+ * @param frame integer Starts at frame 1
  */
 void CLuaHandle::GameFrame(int frameNum)
 {
@@ -880,7 +880,7 @@ void CLuaHandle::GameFrame(int frameNum)
 /*** Called at the end of every game simulation frame
  *
  * @function Callins:GameFramePost
- * @param frame number Starts at frame 1
+ * @param frame integer Starts at frame 1
  */
 void CLuaHandle::GameFramePost(int frameNum)
 {
@@ -935,7 +935,7 @@ void CLuaHandle::GameID(const unsigned char* gameID, unsigned int numBytes)
 /*** Called when a team dies (see `Spring.KillTeam`).
  *
  * @function Callins:TeamDied
- * @param teamID integer
+ * @param teamID TeamID
  */
 void CLuaHandle::TeamDied(int teamID)
 {
@@ -958,7 +958,7 @@ void CLuaHandle::TeamDied(int teamID)
 
 /*** @function Callins:TeamChanged
  *
- * @param teamID integer
+ * @param teamID TeamID
  */
 void CLuaHandle::TeamChanged(int teamID)
 {
@@ -982,7 +982,7 @@ void CLuaHandle::TeamChanged(int teamID)
 /*** Called whenever a player's status changes e.g. becoming a spectator.
  *
  * @function Callins:PlayerChanged
- * @param playerID integer
+ * @param playerID PlayerID
  */
 void CLuaHandle::PlayerChanged(int playerID)
 {
@@ -1006,7 +1006,7 @@ void CLuaHandle::PlayerChanged(int playerID)
 /*** Called whenever a new player joins the game.
  *
  * @function Callins:PlayerAdded
- * @param playerID integer
+ * @param playerID PlayerID
  */
 void CLuaHandle::PlayerAdded(int playerID)
 {
@@ -1030,7 +1030,7 @@ void CLuaHandle::PlayerAdded(int playerID)
 /*** Called whenever a player is removed from the game.
  *
  * @function Callins:PlayerRemoved
- * @param playerID integer
+ * @param playerID PlayerID
  * @param reason integer
  */
 void CLuaHandle::PlayerRemoved(int playerID, int reason)
@@ -1080,10 +1080,10 @@ inline void CLuaHandle::UnitCallIn(const LuaHashString& hs, const CUnit* unit)
 /*** Called at the moment the unit is created.
  *
  * @function Callins:UnitCreated
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param builderID integer?
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param builderID UnitID?
  */
 void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 {
@@ -1111,9 +1111,9 @@ void CLuaHandle::UnitCreated(const CUnit* unit, const CUnit* builder)
 /*** Called at the moment the unit is completed.
  *
  * @function Callins:UnitFinished
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitFinished(const CUnit* unit)
 {
@@ -1125,11 +1125,11 @@ void CLuaHandle::UnitFinished(const CUnit* unit)
 /*** Called when a factory finishes construction of a unit.
  *
  * @function Callins:UnitFromFactory
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param factID integer
- * @param factDefID integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param factID UnitID
+ * @param factDefID UnitDefID
  * @param userOrders boolean
  */
 void CLuaHandle::UnitFromFactory(const CUnit* unit,
@@ -1159,9 +1159,9 @@ void CLuaHandle::UnitFromFactory(const CUnit* unit,
 /*** Called when a living unit becomes a nanoframe again.
  *
  * @function Callins:UnitReverseBuilt
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitReverseBuilt(const CUnit* unit)
 {
@@ -1174,9 +1174,9 @@ void CLuaHandle::UnitReverseBuilt(const CUnit* unit)
 /*** Called when a unit being built starts decaying.
  *
  * @function Callins:UnitConstructionDecayed
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param timeSinceLastBuild number
  * @param iterationPeriod number
  * @param part number
@@ -1207,13 +1207,13 @@ void CLuaHandle::UnitConstructionDecayed(const CUnit* unit, float timeSinceLastB
 /*** Called when a unit is destroyed.
  *
  * @function Callins:UnitDestroyed
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param attackerID integer? Subject to visibility rules
- * @param attackerDefID integer? Subject to visibility rules
- * @param attackerTeam integer? Subject to visibility rules
- * @param weaponDefID integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param attackerID UnitID? Subject to visibility rules
+ * @param attackerDefID UnitDefID? Subject to visibility rules
+ * @param attackerTeam TeamID? Subject to visibility rules
+ * @param weaponDefID WeaponDefID
  */
 void CLuaHandle::UnitDestroyed(const CUnit* unit, const CUnit* attacker, int weaponDefID)
 {
@@ -1245,10 +1245,10 @@ void CLuaHandle::UnitDestroyed(const CUnit* unit, const CUnit* attacker, int wea
 /*** Called when a unit is transferred between teams. This is called before `UnitGiven` and in that moment unit is still assigned to the oldTeam.
  *
  * @function Callins:UnitTaken
- * @param unitID integer
- * @param unitDefID integer
- * @param oldTeam number
- * @param newTeam number
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param oldTeam TeamID
+ * @param newTeam TeamID
  */
 void CLuaHandle::UnitTaken(const CUnit* unit, int oldTeam, int newTeam)
 {
@@ -1274,10 +1274,10 @@ void CLuaHandle::UnitTaken(const CUnit* unit, int oldTeam, int newTeam)
 /*** Called when a unit is transferred between teams. This is called after `UnitTaken` and in that moment unit is assigned to the newTeam.
  *
  * @function Callins:UnitGiven
- * @param unitID integer
- * @param unitDefID integer
- * @param newTeam number
- * @param oldTeam number
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param newTeam TeamID
+ * @param oldTeam TeamID
  */
 void CLuaHandle::UnitGiven(const CUnit* unit, int oldTeam, int newTeam)
 {
@@ -1303,9 +1303,9 @@ void CLuaHandle::UnitGiven(const CUnit* unit, int oldTeam, int newTeam)
 /*** Called when a unit is idle (empty command queue).
  *
  * @function Callins:UnitIdle
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitIdle(const CUnit* unit)
 {
@@ -1317,13 +1317,13 @@ void CLuaHandle::UnitIdle(const CUnit* unit)
 /*** Called after when a unit accepts a command, after `AllowCommand` returns true.
  *
  * @function Callins:UnitCommand
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param cmdID integer
  * @param cmdParams table
  * @param options CommandOptions
- * @param cmdTag number
+ * @param cmdTag integer
  */
 void CLuaHandle::UnitCommand(const CUnit* unit, const Command& command, int playerNum, bool fromSynced, bool fromLua)
 {
@@ -1351,13 +1351,13 @@ void CLuaHandle::UnitCommand(const CUnit* unit, const Command& command, int play
 /*** Called when a unit completes a command.
  *
  * @function Callins:UnitCmdDone
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param cmdID integer
  * @param cmdParams table
  * @param options CommandOptions
- * @param cmdTag number
+ * @param cmdTag integer
  */
 void CLuaHandle::UnitCmdDone(const CUnit* unit, const Command& command)
 {
@@ -1381,16 +1381,16 @@ void CLuaHandle::UnitCmdDone(const CUnit* unit, const Command& command)
 /*** Called when a unit is damaged (after UnitPreDamaged).
  *
  * @function Callins:UnitDamaged
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param damage number
  * @param paralyzer number
- * @param weaponDefID integer
- * @param projectileID integer
- * @param attackerID integer
- * @param attackerDefID integer
- * @param attackerTeam number
+ * @param weaponDefID WeaponDefID
+ * @param projectileID ProjectileID
+ * @param attackerID UnitID
+ * @param attackerDefID UnitDefID
+ * @param attackerTeam TeamID
  */
 void CLuaHandle::UnitDamaged(
 	const CUnit* unit,
@@ -1429,9 +1429,9 @@ void CLuaHandle::UnitDamaged(
 /*** Called when a unit changes its stun status.
  *
  * @function Callins:UnitStunned
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param stunned boolean
  */
 void CLuaHandle::UnitStunned(
@@ -1464,9 +1464,9 @@ void CLuaHandle::UnitStunned(
  *
  * @function Callins:UnitExperience
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param experience number
  * @param oldExperience number
  */
@@ -1496,9 +1496,9 @@ void CLuaHandle::UnitExperience(const CUnit* unit, float oldExperience)
 /*** Called when a unit's harvestStorage is full (according to its unitDef's entry).
  *
  * @function Callins:UnitHarvestStorageFull
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitHarvestStorageFull(const CUnit* unit)
 {
@@ -1519,9 +1519,9 @@ void CLuaHandle::UnitHarvestStorageFull(const CUnit* unit)
  * @param y number
  * @param z number
  * @param strength number
- * @param allyTeam integer
- * @param unitID integer
- * @param unitDefID integer
+ * @param allyTeam AllyTeamID
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
  */
 void CLuaHandle::UnitSeismicPing(const CUnit* unit, int allyTeam,
                                  const float3& pos, float strength)
@@ -1582,10 +1582,10 @@ void CLuaHandle::LosCallIn(const LuaHashString& hs,
  * Also called when a unit enters LOS without any radar coverage.
  *
  * @function Callins:UnitEnteredRadar
- * @param unitID integer
- * @param unitTeam integer
- * @param allyTeam integer
- * @param unitDefID integer
+ * @param unitID UnitID
+ * @param unitTeam TeamID
+ * @param allyTeam AllyTeamID
+ * @param unitDefID UnitDefID
  */
 void CLuaHandle::UnitEnteredRadar(const CUnit* unit, int allyTeam)
 {
@@ -1601,10 +1601,10 @@ void CLuaHandle::UnitEnteredRadar(const CUnit* unit, int allyTeam)
  * Its called after the unit is in LOS, so you can query that unit.
  *
  * @function Callins:UnitEnteredLos
- * @param unitID integer
- * @param unitTeam integer
- * @param allyTeam integer who's LOS the unit entered.
- * @param unitDefID integer
+ * @param unitID UnitID
+ * @param unitTeam TeamID
+ * @param allyTeam AllyTeamID who's LOS the unit entered.
+ * @param unitDefID UnitDefID
  */
 void CLuaHandle::UnitEnteredLos(const CUnit* unit, int allyTeam)
 {
@@ -1621,10 +1621,10 @@ void CLuaHandle::UnitEnteredLos(const CUnit* unit, int allyTeam)
  * widgets cannot get the position of units that left their radar.
  *
  * @function Callins:UnitLeftRadar
- * @param unitID integer
- * @param unitTeam integer
- * @param allyTeam integer
- * @param unitDefID integer
+ * @param unitID UnitID
+ * @param unitTeam TeamID
+ * @param allyTeam AllyTeamID
+ * @param unitDefID UnitDefID
  */
 void CLuaHandle::UnitLeftRadar(const CUnit* unit, int allyTeam)
 {
@@ -1640,10 +1640,10 @@ void CLuaHandle::UnitLeftRadar(const CUnit* unit, int allyTeam)
  * For widgets, this one is called just before the unit leaves los, so you can still get the position of a unit that left los.
  *
  * @function Callins:UnitLeftLos
- * @param unitID integer
- * @param unitTeam integer
- * @param allyTeam integer
- * @param unitDefID integer
+ * @param unitID UnitID
+ * @param unitTeam TeamID
+ * @param allyTeam AllyTeamID
+ * @param unitDefID UnitDefID
  */
 void CLuaHandle::UnitLeftLos(const CUnit* unit, int allyTeam)
 {
@@ -1661,11 +1661,11 @@ void CLuaHandle::UnitLeftLos(const CUnit* unit, int allyTeam)
 /*** Called when a unit is loaded by a transport.
  *
  * @function Callins:UnitLoaded
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param transportID integer
- * @param transportTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param transportID UnitID
+ * @param transportTeam TeamID
  */
 void CLuaHandle::UnitLoaded(const CUnit* unit, const CUnit* transport)
 {
@@ -1693,11 +1693,11 @@ void CLuaHandle::UnitLoaded(const CUnit* unit, const CUnit* transport)
 /*** Called when a unit is unloaded by a transport.
  *
  * @function Callins:UnitUnloaded
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param transportID integer
- * @param transportTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param transportID UnitID
+ * @param transportTeam TeamID
  */
 void CLuaHandle::UnitUnloaded(const CUnit* unit, const CUnit* transport)
 {
@@ -1731,9 +1731,9 @@ void CLuaHandle::UnitUnloaded(const CUnit* unit, const CUnit* transport)
 /***
  *
  * @function Callins:UnitEnteredUnderwater
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitEnteredUnderwater(const CUnit* unit)
 {
@@ -1745,9 +1745,9 @@ void CLuaHandle::UnitEnteredUnderwater(const CUnit* unit)
 /***
  *
  * @function Callins:UnitEnteredWater
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitEnteredWater(const CUnit* unit)
 {
@@ -1760,9 +1760,9 @@ void CLuaHandle::UnitEnteredWater(const CUnit* unit)
  *
  * @function Callins:UnitLeftAir
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitEnteredAir(const CUnit* unit)
 {
@@ -1775,9 +1775,9 @@ void CLuaHandle::UnitEnteredAir(const CUnit* unit)
  *
  * @function Callins:UnitLeftUnderwater
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitLeftUnderwater(const CUnit* unit)
 {
@@ -1789,9 +1789,9 @@ void CLuaHandle::UnitLeftUnderwater(const CUnit* unit)
  *
  * @function Callins:UnitLeftWater
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitLeftWater(const CUnit* unit)
 {
@@ -1804,9 +1804,9 @@ void CLuaHandle::UnitLeftWater(const CUnit* unit)
  *
  * @function Callins:UnitEnteredAir
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitLeftAir(const CUnit* unit)
 {
@@ -1819,9 +1819,9 @@ void CLuaHandle::UnitLeftAir(const CUnit* unit)
  *
  * @function Callins:UnitCloaked
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitCloaked(const CUnit* unit)
 {
@@ -1834,9 +1834,9 @@ void CLuaHandle::UnitCloaked(const CUnit* unit)
  *
  * @function Callins:UnitDecloaked
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitDecloaked(const CUnit* unit)
 {
@@ -1850,8 +1850,8 @@ void CLuaHandle::UnitDecloaked(const CUnit* unit)
  * Both units must be registered with `Script.SetWatchUnit`.
  *
  * @function Callins:UnitUnitCollision
- * @param colliderID integer
- * @param collideeID integer
+ * @param colliderID UnitID
+ * @param collideeID UnitID
  */
 bool CLuaHandle::UnitUnitCollision(const CUnit* collider, const CUnit* collidee)
 {
@@ -1902,8 +1902,8 @@ bool CLuaHandle::UnitUnitCollision(const CUnit* collider, const CUnit* collidee)
  *
  * The unit must be registered with `Script.SetWatchUnit` and the feature registered with `Script.SetWatchFeature`.
  *
- * @param colliderID integer
- * @param collideeID integer
+ * @param colliderID UnitID
+ * @param collideeID UnitID
  */
 bool CLuaHandle::UnitFeatureCollision(const CUnit* collider, const CFeature* collidee)
 {
@@ -1953,9 +1953,9 @@ bool CLuaHandle::UnitFeatureCollision(const CUnit* collider, const CFeature* col
  *
  * @function Callins:UnitMoveFailed
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitMoveFailed(const CUnit* unit)
 {
@@ -1975,9 +1975,9 @@ void CLuaHandle::UnitMoveFailed(const CUnit* unit)
  *
  * @function Callins:UnitArrivedAtGoal
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::UnitArrivedAtGoal(const CUnit* unit)
 {
@@ -1992,9 +1992,9 @@ void CLuaHandle::UnitArrivedAtGoal(const CUnit* unit)
  *
  * @function Callins:RenderUnitDestroyed
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  */
 void CLuaHandle::RenderUnitDestroyed(const CUnit* unit)
 {
@@ -2030,8 +2030,8 @@ void CLuaHandle::RenderUnitDestroyed(const CUnit* unit)
  *
  * @function Callins:FeatureCreated
  *
- * @param featureID integer
- * @param allyTeamID integer
+ * @param featureID FeatureID
+ * @param allyTeamID AllyTeamID
  */
 void CLuaHandle::FeatureCreated(const CFeature* feature)
 {
@@ -2057,8 +2057,8 @@ void CLuaHandle::FeatureCreated(const CFeature* feature)
  *
  * @function Callins:FeatureDestroyed
  *
- * @param featureID integer
- * @param allyTeamID integer
+ * @param featureID FeatureID
+ * @param allyTeamID AllyTeamID
  */
 void CLuaHandle::FeatureDestroyed(const CFeature* feature)
 {
@@ -2084,15 +2084,15 @@ void CLuaHandle::FeatureDestroyed(const CFeature* feature)
  *
  * @function Callins:FeatureDamaged
  *
- * @param featureID integer
- * @param featureDefID integer
- * @param featureTeam number
+ * @param featureID FeatureID
+ * @param featureDefID FeatureDefID
+ * @param featureTeam TeamID
  * @param damage number
- * @param weaponDefID integer
- * @param projectileID integer
- * @param attackerID integer
- * @param attackerDefID integer
- * @param attackerTeam number
+ * @param weaponDefID WeaponDefID
+ * @param projectileID ProjectileID
+ * @param attackerID UnitID
+ * @param attackerDefID UnitDefID
+ * @param attackerTeam TeamID
  */
 void CLuaHandle::FeatureDamaged(
 	const CFeature* feature,
@@ -2141,9 +2141,9 @@ void CLuaHandle::FeatureDamaged(
  *
  * Note that weaponDefID is missing if the projectile is spawned as part of a burst, but `Spring.GetProjectileDefID` and `Spring.GetProjectileName` still work in callin scope using proID.
  *
- * @param proID integer
- * @param proOwnerID integer
- * @param weaponDefID integer
+ * @param proID ProjectileID
+ * @param proOwnerID UnitID
+ * @param weaponDefID WeaponDefID
  *
  * @see Script.SetWatchProjectile
  * @see Script.SetWatchWeapon
@@ -2190,9 +2190,9 @@ void CLuaHandle::ProjectileCreated(const CProjectile* p)
 /*** Called when the projectile is destroyed.
  *
  * @function Callins:ProjectileDestroyed
- * @param proID integer
- * @param ownerID integer
- * @param proWeaponDefID integer
+ * @param proID ProjectileID
+ * @param ownerID UnitID
+ * @param proWeaponDefID WeaponDefID
  *
  * @see Script.SetWatchProjectile
  * @see Script.SetWatchWeapon
@@ -2259,12 +2259,12 @@ bool CLuaHandle::IsExplosionVisible(const WeaponDef* weaponDef, const CExplosion
  *
  * Only called for weaponDefIDs registered via Script.SetWatchExplosion or Script.SetWatchWeapon.
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @param px number
  * @param py number
  * @param pz number
- * @param attackerID integer
- * @param projectileID integer
+ * @param attackerID UnitID
+ * @param projectileID ProjectileID
   *
  * @return boolean noGfx if then no graphical effects are drawn by the engine for this explosion.
  *
@@ -2323,9 +2323,9 @@ bool CLuaHandle::Explosion(int weaponDefID, const WeaponDef* weaponDef, const CE
  *
  * @function Callins:StockpileChanged
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param weaponNum integer
  * @param oldCount integer
  * @param newCount integer
@@ -2358,7 +2358,7 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
  *
  * @function Callins:RecvLuaMsg
  * @param msg string
- * @param playerID integer
+ * @param playerID PlayerID
  */
 bool CLuaHandle::RecvLuaMsg(const string& msg, int playerID)
 {
@@ -2519,10 +2519,10 @@ void CLuaHandle::Save(zipFile archive)
 /*** Called when the unsynced copy of the height-map is altered.
  *
  * @function Callins:UnsyncedHeightMapUpdate
- * @return number x1
- * @return number z1
- * @return number x2
- * @return number z2
+ * @return integer x1
+ * @return integer z1
+ * @return integer x2
+ * @return integer z2
  */
 void CLuaHandle::UnsyncedHeightMapUpdate(const SRectangle& rect)
 {
@@ -2567,8 +2567,8 @@ void CLuaHandle::Update()
 /*** Called whenever the window is resized.
  *
  * @function Callins:ViewResize
- * @param viewSizeX number
- * @param viewSizeY number
+ * @param viewSizeX integer
+ * @param viewSizeY integer
  */
 void CLuaHandle::ViewResize()
 {
@@ -2644,7 +2644,7 @@ void CLuaHandle::SunChanged()
  * 
  * @function Callins:DefaultCommand
  * @param type "unit"|"feature" The type of the object pointed at.
- * @param id integer The `unitID` or `featureID`.
+ * @param id ObjectID The `unitID` or `featureID`.
  * @param cmd integer The current command ID.
  * @return integer The command ID to use as the default, or nil to keep the current ID.
  */
@@ -2846,9 +2846,9 @@ DRAW_CALLIN(DrawShadowFeaturesLua)
  * Called when build square data is computed, before engine rendering.
  * Grid dimensions can be inferred from UnitDefs[unitDefID].xsize and UnitDefs[unitDefID].zsize.
  * Grid origin in square coords: x - xsize/2, z - zsize/2 (accounting for facing).
- * @param unitDefID number
- * @param x number build position x
- * @param z number build position z
+ * @param unitDefID UnitDefID
+ * @param x integer build position x
+ * @param z integer build position z
  * @param facing number build facing
  * @param statuses table flat 1D row-major array of BuildSquareStatus values: BLOCKED=0, OCCUPIED=1, RECLAIMABLE=2, OPEN=3
  */
@@ -2928,8 +2928,8 @@ inline void CLuaHandle::DrawScreenCommon(const LuaHashString& cmdStr)
 /*** Also available to LuaMenu.
  *
  * @function Callins:DrawScreen
- * @param viewSizeX number
- * @param viewSizeY number
+ * @param viewSizeX integer
+ * @param viewSizeY integer
  */
 void CLuaHandle::DrawScreen()
 {
@@ -2944,8 +2944,8 @@ void CLuaHandle::DrawScreen()
 
 /***
  * @function Callins:DrawScreenEffects
- * @param viewSizeX number
- * @param viewSizeY number
+ * @param viewSizeX integer
+ * @param viewSizeY integer
  */
 void CLuaHandle::DrawScreenEffects()
 {
@@ -2964,8 +2964,8 @@ void CLuaHandle::DrawScreenEffects()
  *
  * Note: This callin is invoked after the software rendered cursor (configuration variable HardwareCursor=0) is drawn.
  *
- * @param viewSizeX number
- * @param viewSizeY number
+ * @param viewSizeX integer
+ * @param viewSizeY integer
  */
 void CLuaHandle::DrawScreenPost()
 {
@@ -2981,8 +2981,8 @@ void CLuaHandle::DrawScreenPost()
 /***
  *
  * @function Callins:DrawInMiniMap
- * @param sx number relative to the minimap's position and scale.
- * @param sy number relative to the minimap's position and scale.
+ * @param sx integer relative to the minimap's position and scale.
+ * @param sy integer relative to the minimap's position and scale.
  */
 void CLuaHandle::DrawInMiniMap()
 {
@@ -3009,8 +3009,8 @@ void CLuaHandle::DrawInMiniMap()
 /***
  *
  * @function Callins:DrawInMiniMapBackground
- * @param sx number relative to the minimap's position and scale.
- * @param sy number relative to the minimap's position and scale.
+ * @param sx integer relative to the minimap's position and scale.
+ * @param sy integer relative to the minimap's position and scale.
  */
 void CLuaHandle::DrawInMiniMapBackground()
 {
@@ -3173,12 +3173,12 @@ bool CLuaHandle::KeyMapChanged()
  *
  * Return true if you don't want other callins or the engine to also receive this keypress. A list of key codes can be seen at the SDL wiki.
  *
- * @param keyCode number
+ * @param keyCode integer
  * @param mods KeyModifiers
  * @param isRepeat boolean If you want an action to occur only once check for isRepeat == false.
  * @param label string the name of the key
- * @param utf32char number (deprecated) always 0
- * @param scanCode number
+ * @param utf32char integer (deprecated) always 0
+ * @param scanCode integer
  * @param actionList table? the list of actions for this keypress, when available
  * @return boolean halt whether to halt the chain for consumers of the keypress
  */
@@ -3239,11 +3239,11 @@ bool CLuaHandle::KeyPress(int keyCode, int scanCode, bool isRepeat)
  *
  * @function Callins:KeyRelease
  *
- * @param keyCode number
+ * @param keyCode integer
  * @param mods KeyModifiers
  * @param label string the name of the key
- * @param utf32char number (deprecated) always 0
- * @param scanCode number
+ * @param utf32char integer (deprecated) always 0
+ * @param scanCode integer
  * @param actionList table? the list of actions for this keyrelease, when available
  *
  * @return boolean
@@ -3329,8 +3329,8 @@ bool CLuaHandle::TextInput(const std::string& utf8)
  * @function Callins:TextEditing
  *
  * @param utf8 string
- * @param start number
- * @param length number
+ * @param start integer
+ * @param length integer
  */
 bool CLuaHandle::TextEditing(const std::string& utf8, unsigned int start, unsigned int length)
 {
@@ -3359,9 +3359,9 @@ bool CLuaHandle::TextEditing(const std::string& utf8, unsigned int start, unsign
  * The button parameter supports up to 7 buttons. Must return true for `MouseRelease` and other functions to be called.
  *
  * @function Callins:MousePress
- * @param x number
- * @param y number
- * @param button number
+ * @param x integer
+ * @param y integer
+ * @param button integer
  * @return boolean becomeMouseOwner
  */
 bool CLuaHandle::MousePress(int x, int y, int button)
@@ -3393,9 +3393,9 @@ bool CLuaHandle::MousePress(int x, int y, int button)
  *
  * Please note that in order to have Spring call `Spring.MouseRelease`, you need to have a `Spring.MousePress` call-in in the same addon that returns true.
  *
- * @param x number
- * @param y number
- * @param button number
+ * @param x integer
+ * @param y integer
+ * @param button integer
  * @return boolean becomeMouseOwner
  */
 void CLuaHandle::MouseRelease(int x, int y, int button)
@@ -3420,11 +3420,11 @@ void CLuaHandle::MouseRelease(int x, int y, int button)
  *
  * @function Callins:MouseMove
  *
- * @param x number final x position
- * @param y number final y position
- * @param dx number distance travelled in x
- * @param dy number distance travelled in y
- * @param button number
+ * @param x integer final x position
+ * @param y integer final y position
+ * @param dx integer distance travelled in x
+ * @param dy integer distance travelled in y
+ * @param button integer
  */
 bool CLuaHandle::MouseMove(int x, int y, int dx, int dy, int button)
 {
@@ -3484,8 +3484,8 @@ bool CLuaHandle::MouseWheel(bool up, float value)
  *
  * Must return true for `Mouse*` events and `Spring.GetToolTip` to be called.
  *
- * @param x number
- * @param y number
+ * @param x integer
+ * @param y integer
  * @return boolean isAbove
  */
 bool CLuaHandle::IsAbove(int x, int y)
@@ -3512,8 +3512,8 @@ bool CLuaHandle::IsAbove(int x, int y)
 /*** Called when `Spring.IsAbove` returns true.
  *
  * @function Callins:GetTooltip
- * @param x number
- * @param y number
+ * @param x integer
+ * @param y integer
  * @return string tooltip
  */
 string CLuaHandle::GetTooltip(int x, int y)
@@ -3662,14 +3662,14 @@ void CLuaHandle::MiniMapStateChanged(const bool isMinimized,
 /*** Called when the MiniMap Geometry changes
  * 
  * @function Callins:MiniMapGeometryChanged
- * @param newPosX number in pixels
- * @param newPosY number in pixels
- * @param newDimX number in pixels
- * @param newDimY number in pixels
- * @param oldPosX number in pixels
- * @param oldPosY number in pixels
- * @param oldDimX number in pixels
- * @param oldDimY number in pixels
+ * @param newPosX integer in pixels
+ * @param newPosY integer in pixels
+ * @param newDimX integer in pixels
+ * @param newDimY integer in pixels
+ * @param oldPosX integer in pixels
+ * @param oldPosY integer in pixels
+ * @param oldDimX integer in pixels
+ * @param oldDimY integer in pixels
  */
 void CLuaHandle::MiniMapGeometryChanged(const int2 newPos, const int2 newDim, const int2 oldPos, const int2 oldDim)
 {
@@ -3756,7 +3756,7 @@ bool CLuaHandle::AddConsoleLine(const string& msg, const string& section, int le
 /*** Called when a unit is added to or removed from a control group.
  *
  * @function Callins:GroupChanged
- * @param groupID integer
+ * @param groupID GroupID
  */
 bool CLuaHandle::GroupChanged(int groupID)
 {
@@ -3776,13 +3776,13 @@ bool CLuaHandle::GroupChanged(int groupID)
 /***
  * @function Callins:WorldTooltip
  * @param type "unit"
- * @param unitId integer
+ * @param unitId UnitID
  * @return string tooltip
  */
 /***
  * @function Callins:WorldTooltip
  * @param type "feature"
- * @param featureId integer
+ * @param featureId FeatureID
  * @return string tooltip
  */
 /***
@@ -3843,7 +3843,7 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
 
 /***
  * @function Callins:MapDrawCmd
- * @param playerID integer
+ * @param playerID PlayerID
  * @param type "point"
  * @param posX number
  * @param posY number
@@ -3852,7 +3852,7 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
  */
 /***
  * @function Callins:MapDrawCmd
- * @param playerID integer
+ * @param playerID PlayerID
  * @param type "line"
  * @param pos1X number
  * @param pos1Y number
@@ -3863,7 +3863,7 @@ string CLuaHandle::WorldTooltip(const CUnit* unit,
  */
 /***
  * @function Callins:MapDrawCmd
- * @param playerID integer
+ * @param playerID PlayerID
  * @param type "erase"
  * @param posX number
  * @param posY number
@@ -3952,7 +3952,7 @@ bool CLuaHandle::MapDrawCmd(int playerID, int type,
  * @function Callins:GameSetup
  * @param state READY_MESSAGE the current message the engine would display to the player
  * @param ready boolean whether the player is currently ready or not
- * @param playerStates table<number,READY_STATE> indexed by playerID
+ * @param playerStates table<PlayerID,READY_STATE> indexed by playerID
  * @return boolean? gameHandled disables the engine ui when true
  * @return boolean? newReady whether the player is ready (ignored unless `gameHandled = true`)
  */
@@ -4000,7 +4000,7 @@ bool CLuaHandle::GameSetup(const string& state, bool& ready,
 
 /*** @function Callins:RecvSkirmishAIMessage
  *
- * @param aiTeam integer
+ * @param aiTeam TeamID
  * @param dataStr string
  */
 const char* CLuaHandle::RecvSkirmishAIMessage(int aiTeam, const char* inData, int inSize, size_t* outSize)
@@ -4335,7 +4335,7 @@ int CLuaHandle::CallOutGetFullRead(lua_State* L)
 
 /***
  * @function Script.GetCtrlTeam
- * @return integer teamID
+ * @return TeamID teamID
  */
 int CLuaHandle::CallOutGetCtrlTeam(lua_State* L)
 {
@@ -4346,7 +4346,7 @@ int CLuaHandle::CallOutGetCtrlTeam(lua_State* L)
 
 /***
  * @function Script.GetReadTeam
- * @return integer teamID
+ * @return TeamID teamID
  */
 int CLuaHandle::CallOutGetReadTeam(lua_State* L)
 {
@@ -4357,7 +4357,7 @@ int CLuaHandle::CallOutGetReadTeam(lua_State* L)
 
 /***
  * @function Script.GetReadAllyTeam
- * @return integer allyTeamID
+ * @return AllyTeamID allyTeamID
  */
 int CLuaHandle::CallOutGetReadAllyTeam(lua_State* L)
 {
@@ -4368,7 +4368,7 @@ int CLuaHandle::CallOutGetReadAllyTeam(lua_State* L)
 
 /***
  * @function Script.GetSelectTeam
- * @return integer teamID
+ * @return TeamID teamID
  */
 int CLuaHandle::CallOutGetSelectTeam(lua_State* L)
 {

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -209,8 +209,8 @@ void CUnsyncedLuaHandle::RecvFromSynced(lua_State* srcState, int args)
 /*** For custom rendering of units
  *
  * @function UnsyncedCallins:DrawUnit
- * @param unitID integer
- * @param drawMode number
+ * @param unitID UnitID
+ * @param drawMode integer
  * @return boolean suppressEngineDraw
  * @deprecated
  */
@@ -246,8 +246,8 @@ bool CUnsyncedLuaHandle::DrawUnit(const CUnit* unit)
 /*** For custom rendering of features
  *
  * @function UnsyncedCallins:DrawFeature
- * @param featureID integer
- * @param drawMode number
+ * @param featureID FeatureID
+ * @param drawMode integer
  * @return boolean suppressEngineDraw
  * @deprecated
  */
@@ -282,9 +282,9 @@ bool CUnsyncedLuaHandle::DrawFeature(const CFeature* feature)
 /*** For custom rendering of shields.
  *
  * @function UnsyncedCallins:DrawShield
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer
- * @param drawMode number
+ * @param drawMode integer
  * @return boolean suppressEngineDraw
  * @deprecated
  */
@@ -321,8 +321,8 @@ bool CUnsyncedLuaHandle::DrawShield(const CUnit* unit, const CWeapon* weapon)
 /*** For custom rendering of weapon (& other) projectiles
  *
  * @function UnsyncedCallins:DrawProjectile
- * @param projectileID integer
- * @param drawMode number
+ * @param projectileID ProjectileID
+ * @param drawMode integer
  * @return boolean suppressEngineDraw
  * @deprecated
  */
@@ -360,7 +360,7 @@ bool CUnsyncedLuaHandle::DrawProjectile(const CProjectile* projectile)
  *
  * @function UnsyncedCallins:DrawMaterial
  * @param uuid integer
- * @param drawMode number
+ * @param drawMode integer
  * @return boolean suppressEngineDraw
  * @deprecated
  */
@@ -573,13 +573,13 @@ bool CSyncedLuaHandle::SyncedActionFallback(const std::string& msg, int playerID
 /*** Called when the unit reaches an unknown command in its queue (i.e. one not handled by the engine).
  *
  * @function SyncedCallins:CommandFallback
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param cmdID integer
  * @param cmdParams number[]
  * @param cmdOptions CommandOptions
- * @param cmdTag number
+ * @param cmdTag integer
  * @return boolean whether to remove the command from the queue
  */
 bool CSyncedLuaHandle::CommandFallback(const CUnit* unit, const Command& cmd)
@@ -609,13 +609,13 @@ bool CSyncedLuaHandle::CommandFallback(const CUnit* unit, const Command& cmd)
  *
  * The queue remains untouched when a command is blocked, whether it would be queued or replace the queue.
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param cmdID integer
  * @param cmdParams number[]
  * @param cmdOptions CommandOptions
- * @param cmdTag number
+ * @param cmdTag integer
  * @param synced boolean
  * @param fromLua boolean
  * @return boolean whether it should be let into the queue.
@@ -650,9 +650,9 @@ bool CSyncedLuaHandle::AllowCommand(const CUnit* unit, const Command& cmd, int p
 /*** Called just before unit is created.
  *
  * @function SyncedCallins:AllowUnitCreation
- * @param unitDefID integer
- * @param builderID integer
- * @param builderTeam integer
+ * @param unitDefID UnitDefID
+ * @param builderID UnitID
+ * @param builderTeam TeamID
  * @param x number
  * @param y number
  * @param z number
@@ -697,10 +697,10 @@ std::pair <bool, bool> CSyncedLuaHandle::AllowUnitCreation(
 /*** Called just before a unit is transferred to a different team.
  *
  * @function SyncedCallins:AllowUnitTransfer
- * @param unitID integer
- * @param unitDefID integer
- * @param oldTeam integer
- * @param newTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param oldTeam TeamID
+ * @param newTeam TeamID
  * @param capture boolean
  * @return boolean whether or not the transfer is permitted.
  */
@@ -734,10 +734,10 @@ bool CSyncedLuaHandle::AllowUnitTransfer(const CUnit* unit, int newTeam, bool ca
 /*** Called just before a unit progresses its build percentage.
  *
  * @function SyncedCallins:AllowUnitBuildStep
- * @param builderID integer
- * @param builderTeam integer
- * @param unitID integer
- * @param unitDefID integer
+ * @param builderID UnitID
+ * @param builderTeam TeamID
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
  * @param part number
  * @return boolean whether or not the build makes progress.
  */
@@ -771,10 +771,10 @@ bool CSyncedLuaHandle::AllowUnitBuildStep(const CUnit* builder, const CUnit* uni
 /***
  *
  * @function SyncedCallins:AllowUnitCaptureStep
- * @param builderID integer
- * @param builderTeam integer
- * @param unitID integer
- * @param unitDefID integer
+ * @param builderID UnitID
+ * @param builderTeam TeamID
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
  * @param part number
  * @return boolean whether or not the capture makes progress.
  */
@@ -808,12 +808,12 @@ bool CSyncedLuaHandle::AllowUnitCaptureStep(const CUnit* builder, const CUnit* u
 /***
  *
  * @function SyncedCallins:AllowUnitTransport
- * @param transporterID integer
- * @param transporterUnitDefID integer
- * @param transporterTeam integer
- * @param transporteeID integer
- * @param transporteeUnitDefID integer
- * @param transporteeTeam integer
+ * @param transporterID UnitID
+ * @param transporterUnitDefID UnitDefID
+ * @param transporterTeam TeamID
+ * @param transporteeID UnitID
+ * @param transporteeUnitDefID UnitDefID
+ * @param transporteeTeam TeamID
  * @return boolean whether or not the transport is allowed
  */
 bool CSyncedLuaHandle::AllowUnitTransport(const CUnit* transporter, const CUnit* transportee)
@@ -846,12 +846,12 @@ bool CSyncedLuaHandle::AllowUnitTransport(const CUnit* transporter, const CUnit*
 /***
  *
  * @function SyncedCallins:AllowUnitTransportLoad
- * @param transporterID integer
- * @param transporterUnitDefID integer
- * @param transporterTeam integer
- * @param transporteeID integer
- * @param transporteeUnitDefID integer
- * @param transporteeTeam integer
+ * @param transporterID UnitID
+ * @param transporterUnitDefID UnitDefID
+ * @param transporterTeam TeamID
+ * @param transporteeID UnitID
+ * @param transporteeUnitDefID UnitDefID
+ * @param transporteeTeam TeamID
  * @param x number
  * @param y number
  * @param z number
@@ -896,12 +896,12 @@ bool CSyncedLuaHandle::AllowUnitTransportLoad(
 /***
  *
  * @function SyncedCallins:AllowUnitTransportUnload
- * @param transporterID integer
- * @param transporterUnitDefID integer
- * @param transporterTeam integer
- * @param transporteeID integer
- * @param transporteeUnitDefID integer
- * @param transporteeTeam integer
+ * @param transporterID UnitID
+ * @param transporterUnitDefID UnitDefID
+ * @param transporterTeam TeamID
+ * @param transporteeID UnitID
+ * @param transporteeUnitDefID UnitDefID
+ * @param transporteeTeam TeamID
  * @param x number
  * @param y number
  * @param z number
@@ -944,8 +944,8 @@ bool CSyncedLuaHandle::AllowUnitTransportUnload(
 /***
  *
  * @function SyncedCallins:AllowUnitCloak
- * @param unitID integer
- * @param enemyID integer?
+ * @param unitID UnitID
+ * @param enemyID UnitID?
  * @return boolean whether unit is allowed to cloak
  */
 bool CSyncedLuaHandle::AllowUnitCloak(const CUnit* unit, const CUnit* enemy)
@@ -980,9 +980,9 @@ bool CSyncedLuaHandle::AllowUnitCloak(const CUnit* unit, const CUnit* enemy)
 /***
  *
  * @function SyncedCallins:AllowUnitDecloak
- * @param unitID integer
- * @param objectID integer?
- * @param weaponNum number?
+ * @param unitID UnitID
+ * @param objectID ObjectID?
+ * @param weaponNum integer?
  * @return boolean whether unit is allowed to decloak
  */
 bool CSyncedLuaHandle::AllowUnitDecloak(const CUnit* unit, const CSolidObject* object, const CWeapon* weapon)
@@ -1024,8 +1024,8 @@ bool CSyncedLuaHandle::AllowUnitDecloak(const CUnit* unit, const CSolidObject* o
 /***
  *
  * @function SyncedCallins:AllowUnitKamikaze
- * @param unitID integer
- * @param targetID integer
+ * @param unitID UnitID
+ * @param targetID UnitID
  * @return boolean whether unit is allowed to selfd
  */
 bool CSyncedLuaHandle::AllowUnitKamikaze(const CUnit* unit, const CUnit* target, bool allowed)
@@ -1054,8 +1054,8 @@ bool CSyncedLuaHandle::AllowUnitKamikaze(const CUnit* unit, const CUnit* target,
 /*** Called just before feature is created.
  *
  * @function SyncedCallins:AllowFeatureCreation
- * @param featureDefID integer
- * @param teamID integer
+ * @param featureDefID FeatureDefID
+ * @param teamID TeamID
  * @param x number
  * @param y number
  * @param z number
@@ -1098,10 +1098,10 @@ bool CSyncedLuaHandle::AllowFeatureCreation(const FeatureDef* featureDef, int te
  * Eg. for a 30 workertime builder, that's a build power of 1 per frame.
  * For a 50 buildtime feature reclaimed by this builder, part will be 100/-50(/1) = -2%, or -0.02 numerically.
  *
- * @param builderID integer
- * @param builderTeam integer
- * @param featureID integer
- * @param featureDefID integer
+ * @param builderID UnitID
+ * @param builderTeam TeamID
+ * @param featureID FeatureID
+ * @param featureDefID FeatureDefID
  * @param part number
  *
  * @return boolean whether or not the change is permitted
@@ -1136,7 +1136,7 @@ bool CSyncedLuaHandle::AllowFeatureBuildStep(const CUnit* builder, const CFeatur
 /*** Called when a team sets the sharing level of a resource.
  *
  * @function SyncedCallins:AllowResourceLevel
- * @param teamID integer
+ * @param teamID TeamID
  * @param res string
  * @param level number
  * @return boolean whether or not the sharing level is permitted
@@ -1169,8 +1169,8 @@ bool CSyncedLuaHandle::AllowResourceLevel(int teamID, const std::string& type, f
 /*** Called just before resources are transferred between players.
  *
  * @function SyncedCallins:AllowResourceTransfer
- * @param oldTeamID integer
- * @param newTeamID integer
+ * @param oldTeamID TeamID
+ * @param newTeamID TeamID
  * @param res string
  * @param amount number
  * @return boolean whether or not the transfer is permitted.
@@ -1240,10 +1240,10 @@ bool CSyncedLuaHandle::ResourceExcess(const std::map <int, SResourcePack>& exces
 /*** Determines if this unit can be controlled directly in FPS view.
  *
  * @function SyncedCallins:AllowDirectUnitControl
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param playerID integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param playerID PlayerID
  * @return boolean allow
  */
 bool CSyncedLuaHandle::AllowDirectUnitControl(int playerID, const CUnit* unit)
@@ -1276,8 +1276,8 @@ bool CSyncedLuaHandle::AllowDirectUnitControl(int playerID, const CUnit* unit)
  *
  * @function SyncedCallins:AllowBuilderHoldFire
  *
- * @param unitID integer
- * @param unitDefID integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
  * @param action -1|CMD
  * 
  * One of the following:
@@ -1329,9 +1329,9 @@ bool CSyncedLuaHandle::AllowBuilderHoldFire(const CUnit* unit, int action)
  *     3 - the player failed to load.
  *     The default 'failed to choose' start-position is the north-west point of their startbox, or (0,0,0) if they do not have a startbox.
  *
- * @param playerID integer
- * @param teamID integer
- * @param readyState number
+ * @param playerID PlayerID
+ * @param teamID TeamID
+ * @param readyState integer
  * @param clampedX number
  * @param clampedY number
  * @param clampedZ number
@@ -1377,10 +1377,10 @@ bool CSyncedLuaHandle::AllowStartPosition(int playerID, int teamID, unsigned cha
  *
  * @function SyncedCallins:MoveCtrlNotify
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param data number was supposed to indicate the type of notification but currently never has a value other than 1 ("unit hit the ground").
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param data integer was supposed to indicate the type of notification but currently never has a value other than 1 ("unit hit the ground").
  *
  * @return boolean whether or not the unit should remain script-controlled (false) or return to engine controlled movement (true).
  */
@@ -1414,12 +1414,12 @@ bool CSyncedLuaHandle::MoveCtrlNotify(const CUnit* unit, int data)
 /*** Called when pre-building terrain levelling terraforms are completed (c.f. levelGround)
  *
  * @function SyncedCallins:TerraformComplete
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
- * @param buildUnitID integer
- * @param buildUnitDefID integer
- * @param buildUnitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
+ * @param buildUnitID UnitID
+ * @param buildUnitDefID UnitDefID
+ * @param buildUnitTeam TeamID
  * @return boolean if true the current build order is terminated
  */
 bool CSyncedLuaHandle::TerraformComplete(const CUnit* unit, const CUnit* build)
@@ -1479,16 +1479,16 @@ bool CSyncedLuaHandle::TerraformComplete(const CUnit* unit, const CUnit* build)
  * 1st is stored under *newDamage if newDamage != NULL
  * 2nd is stored under *impulseMult if impulseMult != NULL
  *
- * @param unitID integer
- * @param unitDefID integer
- * @param unitTeam integer
+ * @param unitID UnitID
+ * @param unitDefID UnitDefID
+ * @param unitTeam TeamID
  * @param damage number
  * @param paralyzer boolean
- * @param weaponDefID integer? Synced Only
- * @param projectileID integer? Synced Only
- * @param attackerID integer? Synced Only
- * @param attackerDefID integer? Synced Only
- * @param attackerTeam integer? Synced Only
+ * @param weaponDefID WeaponDefID? Synced Only
+ * @param projectileID ProjectileID? Synced Only
+ * @param attackerID UnitID? Synced Only
+ * @param attackerDefID UnitDefID? Synced Only
+ * @param attackerTeam TeamID? Synced Only
  *
  * @return number newDamage, number impulseMult
  */
@@ -1571,15 +1571,15 @@ bool CSyncedLuaHandle::UnitPreDamaged(
  *
  * Allows fine control over how much damage and impulse is applied.
  *
- * @param featureID integer
- * @param featureDefID integer
- * @param featureTeam integer
+ * @param featureID FeatureID
+ * @param featureDefID FeatureDefID
+ * @param featureTeam TeamID
  * @param damage number
- * @param weaponDefID integer
- * @param projectileID integer
- * @param attackerID integer
- * @param attackerDefID integer
- * @param attackerTeam integer
+ * @param weaponDefID WeaponDefID
+ * @param projectileID ProjectileID
+ * @param attackerID UnitID
+ * @param attackerDefID UnitDefID
+ * @param attackerTeam TeamID
  * @return number newDamage
  * @return number impulseMult
  */
@@ -1652,13 +1652,13 @@ bool CSyncedLuaHandle::FeaturePreDamaged(
  *
  * @function SyncedCallins:ShieldPreDamaged
  *
- * @param projectileID integer `-1` when the weapon type is `BeamLaser` or `LightningCannon`
- * @param projectileOwnerID integer `-1` when the weapon type is `BeamLaser` or `LightningCannon`
+ * @param projectileID ProjectileID `-1` when the weapon type is `BeamLaser` or `LightningCannon`
+ * @param projectileOwnerID UnitID `-1` when the weapon type is `BeamLaser` or `LightningCannon`
  * @param shieldWeaponNum integer
- * @param shieldCarrierID integer
+ * @param shieldCarrierID UnitID
  * @param bounceProjectile boolean
  * @param beamEmitterWeaponNum integer? present only when the weapon type is `BeamLaser` or `LightningCannon`
- * @param beamEmitterUnitID integer? present only when the weapon type is `BeamLaser` or `LightningCannon`
+ * @param beamEmitterUnitID UnitID? present only when the weapon type is `BeamLaser` or `LightningCannon`
  * @param startX number
  * @param startY number
  * @param startZ number
@@ -1734,9 +1734,9 @@ bool CSyncedLuaHandle::ShieldPreDamaged(
  *
  * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
- * @param attackerID integer
+ * @param attackerID UnitID
  * @param attackerWeaponNum integer
- * @param attackerWeaponDefID integer
+ * @param attackerWeaponDefID WeaponDefID
  *
  * @return boolean allowCheck
  * @return boolean ignoreCheck
@@ -1781,10 +1781,10 @@ int CSyncedLuaHandle::AllowWeaponTargetCheck(unsigned int attackerID, unsigned i
  *
  * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
- * @param attackerID integer
- * @param targetID integer
+ * @param attackerID UnitID
+ * @param targetID UnitID
  * @param attackerWeaponNum integer
- * @param attackerWeaponDefID integer
+ * @param attackerWeaponDefID WeaponDefID
  * @param defPriority number
  *
  * @return boolean allowed
@@ -1851,9 +1851,9 @@ bool CSyncedLuaHandle::AllowWeaponTarget(
  *
  * Only called for weaponDefIDs registered via `Script.SetWatchAllowTarget` or `Script.SetWatchWeapon`.
  *
- * @param interceptorUnitID integer
+ * @param interceptorUnitID UnitID
  * @param interceptorWeaponID integer
- * @param targetProjectileID integer
+ * @param targetProjectileID ProjectileID
  *
  * @return boolean allowed
  *
@@ -2191,7 +2191,7 @@ int CSyncedLuaHandle::GetWatchWeaponDef(lua_State* L) {
  *
  * @function Script.GetWatchUnit
  *
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @return boolean watched Watch status.
  *
  * @see Script.SetWatchUnit
@@ -2204,7 +2204,7 @@ GetWatchDef(Synced, Unit)
  *
  * @function Script.GetWatchFeature
  *
- * @param featureDefID integer
+ * @param featureDefID FeatureDefID
  * @return boolean watched `true` if callins are registered, otherwise `false`.
  *
  * @see Script.SetWatchFeature
@@ -2222,7 +2222,7 @@ GetWatchDef(Synced, Feature)
  * Script.GetWatchExplosion(weaponDefID) or Script.GetWatchProjectile(weaponDefID) or Script.GetWatchAllowTarget(weaponDefID)
  * ```
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @return boolean watched True if watch is enabled for any weaponDefID callins.
  *
  * @see Script.SetWatchWeapon
@@ -2232,7 +2232,7 @@ GetWatchDef(Synced, Feature)
  *
  * @function Script.GetWatchExplosion
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @return boolean watched `true` if callins are registered, otherwise `false`.
  *
  * @see Script.SetWatchExplosion
@@ -2246,7 +2246,7 @@ GetWatchDef(Unsynced, Explosion)
  *
  * @function Script.GetWatchProjectile
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @return boolean watched `true` if callins are registered, otherwise `false`.
  *
  * @see Script.SetWatchProjectile
@@ -2259,7 +2259,7 @@ GetWatchDef(Synced, Projectile)
  *
  * @function Script.GetWatchAllowTarget
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @return boolean watched `true` if callins are registered, otherwise `false`.
  *
  * @see Script.SetWatchAllowTarget
@@ -2272,7 +2272,7 @@ GetWatchDef(Synced, AllowTarget)
  *
  * @function Script.SetWatchUnit
  *
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchUnit
@@ -2288,7 +2288,7 @@ SetWatchDef(Synced, Unit)
  *
  * @function Script.SetWatchFeature
  *
- * @param featureDefID integer
+ * @param featureDefID FeatureDefID
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchFeature
@@ -2312,7 +2312,7 @@ SetWatchDef(Synced, Feature)
  *
  * Generally it's better to use those methods to avoid registering uneeded callins.
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchWeapon
@@ -2325,7 +2325,7 @@ SetWatchDef(Synced, Feature)
  *
  * @function Script.SetWatchExplosion
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchExplosion
@@ -2340,7 +2340,7 @@ SetWatchDef(Unsynced, Explosion)
  *
  * @function Script.SetWatchProjectile
  *
- * @param weaponDefID integer weaponDefID for weapons or -1 to watch for debris.
+ * @param weaponDefID WeaponDefID weaponDefID for weapons or -1 to watch for debris.
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchProjectile
@@ -2355,7 +2355,7 @@ SetWatchDef(Synced, Projectile)
  *
  * @function Script.SetWatchAllowTarget
  *
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchAllowTarget
@@ -2542,7 +2542,7 @@ string CSplitLuaHandle::LoadFile(const std::string& filename, const std::string&
 /*** Calls a function from given team's PoV. In particular this makes callouts obey that team's visibility rules.
  *
  * @function Spring.CallAsTeam
- * @param teamID integer Team ID.
+ * @param teamID TeamID Team ID.
  * @param func fun(...) The function to call.
  * @param ... any Arguments to pass to the function.
  * @return any ... The return values of the function.

--- a/rts/Lua/LuaObjectRendering.cpp
+++ b/rts/Lua/LuaObjectRendering.cpp
@@ -136,7 +136,7 @@ void LuaObjectRenderingImpl::PushFunction(lua_State* L, int (*fnPntr)(lua_State*
 /*** Get the number of LOD levels and the current LOD.
  *
  * @function ObjectRenderingTable.GetLODCount
- * @param objectID integer
+ * @param objectID ObjectID
  * @return integer lodCount
  * @return integer currentLOD
  */
@@ -158,7 +158,7 @@ int LuaObjectRenderingImpl::GetLODCount(lua_State* L)
 /*** Set the number of LOD levels.
  *
  * @function ObjectRenderingTable.SetLODCount
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodCount integer
  * @return nil
  */
@@ -195,7 +195,7 @@ static int SetLODLengthCommon(lua_State* L, CSolidObject* obj, float scale)
 /*** Set the LOD transition length for a given level.
  *
  * @function ObjectRenderingTable.SetLODLength
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param lodLength number
  * @return nil
@@ -210,7 +210,7 @@ int LuaObjectRenderingImpl::SetLODLength(lua_State* L)
 /*** Set the LOD transition distance for a given level (scaled for 45-degree FOV).
  *
  * @function ObjectRenderingTable.SetLODDistance
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param lodDistance number
  * @return nil
@@ -231,7 +231,7 @@ int LuaObjectRenderingImpl::SetLODDistance(lua_State* L)
 /*** Set a display list for a piece at a given LOD and material.
  *
  * @function ObjectRenderingTable.SetPieceList
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param piece integer
  * @param ... any
@@ -387,7 +387,7 @@ static LuaMatRef ParseMaterial(lua_State* L, int index, LuaMatType matType) {
 /*** Get a material reference for a LOD level.
  *
  * @function ObjectRenderingTable.GetMaterial
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param materialName string
  * @return userdata matRef
@@ -417,7 +417,7 @@ int LuaObjectRenderingImpl::GetMaterial(lua_State* L)
 /*** Set a material for a LOD level.
  *
  * @function ObjectRenderingTable.SetMaterial
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param materialName string
  * @param materialTable table
@@ -462,7 +462,7 @@ int LuaObjectRenderingImpl::SetMaterial(lua_State* L)
 /*** Set the last LOD level that uses a given material.
  *
  * @function ObjectRenderingTable.SetMaterialLastLOD
- * @param objectID integer
+ * @param objectID ObjectID
  * @param materialName string
  * @param lastLOD integer
  * @return nil
@@ -488,7 +488,7 @@ int LuaObjectRenderingImpl::SetMaterialLastLOD(lua_State* L)
 /*** Set display lists for a material.
  *
  * @function ObjectRenderingTable.SetMaterialDisplayLists
- * @param objectID integer
+ * @param objectID ObjectID
  * @param lodLevel integer
  * @param materialName string
  * @param displayListTable table
@@ -583,13 +583,13 @@ static int SetMaterialUniform(lua_State* L, LuaObjType objType, LuaMatShader::Pa
 }
 
 /*** @function ObjectRenderingTable.SetDeferredMaterialUniform
- * @param objectID integer
+ * @param objectID ObjectID
  * @param ... any uniform values
  * @return nil
  */
 int LuaObjectRenderingImpl::SetDeferredMaterialUniform(lua_State* L) { return (SetMaterialUniform(L, GetObjectType(), LuaMatShader::LUASHADER_PASS_DFR)); }
 /*** @function ObjectRenderingTable.SetForwardMaterialUniform
- * @param objectID integer
+ * @param objectID ObjectID
  * @param ... any uniform values
  * @return nil
  */
@@ -632,13 +632,13 @@ static int ClearMaterialUniform(lua_State* L, LuaObjType objType, LuaMatShader::
 }
 
 /*** @function ObjectRenderingTable.ClearDeferredMaterialUniform
- * @param objectID integer
+ * @param objectID ObjectID
  * @param ... any uniform indices
  * @return nil
  */
 int LuaObjectRenderingImpl::ClearDeferredMaterialUniform(lua_State* L) { return (ClearMaterialUniform(L, GetObjectType(), LuaMatShader::LUASHADER_PASS_FWD)); }
 /*** @function ObjectRenderingTable.ClearForwardMaterialUniform
- * @param objectID integer
+ * @param objectID ObjectID
  * @param ... any uniform indices
  * @return nil
  */
@@ -666,7 +666,7 @@ static int SetObjectLuaDraw(lua_State* L, ObjectType* obj)
 /*** Enable or disable custom Lua drawing for a unit.
  *
  * @function ObjectRenderingTable.SetUnitLuaDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @param enable boolean
  * @return nil
  */
@@ -679,7 +679,7 @@ int LuaObjectRenderingImpl::SetUnitLuaDraw(lua_State* L)
 /*** Enable or disable custom Lua drawing for a feature.
  *
  * @function ObjectRenderingTable.SetFeatureLuaDraw
- * @param featureID integer
+ * @param featureID FeatureID
  * @param enable boolean
  * @return nil
  */
@@ -692,7 +692,7 @@ int LuaObjectRenderingImpl::SetFeatureLuaDraw(lua_State* L)
 /*** Enable or disable custom Lua drawing for a projectile.
  *
  * @function ObjectRenderingTable.SetProjectileLuaDraw
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param enable boolean
  * @return nil
  */
@@ -730,7 +730,7 @@ static void PrintObjectLOD(const CSolidObject* obj, int lod)
 /*** Print debug info about the object's material data.
  *
  * @function ObjectRenderingTable.Debug
- * @param objectID integer
+ * @param objectID ObjectID
  * @return nil
  */
 int LuaObjectRenderingImpl::Debug(lua_State* L)

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -1221,8 +1221,8 @@ int LuaOpenGL::GetScreenViewTrans(lua_State* L)
 
 /***
  * @function gl.GetViewSizes
- * @return number x
- * @return number y
+ * @return integer x
+ * @return integer y
  */
 int LuaOpenGL::GetViewSizes(lua_State* L)
 {
@@ -1541,7 +1541,7 @@ static bool GLObjectDrawWithLuaMat(lua_State* L, CSolidObject* obj, LuaObjType o
  * Pushes or pops the model render state for the given object.
  * 
  * Parses params, starting at param 2:
- * @param teamID integer
+ * @param teamID TeamID
  * @param rawState boolean? (Default: `true`)
  * @param toScreen boolean? (Default: `false`)
  * @param opaque boolean? (Default: `true`) If `true`, draw opaque; if `false`, draw alpha.
@@ -1666,7 +1666,7 @@ int LuaOpenGL::UnitCommon(lua_State* L, bool applyTransform, bool callDrawUnit)
  * Draw the unit, applying transform.
  * 
  * @function gl.Unit
- * @param unitID integer
+ * @param unitID UnitID
  * @param doRawDraw boolean? (Default: `false`)
  * @param useLuaMat integer?
  * @param noLuaCall boolean? (Default: `false`) Skip the `DrawUnit` callin.
@@ -1681,7 +1681,7 @@ int LuaOpenGL::Unit(lua_State* L) { return (UnitCommon(L, true, true)); }
  * recursion is blocked.
  * 
  * @function gl.UnitRaw
- * @param unitID integer
+ * @param unitID UnitID
  * @param doRawDraw boolean? (Default: `false`)
  * @param useLuaMat integer?
  * @param noLuaCall boolean? (Default: `true`) Skip the `DrawUnit` callin.
@@ -1691,7 +1691,7 @@ int LuaOpenGL::UnitRaw(lua_State* L) { return (UnitCommon(L, false, false)); }
 
 /***
  * @function gl.UnitTextures
- * @param unitID integer
+ * @param unitID UnitID
  * @param push boolean If `true`, push the render state; if `false`, pop it.
  */
 int LuaOpenGL::UnitTextures(lua_State* L)
@@ -1703,8 +1703,8 @@ int LuaOpenGL::UnitTextures(lua_State* L)
 
 /***
  * @function gl.UnitShape
- * @param unitDefID integer
- * @param teamID integer
+ * @param unitDefID UnitDefID
+ * @param teamID TeamID
  * @param rawState boolean? (Default: `true`)
  * @param toScreen boolean? (Default: `false`)
  * @param opaque boolean? (Default: `true`) If `true`, draw opaque; if `false`, draw alpha.
@@ -1718,7 +1718,7 @@ int LuaOpenGL::UnitShape(lua_State* L)
 
 /***
  * @function gl.UnitShapeTextures
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param push boolean If `true`, push the render state; if `false`, pop it.
  */
 int LuaOpenGL::UnitShapeTextures(lua_State* L)
@@ -1731,7 +1731,7 @@ int LuaOpenGL::UnitShapeTextures(lua_State* L)
 
 /***
  * @function gl.UnitMultMatrix
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaOpenGL::UnitMultMatrix(lua_State* L)
 {
@@ -1749,7 +1749,7 @@ int LuaOpenGL::UnitMultMatrix(lua_State* L)
 
 /***
  * @function gl.UnitPiece
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceID integer
  */ 
 int LuaOpenGL::UnitPiece(lua_State* L)
@@ -1760,14 +1760,14 @@ int LuaOpenGL::UnitPiece(lua_State* L)
 
 /***
  * @function gl.UnitPieceMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceID integer
  */ 
 int LuaOpenGL::UnitPieceMatrix(lua_State* L) {return (UnitPieceMultMatrix(L)); }
 
 /***
  * @function gl.UnitPieceMultMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceID integer
  */ 
 int LuaOpenGL::UnitPieceMultMatrix(lua_State* L)
@@ -1834,7 +1834,7 @@ int LuaOpenGL::FeatureCommon(lua_State* L, bool applyTransform, bool callDrawFea
  * Draw the feature, applying transform.
  * 
  * @function gl.Feature
- * @param featureID integer
+ * @param featureID FeatureID
  * @param doRawDraw boolean? (Default: `false`)
  * @param useLuaMat integer?
  * @param noLuaCall boolean? (Default: `false`) Skip the `DrawFeature` callin.
@@ -1848,7 +1848,7 @@ int LuaOpenGL::Feature(lua_State* L) { return (FeatureCommon(L, true, true)); }
  * recursion is blocked.
  
  * @function gl.FeatureRaw
- * @param featureID integer
+ * @param featureID FeatureID
  * @param doRawDraw boolean? (Default: `false`)
  * @param useLuaMat integer?
  * @param noLuaCall boolean? (Default: `true`) Skip the `DrawFeature` callin.
@@ -1857,7 +1857,7 @@ int LuaOpenGL::FeatureRaw(lua_State* L) { return (FeatureCommon(L, false, false)
 
 /***
  * @function gl.FeatureTextures
- * @param featureID integer
+ * @param featureID FeatureID
  * @param push boolean If `true`, push the render state; if `false`, pop it.
  */
 int LuaOpenGL::FeatureTextures(lua_State* L)
@@ -1869,8 +1869,8 @@ int LuaOpenGL::FeatureTextures(lua_State* L)
 
 /***
  * @function gl.FeatureShape
- * @param featureDefID integer
- * @param teamID integer
+ * @param featureDefID FeatureDefID
+ * @param teamID TeamID
  * @param rawState boolean? (Default: `true`)
  * @param toScreen boolean? (Default: `false`)
  * @param opaque boolean? (Default: `true`) If `true`, draw opaque; if `false`, draw alpha.
@@ -1884,7 +1884,7 @@ int LuaOpenGL::FeatureShape(lua_State* L)
 
 /***
  * @function gl.FeatureShapeTextures
- * @param featureDefID integer
+ * @param featureDefID FeatureDefID
  * @param push boolean If `true`, push the render state; if `false`, pop it.
  */
 int LuaOpenGL::FeatureShapeTextures(lua_State* L)
@@ -1897,7 +1897,7 @@ int LuaOpenGL::FeatureShapeTextures(lua_State* L)
 
 /***
  * @function gl.FeatureMultMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  */
 int LuaOpenGL::FeatureMultMatrix(lua_State* L)
 {
@@ -1915,7 +1915,7 @@ int LuaOpenGL::FeatureMultMatrix(lua_State* L)
 
 /***
  * @function gl.FeaturePiece
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceID integer
  */
 int LuaOpenGL::FeaturePiece(lua_State* L)
@@ -1927,7 +1927,7 @@ int LuaOpenGL::FeaturePiece(lua_State* L)
 
 /***
  * @function gl.FeaturePieceMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceID integer
  */
 int LuaOpenGL::FeaturePieceMatrix(lua_State* L) { return (FeaturePieceMultMatrix(L)); }
@@ -1935,7 +1935,7 @@ int LuaOpenGL::FeaturePieceMatrix(lua_State* L) { return (FeaturePieceMultMatrix
 
 /***
  * @function gl.FeaturePieceMultMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceID integer
  */
 int LuaOpenGL::FeaturePieceMultMatrix(lua_State* L)
@@ -1952,7 +1952,7 @@ int LuaOpenGL::FeaturePieceMultMatrix(lua_State* L)
 
 /***
  * @function gl.DrawListAtUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param listIndex integer
  * @param useMidPos boolean? (Default: `true`)
  * @param scaleX number? (Default: `1.0`)
@@ -2009,7 +2009,7 @@ int LuaOpenGL::DrawListAtUnit(lua_State* L)
 
 /***
  * @function gl.DrawFuncAtUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param useMidPos boolean? (Default: `true`)
  * @param fun(...) func Function to call.
  * @param ... any Arguments passed to function.
@@ -2067,7 +2067,7 @@ int LuaOpenGL::DrawFuncAtUnit(lua_State* L)
  * @param resolution integer
  * @param slope number
  * @param gravity number?
- * @param weaponDefID integer?
+ * @param weaponDefID WeaponDefID?
  */
 int LuaOpenGL::DrawGroundCircle(lua_State* L)
 {

--- a/rts/Lua/LuaPathFinder.cpp
+++ b/rts/Lua/LuaPathFinder.cpp
@@ -213,7 +213,7 @@ static void CreatePathMetatable(lua_State* L)
 
 /***
  * @function Spring.RequestPath
- * @param moveID number|string
+ * @param moveID integer|string
  * @param startX number
  * @param startY number
  * @param startZ number
@@ -303,7 +303,7 @@ int LuaPathFinder::InitPathNodeCostsArray(lua_State* L)
 
 /***
  * @function Spring.FreePathNodeCostsArray
- * @param overlayIndex number
+ * @param overlayIndex integer
  * @return boolean success
  */
 int LuaPathFinder::FreePathNodeCostsArray(lua_State* L)
@@ -341,7 +341,7 @@ int LuaPathFinder::FreePathNodeCostsArray(lua_State* L)
 
 /***
  * @function Spring.SetPathNodeCosts
- * @param overlayIndex number
+ * @param overlayIndex integer
  * @return boolean success
  */
 int LuaPathFinder::SetPathNodeCosts(lua_State* L)
@@ -370,7 +370,7 @@ int LuaPathFinder::SetPathNodeCosts(lua_State* L)
 
 /***
  * @function Spring.GetPathNodeCosts
- * @param overlayIndex number
+ * @param overlayIndex integer
  * @return boolean|table costs
  */
 int LuaPathFinder::GetPathNodeCosts(lua_State* L)

--- a/rts/Lua/LuaRBOs.cpp
+++ b/rts/Lua/LuaRBOs.cpp
@@ -152,7 +152,7 @@ int LuaRBOs::meta_newindex(lua_State* L)
  * @x_helper
  * @field target GL
  * @field format GL
- * @field samples number? any number here will result in creation of multisampled RBO
+ * @field samples integer? any number here will result in creation of multisampled RBO
  */
 
 /***

--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -1054,7 +1054,7 @@ namespace {
  * Writes user-defined model uniforms for a unit.
  *
  * @function gl.SetUnitBufferUniforms
- * @param unitID integer
+ * @param unitID UnitID
  * @param values number[]
  * @param offset integer?
  * @return integer count
@@ -1064,7 +1064,7 @@ int LuaShaders::SetUnitBufferUniforms(lua_State* L) { return SetObjectBufferUnif
  * Writes user-defined model uniforms for a feature.
  *
  * @function gl.SetFeatureBufferUniforms
- * @param featureID integer
+ * @param featureID FeatureID
  * @param values number[]
  * @param offset integer?
  * @return integer count
@@ -1351,7 +1351,7 @@ int LuaShaders::UniformSubroutine(lua_State* L)
  *
  * Return the GLSL compliant definition of UniformMatricesBuffer(idx=0) or UniformParamsBuffer(idx=1) structure.
  *
- * @param index number
+ * @param index integer
  * @return string glslDefinition
  */
 int LuaShaders::GetEngineUniformBufferDef(lua_State* L)
@@ -1373,7 +1373,7 @@ int LuaShaders::GetEngineUniformBufferDef(lua_State* L)
  *
  * Return the GLSL compliant definition of ModelUniformData structure (per Unit/Feature buffer available on GPU)
  *
- * @param index number
+ * @param index integer
  * @return string glslDefinition
  */
 int LuaShaders::GetEngineModelUniformDataDef(lua_State* L)
@@ -1391,9 +1391,9 @@ int LuaShaders::GetEngineModelUniformDataDef(lua_State* L)
  *
  * Return the current size values of ModelUniformData structure (per Unit/Feature buffer available on GPU)
  *
- * @param index number
- * @return number sizeInElements
- * @return number sizeInBytesOnCPU
+ * @param index integer
+ * @return integer sizeInElements
+ * @return integer sizeInBytesOnCPU
 
  */
 int LuaShaders::GetEngineModelUniformDataSize(lua_State* L)
@@ -1412,8 +1412,8 @@ int LuaShaders::GetEngineModelUniformDataSize(lua_State* L)
  *
  * @function gl.SetGeometryShaderParameter
  * @param shaderID integer
- * @param key number
- * @param value number
+ * @param key GL
+ * @param value integer
  * @return nil
  */
 int LuaShaders::SetGeometryShaderParameter(lua_State* L)

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -887,8 +887,8 @@ static inline bool IsPlayerSynced(const CPlayer* player)
 /*** Changes the value of the (one-sided) alliance between: firstAllyTeamID -> secondAllyTeamID.
  *
  * @function Spring.SetAlly
- * @param firstAllyTeamID integer
- * @param secondAllyTeamID integer
+ * @param firstAllyTeamID AllyTeamID
+ * @param secondAllyTeamID AllyTeamID
  * @param ally boolean
  * @return nil
  */
@@ -910,7 +910,7 @@ int LuaSyncedCtrl::SetAlly(lua_State* L)
 /*** Changes the start box position of an allyTeam.
  *
  * @function Spring.SetAllyTeamStartBox
- * @param allyTeamID integer
+ * @param allyTeamID AllyTeamID
  * @param xMin number left start box boundary (elmos)
  * @param zMin number top start box boundary (elmos)
  * @param xMax number right start box boundary (elmos)
@@ -942,8 +942,8 @@ int LuaSyncedCtrl::SetAllyTeamStartBox(lua_State* L)
 /*** Assigns a player to a team.
  *
  * @function Spring.AssignPlayerToTeam
- * @param playerID integer
- * @param teamID integer
+ * @param playerID PlayerID
+ * @param teamID TeamID
  * @return nil
  */
 int LuaSyncedCtrl::AssignPlayerToTeam(lua_State* L)
@@ -971,7 +971,7 @@ int LuaSyncedCtrl::AssignPlayerToTeam(lua_State* L)
  * If the position argument is outside the team's startbox, the position is clamped.
  * 
  * @function Spring.SetTeamStartPosition
- * @param teamID integer
+ * @param teamID TeamID
  * @param x number left position (elmos)
  * @param y number vertical position (elmos)
  * @param z number top position (elmos)
@@ -1004,7 +1004,7 @@ int LuaSyncedCtrl::SetTeamStartPosition(lua_State* L)
  * Use to mark a player (un)ready in the pregame phase.
  *
  * @function Spring.SetPlayerReadyState
- * @param playerID integer
+ * @param playerID PlayerID
  * @param ready boolean
  * @return boolean true if the state was set, false if the playerID was invalid
  */
@@ -1027,7 +1027,7 @@ int LuaSyncedCtrl::SetPlayerReadyState(lua_State* L)
 /*** Changes access to global line of sight for a team and its allies.
  *
  * @function Spring.SetGlobalLos
- * @param allyTeamID integer
+ * @param allyTeamID AllyTeamID
  * @param globallos boolean
  * @return nil
  */
@@ -1088,7 +1088,7 @@ int LuaSyncedCtrl::SetGodMode(lua_State* L)
  *
  * Gaia team cannot be killed.
  *
- * @param teamID integer
+ * @param teamID TeamID
  * @return nil
  */
 int LuaSyncedCtrl::KillTeam(lua_State* L)
@@ -1116,7 +1116,7 @@ int LuaSyncedCtrl::KillTeam(lua_State* L)
 /*** Declare game over.
  * 
  * @function Spring.GameOver
- * @param winningAllyTeamIDs integer[] A list of winning ally team IDs.
+ * @param winningAllyTeamIDs AllyTeamID[] A list of winning ally team IDs.
  *
  * Pass multiple winners to declare a draw.
  * Pass no arguments if undecided (e.g. when dropped from the host).
@@ -1189,7 +1189,7 @@ int LuaSyncedCtrl::SetWind(lua_State* L)
  * Counts as production in post-game graph statistics.
  *
  * @function Spring.AddTeamResource
- * @param teamID integer
+ * @param teamID TeamID
  * @param type ResourceName
  * @param amount number
  * @return nil
@@ -1227,7 +1227,7 @@ int LuaSyncedCtrl::AddTeamResource(lua_State* L)
  * Counts as usage in post-game graph statistics.
  *
  * @function Spring.UseTeamResource
- * @param teamID integer
+ * @param teamID TeamID
  * @param type ResourceName Resource type.
  * @param amount number Amount of resource to use.
  * @return boolean hadEnough
@@ -1238,7 +1238,7 @@ int LuaSyncedCtrl::AddTeamResource(lua_State* L)
  * Counts as usage in post-game graph statistics.
  *
  * @function Spring.UseTeamResource
- * @param teamID integer
+ * @param teamID TeamID
  * @param amount ResourceUsage
  * @return boolean hadEnough
  * True if enough of the resource type(s) were available and was consumed, otherwise false.
@@ -1321,7 +1321,7 @@ int LuaSyncedCtrl::UseTeamResource(lua_State* L)
 
 /***
  * @function Spring.SetTeamResource
- * @param teamID integer
+ * @param teamID TeamID
  * @param resource ResourceName|StorageName
  * @param amount number
  * @return nil
@@ -1372,7 +1372,7 @@ int LuaSyncedCtrl::SetTeamResource(lua_State* L)
 /*** Changes the resource amount for a team beyond which resources aren't stored but transferred to other allied teams if possible.
  *
  * @function Spring.SetTeamShareLevel
- * @param teamID integer
+ * @param teamID TeamID
  * @param type ResourceName
  * @param amount number
  * @return nil
@@ -1413,7 +1413,7 @@ int LuaSyncedCtrl::SetTeamShareLevel(lua_State* L)
  * to handle it manually it's now also up to you to track stats.
  *
  * @function Spring.AddTeamResourceExcessStats
- * @param teamID integer
+ * @param teamID TeamID
  * @param type ResourceName
  * @param excess number Amount wasted this tick.
  * @return nil
@@ -1459,8 +1459,8 @@ int LuaSyncedCtrl::AddTeamResourceExcessStats(lua_State* L)
  * used/produced in end-game statistics graphs.
  *
  * @function Spring.ShareTeamResource
- * @param teamID_src integer
- * @param teamID_recv integer
+ * @param teamID_src TeamID
+ * @param teamID_recv TeamID
  * @param type ResourceName
  * @param amount number
  * @return nil
@@ -1627,7 +1627,7 @@ int LuaSyncedCtrl::SetGameRulesParam(lua_State* L)
 
 /***
  * @function Spring.SetTeamRulesParam
- * @param teamID integer
+ * @param teamID TeamID
  * @param paramName string
  * @param paramValue (number|string|boolean)? numeric paramValues in quotes will be converted to number.
  * @param losAccess losAccess?
@@ -1645,7 +1645,7 @@ int LuaSyncedCtrl::SetTeamRulesParam(lua_State* L)
 
 /***
  * @function Spring.SetPlayerRulesParam
- * @param playerID integer
+ * @param playerID PlayerID
  * @param paramName string
  * @param paramValue (number|string|boolean)? numeric paramValues in quotes will be converted to number.
  * @param losAccess losAccess?
@@ -1669,7 +1669,7 @@ int LuaSyncedCtrl::SetPlayerRulesParam(lua_State* L)
 /***
  *
  * @function Spring.SetUnitRulesParam
- * @param unitID integer
+ * @param unitID UnitID
  * @param paramName string
  * @param paramValue (number|string|boolean)? numeric paramValues in quotes will be converted to number.
  * @param losAccess losAccess?
@@ -1689,7 +1689,7 @@ int LuaSyncedCtrl::SetUnitRulesParam(lua_State* L)
 
 /***
  * @function Spring.SetFeatureRulesParam
- * @param featureID integer
+ * @param featureID FeatureID
  * @param paramName string
  * @param paramValue (number|string|boolean)? numeric paramValues in quotes will be converted to number.
  * @param losAccess losAccess?
@@ -1753,11 +1753,11 @@ static inline void ParseCobArgs(
 
 /***
  * @function Spring.CallCOBScript
- * @param unitID integer
+ * @param unitID UnitID
  * @param funcName integer|string? Function ID or name.
  * @param retArgs integer Number of values to return.
  * @param ... any Arguments
- * @return number ...
+ * @return integer ...
  */
 int LuaSyncedCtrl::CallCOBScript(lua_State* L)
 {
@@ -1813,7 +1813,7 @@ int LuaSyncedCtrl::CallCOBScript(lua_State* L)
 
 /***
  * @function Spring.GetCOBScriptID
- * @param unitID integer
+ * @param unitID UnitID
  * @param funcName string
  * @return integer? funcID
  */
@@ -1861,12 +1861,12 @@ int LuaSyncedCtrl::GetCOBScriptID(lua_State* L)
  * @param posY number
  * @param posZ number
  * @param facing Facing
- * @param teamID integer?
+ * @param teamID TeamID?
  * @param build boolean? (Default: `false`) The unit is created in "being built" state with zero `buildProgress`.
  * @param flattenGround boolean? (Default: `true`) The unit flattens ground, if it normally does so.
- * @param unitID integer? Request a specific unitID.
- * @param builderID integer?
- * @return integer? unitID The ID of the created unit, or `nil` if the unit could not be created.
+ * @param unitID UnitID? Request a specific unitID.
+ * @param builderID UnitID?
+ * @return UnitID? unitID The ID of the created unit, or `nil` if the unit could not be created.
  */
 int LuaSyncedCtrl::CreateUnit(lua_State* L)
 {
@@ -1953,10 +1953,10 @@ int LuaSyncedCtrl::CreateUnit(lua_State* L)
 /***
  * @function Spring.DestroyUnit
  * @see Spring.CreateUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param selfd boolean? (Default: `false`) makes the unit act like it self-destructed.
  * @param reclaimed boolean? (Default: `false`) don't show any DeathSequences, don't leave a wreckage. This does not give back the resources to the team!
- * @param attackerID integer?
+ * @param attackerID UnitID?
  * @param cleanupImmediately boolean? (Default: `false`) stronger version of reclaimed, removes the unit unconditionally and makes its ID available for immediate reuse (otherwise it takes a few frames)
  * @return nil
  */
@@ -1996,8 +1996,8 @@ int LuaSyncedCtrl::DestroyUnit(lua_State* L)
 
 /***
  * @function Spring.TransferUnit
- * @param unitID integer
- * @param newTeamID integer
+ * @param unitID UnitID
+ * @param newTeamID TeamID
  * @param given boolean? (Default: `true`) if false, the unit is captured.
  * @param adjustUnitLimit boolean? (Default: `false`) if true, also transfer the limit slot
  * @return boolean successfulTransfer
@@ -2061,9 +2061,9 @@ int LuaSyncedCtrl::TransferUnit(lua_State* L)
  * - `transferAmnt` must be lower or equal than the origin team current maxunits (can't transfer limit team does not have available)
  * - `transferAmnt` must be lower than origin team maxunits - currentunitscount (can't transfer limit if origin team would be already over the limit after transfer)
  *
- * @param fromTeamID number
- * @param newTeamID number
- * @param transferAmnt number
+ * @param fromTeamID TeamID
+ * @param newTeamID TeamID
+ * @param transferAmnt integer
  * @return boolean successfulTransfer Whether the max unit limit was successfully transferred.
  */
 int LuaSyncedCtrl::TransferTeamMaxUnits(lua_State* L)
@@ -2099,7 +2099,7 @@ int LuaSyncedCtrl::TransferTeamMaxUnits(lua_State* L)
 
 /***
  * @function Spring.SetUnitCosts
- * @param unitID integer
+ * @param unitID UnitID
  * @param where table<number,number> keys and values are, respectively and in this order: buildTime=amount, metalCost=amount, energyCost=amount
  * @return nil
  */
@@ -2228,7 +2228,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 
 /***
  * @function Spring.SetUnitResourcing
- * @param unitID integer
+ * @param unitID UnitID
  * @param res string
  * @param amount number
  * @return nil
@@ -2236,7 +2236,7 @@ static bool SetUnitStorageParam(CUnit* unit, const char* name, float value)
 
 /***
  * @function Spring.SetUnitResourcing
- * @param unitID integer
+ * @param unitID UnitID
  * @param res table<string,number> keys are: "[u|c][u|m][m|e]" unconditional | conditional, use | make, metal | energy. Values are amounts
  * @return nil
  */
@@ -2274,14 +2274,14 @@ int LuaSyncedCtrl::SetUnitResourcing(lua_State* L)
 
 /***
  * @function Spring.SetUnitStorage
- * @param unitID integer
+ * @param unitID UnitID
  * @param res string
  * @param amount number
  */
 
 /***
  * @function Spring.SetUnitStorage
- * @param unitID integer
+ * @param unitID UnitID
  * @param res ResourceUsage keys are: "[m|e]" metal | energy. Values are amounts
  */
 int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
@@ -2313,7 +2313,7 @@ int LuaSyncedCtrl::SetUnitStorage(lua_State* L)
 
 /***
  * @function Spring.SetUnitTooltip
- * @param unitID integer
+ * @param unitID UnitID
  * @param tooltip string
  * @return nil
  */
@@ -2349,7 +2349,7 @@ int LuaSyncedCtrl::SetUnitTooltip(lua_State* L)
  * Note, if your game's custom shading framework doesn't support reverting into nanoframes
  * then reverting into nanoframes via the "build" tag will fail to render properly.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param health number|SetUnitHealthAmounts If a number, sets the units health
  * to that value. Pass a table to update health, capture progress, paralyze
  * damage, and build progress.
@@ -2410,7 +2410,7 @@ int LuaSyncedCtrl::SetUnitHealth(lua_State* L)
 
 /***
  * @function Spring.SetUnitMaxHealth
- * @param unitID integer
+ * @param unitID UnitID
  * @param maxHealth number
  * @return nil
  */
@@ -2429,8 +2429,8 @@ int LuaSyncedCtrl::SetUnitMaxHealth(lua_State* L)
 
 /***
  * @function Spring.SetUnitStockpile
- * @param unitID integer
- * @param stockpile number?
+ * @param unitID UnitID
+ * @param stockpile integer?
  * @param buildPercent number?
  * @return nil
  */
@@ -2571,7 +2571,7 @@ static bool SetSingleUnitWeaponState(lua_State* L, CWeapon* weapon, int index)
 /***
  *
  * @function Spring.SetUnitUseWeapons
- * @param unitID integer
+ * @param unitID UnitID
  * @param forceUseWeapons number?
  * @param allowUseWeapons number?
  * @return nil
@@ -2590,16 +2590,16 @@ int LuaSyncedCtrl::SetUnitUseWeapons(lua_State* L)
 
 /***
  * @function Spring.SetUnitWeaponState
- * @param unitID integer
- * @param weaponNum number
+ * @param unitID UnitID
+ * @param weaponNum integer
  * @param states WeaponState
  * @return nil
  */
 
 /***
  * @function Spring.SetUnitWeaponState
- * @param unitID integer
- * @param weaponNum number
+ * @param unitID UnitID
+ * @param weaponNum integer
  * @param key string
  * @param value number
  * @return nil
@@ -2726,15 +2726,15 @@ static int SetSingleDynDamagesKey(lua_State* L, DynDamageArray* damages, int ind
 
 /***
  * @function Spring.SetUnitWeaponDamages
- * @param unitID integer
- * @param weaponNum number|"selfDestruct"|"explode"
+ * @param unitID UnitID
+ * @param weaponNum integer|"selfDestruct"|"explode"
  * @param damages WeaponDamages
  * @return nil
  */
 /***
  * @function Spring.SetUnitWeaponDamages
- * @param unitID integer
- * @param weaponNum number|"selfDestruct"|"explode"
+ * @param unitID UnitID
+ * @param weaponNum integer|"selfDestruct"|"explode"
  * @param key string
  * @param value number
  * @return nil
@@ -2786,7 +2786,7 @@ int LuaSyncedCtrl::SetUnitWeaponDamages(lua_State* L)
 
 /*** @function Spring.SetUnitMaxRange
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param maxRange number
  * @return nil
  */
@@ -2806,7 +2806,7 @@ int LuaSyncedCtrl::SetUnitMaxRange(lua_State* L)
  * @function Spring.SetUnitExperience
  * @see Spring.AddUnitExperience
  * @see Spring.GetUnitExperience
- * @param unitID integer
+ * @param unitID UnitID
  * @param experience number
  * @return nil
  */
@@ -2825,7 +2825,7 @@ int LuaSyncedCtrl::SetUnitExperience(lua_State* L)
  * @function Spring.AddUnitExperience
  * @see Spring.SetUnitExperience
  * @see Spring.GetUnitExperience
- * @param unitID integer
+ * @param unitID UnitID
  * @param deltaExperience number Can be negative to subtract, but the unit will never have negative total afterwards
  * @return nil
  */
@@ -2844,7 +2844,7 @@ int LuaSyncedCtrl::AddUnitExperience(lua_State* L)
 
 /***
  * @function Spring.SetUnitArmored
- * @param unitID integer
+ * @param unitID UnitID
  * @param armored boolean?
  * @param armorMultiple number?
  * @return nil
@@ -2936,8 +2936,8 @@ static unsigned char ParseLosBits(lua_State* L, int index, unsigned char bits)
  * @see Spring.SetUnitLosState
  * @function Spring.SetUnitLosMask
  *
- * @param unitID integer
- * @param allyTeam number
+ * @param unitID UnitID
+ * @param allyTeam AllyTeamID
  * @param losTypes LosTable|LosMask|integer A bitmask of `LosMask` bits or a
  * table. True bits disable engine updates to visibility.
  */
@@ -2983,8 +2983,8 @@ int LuaSyncedCtrl::SetUnitLosMask(lua_State* L)
  *
  * @see Spring.SetUnitLosMask
  * @function Spring.SetUnitLosState
- * @param unitID integer
- * @param allyTeam number
+ * @param unitID UnitID
+ * @param allyTeam AllyTeamID
  * @param losTypes LosTable|LosMask|integer A bitmask of `LosMask` bits or a
  * table
  */
@@ -3023,7 +3023,7 @@ int LuaSyncedCtrl::SetUnitLosState(lua_State* L)
  * - if the boolean is false it takes the default decloak distance for that unitdef,
  * - if the boolean is true it takes the absolute value of it.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param cloak (boolean|number)?
  * @param cloakArg (boolean|number)?
  * @return nil
@@ -3060,7 +3060,7 @@ int LuaSyncedCtrl::SetUnitCloak(lua_State* L)
 
 /***
  * @function Spring.SetUnitStealth
- * @param unitID integer
+ * @param unitID UnitID
  * @param stealth boolean
  * @return nil
  */
@@ -3078,7 +3078,7 @@ int LuaSyncedCtrl::SetUnitStealth(lua_State* L)
 
 /***
  * @function Spring.SetUnitSonarStealth
- * @param unitID integer
+ * @param unitID UnitID
  * @param sonarStealth boolean
  * @return nil
  */
@@ -3095,7 +3095,7 @@ int LuaSyncedCtrl::SetUnitSonarStealth(lua_State* L)
 
 /***
  * @function Spring.SetUnitSeismicSignature
- * @param unitID integer
+ * @param unitID UnitID
  * @param seismicSignature number
  * @return nil
  */
@@ -3133,7 +3133,7 @@ int LuaSyncedCtrl::SetUnitLeavesGhost(lua_State* L)
 
 /***
  * @function Spring.SetUnitAlwaysVisible
- * @param unitID integer
+ * @param unitID UnitID
  * @param alwaysVisible boolean
  * @return nil
  */
@@ -3146,7 +3146,7 @@ int LuaSyncedCtrl::SetUnitAlwaysVisible(lua_State* L)
 /***
  *
  * @function Spring.SetUnitUseAirLos
- * @param unitID integer
+ * @param unitID UnitID
  * @param useAirLos boolean
  * @return nil
  */
@@ -3158,7 +3158,7 @@ int LuaSyncedCtrl::SetUnitUseAirLos(lua_State* L)
 
 /***
  * @function Spring.SetUnitMetalExtraction
- * @param unitID integer
+ * @param unitID UnitID
  * @param depth number corresponds to metal extraction rate
  * @param range number? similar to "extractsMetal" in unitDefs.
  * @return nil
@@ -3186,7 +3186,7 @@ int LuaSyncedCtrl::SetUnitMetalExtraction(lua_State* L)
 /*** See also harvestStorage UnitDef tag.
  *
  * @function Spring.SetUnitHarvestStorage
- * @param unitID integer
+ * @param unitID UnitID
  * @param metal number?
  * @return nil
  */
@@ -3207,7 +3207,7 @@ int LuaSyncedCtrl::SetUnitHarvestStorage(lua_State* L)
 /***
  *
  * @function Spring.SetUnitBuildParams
- * @param unitID integer
+ * @param unitID UnitID
  * @param paramName string one of `buildRange`|`buildDistance`|`buildRange3D`
  * @param value (number|boolean)? boolean when `paramName` is `buildRange3D`, otherwise number.
  * @return nil
@@ -3240,7 +3240,7 @@ int LuaSyncedCtrl::SetUnitBuildParams(lua_State* L)
 
 /***
  * @function Spring.SetUnitBuildSpeed
- * @param builderID integer
+ * @param builderID UnitID
  * @param buildSpeed number
  * @param repairSpeed number?
  * @param reclaimSpeed number?
@@ -3295,7 +3295,7 @@ int LuaSyncedCtrl::SetUnitBuildSpeed(lua_State* L)
  * This saves a lot of engine calls, by replacing: function script.QueryNanoPiece() return currentpiece end
  * Use it!
  *
- * @param builderID integer
+ * @param builderID UnitID
  * @param pieces table
  * @return nil
  *
@@ -3351,7 +3351,7 @@ int LuaSyncedCtrl::SetUnitNanoPieces(lua_State* L)
 
 /***
  * @function Spring.SetUnitBlocking
- * @param unitID integer
+ * @param unitID UnitID
  * @param isBlocking boolean? If `true` add this unit to the `GroundBlockingMap`, but only if it collides with solid objects (or is being set to collide with the `isSolidObjectCollidable` argument). If `false`, remove this unit from the `GroundBlockingMap`. No change if `nil`.
  * @param isSolidObjectCollidable boolean? Enable or disable collision with solid objects, or no change if `nil`.
  * @param isProjectileCollidable boolean? Enable or disable collision with projectiles, or no change if `nil`.
@@ -3369,7 +3369,7 @@ int LuaSyncedCtrl::SetUnitBlocking(lua_State* L)
 
 /***
  * @function Spring.SetUnitCrashing
- * @param unitID integer
+ * @param unitID UnitID
  * @param crashing boolean?
  * @return boolean success
  */
@@ -3404,7 +3404,7 @@ int LuaSyncedCtrl::SetUnitCrashing(lua_State* L) {
 
 /***
  * @function Spring.SetUnitShieldState
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer? (Default: `-1`)
  * @param enabled boolean?
  * @param power number?
@@ -3442,7 +3442,7 @@ int LuaSyncedCtrl::SetUnitShieldState(lua_State* L)
 
 /***
  * @function Spring.SetUnitShieldRechargeDelay
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer? (optional if the unit only has one shield)
  * @param rechargeTime number? (in seconds; emulates a regular hit if nil)
  * @return nil
@@ -3479,7 +3479,7 @@ int LuaSyncedCtrl::SetUnitShieldRechargeDelay(lua_State* L)
 
 /***
  * @function Spring.SetUnitFlanking
- * @param unitID integer
+ * @param unitID UnitID
  * @param type string "dir"|"minDamage"|"maxDamage"|"moveFactor"|"mode"
  * @param arg1 number x|minDamage|maxDamage|moveFactor|mode
  * @param y number? only when type is "dir"
@@ -3526,7 +3526,7 @@ int LuaSyncedCtrl::SetUnitFlanking(lua_State* L)
 
 /***
  * @function Spring.SetUnitPhysicalStateBit
- * @param unitID integer
+ * @param unitID UnitID
  * @param Physical number[bit] state bit
  * @return nil
  */
@@ -3545,8 +3545,8 @@ int LuaSyncedCtrl::SetUnitPhysicalStateBit(lua_State* L)
 
 /***
  * @function Spring.GetUnitPhysicalState
- * @param unitID integer
- * @return number Unit's PhysicalState bitmask
+ * @param unitID UnitID
+ * @return integer Unit's PhysicalState bitmask
  */
 int LuaSyncedCtrl::GetUnitPhysicalState(lua_State* L)
 {
@@ -3570,7 +3570,7 @@ int LuaSyncedCtrl::SetUnitFuel(lua_State* L) { return 0; } // FIXME: DELETE ME
  *
  * @function Spring.SetUnitNeutral
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param neutral boolean
  * @return nil|boolean setNeutral
  */
@@ -3589,8 +3589,8 @@ int LuaSyncedCtrl::SetUnitNeutral(lua_State* L)
 /*** Defines a unit's target.
  *
  * @function Spring.SetUnitTarget
- * @param unitID integer
- * @param enemyUnitID integer? when nil drops the units current target.
+ * @param unitID UnitID
+ * @param enemyUnitID UnitID? when nil drops the units current target.
  * @param dgun boolean? (Default: `false`)
  * @param userTarget boolean? (Default: `false`)
  * @param dontForceTarget boolean?
@@ -3600,7 +3600,7 @@ int LuaSyncedCtrl::SetUnitNeutral(lua_State* L)
 
 /***
  * @function Spring.SetUnitTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param x number? when nil or not passed it will drop target and ignore other parameters
  * @param y number?
  * @param z number?
@@ -3670,7 +3670,7 @@ int LuaSyncedCtrl::SetUnitTarget(lua_State* L)
 
 /***
  * @function Spring.SetUnitMidAndAimPos
- * @param unitID integer
+ * @param unitID UnitID
  * @param mpX number new middle positionX of unit
  * @param mpY number new middle positionY of unit
  * @param mpZ number new middle positionZ of unit
@@ -3718,7 +3718,7 @@ int LuaSyncedCtrl::SetUnitMidAndAimPos(lua_State* L)
 
 /***
  * @function Spring.SetUnitRadiusAndHeight
- * @param unitID integer
+ * @param unitID UnitID
  * @param radius number?
  * @param height number?
  * @return boolean success
@@ -3755,7 +3755,7 @@ int LuaSyncedCtrl::SetUnitRadiusAndHeight(lua_State* L)
 /***
  * @function Spring.SetUnitBuildeeRadius
  * Sets the unit's radius for when targeted by build, repair, reclaim-type commands.
- * @param unitID integer
+ * @param unitID UnitID
  * @param build number radius for when targeted by build, repair, reclaim-type commands.
  * @return nil
  */
@@ -3775,9 +3775,9 @@ int LuaSyncedCtrl::SetUnitBuildeeRadius(lua_State* L)
 /*** Changes the pieces hierarchy of a unit by attaching a piece to a new parent.
  *
  * @function Spring.SetUnitPieceParent
- * @param unitID integer
- * @param AlteredPiece number
- * @param ParentPiece number
+ * @param unitID UnitID
+ * @param AlteredPiece integer
+ * @param ParentPiece integer
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitPieceParent(lua_State* L)
@@ -3819,8 +3819,8 @@ int LuaSyncedCtrl::SetUnitPieceParent(lua_State* L)
  *
  * If any of the first three elements are non-zero, and also blocks all script animations from modifying it until {0, 0, 0} is passed.
  *
- * @param unitID integer
- * @param pieceNum number
+ * @param unitID UnitID
+ * @param pieceNum integer
  * @param matrix number[] an array of 16 floats
  * @return boolean? valid - if the matrix can be used for the purpose of defining the piece spatial transformation. Blocks the piece animation, if true.
  */
@@ -3833,16 +3833,16 @@ int LuaSyncedCtrl::SetUnitPieceMatrix(lua_State* L)
 
 /***
  * @function Spring.SetUnitCollisionVolumeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param scaleX number
  * @param scaleY number
  * @param scaleZ number
  * @param offsetX number
  * @param offsetY number
  * @param offsetZ number
- * @param vType number
- * @param tType number
- * @param Axis number
+ * @param vType integer
+ * @param tType integer
+ * @param Axis integer
  * @return nil
  *
  *  enum COLVOL_TYPES {
@@ -3873,8 +3873,8 @@ int LuaSyncedCtrl::SetUnitCollisionVolumeData(lua_State* L)
 
 /***
  * @function Spring.SetUnitPieceCollisionVolumeData
- * @param unitID integer
- * @param pieceIndex number
+ * @param unitID UnitID
+ * @param pieceIndex integer
  * @param enable boolean
  * @param scaleX number
  * @param scaleY number
@@ -3882,8 +3882,8 @@ int LuaSyncedCtrl::SetUnitCollisionVolumeData(lua_State* L)
  * @param offsetX number
  * @param offsetY number
  * @param offsetZ number
- * @param volumeType number?
- * @param primaryAxis number?
+ * @param volumeType integer?
+ * @param primaryAxis integer?
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitPieceCollisionVolumeData(lua_State* L)
@@ -3895,8 +3895,8 @@ int LuaSyncedCtrl::SetUnitPieceCollisionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.SetUnitPieceVisible
- * @param unitID integer
- * @param pieceIndex number
+ * @param unitID UnitID
+ * @param pieceIndex integer
  * @param visible boolean
  * @return nil
  */
@@ -3908,10 +3908,10 @@ int LuaSyncedCtrl::SetUnitPieceVisible(lua_State* L)
 
 /***
  * @function Spring.SetUnitSensorRadius
- * @param unitID integer
+ * @param unitID UnitID
  * @param type "los"|"airLos"|"radar"|"sonar"|"seismic"|"radarJammer"|"sonarJammer"
- * @param radius number
- * @return number? New radius, or `nil` if unit is invalid.
+ * @param radius integer
+ * @return integer? New radius, or `nil` if unit is invalid.
  */
 int LuaSyncedCtrl::SetUnitSensorRadius(lua_State* L)
 {
@@ -3963,14 +3963,14 @@ int LuaSyncedCtrl::SetUnitSensorRadius(lua_State* L)
  * native "is under cursor" checks and some Lua interfaces.
  *
  * @function Spring.SetUnitPosErrorParams
- * @param unitID integer
+ * @param unitID UnitID
  * @param posErrorVectorX number?
  * @param posErrorVectorY number?
  * @param posErrorVectorZ number?
  * @param posErrorDeltaX number?
  * @param posErrorDeltaY number?
  * @param posErrorDeltaZ number?
- * @param nextPosErrorUpdate number?
+ * @param nextPosErrorUpdate integer?
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitPosErrorParams(lua_State* L)
@@ -3999,7 +3999,7 @@ int LuaSyncedCtrl::SetUnitPosErrorParams(lua_State* L)
 /*** Used by default commands to get in build-, attackrange etc.
  *
  * @function Spring.SetUnitMoveGoal
- * @param unitID integer
+ * @param unitID UnitID
  * @param goalX number
  * @param goalY number
  * @param goalZ number
@@ -4035,7 +4035,7 @@ int LuaSyncedCtrl::SetUnitMoveGoal(lua_State* L)
 /*** Used in conjunction with Spring.UnitAttach et al. to re-implement old airbase & fuel system in Lua.
  *
  * @function Spring.SetUnitLandGoal
- * @param unitID integer
+ * @param unitID UnitID
  * @param goalX number
  * @param goalY number
  * @param goalZ number
@@ -4064,7 +4064,7 @@ int LuaSyncedCtrl::SetUnitLandGoal(lua_State* L)
 
 /***
  * @function Spring.ClearUnitGoal
- * @param unitID integer
+ * @param unitID UnitID
  * @param maneuver boolean?
  * @return nil
  */
@@ -4082,7 +4082,7 @@ int LuaSyncedCtrl::ClearUnitGoal(lua_State* L)
 
 /***
  * @function Spring.SetUnitPhysics
- * @param unitID integer
+ * @param unitID UnitID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -4104,7 +4104,7 @@ int LuaSyncedCtrl::SetUnitPhysics(lua_State* L)
 
 /***
  * @function Spring.SetUnitMass
- * @param unitID integer
+ * @param unitID UnitID
  * @param mass number
  * @return nil
  */
@@ -4119,7 +4119,7 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
  *
  * Sets a unit's position in 2D, at terrain height.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param x number
  * @param z number
  * @param floating boolean? (Default: `false`) If true, over water the position is on surface. If false, on seafloor.
@@ -4132,7 +4132,7 @@ int LuaSyncedCtrl::SetUnitMass(lua_State* L)
  *
  * Sets a unit's position in 3D, at an arbitrary height.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param x number
  * @param y number
  * @param z number
@@ -4172,7 +4172,7 @@ int LuaSyncedCtrl::SetUnitPosition(lua_State* L)
 /***
  * @function Spring.SetUnitRotation
  * Note: PYR order
- * @param unitID integer
+ * @param unitID UnitID
  * @param pitch number Rotation in X axis
  * @param yaw number Rotation in Y axis
  * @param roll number Rotation in Z axis
@@ -4192,7 +4192,7 @@ int LuaSyncedCtrl::SetUnitRotation(lua_State* L)
  * @deprecated It's strongly that you use the overload that accepts
  * a right direction as `frontDir` alone doesn't define object orientation.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param frontx number
  * @param fronty number
  * @param frontz number
@@ -4205,7 +4205,7 @@ int LuaSyncedCtrl::SetUnitRotation(lua_State* L)
   *
   * Both vectors will be normalized in the engine.
   *
-  * @param unitID integer
+  * @param unitID UnitID
   * @param frontx number
   * @param fronty number
   * @param frontz number
@@ -4245,7 +4245,7 @@ int LuaSyncedCtrl::SetUnitDirection(lua_State* L)
  * completely upright, new `{upx, upy, upz}` direction will be used as new "up"
  * vector, the rotation set by "heading" will remain preserved.
  * 
- * @param unitID integer
+ * @param unitID UnitID
  * @param heading Heading
  * @param upx number
  * @param upy number
@@ -4261,7 +4261,7 @@ int LuaSyncedCtrl::SetUnitHeadingAndUpDir(lua_State* L)
  *
  * @see Spring.SetUnitMoveCtrl for disabling/enabling this control
  * @function Spring.SetUnitVelocity
- * @param unitID integer
+ * @param unitID UnitID
  * @param velX number in elmos/frame
  * @param velY number in elmos/frame
  * @param velZ number in elmos/frame
@@ -4275,7 +4275,7 @@ int LuaSyncedCtrl::SetUnitVelocity(lua_State* L)
 /***
  *
  * @function Spring.SetFactoryBuggerOff
- * @param unitID integer
+ * @param unitID UnitID
  * @param buggerOff boolean?
  * @param offset number?
  * @param radius number?
@@ -4313,11 +4313,11 @@ int LuaSyncedCtrl::SetFactoryBuggerOff(lua_State* L)
  * @param y number
  * @param z number? uses ground height when unspecified
  * @param radius number
- * @param teamID integer
+ * @param teamID TeamID
  * @param spherical boolean? (Default: `true`)
  * @param forced boolean? (Default: `true`)
- * @param excludeUnitID integer?
- * @param excludeUnitDefIDs number[]?
+ * @param excludeUnitID UnitID?
+ * @param excludeUnitDefIDs UnitDefID[]?
  * @return nil
  */
 int LuaSyncedCtrl::BuggerOff(lua_State* L)
@@ -4386,11 +4386,11 @@ static std::optional<std::tuple<float, int, CUnit*, int, float3> > ParseDamagePa
  * If health goes below 0 and featureDef is `destructable` the feature will be deleted and
  * a wreck created.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param damage number
- * @param paralyze number? (Default: `0`) equals to the paralyzetime in the WeaponDef.
- * @param attackerID integer? (Default: `-1`)
- * @param weaponID integer? (Default: `-1`)
+ * @param paralyze integer? (Default: `0`) equals to the paralyzetime in the WeaponDef.
+ * @param attackerID UnitID? (Default: `-1`)
+ * @param weaponID WeaponDefID? (Default: `-1`)
  * @param impulseX number?
  * @param impulseY number?
  * @param impulseZ number?
@@ -4423,11 +4423,11 @@ int LuaSyncedCtrl::AddFeatureDamage(lua_State* L)
 /***
  * @function Spring.AddUnitDamage
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param damage number
- * @param paralyze number? (Default: `0`) equals to the paralyzetime in the WeaponDef.
- * @param attackerID integer? (Default: `-1`)
- * @param weaponID integer? (Default: `-1`)
+ * @param paralyze integer? (Default: `0`) equals to the paralyzetime in the WeaponDef.
+ * @param attackerID UnitID? (Default: `-1`)
+ * @param weaponID WeaponDefID? (Default: `-1`)
  * @param impulseX number?
  * @param impulseY number?
  * @param impulseZ number?
@@ -4459,7 +4459,7 @@ int LuaSyncedCtrl::AddUnitDamage(lua_State* L)
 
 /***
  * @function Spring.AddUnitImpulse
- * @param unitID integer
+ * @param unitID UnitID
  * @param x number
  * @param y number
  * @param z number
@@ -4484,7 +4484,7 @@ int LuaSyncedCtrl::AddUnitImpulse(lua_State* L)
 
 /***
  * @function Spring.AddUnitSeismicPing
- * @param unitID integer
+ * @param unitID UnitID
  * @param pindSize number
  * @return nil
  */
@@ -4504,7 +4504,7 @@ int LuaSyncedCtrl::AddUnitSeismicPing(lua_State* L)
 
 /***
  * @function Spring.AddUnitResource
- * @param unitID integer
+ * @param unitID UnitID
  * @param resource string "m" | "e"
  * @param amount number
  * @return nil
@@ -4533,7 +4533,7 @@ int LuaSyncedCtrl::AddUnitResource(lua_State* L)
 
 /***
  * @function Spring.UseUnitResource
- * @param unitID integer
+ * @param unitID UnitID
  * @param resource ResourceName
  * @param amount number
  * @return boolean? okay
@@ -4541,7 +4541,7 @@ int LuaSyncedCtrl::AddUnitResource(lua_State* L)
 
 /***
  * @function Spring.UseUnitResource
- * @param unitID integer
+ * @param unitID UnitID
  * @param resources ResourceUsage
  * @return boolean? okay
  */
@@ -4612,7 +4612,7 @@ int LuaSyncedCtrl::UseUnitResource(lua_State* L)
 /***
  *
  * @function Spring.AddObjectDecal
- * @param unitID integer
+ * @param unitID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::AddObjectDecal(lua_State* L)
@@ -4629,7 +4629,7 @@ int LuaSyncedCtrl::AddObjectDecal(lua_State* L)
 
 /***
  * @function Spring.RemoveObjectDecal
- * @param unitID integer
+ * @param unitID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::RemoveObjectDecal(lua_State* L)
@@ -4693,9 +4693,9 @@ int LuaSyncedCtrl::RemoveGrass(lua_State* L)
  * @param y number
  * @param z number
  * @param heading Heading?
- * @param teamID integer?
- * @param featureID integer?
- * @return integer? featureID returns nil if creation was unsuccessful
+ * @param teamID TeamID?
+ * @param featureID FeatureID?
+ * @return FeatureID? featureID returns nil if creation was unsuccessful
  */
 int LuaSyncedCtrl::CreateFeature(lua_State* L)
 {
@@ -4786,7 +4786,7 @@ void LuaSyncedCtrl::DestroyFeatureCommon(lua_State* L, CFeature* feature)
 
 /***
  * @function Spring.DestroyFeature
- * @param featureID integer
+ * @param featureID FeatureID
  * @return nil
  */
 int LuaSyncedCtrl::DestroyFeature(lua_State* L)
@@ -4804,8 +4804,8 @@ int LuaSyncedCtrl::DestroyFeature(lua_State* L)
 /*** Feature Control
  *
  * @function Spring.TransferFeature
- * @param featureID integer
- * @param teamID integer
+ * @param featureID FeatureID
+ * @param teamID TeamID
  * @return nil
  */
 int LuaSyncedCtrl::TransferFeature(lua_State* L)
@@ -4825,7 +4825,7 @@ int LuaSyncedCtrl::TransferFeature(lua_State* L)
 
 /***
  * @function Spring.SetFeatureAlwaysVisible
- * @param featureID integer
+ * @param featureID FeatureID
  * @param enable boolean
  * @return nil
  */
@@ -4837,7 +4837,7 @@ int LuaSyncedCtrl::SetFeatureAlwaysVisible(lua_State* L)
 /***
  *
  * @function Spring.SetFeatureUseAirLos
- * @param featureID integer
+ * @param featureID FeatureID
  * @param useAirLos boolean
  * @return nil
  */
@@ -4849,7 +4849,7 @@ int LuaSyncedCtrl::SetFeatureUseAirLos(lua_State* L)
 
 /***
  * @function Spring.SetFeatureHealth
- * @param featureID integer
+ * @param featureID FeatureID
  * @param health number
  * @param checkDestruction boolean? (Default: `false`) Whether to destroy feature if feature goes below 0 health.
  * @return nil
@@ -4873,7 +4873,7 @@ int LuaSyncedCtrl::SetFeatureHealth(lua_State* L)
 /***
  *
  * @function Spring.SetFeatureMaxHealth
- * @param featureID integer
+ * @param featureID FeatureID
  * @param maxHealth number minimum 0.1
  * @return nil
  */
@@ -4892,7 +4892,7 @@ int LuaSyncedCtrl::SetFeatureMaxHealth(lua_State* L)
 
 /***
  * @function Spring.SetFeatureReclaim
- * @param featureID integer
+ * @param featureID FeatureID
  * @param reclaimLeft number
  * @return nil
  */
@@ -4909,7 +4909,7 @@ int LuaSyncedCtrl::SetFeatureReclaim(lua_State* L)
 
 /***
  * @function Spring.SetFeatureResources
- * @param featureID integer
+ * @param featureID FeatureID
  * @param metal number
  * @param energy number
  * @param reclaimTime number?
@@ -4939,7 +4939,7 @@ int LuaSyncedCtrl::SetFeatureResources(lua_State* L)
 /***
  * @function Spring.SetFeatureResurrect
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param unitDef (string|integer)? Can be a number id or a string name, this allows cancelling resurrection by passing `-1`.
  * @param facing Facing? (Default: `"south"`)
  * @param progress number? Set the level of progress.
@@ -4976,7 +4976,7 @@ int LuaSyncedCtrl::SetFeatureResurrect(lua_State* L)
  * Enable feature movement control.
  * 
  * @function Spring.SetFeatureMoveCtrl
- * @param featureID integer
+ * @param featureID FeatureID
  * @param enabled true Enable feature movement.
  * @param initialVelocityX number? Initial velocity on X axis, or `nil` for no change.
  * @param initialVelocityY number? Initial velocity on Y axis, or `nil` for no change.
@@ -5005,7 +5005,7 @@ int LuaSyncedCtrl::SetFeatureResurrect(lua_State* L)
  * ```
  * 
  * @function Spring.SetFeatureMoveCtrl
- * @param featureID integer
+ * @param featureID FeatureID
  * @param enabled false Disable feature movement.
  * @param velocityMaskX number? Lock velocity change in X dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
  * @param velocityMaskY number? Lock velocity change in Y dimension when not using `MoveCtrl`. `0` to lock, non-zero to allow, or `nil` to for no change.
@@ -5049,7 +5049,7 @@ int LuaSyncedCtrl::SetFeatureMoveCtrl(lua_State* L)
 
 /***
  * @function Spring.SetFeaturePhysics
- * @param featureID integer
+ * @param featureID FeatureID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -5072,7 +5072,7 @@ int LuaSyncedCtrl::SetFeaturePhysics(lua_State* L)
 
 /***
  * @function Spring.SetFeatureMass
- * @param featureID integer
+ * @param featureID FeatureID
  * @param mass number
  * @return nil
  */
@@ -5084,7 +5084,7 @@ int LuaSyncedCtrl::SetFeatureMass(lua_State* L)
 
 /***
  * @function Spring.SetFeaturePosition
- * @param featureID integer
+ * @param featureID FeatureID
  * @param x number
  * @param y number
  * @param z number
@@ -5111,7 +5111,7 @@ int LuaSyncedCtrl::SetFeaturePosition(lua_State* L)
 /***
  * @function Spring.SetFeatureRotation
  * Note: PYR order
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pitch number Rotation in X axis
  * @param yaw number Rotation in Y axis
  * @param roll number Rotation in Z axis
@@ -5131,7 +5131,7 @@ int LuaSyncedCtrl::SetFeatureRotation(lua_State* L)
  * @deprecated It's strongly that you use the overload that accepts
  * a right direction as `frontDir` alone doesn't define object orientation.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param frontx number
  * @param fronty number
  * @param frontz number
@@ -5144,7 +5144,7 @@ int LuaSyncedCtrl::SetFeatureRotation(lua_State* L)
   *
   * Both vectors will be normalized in the engine.
   *
-  * @param featureID integer
+  * @param featureID FeatureID
   * @param frontx number
   * @param fronty number
   * @param frontz number
@@ -5164,7 +5164,7 @@ int LuaSyncedCtrl::SetFeatureDirection(lua_State* L)
  * completely upright, new `{upx, upy, upz}` direction will be used as new "up"
  * vector, the rotation set by "heading" will remain preserved.
  * 
- * @param featureID integer
+ * @param featureID FeatureID
  * @param heading Heading
  * @param upx number
  * @param upy number
@@ -5180,7 +5180,7 @@ int LuaSyncedCtrl::SetFeatureHeadingAndUpDir(lua_State* L)
  *
  * @see Spring.SetFeatureMoveCtrl for disabling/enabling this control
  * @function Spring.SetFeatureVelocity
- * @param featureID integer
+ * @param featureID FeatureID
  * @param velX number in elmos/frame
  * @param velY number in elmos/frame
  * @param velZ number in elmos/frame
@@ -5193,7 +5193,7 @@ int LuaSyncedCtrl::SetFeatureVelocity(lua_State* L)
 
 /***
  * @function Spring.SetFeatureBlocking
- * @param featureID integer
+ * @param featureID FeatureID
  * @param isBlocking boolean? If `true` add this feature to the `GroundBlockingMap`, but only if it collides with solid objects (or is being set to collide with the `isSolidObjectCollidable` argument). If `false`, remove this feature from the `GroundBlockingMap`. No change if `nil`.
  * @param isSolidObjectCollidable boolean? Enable or disable collision with solid objects, or no change if `nil`.
  * @param isProjectileCollidable boolean? Enable or disable collision with projectiles, or no change if `nil`.
@@ -5211,7 +5211,7 @@ int LuaSyncedCtrl::SetFeatureBlocking(lua_State* L)
 
 /***
  * @function Spring.SetFeatureNoSelect
- * @param featureID integer
+ * @param featureID FeatureID
  * @param noSelect boolean
  * @return nil
  */
@@ -5232,7 +5232,7 @@ int LuaSyncedCtrl::SetFeatureNoSelect(lua_State* L)
  *
  * Check `Spring.SetUnitMidAndAimPos` for further explanation of the arguments.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param mpX number
  * @param mpY number
  * @param mpZ number
@@ -5280,7 +5280,7 @@ int LuaSyncedCtrl::SetFeatureMidAndAimPos(lua_State* L)
 
 /***
  * @function Spring.SetFeatureRadiusAndHeight
- * @param featureID integer
+ * @param featureID FeatureID
  * @param radius number?
  * @param height number?
  * @return boolean success
@@ -5318,16 +5318,16 @@ int LuaSyncedCtrl::SetFeatureRadiusAndHeight(lua_State* L)
  *
  * Check `Spring.SetUnitCollisionVolumeData` for further explanation of the arguments.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param scaleX number
  * @param scaleY number
  * @param scaleZ number
  * @param offsetX number
  * @param offsetY number
  * @param offsetZ number
- * @param vType number
- * @param tType number
- * @param Axis number
+ * @param vType integer
+ * @param tType integer
+ * @param Axis integer
  * @return nil
  */
 int LuaSyncedCtrl::SetFeatureCollisionVolumeData(lua_State* L)
@@ -5338,8 +5338,8 @@ int LuaSyncedCtrl::SetFeatureCollisionVolumeData(lua_State* L)
 
 /***
  * @function Spring.SetFeaturePieceCollisionVolumeData
- * @param featureID integer
- * @param pieceIndex number
+ * @param featureID FeatureID
+ * @param pieceIndex integer
  * @param enable boolean
  * @param scaleX number
  * @param scaleY number
@@ -5360,8 +5360,8 @@ int LuaSyncedCtrl::SetFeaturePieceCollisionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.SetFeaturePieceVisible
- * @param featureID integer
- * @param pieceIndex number
+ * @param featureID FeatureID
+ * @param pieceIndex integer
  * @param visible boolean
  * @return nil
  */
@@ -5374,8 +5374,8 @@ int LuaSyncedCtrl::SetFeaturePieceVisible(lua_State* L)
  *
  * @function Spring.SetFeaturePieceMatrix
  *
- * @param featureID integer
- * @param pieceIndex number
+ * @param featureID FeatureID
+ * @param pieceIndex integer
  * @param matrix number[] an array of 16 floats
  * @return boolean? valid - if the matrix can be used for the purpose of defining the piece spatial transformation
  */
@@ -5393,7 +5393,7 @@ int LuaSyncedCtrl::SetFeaturePieceMatrix(lua_State* L)
  * Starts or resets an internal feature fire timer, when reaching zero the
  * feature will be destroyed.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param fireTime number in seconds
  */
 int LuaSyncedCtrl::SetFeatureFireTime(lua_State* L)
@@ -5428,7 +5428,7 @@ int LuaSyncedCtrl::SetFeatureFireTime(lua_State* L)
  *
  * The smoke timer affects both the duration and size of the smoke particles.
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param smokeTime number in seconds
  */
 int LuaSyncedCtrl::SetFeatureSmokeTime(lua_State* L)
@@ -5463,10 +5463,10 @@ int LuaSyncedCtrl::SetFeatureSmokeTime(lua_State* L)
  *
  * @function Spring.CreateUnitWreck
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param wreckLevel integer? (Default: `1`) Wreck index to use.
  * @param doSmoke boolean? (Default: `true`) Wreck emits smoke when `true`. 
- * @return integer? featureID The wreck featureID, or nil if it couldn't be created or unit doesn't exist.
+ * @return FeatureID? featureID The wreck featureID, or nil if it couldn't be created or unit doesn't exist.
  */
 int LuaSyncedCtrl::CreateUnitWreck(lua_State* L)
 {
@@ -5493,10 +5493,10 @@ int LuaSyncedCtrl::CreateUnitWreck(lua_State* L)
  *
  * @function Spring.CreateFeatureWreck
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param wreckLevel integer? (Default: `1`) Wreck index to use.
  * @param doSmoke boolean? (Default: `false`) Wreck emits smoke when `true`.
- * @return integer? featureID The wreck featureID, or nil if it couldn't be created or unit doesn't exist.
+ * @return FeatureID? featureID The wreck featureID, or nil if it couldn't be created or unit doesn't exist.
  */
 
 int LuaSyncedCtrl::CreateFeatureWreck(lua_State* L)
@@ -5526,7 +5526,7 @@ int LuaSyncedCtrl::CreateFeatureWreck(lua_State* L)
 
 /***
  * @function Spring.SetProjectileAlwaysVisible
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param alwaysVisible boolean
  * @return nil
  */
@@ -5539,7 +5539,7 @@ int LuaSyncedCtrl::SetProjectileAlwaysVisible(lua_State* L)
 /***
  *
  * @function Spring.SetProjectileUseAirLos
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param useAirLos boolean
  * @return nil
  */
@@ -5558,7 +5558,7 @@ int LuaSyncedCtrl::SetProjectileUseAirLos(lua_State* L)
  *
  * @function Spring.SetProjectileMoveControl
  *
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param enable boolean?
  */
 int LuaSyncedCtrl::SetProjectileMoveControl(lua_State* L)
@@ -5577,7 +5577,7 @@ int LuaSyncedCtrl::SetProjectileMoveControl(lua_State* L)
 /*** Set the position of a projectile
  *
  * @function Spring.SetProjectilePosition
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param posX number? (Default: `0`)
  * @param posY number? (Default: `0`)
  * @param posZ number? (Default: `0`)
@@ -5605,7 +5605,7 @@ int LuaSyncedCtrl::SetProjectilePosition(lua_State* L)
  *
  * @see Spring.SetProjectileMoveControl
  * @function Spring.SetProjectileVelocity
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param velX number in elmos/frame
  * @param velY number in elmos/frame
  * @param velZ number in elmos/frame
@@ -5617,7 +5617,7 @@ int LuaSyncedCtrl::SetProjectileVelocity(lua_State* L)
 
 /***
  * @function Spring.SetProjectileCollision
- * @param projectileID integer
+ * @param projectileID ProjectileID
  */
 int LuaSyncedCtrl::SetProjectileCollision(lua_State* L)
 {
@@ -5641,8 +5641,8 @@ int LuaSyncedCtrl::SetProjectileCollision(lua_State* L)
 /*** Set projectile target (object)
  *
  * @function Spring.SetProjectileTarget
- * @param projectileID integer
- * @param targetID number
+ * @param projectileID ProjectileID
+ * @param targetID UnitID|FeatureID|ProjectileID
  * @param targetType ProjectileTargetType
  * @return boolean? validTarget
  */
@@ -5651,7 +5651,7 @@ int LuaSyncedCtrl::SetProjectileCollision(lua_State* L)
  *
  * @function Spring.SetProjectileTarget
  *
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -5734,8 +5734,8 @@ int LuaSyncedCtrl::SetProjectileTarget(lua_State* L)
 /*** Set Time To Live for a projectile
  *
  * @function Spring.SetProjectileTimeToLive
- * @param projectileID integer
- * @param ttl number Remaining time to live in frames
+ * @param projectileID ProjectileID
+ * @param ttl integer Remaining time to live in frames
  */
 int LuaSyncedCtrl::SetProjectileTimeToLive(lua_State* L)
 {
@@ -5755,7 +5755,7 @@ int LuaSyncedCtrl::SetProjectileTimeToLive(lua_State* L)
 
 /***
  * @function Spring.SetProjectileIsIntercepted
- * @param projectileID integer
+ * @param projectileID ProjectileID
  */
 int LuaSyncedCtrl::SetProjectileIsIntercepted(lua_State* L)
 {
@@ -5810,7 +5810,7 @@ int LuaSyncedCtrl::SetProjectileDamages(lua_State* L)
 
 /***
  * @function Spring.SetProjectileIgnoreTrackingError
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param ignore boolean
  */
 int LuaSyncedCtrl::SetProjectileIgnoreTrackingError(lua_State* L)
@@ -5839,7 +5839,7 @@ int LuaSyncedCtrl::SetProjectileIgnoreTrackingError(lua_State* L)
 
 /***
  * @function Spring.SetProjectileGravity
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param grav number? (Default: `0`)
  * @return nil
  */
@@ -5865,8 +5865,8 @@ int LuaSyncedCtrl::SetProjectileSpinVec(lua_State* L) { return 0; } // FIXME: DE
  * Non passed or nil args don't set params.
  *
  * @function Spring.SetPieceProjectileParams
- * @param projectileID integer
- * @param explosionFlags number?
+ * @param projectileID ProjectileID
+ * @param explosionFlags integer?
  * @param spinAngle number?
  * @param spinSpeed number?
  * @param spinVectorX number?
@@ -5896,7 +5896,7 @@ int LuaSyncedCtrl::SetPieceProjectileParams(lua_State* L)
 //
 /***
  * @function Spring.SetProjectileCEG
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param ceg_name string
  * @return nil
  */
@@ -5935,7 +5935,7 @@ int LuaSyncedCtrl::SetProjectileCEG(lua_State* L)
 
 /***
  * @function Spring.UnitFinishCommand
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
 {
@@ -5952,7 +5952,7 @@ int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
 
 /***
  * @function Spring.GiveOrderToUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -5990,7 +5990,7 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
  * Give order to multiple units, specified by table keys.
  * 
  * @function Spring.GiveOrderToUnitMap
- * @param unitMap table<integer, any> A table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> A table with unit IDs as keys.
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -6032,7 +6032,7 @@ int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
 /***
  *
  * @function Spring.GiveOrderToUnitArray
- * @param unitIDs integer[] An array of unit IDs.
+ * @param unitIDs UnitID[] An array of unit IDs.
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -6076,7 +6076,7 @@ int LuaSyncedCtrl::GiveOrderToUnitArray(lua_State* L)
 /***
  *
  * @function Spring.GiveOrderArrayToUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param commands CreateCommand[]
  * @return boolean ordersGiven
  */
@@ -6114,7 +6114,7 @@ int LuaSyncedCtrl::GiveOrderArrayToUnit(lua_State* L)
 
 /***
  * @function Spring.GiveOrderArrayToUnitMap
- * @param unitMap table<integer, any> A table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> A table with unit IDs as keys.
  * @param commands CreateCommand[]
  * @return integer unitsOrdered The number of units ordered.
  */
@@ -6154,7 +6154,7 @@ int LuaSyncedCtrl::GiveOrderArrayToUnitMap(lua_State* L)
 
 /***
  * @function Spring.GiveOrderArrayToUnitArray
- * @param unitIDs integer[] Array of unit IDs.
+ * @param unitIDs UnitID[] Array of unit IDs.
  * @param commands CreateCommand[]
  * @param pairwise boolean? (Default: `false`) When `false`, assign all commands to each unit.
  *
@@ -7117,7 +7117,7 @@ int LuaSyncedCtrl::SetSmoothMeshFunc(lua_State* L)
  * @function Spring.SetMapSquareTerrainType
  * @param x number
  * @param z number
- * @param newType number
+ * @param newType integer
  * @return integer? oldType
  */
 int LuaSyncedCtrl::SetMapSquareTerrainType(lua_State* L)
@@ -7145,7 +7145,7 @@ int LuaSyncedCtrl::SetMapSquareTerrainType(lua_State* L)
 
 /***
  * @function Spring.SetTerrainTypeData
- * @param typeIndex number
+ * @param typeIndex integer
  * @param speedTanks number? (Default: nil)
  * @param speedKBOts number? (Default: nil)
  * @param speedHovers number? (Default: nil)
@@ -7192,9 +7192,9 @@ int LuaSyncedCtrl::SetTerrainTypeData(lua_State* L)
 
 /***
  * @function Spring.SetSquareBuildingMask
- * @param x number
- * @param z number
- * @param mask number
+ * @param x integer
+ * @param z integer
+ * @param mask integer
  * @return nil
  *
  * See also buildingMask unitdef tag.
@@ -7224,7 +7224,7 @@ int LuaSyncedCtrl::SetSquareBuildingMask(lua_State* L)
 
 /***
  * @function Spring.UnitWeaponFire
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer
  * @return nil
  */
@@ -7247,7 +7247,7 @@ int LuaSyncedCtrl::UnitWeaponFire(lua_State* L)
 // NB: not permanent
 /***
  * @function Spring.UnitWeaponHoldFire
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer
  * @return nil
  */
@@ -7278,7 +7278,7 @@ int LuaSyncedCtrl::UnitWeaponHoldFire(lua_State* L)
  * the normal update rate is set.
  *
  * @function Spring.ForceUnitCollisionUpdate
- * @param unitID integer
+ * @param unitID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::ForceUnitCollisionUpdate(lua_State* L)
@@ -7296,9 +7296,9 @@ int LuaSyncedCtrl::ForceUnitCollisionUpdate(lua_State* L)
 /***
  *
  * @function Spring.UnitAttach
- * @param transporterID integer
- * @param passengerID integer
- * @param pieceNum number
+ * @param transporterID UnitID
+ * @param passengerID UnitID
+ * @param pieceNum integer
  * @param force boolean?
  * @return nil
  */
@@ -7337,7 +7337,7 @@ int LuaSyncedCtrl::UnitAttach(lua_State* L)
 
 /***
  * @function Spring.UnitDetach
- * @param passengerID integer
+ * @param passengerID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::UnitDetach(lua_State* L)
@@ -7359,7 +7359,7 @@ int LuaSyncedCtrl::UnitDetach(lua_State* L)
 
 /***
  * @function Spring.UnitDetachFromAir
- * @param passengerID integer
+ * @param passengerID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::UnitDetachFromAir(lua_State* L)
@@ -7392,8 +7392,8 @@ int LuaSyncedCtrl::UnitDetachFromAir(lua_State* L)
 /*** Disables collisions between the two units to allow colvol intersection during the approach.
  *
  * @function Spring.SetUnitLoadingTransport
- * @param passengerID integer
- * @param transportID integer
+ * @param passengerID UnitID
+ * @param transportID UnitID
  * @return nil
  */
 int LuaSyncedCtrl::SetUnitLoadingTransport(lua_State* L)
@@ -7426,8 +7426,8 @@ int LuaSyncedCtrl::SetUnitLoadingTransport(lua_State* L)
  * @field spread xyz?
  * @field error xyz?
  * @field end xyz?
- * @field owner integer?
- * @field team integer?
+ * @field owner UnitID?
+ * @field team TeamID?
  * @field ttl number?
  * @field gravity number?
  * @field tracking number?
@@ -7441,9 +7441,9 @@ int LuaSyncedCtrl::SetUnitLoadingTransport(lua_State* L)
 /***
  *
  * @function Spring.SpawnProjectile
- * @param weaponDefID integer
+ * @param weaponDefID WeaponDefID
  * @param projectileParams ProjectileParams
- * @return integer? projectileID
+ * @return ProjectileID? projectileID
  */
 int LuaSyncedCtrl::SpawnProjectile(lua_State* L)
 {
@@ -7463,7 +7463,7 @@ int LuaSyncedCtrl::SpawnProjectile(lua_State* L)
 /*** Silently removes projectiles (no explosion).
  *
  * @function Spring.DeleteProjectile
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return nil
  */
 int LuaSyncedCtrl::DeleteProjectile(lua_State* L)
@@ -7597,10 +7597,10 @@ static int SetExplosionParam(lua_State* L, CExplosionParams& params, DamageArray
  *
  * @class ExplosionParams
  * @x_helper
- * @field weaponDef number?
- * @field owner number?
- * @field hitUnit number?
- * @field hitFeature number?
+ * @field weaponDef WeaponDefID?
+ * @field owner UnitID?
+ * @field hitUnit UnitID?
+ * @field hitFeature FeatureID?
  * @field craterAreaOfEffect number?
  * @field damageAreaOfEffect number?
  * @field edgeEffectiveness number?
@@ -7727,7 +7727,7 @@ int LuaSyncedCtrl::SpawnCEG(lua_State* L)
 /*** Equal to the UnitScript versions of EmitSFX, but takes position and direction arguments (in either unit- or piece-space) instead of a piece index.
  *
  * @function Spring.SpawnSFX
- * @param unitID integer? (Default: `0`)
+ * @param unitID UnitID? (Default: `0`)
  * @param sfxID integer? (Default: `0`)
  * @param posX number? (Default: `0`)
  * @param posY number? (Default: `0`)
@@ -7816,7 +7816,7 @@ int LuaSyncedCtrl::SetExperienceGrade(lua_State* L)
 /***
  *
  * @function Spring.SetRadarErrorParams
- * @param allyTeamID integer
+ * @param allyTeamID AllyTeamID
  * @param allyteamErrorSize number
  * @param baseErrorSize number?
  * @param baseErrorMult number?
@@ -7950,7 +7950,7 @@ static bool ParseCommandDescription(lua_State* L, int table,
 
 /***
  * @function Spring.EditUnitCmdDesc
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdDescID integer
  * @param cmdArray CommandDescription
  */
@@ -7984,7 +7984,7 @@ int LuaSyncedCtrl::EditUnitCmdDesc(lua_State* L)
  * Insert a command description at a specific index.
  * 
  * @function Spring.InsertUnitCmdDesc
- * @param unitID integer
+ * @param unitID UnitID
  * @param index integer
  * @param cmdDesc CommandDescription
  */
@@ -7992,7 +7992,7 @@ int LuaSyncedCtrl::EditUnitCmdDesc(lua_State* L)
  * Insert a command description at the last position.
  * 
  * @function Spring.InsertUnitCmdDesc
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdDesc CommandDescription
  */
 int LuaSyncedCtrl::InsertUnitCmdDesc(lua_State* L)
@@ -8031,7 +8031,7 @@ int LuaSyncedCtrl::InsertUnitCmdDesc(lua_State* L)
 
 /***
  * @function Spring.RemoveUnitCmdDesc
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdDescID integer?
  */
 int LuaSyncedCtrl::RemoveUnitCmdDesc(lua_State* L)

--- a/rts/Lua/LuaSyncedMoveCtrl.cpp
+++ b/rts/Lua/LuaSyncedMoveCtrl.cpp
@@ -139,7 +139,7 @@ static inline DerivedMoveType* ParseDerivedMoveType(lua_State* L, const char* ca
 
 /***
  * @function MoveCtrl.IsEnabled
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isEnabled
  */
 int LuaSyncedMoveCtrl::IsEnabled(lua_State* L)
@@ -156,7 +156,7 @@ int LuaSyncedMoveCtrl::IsEnabled(lua_State* L)
 
 /***
  * @function MoveCtrl.Enable
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedMoveCtrl::Enable(lua_State* L)
 {
@@ -172,7 +172,7 @@ int LuaSyncedMoveCtrl::Enable(lua_State* L)
 
 /***
  * @function MoveCtrl.Disable
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedMoveCtrl::Disable(lua_State* L)
 {
@@ -190,7 +190,7 @@ int LuaSyncedMoveCtrl::Disable(lua_State* L)
 
 /***
  * @function MoveCtrl.SetTag
- * @param unitID integer
+ * @param unitID UnitID
  * @param tag integer
  */
 int LuaSyncedMoveCtrl::SetTag(lua_State* L)
@@ -228,7 +228,7 @@ int LuaSyncedMoveCtrl::GetTag(lua_State* L)
 
 /***
  * @function MoveCtrl.SetProgressState
- * @param unitID integer
+ * @param unitID UnitID
  * @param state
  * | 0 # Done
  * | 1 # Active
@@ -278,7 +278,7 @@ int LuaSyncedMoveCtrl::SetProgressState(lua_State* L)
 
 /***
  * @function MoveCtrl.SetExtrapolate
- * @param unitID integer
+ * @param unitID UnitID
  * @param extrapolate boolean
  */
 int LuaSyncedMoveCtrl::SetExtrapolate(lua_State* L)
@@ -297,7 +297,7 @@ int LuaSyncedMoveCtrl::SetExtrapolate(lua_State* L)
 
 /***
  * @function MoveCtrl.SetPhysics
- * @param unitID integer
+ * @param unitID UnitID
  * @param posX number Position X component.
  * @param posY number Position Y component.
  * @param posZ number Position Z component.
@@ -328,7 +328,7 @@ int LuaSyncedMoveCtrl::SetPhysics(lua_State* L)
 
 /***
  * @function MoveCtrl.SetPosition
- * @param unitID integer
+ * @param unitID UnitID
  * @param posX number Position X component.
  * @param posY number Position Y component.
  * @param posZ number Position Z component.
@@ -351,7 +351,7 @@ int LuaSyncedMoveCtrl::SetPosition(lua_State* L)
 
 /***
  * @function MoveCtrl.SetVelocity
- * @param unitID integer
+ * @param unitID UnitID
  * @param velX number Velocity X component.
  * @param velY number Velocity Y component.
  * @param velZ number Velocity Z component.
@@ -374,7 +374,7 @@ int LuaSyncedMoveCtrl::SetVelocity(lua_State* L)
 
 /***
  * @function MoveCtrl.SetRelativeVelocity
- * @param unitID integer
+ * @param unitID UnitID
  * @param relVelX number Relative velocity X component.
  * @param relVelY number Relative velocity Y component.
  * @param relVelZ number Relative velocity Z component.
@@ -397,7 +397,7 @@ int LuaSyncedMoveCtrl::SetRelativeVelocity(lua_State* L)
 
 /***
  * @function MoveCtrl.SetRotation
- * @param unitID integer
+ * @param unitID UnitID
  * @param rotX number Rotation X component.
  * @param rotY number Rotation Y component.
  * @param rotZ number Rotation Z component.
@@ -431,7 +431,7 @@ int LuaSyncedMoveCtrl::SetRotationOffset(lua_State* L)
 
 /***
  * @function MoveCtrl.SetRotationVelocity
- * @param unitID integer
+ * @param unitID UnitID
  * @param rotVelX number Rotation velocity X component.
  * @param rotVelY number Rotation velocity Y component.
  * @param rotVelZ number Rotation velocity Z component.
@@ -453,7 +453,7 @@ int LuaSyncedMoveCtrl::SetRotationVelocity(lua_State* L)
 
 /***
  * @function MoveCtrl.SetHeading
- * @param unitID integer
+ * @param unitID UnitID
  * @param heading Heading
  */
 int LuaSyncedMoveCtrl::SetHeading(lua_State* L)
@@ -474,7 +474,7 @@ int LuaSyncedMoveCtrl::SetHeading(lua_State* L)
 
 /***
  * @function MoveCtrl.SetTrackSlope
- * @param unitID integer
+ * @param unitID UnitID
  * @param trackSlope boolean
  */
 int LuaSyncedMoveCtrl::SetTrackSlope(lua_State* L)
@@ -491,7 +491,7 @@ int LuaSyncedMoveCtrl::SetTrackSlope(lua_State* L)
 
 /***
  * @function MoveCtrl.SetTrackGround
- * @param unitID integer
+ * @param unitID UnitID
  * @param trackGround boolean
  */
 int LuaSyncedMoveCtrl::SetTrackGround(lua_State* L)
@@ -508,7 +508,7 @@ int LuaSyncedMoveCtrl::SetTrackGround(lua_State* L)
 
 /***
  * @function MoveCtrl.SetTrackLimits
- * @param unitID integer
+ * @param unitID UnitID
  * @param trackLimits boolean
  */
 int LuaSyncedMoveCtrl::SetTrackLimits(lua_State* L)
@@ -525,7 +525,7 @@ int LuaSyncedMoveCtrl::SetTrackLimits(lua_State* L)
 
 /***
  * @function MoveCtrl.SetGroundOffset
- * @param unitID integer
+ * @param unitID UnitID
  * @param groundOffset number
  */
 int LuaSyncedMoveCtrl::SetGroundOffset(lua_State* L)
@@ -542,7 +542,7 @@ int LuaSyncedMoveCtrl::SetGroundOffset(lua_State* L)
 
 /***
  * @function MoveCtrl.SetGravity
- * @param unitID integer
+ * @param unitID UnitID
  * @param gravityFactor number
  */
 int LuaSyncedMoveCtrl::SetGravity(lua_State* L)
@@ -559,7 +559,7 @@ int LuaSyncedMoveCtrl::SetGravity(lua_State* L)
 
 /***
  * @function MoveCtrl.SetDrag
- * @param unitID integer
+ * @param unitID UnitID
  * @param drag number
  */
 int LuaSyncedMoveCtrl::SetDrag(lua_State* L)
@@ -576,7 +576,7 @@ int LuaSyncedMoveCtrl::SetDrag(lua_State* L)
 
 /***
  * @function MoveCtrl.SetWindFactor
- * @param unitID integer
+ * @param unitID UnitID
  * @param windFactor number
  */
 int LuaSyncedMoveCtrl::SetWindFactor(lua_State* L)
@@ -593,7 +593,7 @@ int LuaSyncedMoveCtrl::SetWindFactor(lua_State* L)
 
 /***
  * @function MoveCtrl.SetLimits
- * @param unitID integer
+ * @param unitID UnitID
  * @param minX number Minimum position X component.
  * @param minY number Minimum position Y component.
  * @param minZ number Minimum position Z component.
@@ -618,7 +618,7 @@ int LuaSyncedMoveCtrl::SetLimits(lua_State* L)
 
 /***
  * @function MoveCtrl.SetNoBlocking
- * @param unitID integer
+ * @param unitID UnitID
  * @param noBlocking boolean
  */
 int LuaSyncedMoveCtrl::SetNoBlocking(lua_State* L)
@@ -641,7 +641,7 @@ int LuaSyncedMoveCtrl::SetSlopeStop(lua_State* L) { return 0; }
 
 /***
  * @function MoveCtrl.SetCollideStop
- * @param unitID integer
+ * @param unitID UnitID
  * @param collideStop boolean
  */
 int LuaSyncedMoveCtrl::SetCollideStop(lua_State* L)
@@ -658,7 +658,7 @@ int LuaSyncedMoveCtrl::SetCollideStop(lua_State* L)
 
 /***
  * @function MoveCtrl.SetLimitsStop
- * @param unitID integer
+ * @param unitID UnitID
  * @param limitsStop boolean
  */
 int LuaSyncedMoveCtrl::SetLimitsStop(lua_State* L)
@@ -728,15 +728,15 @@ static inline bool SetMoveTypeValue(lua_State* L, AMoveType* moveType, int keyId
  * 
  * Overload 1:
  * @param <MoveTypeTable> boolean
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  *
  * Overload 2:
  * @param <NumberKey> number
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  *
  * Overload 3:
  * @param <BooleanKey> boolean
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 static int SetMoveTypeData(lua_State* L, AMoveType* moveType, const char* caller)
 {
@@ -797,13 +797,13 @@ static int SetMoveTypeData(lua_State* L, AMoveType* moveType, const char* caller
 
 /***
  * @function MoveCtrl.SetGunshipMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param moveType HoverAirMoveType
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetGunshipMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeBooleanKey
  * | "collide"
@@ -812,11 +812,11 @@ static int SetMoveTypeData(lua_State* L, AMoveType* moveType, const char* caller
  * | "useSmoothMesh"
  * | "bankingAllowed"
  * @param value boolean
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetGunshipMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeNumberKey
  * | "wantedHeight"
@@ -828,7 +828,7 @@ static int SetMoveTypeData(lua_State* L, AMoveType* moveType, const char* caller
  * | "currentPitch"
  * | "maxDrift"
  * @param value number
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 int LuaSyncedMoveCtrl::SetGunshipMoveTypeData(lua_State* L)
 {
@@ -859,24 +859,24 @@ int LuaSyncedMoveCtrl::SetGunshipMoveTypeData(lua_State* L)
 
 /***
  * @function MoveCtrl.SetAirMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param moveType StrafeAirMoveType
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetAirMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeBooleanKey
  * | "collide"
  * | "useSmoothMesh"
  * | "loopbackAttack"
   * @param value boolean
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetAirMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeNumberKey
  * | "wantedHeight" 
@@ -893,15 +893,15 @@ int LuaSyncedMoveCtrl::SetGunshipMoveTypeData(lua_State* L)
  * | "attackSafetyDistance" 
  * | "myGravity" 
  * @param value number
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetAirMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | "maneuverBlockTime"
  * @param value integer
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 int LuaSyncedMoveCtrl::SetAirMoveTypeData(lua_State* L)
 {
@@ -928,24 +928,24 @@ int LuaSyncedMoveCtrl::SetAirMoveTypeData(lua_State* L)
 
 /***
  * @function MoveCtrl.SetGroundMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param moveType GroundMoveType
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetGroundMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeBooleanKey
  * | "atGoal"
  * | "atEndOfPath"
  * | "pushResistant"
  * @param value boolean
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetGroundMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | GenericMoveTypeNumberKey
  * | "turnRate"
@@ -958,15 +958,15 @@ int LuaSyncedMoveCtrl::SetAirMoveTypeData(lua_State* L)
  * | "maxReverseSpeed"
  * | "sqSkidSpeedMult"
  * @param value number
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 /***
  * @function MoveCtrl.SetGroundMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param key
  * | "minScriptChangeHeading"
  * @param value integer
- * @return number numAssignedValues
+ * @return integer numAssignedValues
  */
 int LuaSyncedMoveCtrl::SetGroundMoveTypeData(lua_State* L)
 {
@@ -980,7 +980,7 @@ int LuaSyncedMoveCtrl::SetGroundMoveTypeData(lua_State* L)
 
 /***
  * @function MoveCtrl.SetMoveDef
- * @param unitID integer
+ * @param unitID UnitID
  * @param moveDef integer|string Name or path type of the MoveDef.
  * @return boolean success `true` if the `MoveDef` was set, `false` if `unitID` or `moveDef` were invalid, or if the unit does not support a `MoveDef`.
  */

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -100,13 +100,13 @@ static const LuaHashString hs_n("n");
 
 bool LuaSyncedRead::PushEntries(lua_State* L)
 {
-	/*** @field Spring.ALL_UNITS number */
+	/*** @field Spring.ALL_UNITS integer */
 	LuaPushNamedNumber(L, "ALL_UNITS", LuaUtils::AllUnits);
-	/*** @field Spring.MY_UNITS number */
+	/*** @field Spring.MY_UNITS integer */
 	LuaPushNamedNumber(L, "MY_UNITS", LuaUtils::MyUnits);
-	/*** @field Spring.ALLY_UNITS number */
+	/*** @field Spring.ALLY_UNITS integer */
 	LuaPushNamedNumber(L, "ALLY_UNITS", LuaUtils::AllyUnits);
-	/*** @field Spring.ENEMY_UNITS number */
+	/*** @field Spring.ENEMY_UNITS integer */
 	LuaPushNamedNumber(L, "ENEMY_UNITS", LuaUtils::EnemyUnits);
 
 	// READ routines, sync safe
@@ -842,7 +842,7 @@ int LuaSyncedRead::IsNoCostEnabled(lua_State* L)
  *
  * @function Spring.GetGlobalLos
  *
- * @param teamID integer?
+ * @param teamID TeamID?
  *
  * @return boolean enabled
  */
@@ -909,8 +909,8 @@ int LuaSyncedRead::IsGameOver(lua_State* L)
  *
  * @function Spring.GetGameFrame
  *
- * @return number t1 frameNum % dayFrames
- * @return number t2 frameNum / dayFrames
+ * @return integer t1 frameNum % dayFrames
+ * @return integer t2 frameNum / dayFrames
  */
 int LuaSyncedRead::GetGameFrame(lua_State* L)
 {
@@ -1010,7 +1010,7 @@ int LuaSyncedRead::GetGameRulesParams(lua_State* L)
  *
  * @function Spring.GetTeamRulesParams
  *
- * @param teamID integer
+ * @param teamID TeamID
  *
  * @return RulesParams rulesParams map with rules names as key and values as values
  */
@@ -1036,7 +1036,7 @@ int LuaSyncedRead::GetTeamRulesParams(lua_State* L)
  *
  * @function Spring.GetPlayerRulesParams
  *
- * @param playerID integer
+ * @param playerID PlayerID
  *
  * @return RulesParams rulesParams map with rules names as key and values as values
  */
@@ -1105,7 +1105,7 @@ static int GetUnitRulesParamLosMask(lua_State* L, const CUnit* unit)
  *
  * @function Spring.GetUnitRulesParams
  *
- * @param unitID integer
+ * @param unitID UnitID
  *
  * @return RulesParams rulesParams map with rules names as key and values as values
  */
@@ -1123,7 +1123,7 @@ int LuaSyncedRead::GetUnitRulesParams(lua_State* L)
  *
  * @function Spring.GetFeatureRulesParams
  *
- * @param featureID integer
+ * @param featureID FeatureID
  *
  * @return RulesParams rulesParams map with rules names as key and values as values
  */
@@ -1174,7 +1174,7 @@ int LuaSyncedRead::GetGameRulesParam(lua_State* L)
  *
  * @function Spring.GetTeamRulesParam
  *
- * @param teamID integer
+ * @param teamID TeamID
  * @param ruleRef number|string the rule index or name
  *
  * @return number|string|nil value
@@ -1202,7 +1202,7 @@ int LuaSyncedRead::GetTeamRulesParam(lua_State* L)
  *
  * @function Spring.GetPlayerRulesParam
  *
- * @param playerID integer
+ * @param playerID PlayerID
  * @param ruleRef number|string the rule index or name
  *
  * @return number|string|nil value
@@ -1233,7 +1233,7 @@ int LuaSyncedRead::GetPlayerRulesParam(lua_State* L)
  *
  * @function Spring.GetUnitRulesParam
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param ruleRef number|string the rule index or name
  *
  * @return number|string|nil value
@@ -1252,7 +1252,7 @@ int LuaSyncedRead::GetUnitRulesParam(lua_State* L)
  *
  * @function Spring.GetFeatureRulesParam
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param ruleRef number|string the rule index or name
  *
  * @return number|string|nil value
@@ -1388,7 +1388,7 @@ int LuaSyncedRead::GetModOptions(lua_State* L)
  * @param x number
  * @param z number
  *
- * @return number heading
+ * @return integer heading
  */
 int LuaSyncedRead::GetHeadingFromVector(lua_State* L)
 {
@@ -1404,7 +1404,7 @@ int LuaSyncedRead::GetHeadingFromVector(lua_State* L)
  *
  * @function Spring.GetVectorFromHeading
  *
- * @param heading number
+ * @param heading integer
  *
  * @return number x
  * @return number z
@@ -1420,7 +1420,7 @@ int LuaSyncedRead::GetVectorFromHeading(lua_State* L)
 
 /***
  * @function Spring.GetFacingFromHeading
- * @param heading number
+ * @param heading integer
  * @return FacingInteger facing
  */
 int LuaSyncedRead::GetFacingFromHeading(lua_State* L)
@@ -1432,7 +1432,7 @@ int LuaSyncedRead::GetFacingFromHeading(lua_State* L)
 /***
  * @function Spring.GetHeadingFromFacing
  * @param facing FacingInteger
- * @return number heading
+ * @return integer heading
  */
 int LuaSyncedRead::GetHeadingFromFacing(lua_State* L)
 {
@@ -1532,7 +1532,7 @@ int LuaSyncedRead::GetSideData(lua_State* L)
  *
  * @function Spring.GetGaiaTeamID
  *
- * @return integer teamID
+ * @return TeamID teamID
  */
 int LuaSyncedRead::GetGaiaTeamID(lua_State* L)
 {
@@ -1548,7 +1548,7 @@ int LuaSyncedRead::GetGaiaTeamID(lua_State* L)
  *
  * @function Spring.GetAllyTeamStartBox
  *
- * @param allyID integer
+ * @param allyID AllyTeamID
  *
  * @return number? xMin
  * @return number? zMin
@@ -1580,7 +1580,7 @@ int LuaSyncedRead::GetAllyTeamStartBox(lua_State* L)
  *
  * @function Spring.GetTeamStartPosition
  *
- * @param teamID integer
+ * @param teamID TeamID
  *
  * @return number? x
  * @return number? y
@@ -1633,7 +1633,7 @@ int LuaSyncedRead::GetMapStartPositions(lua_State* L)
 /***
  *
  * @function Spring.GetAllyTeamList
- * @return integer[] allyTeamIDs
+ * @return AllyTeamID[] allyTeamIDs
  */
 int LuaSyncedRead::GetAllyTeamList(lua_State* L)
 {
@@ -1655,15 +1655,15 @@ int LuaSyncedRead::GetAllyTeamList(lua_State* L)
  * 
  * @function Spring.GetTeamList
  * @param allyTeamID -1|nil (Default: `-1`) 
- * @return number[] teamIDs List of team IDs.
+ * @return TeamID[] teamIDs List of team IDs.
  */
 
 /***
  * Get team IDs in a specific ally team.
  * 
  * @function Spring.GetTeamList
- * @param allyTeamID integer The ally team ID to filter teams by. A value less than 0 will return all teams.
- * @return number[]? teamIDs List of team IDs or `nil` if `allyTeamID` is invalid.
+ * @param allyTeamID AllyTeamID The ally team ID to filter teams by. A value less than 0 will return all teams.
+ * @return TeamID[]? teamIDs List of team IDs or `nil` if `allyTeamID` is invalid.
  */
 int LuaSyncedRead::GetTeamList(lua_State* L)
 {
@@ -1700,9 +1700,9 @@ int LuaSyncedRead::GetTeamList(lua_State* L)
 /***
  *
  * @function Spring.GetPlayerList
- * @param teamID integer? (Default: `-1`) to filter by when >= 0
+ * @param teamID TeamID? (Default: `-1`) to filter by when >= 0
  * @param active boolean? (Default: `false`) whether to filter only active teams
- * @return number[]? list of playerIDs
+ * @return PlayerID[]? list of playerIDs
  */
 int LuaSyncedRead::GetPlayerList(lua_State* L)
 {
@@ -1754,14 +1754,14 @@ int LuaSyncedRead::GetPlayerList(lua_State* L)
 /***
  *
  * @function Spring.GetTeamInfo
- * @param teamID integer
+ * @param teamID TeamID
  * @param getTeamKeys boolean? (Default: `true`) whether to return the customTeamKeys table
- * @return integer? teamID
- * @return number leader
+ * @return TeamID? teamID
+ * @return PlayerID leader
  * @return number isDead
  * @return number hasAI
  * @return string side
- * @return number allyTeam
+ * @return AllyTeamID allyTeam
  * @return number incomeMultiplier
  * @return table<string,string> customTeamKeys when getTeamKeys is true, otherwise nil
  */
@@ -1805,8 +1805,8 @@ int LuaSyncedRead::GetTeamInfo(lua_State* L)
 /***
  *
  * @function Spring.GetTeamAllyTeamID
- * @param teamID integer
- * @return integer? allyTeamID
+ * @param teamID TeamID
+ * @return AllyTeamID? allyTeamID
  */
 int LuaSyncedRead::GetTeamAllyTeamID(lua_State* L)
 {
@@ -1826,7 +1826,7 @@ int LuaSyncedRead::GetTeamAllyTeamID(lua_State* L)
 /***
  *
  * @function Spring.GetTeamResources
- * @param teamID integer
+ * @param teamID TeamID
  * @param resource ResourceName
  * @return number? currentLevel The current amount of the resource that the team has in storage at this moment
  * @return number storage       The maximum storage capacity for the resource.
@@ -1885,13 +1885,13 @@ int LuaSyncedRead::GetTeamResources(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnitStats
- * @param teamID integer
- * @return number? killed
- * @return number died
- * @return number capturedBy
- * @return number capturedFrom
- * @return number received
- * @return number sent
+ * @param teamID TeamID
+ * @return integer? killed
+ * @return integer died
+ * @return integer capturedBy
+ * @return integer capturedFrom
+ * @return integer received
+ * @return integer sent
  */
 int LuaSyncedRead::GetTeamUnitStats(lua_State* L)
 {
@@ -1920,7 +1920,7 @@ int LuaSyncedRead::GetTeamUnitStats(lua_State* L)
 /***
  *
  * @function Spring.GetTeamResourceStats
- * @param teamID integer
+ * @param teamID TeamID
  * @param resource ResourceName
  * @return number? used
  * @return number produced
@@ -1973,7 +1973,7 @@ int LuaSyncedRead::GetTeamResourceStats(lua_State* L)
  * Returns a team's damage stats. Note that all damage is counted,
  * including self-inflicted and unconfirmed out-of-sight.
  *
- * @param teamID integer
+ * @param teamID TeamID
  * @return number damageDealt
  * @return number damageReceived
  */
@@ -2000,8 +2000,8 @@ int LuaSyncedRead::GetTeamDamageStats(lua_State* L)
 /***
  * @class TeamStats
  * @x_helper
- * @field time number
- * @field frame number
+ * @field time integer
+ * @field frame integer
  * @field metalUsed number
  * @field metalProduced number
  * @field metalExcess number
@@ -2025,13 +2025,13 @@ int LuaSyncedRead::GetTeamDamageStats(lua_State* L)
 /***
  * Get the number of history entries.
  * @function Spring.GetTeamStatsHistory
- * @param teamID integer
+ * @param teamID TeamID
  * @return integer? historyCount The number of history entries, or `nil` if unable to resolve team.
  */
 /***
  * Get team stats history.
  * @function Spring.GetTeamStatsHistory
- * @param teamID integer
+ * @param teamID TeamID
  * @param startIndex integer
  * @param endIndex integer? (Default: startIndex)
  * @return TeamStats[] The team stats history, or `nil` if unable to resolve team.
@@ -2124,7 +2124,7 @@ int LuaSyncedRead::GetTeamStatsHistory(lua_State* L)
 /***
  *
  * @function Spring.GetTeamLuaAI
- * @param teamID integer
+ * @param teamID TeamID
  * @return string
  */
 int LuaSyncedRead::GetTeamLuaAI(lua_State* L)
@@ -2159,9 +2159,9 @@ int LuaSyncedRead::GetTeamLuaAI(lua_State* L)
  * Also returns the current unit count for readable teams as the 2nd value.
  *
  * @function Spring.GetTeamMaxUnits
- * @param teamID integer
- * @return number maxUnits
- * @return number? currentUnits
+ * @param teamID TeamID
+ * @return integer maxUnits
+ * @return integer? currentUnits
  */
 int LuaSyncedRead::GetTeamMaxUnits(lua_State* L)
 {
@@ -2182,17 +2182,17 @@ int LuaSyncedRead::GetTeamMaxUnits(lua_State* L)
 /***
  *
  * @function Spring.GetPlayerInfo
- * @param playerID integer
+ * @param playerID PlayerID
  * @param getPlayerOpts boolean? (Default: `true`) whether to return custom player options
  * @return string name
  * @return boolean active
  * @return boolean spectator
- * @return integer teamID
- * @return integer allyTeamID
+ * @return TeamID teamID
+ * @return AllyTeamID allyTeamID
  * @return number pingTime
  * @return number cpuUsage
  * @return string country
- * @return number rank
+ * @return integer rank
  * @return boolean hasSkirmishAIsInTeam
  * @return {[string]: string} playerOpts when playerOpts is true
  * @return boolean desynced
@@ -2247,8 +2247,8 @@ int LuaSyncedRead::GetPlayerInfo(lua_State* L)
 /*** Returns unit controlled by player on FPS mode
  *
  * @function Spring.GetPlayerControlledUnit
- * @param playerID integer
- * @return number?
+ * @param playerID PlayerID
+ * @return UnitID?
  */
 int LuaSyncedRead::GetPlayerControlledUnit(lua_State* L)
 {
@@ -2283,10 +2283,10 @@ int LuaSyncedRead::GetPlayerControlledUnit(lua_State* L)
 /***
  *
  * @function Spring.GetAIInfo
- * @param teamID integer
+ * @param teamID TeamID
  * @return integer skirmishAIID
  * @return string name
- * @return integer hostingPlayerID
+ * @return PlayerID hostingPlayerID
  * @return string shortName When synced `"SYNCED_NOSHORTNAME"`, otherwise the AI shortname or `"UNKNOWN"`.
  * @return string version When synced `"SYNCED_NOVERSION"`, otherwise the AI version or `"UNKNOWN"`.
  * @return table<string,string> options
@@ -2342,7 +2342,7 @@ int LuaSyncedRead::GetAIInfo(lua_State* L)
 /***
  *
  * @function Spring.GetAllyTeamInfo
- * @param allyTeamID integer
+ * @param allyTeamID AllyTeamID
  * @return table<string,string>?
  */
 int LuaSyncedRead::GetAllyTeamInfo(lua_State* L)
@@ -2368,8 +2368,8 @@ int LuaSyncedRead::GetAllyTeamInfo(lua_State* L)
 /***
  *
  * @function Spring.AreTeamsAllied
- * @param teamID1 number
- * @param teamID2 number
+ * @param teamID1 TeamID
+ * @param teamID2 TeamID
  * @return boolean?
  */
 int LuaSyncedRead::AreTeamsAllied(lua_State* L)
@@ -2388,8 +2388,8 @@ int LuaSyncedRead::AreTeamsAllied(lua_State* L)
 /***
  *
  * @function Spring.ArePlayersAllied
- * @param playerID1 number
- * @param playerID2 number
+ * @param playerID1 PlayerID
+ * @param playerID2 PlayerID
  * @return boolean?
  */
 int LuaSyncedRead::ArePlayersAllied(lua_State* L)
@@ -2433,7 +2433,7 @@ int LuaSyncedRead::ArePlayersAllied(lua_State* L)
  *
  * @see UnsyncedRead.GetVisibleUnits
  *
- * @return number[] unitIDs
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetAllUnits(lua_State* L)
 {
@@ -2462,8 +2462,8 @@ int LuaSyncedRead::GetAllUnits(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnits
- * @param teamID integer
- * @return number[]? unitIDs
+ * @param teamID TeamID
+ * @return UnitID[]? unitIDs
  */
 int LuaSyncedRead::GetTeamUnits(lua_State* L)
 {
@@ -2562,8 +2562,8 @@ static inline void InsertSearchUnitDefs(const UnitDef* ud, bool allied)
 /***
  *
  * @function Spring.GetTeamUnitsSorted
- * @param teamID integer
- * @return table<integer,integer> unitsByDef A table where keys are unitDefIDs and values are unitIDs
+ * @param teamID TeamID
+ * @return table<UnitDefID,UnitID[]> unitsByDef A table where keys are unitDefIDs and values are arrays of unitIDs
  */
 int LuaSyncedRead::GetTeamUnitsSorted(lua_State* L)
 {
@@ -2658,8 +2658,8 @@ int LuaSyncedRead::GetTeamUnitsSorted(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnitsCounts
- * @param teamID integer
- * @return table<number,number>? countByUnit A table where keys are unitDefIDs and values are counts.
+ * @param teamID TeamID
+ * @return table<UnitDefID,integer>? countByUnit A table where keys are unitDefIDs and values are counts.
  */
 int LuaSyncedRead::GetTeamUnitsCounts(lua_State* L)
 {
@@ -2741,9 +2741,9 @@ int LuaSyncedRead::GetTeamUnitsCounts(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnitsByDefs
- * @param teamID integer
- * @param unitDefIDs number|number[]
- * @return number[]? unitIDs
+ * @param teamID TeamID
+ * @param unitDefIDs UnitDefID|UnitDefID[]
+ * @return UnitID[]? unitIDs
  */
 int LuaSyncedRead::GetTeamUnitsByDefs(lua_State* L)
 {
@@ -2817,9 +2817,9 @@ int LuaSyncedRead::GetTeamUnitsByDefs(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnitDefCount
- * @param teamID integer
- * @param unitDefID integer
- * @return number? count
+ * @param teamID TeamID
+ * @param unitDefID UnitDefID
+ * @return integer? count
  */
 int LuaSyncedRead::GetTeamUnitDefCount(lua_State* L)
 {
@@ -2878,8 +2878,8 @@ int LuaSyncedRead::GetTeamUnitDefCount(lua_State* L)
 /***
  *
  * @function Spring.GetTeamUnitCount
- * @param teamID integer
- * @return number? count
+ * @param teamID TeamID
+ * @return integer? count
  */
 int LuaSyncedRead::GetTeamUnitCount(lua_State* L)
 {
@@ -2985,8 +2985,8 @@ static void GetFilteredUnits(lua_State *L, int allegiance, const std::vector<CUn
  * @param zmin number
  * @param xmax number
  * @param zmax number
- * @param allegiance number?
- * @return number[] unitIDs
+ * @param allegiance integer?
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetUnitsInRectangle(lua_State* L)
 {
@@ -3033,8 +3033,8 @@ int LuaSyncedRead::GetUnitsInRectangle(lua_State* L)
  * @param xmax number
  * @param ymax number
  * @param zmax number
- * @param allegiance number?
- * @return number[] unitIDs
+ * @param allegiance integer?
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetUnitsInBox(lua_State* L)
 {
@@ -3075,8 +3075,8 @@ int LuaSyncedRead::GetUnitsInBox(lua_State* L)
  * @param x number
  * @param z number
  * @param radius number
- * @param teamID integer? filter by team, defaults to all units
- * @return number[] unitIDs
+ * @param teamID TeamID? filter by team, defaults to all units
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetUnitsInCylinder(lua_State* L)
 {
@@ -3117,7 +3117,7 @@ int LuaSyncedRead::GetUnitsInCylinder(lua_State* L)
  * @param y number
  * @param z number
  * @param radius number
- * @return number[] unitIDs
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetUnitsInSphere(lua_State* L)
 {
@@ -3191,7 +3191,7 @@ static inline bool UnitInPlanes(const float3& pos, const float radius, const vec
  *
  * @param planes Plane[]
  * @param allegiance integer?
- * @return integer[] unitIDs
+ * @return UnitID[] unitIDs
  */
 int LuaSyncedRead::GetUnitsInPlanes(lua_State* L)
 {
@@ -3315,9 +3315,9 @@ int LuaSyncedRead::GetUnitMapCentroid(lua_State* L)
 /***
  *
  * @function Spring.GetUnitNearestAlly
- * @param unitID integer
+ * @param unitID UnitID
  * @param range number? (Default: `1.0e9`)
- * @return integer? unitID
+ * @return UnitID? unitID
  */
 int LuaSyncedRead::GetUnitNearestAlly(lua_State* L)
 {
@@ -3340,7 +3340,7 @@ int LuaSyncedRead::GetUnitNearestAlly(lua_State* L)
 /***
  *
  * @function Spring.GetUnitNearestEnemy
- * @param unitID integer
+ * @param unitID UnitID
  * @param range number? (Default: `1.0e9`) range of the search.
  * @param useLOS boolean? (Default: `true`) requires LOS/radar visibility of allied team.
  * @param sphereDistTest boolean? (Default: `false`) determines if using spherical(3D, includes target radius) or cylindrical(2D) search.
@@ -3379,11 +3379,11 @@ int LuaSyncedRead::GetUnitNearestEnemy(lua_State* L)
  * @param y number y coordinate of query position
  * @param z number z coordinate of query position
  * @param range number? (Default: `1.0e9`)
- * @param allyTeamID number? whose enemies to consider, always own in non-full-read contexts
+ * @param allyTeamID AllyTeamID? whose enemies to consider, always own in non-full-read contexts
  * @param useLOS boolean? (Default: true) requires LOS/radar visibility or not. Always true in non-full-read contexts
  * @param sphereDistTest boolean? (Default: `false`) For non-LOS mode only. Determines if using spherical(3D, includes target radius) or cylindrical(2D) search
  * @param checkSightDist boolean? (Default: `false`) For non-LOS mode only. Determine if during filter process, if candidate distance to be within candidate LOS radius
- * @return integer? unitID
+ * @return UnitID? unitID
  */
 int LuaSyncedRead::GetClosestEnemyUnit(lua_State* L)
 {
@@ -3464,7 +3464,7 @@ inline void ProcessFeatures(lua_State* L, const vector<CFeature*>& features) {
  * @param zmin number
  * @param xmax number
  * @param zmax number
- * @return number[] featureIDs
+ * @return FeatureID[] featureIDs
  */
 int LuaSyncedRead::GetFeaturesInRectangle(lua_State* L)
 {
@@ -3490,7 +3490,7 @@ int LuaSyncedRead::GetFeaturesInRectangle(lua_State* L)
  * @param y number
  * @param z number
  * @param radius number
- * @return number[] featureIDs
+ * @return FeatureID[] featureIDs
  */
 int LuaSyncedRead::GetFeaturesInSphere(lua_State* L)
 {
@@ -3514,8 +3514,8 @@ int LuaSyncedRead::GetFeaturesInSphere(lua_State* L)
  * @param x number
  * @param z number
  * @param radius number
- * @param allegiance number?
- * @return number[] featureIDs
+ * @param allegiance integer?
+ * @return FeatureID[] featureIDs
  */
 int LuaSyncedRead::GetFeaturesInCylinder(lua_State* L)
 {
@@ -3581,7 +3581,7 @@ static void GetProjectilesLuaTable(lua_State* L, const std::vector<CProjectile*>
  * @function Spring.GetAllProjectiles
  * @param excludeWeaponProjectiles boolean? (Default: `false`)
  * @param excludePieceProjectiles boolean? (Default: `false`)
- * @return number[] projectileIDs
+ * @return ProjectileID[] projectileIDs
  */
 int LuaSyncedRead::GetAllProjectiles(lua_State* L)
 {
@@ -3601,7 +3601,7 @@ int LuaSyncedRead::GetAllProjectiles(lua_State* L)
  * @param zmax number
  * @param excludeWeaponProjectiles boolean? (Default: `false`)
  * @param excludePieceProjectiles boolean? (Default: `false`)
- * @return number[] projectileIDs
+ * @return ProjectileID[] projectileIDs
  */
 int LuaSyncedRead::GetProjectilesInRectangle(lua_State* L)
 {
@@ -3631,7 +3631,7 @@ int LuaSyncedRead::GetProjectilesInRectangle(lua_State* L)
  * @param radius number
  * @param excludeWeaponProjectiles boolean? (Default: false)
  * @param excludePieceProjectiles boolean? (Default: false)
- * @return number[] projectileIDs
+ * @return ProjectileID[] projectileIDs
  */
 int LuaSyncedRead::GetProjectilesInSphere(lua_State* L)
 {
@@ -3659,7 +3659,7 @@ int LuaSyncedRead::GetProjectilesInSphere(lua_State* L)
  * Dead units are not valid.
  *
  * @function Spring.ValidUnitID
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean
  */
 int LuaSyncedRead::ValidUnitID(lua_State* L)
@@ -3672,8 +3672,8 @@ int LuaSyncedRead::ValidUnitID(lua_State* L)
 /***
  * @class UnitState
  * @x_helper
- * @field firestate number
- * @field movestate number
+ * @field firestate integer
+ * @field movestate integer
  * @field repeat boolean?
  * @field cloak boolean?
  * @field active boolean?
@@ -3689,7 +3689,7 @@ int LuaSyncedRead::ValidUnitID(lua_State* L)
  * Gets various states for the given unit.
  *
  * @function Spring.GetUnitStates
- * @param unitID integer
+ * @param unitID UnitID
  * @param retTable false Return a table instead of multiple values. Defaults to `true`
  * @param binState true Include binary state (activated, etc)? Defaults to `retTable`
  * @param amtState true Include Air/Hover MoveType state if available? Defaults to `retTable`
@@ -3702,10 +3702,10 @@ int LuaSyncedRead::ValidUnitID(lua_State* L)
  * @return boolean trajectory
  * @return boolean? autoLand
  * @return boolean? loopbackAttack
- * @overload fun(unitID: integer, retTable: false, binState: false?, amtState: false?): number, number, number
- * @overload fun(unitID: integer, retTable: false, binState: true, amtState: false?): number, number, number, boolean, boolean, boolean, boolean
- * @overload fun(unitID: integer, retTable: false, binState: false?, amtState: true): number, number, number, boolean?, boolean?
- * @overload fun(unitID: integer, retTable: true?, binState: boolean?, amtState: boolean?): UnitState
+ * @overload fun(unitID: UnitID, retTable: false, binState: false?, amtState: false?): number, number, number
+ * @overload fun(unitID: UnitID, retTable: false, binState: true, amtState: false?): number, number, number, boolean, boolean, boolean, boolean
+ * @overload fun(unitID: UnitID, retTable: false, binState: false?, amtState: true): number, number, number, boolean?, boolean?
+ * @overload fun(unitID: UnitID, retTable: true?, binState: boolean?, amtState: boolean?): UnitState
  */
 int LuaSyncedRead::GetUnitStates(lua_State* L)
 {
@@ -3797,7 +3797,7 @@ int LuaSyncedRead::GetUnitStates(lua_State* L)
 /***
  *
  * @function Spring.GetUnitArmored
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? armored
  * @return number armorMultiple
  */
@@ -3816,7 +3816,7 @@ int LuaSyncedRead::GetUnitArmored(lua_State* L)
 /***
  *
  * @function Spring.GetUnitIsActive
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isActive
  */
 int LuaSyncedRead::GetUnitIsActive(lua_State* L)
@@ -3833,7 +3833,7 @@ int LuaSyncedRead::GetUnitIsActive(lua_State* L)
 /***
  *
  * @function Spring.GetUnitIsCloaked
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isCloaked
  */
 int LuaSyncedRead::GetUnitIsCloaked(lua_State* L)
@@ -3850,7 +3850,7 @@ int LuaSyncedRead::GetUnitIsCloaked(lua_State* L)
 /***
  *
  * @function Spring.GetUnitSeismicSignature
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? seismicSignature
  */
 int LuaSyncedRead::GetUnitSeismicSignature(lua_State* L)
@@ -3882,7 +3882,7 @@ int LuaSyncedRead::GetUnitLeavesGhost(lua_State* L)
 /***
  *
  * @function Spring.GetUnitSelfDTime
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer? selfDTime
  */
 int LuaSyncedRead::GetUnitSelfDTime(lua_State* L)
@@ -3899,7 +3899,7 @@ int LuaSyncedRead::GetUnitSelfDTime(lua_State* L)
 /***
  *
  * @function Spring.GetUnitStockpile
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer? numStockpiled
  * @return integer? numStockpileQued
  * @return number? buildPercent
@@ -3923,9 +3923,9 @@ int LuaSyncedRead::GetUnitStockpile(lua_State* L)
 /***
  *
  * @function Spring.GetUnitSensorRadius
- * @param unitID integer
+ * @param unitID UnitID
  * @param type string one of los, airLos, radar, sonar, seismic, radarJammer, sonarJammer
- * @return number? radius
+ * @return integer? radius
  */
 int LuaSyncedRead::GetUnitSensorRadius(lua_State* L)
 {
@@ -3966,15 +3966,15 @@ int LuaSyncedRead::GetUnitSensorRadius(lua_State* L)
 /***
  *
  * @function Spring.GetUnitPosErrorParams
- * @param unitID integer
- * @param allyTeamID integer?
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID?
  * @return number? posErrorVectorX
  * @return number posErrorVectorY
  * @return number posErrorVectorZ
  * @return number posErrorDeltaX
  * @return number posErrorDeltaY
  * @return number posErrorDeltaZ
- * @return number nextPosErrorUpdatebaseErrorMult
+ * @return integer nextPosErrorUpdate
  * @return boolean posErrorBit
  */
 int LuaSyncedRead::GetUnitPosErrorParams(lua_State* L)
@@ -4003,7 +4003,7 @@ int LuaSyncedRead::GetUnitPosErrorParams(lua_State* L)
 /***
  *
  * @function Spring.GetUnitTooltip
- * @param unitID integer
+ * @param unitID UnitID
  * @return string?
  */
 int LuaSyncedRead::GetUnitTooltip(lua_State* L)
@@ -4043,8 +4043,8 @@ int LuaSyncedRead::GetUnitTooltip(lua_State* L)
 /***
  *
  * @function Spring.GetUnitDefID
- * @param unitID integer
- * @return number?
+ * @param unitID UnitID
+ * @return UnitDefID?
  */
 int LuaSyncedRead::GetUnitDefID(lua_State* L)
 {
@@ -4073,7 +4073,7 @@ int LuaSyncedRead::GetUnitDefID(lua_State* L)
 * numerical ID is not too useful so you can use the name, but this
 * may get deprecated at some point.
 * 
-* @param unitID integer
+* @param unitID UnitID
 *
 * @return integer|false|nil moveDefID
 * @return string|nil moveDefName
@@ -4101,8 +4101,8 @@ int LuaSyncedRead::GetUnitMoveDefID(lua_State* L)
 /***
  *
  * @function Spring.GetUnitTeam
- * @param unitID integer
- * @return number?
+ * @param unitID UnitID
+ * @return TeamID?
  */
 int LuaSyncedRead::GetUnitTeam(lua_State* L)
 {
@@ -4118,8 +4118,8 @@ int LuaSyncedRead::GetUnitTeam(lua_State* L)
 /***
  *
  * @function Spring.GetUnitAllyTeam
- * @param unitID integer
- * @return number?
+ * @param unitID UnitID
+ * @return AllyTeamID?
  */
 int LuaSyncedRead::GetUnitAllyTeam(lua_State* L)
 {
@@ -4139,7 +4139,7 @@ int LuaSyncedRead::GetUnitAllyTeam(lua_State* L)
  * Note that a "neutral" unit can belong to any ally-team (ally, enemy, Gaia).
  * To check if a unit is Gaia, check its owner team.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean?
  */
 int LuaSyncedRead::GetUnitNeutral(lua_State* L)
@@ -4156,7 +4156,7 @@ int LuaSyncedRead::GetUnitNeutral(lua_State* L)
 /***
  *
  * @function Spring.GetUnitHealth
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? health
  * @return number maxHealth
  * @return number paralyzeDamage
@@ -4195,7 +4195,7 @@ int LuaSyncedRead::GetUnitHealth(lua_State* L)
 /***
  *
  * @function Spring.GetUnitIsDead
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean?
  */
 int LuaSyncedRead::GetUnitIsDead(lua_State* L)
@@ -4218,7 +4218,7 @@ int LuaSyncedRead::GetUnitIsDead(lua_State* L)
  * Use other callouts to differentiate them if you need to.
  *
  * @function Spring.GetUnitIsStunned
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? stunnedOrBuilt unit is disabled
  * @return boolean stunned unit is either stunned via EMP or being transported by a non-fireplatform
  * @return boolean beingBuilt unit is under construction
@@ -4239,7 +4239,7 @@ int LuaSyncedRead::GetUnitIsStunned(lua_State* L)
 /***
  *
  * @function Spring.GetUnitIsBeingBuilt
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean beingBuilt
  * @return number buildProgress
  */
@@ -4257,7 +4257,7 @@ int LuaSyncedRead::GetUnitIsBeingBuilt(lua_State* L)
 /***
  *
  * @function Spring.GetUnitResources
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? metalMake
  * @return number metalUse
  * @return number energyMake
@@ -4278,7 +4278,7 @@ int LuaSyncedRead::GetUnitResources(lua_State* L)
 
 /***
  * @function Spring.GetUnitStorage
- * @param unitID integer
+ * @param unitID UnitID
  * @return number Unit's metal storage
  * @return number Unit's energy storage
  */
@@ -4296,7 +4296,7 @@ int LuaSyncedRead::GetUnitStorage(lua_State* L)
 
 /***
  * @function Spring.GetUnitCosts
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? buildTime
  * @return number metalCost
  * @return number energyCost
@@ -4322,7 +4322,7 @@ int LuaSyncedRead::GetUnitCosts(lua_State* L)
 
 /***
  * @function Spring.GetUnitCostTable
- * @param unitID integer
+ * @param unitID UnitID
  * @return ResourceCost? cost The cost of the unit, or `nil` if invalid.
  * @return number? buildTime The build time the unit, or `nil` if invalid.
  */
@@ -4346,7 +4346,7 @@ int LuaSyncedRead::GetUnitCostTable(lua_State* L)
 /***
  *
  * @function Spring.GetUnitMetalExtraction
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? metalExtraction
  */
 int LuaSyncedRead::GetUnitMetalExtraction(lua_State* L)
@@ -4366,7 +4366,7 @@ int LuaSyncedRead::GetUnitMetalExtraction(lua_State* L)
 /***
  *
  * @function Spring.GetUnitExperience
- * @param unitID integer
+ * @param unitID UnitID
  * @return number xp [0.0; +∞)
  * @return number limXp [0.0; 1.0) as experience approaches infinity
  */
@@ -4385,7 +4385,7 @@ int LuaSyncedRead::GetUnitExperience(lua_State* L)
 /***
  *
  * @function Spring.GetUnitHeight
- * @param unitID integer
+ * @param unitID UnitID
  * @return number?
  */
 int LuaSyncedRead::GetUnitHeight(lua_State* L)
@@ -4402,7 +4402,7 @@ int LuaSyncedRead::GetUnitHeight(lua_State* L)
 /***
  *
  * @function Spring.GetUnitRadius
- * @param unitID integer
+ * @param unitID UnitID
  * @return number?
  */
 int LuaSyncedRead::GetUnitRadius(lua_State* L)
@@ -4419,7 +4419,7 @@ int LuaSyncedRead::GetUnitRadius(lua_State* L)
  *
  * @function Spring.GetUnitBuildeeRadius
  * Gets the unit's radius for when targeted by build, repair, reclaim-type commands.
- * @param unitID integer
+ * @param unitID UnitID
  * @return number?
  */
 int LuaSyncedRead::GetUnitBuildeeRadius(lua_State* L)
@@ -4435,7 +4435,7 @@ int LuaSyncedRead::GetUnitBuildeeRadius(lua_State* L)
 /***
  *
  * @function Spring.GetUnitMass
- * @param unitID integer
+ * @param unitID UnitID
  * @return number?
  */
 int LuaSyncedRead::GetUnitMass(lua_State* L)
@@ -4446,7 +4446,7 @@ int LuaSyncedRead::GetUnitMass(lua_State* L)
 /***
  *
  * @function Spring.GetUnitPosition
- * @param unitID integer
+ * @param unitID UnitID
  * @param midPos boolean? (Default: `false`) return midpoint as well
  * @param aimPos boolean? (Default: `false`) return aimpoint as well
  * @return number? basePointX
@@ -4469,7 +4469,7 @@ int LuaSyncedRead::GetUnitPosition(lua_State* L)
  * @function Spring.GetUnitBasePosition
  * The same as `Spring.GetUnitPosition`, but without the optional midpoint calculations.
  * @see Spring.GetUnitPosition 
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? posX
  * @return number? posY
  * @return number? posZ
@@ -4483,7 +4483,7 @@ int LuaSyncedRead::GetUnitBasePosition(lua_State* L)
 /***
  *
  * @function Spring.GetUnitVectors
- * @param unitID integer
+ * @param unitID UnitID
  * @return float3? front
  * @return float3 up
  * @return float3 right
@@ -4512,7 +4512,7 @@ int LuaSyncedRead::GetUnitVectors(lua_State* L)
  *
  * @function Spring.GetUnitRotation
  * Note: PYR order
- * @param unitID integer
+ * @param unitID UnitID
  * @return number pitch Rotation in X axis
  * @return number yaw Rotation in Y axis
  * @return number roll Rotation in Z axis
@@ -4526,7 +4526,7 @@ int LuaSyncedRead::GetUnitRotation(lua_State* L)
 /***
  *
  * @function Spring.GetUnitDirection
- * @param unitID integer
+ * @param unitID UnitID
  * @return number frontDirX
  * @return number frontDirY
  * @return number frontDirZ
@@ -4563,7 +4563,7 @@ int LuaSyncedRead::GetUnitDirection(lua_State* L)
 /***
  *
  * @function Spring.GetUnitHeading
- * @param unitID integer
+ * @param unitID UnitID
  * @param convertToRadians boolean? (Default: `false`)
  * @return number heading
  */
@@ -4586,7 +4586,7 @@ int LuaSyncedRead::GetUnitHeading(lua_State* L)
 /***
  *
  * @function Spring.GetUnitVelocity
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitVelocity(lua_State* L)
 {
@@ -4597,7 +4597,7 @@ int LuaSyncedRead::GetUnitVelocity(lua_State* L)
 /***
  *
  * @function Spring.GetUnitBuildFacing
- * @param unitID integer
+ * @param unitID UnitID
  * @return FacingInteger? buildFacing facing of footprint, `0` - `3`
  */
 int LuaSyncedRead::GetUnitBuildFacing(lua_State* L)
@@ -4617,7 +4617,7 @@ int LuaSyncedRead::GetUnitBuildFacing(lua_State* L)
  *
  * Works for both mobile builders and factories.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer buildeeUnitID or nil
  */
 int LuaSyncedRead::GetUnitIsBuilding(lua_State* L)
@@ -4714,7 +4714,7 @@ static int GetFactoryWorkerTask(lua_State* L, const CFactory *factory)
  * The possible commands returned are repair, reclaim, resurrect, capture, restore,
  * and build commands (negative buildee unitDefID).
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer cmdID of the relevant command
  * @return integer targetID if applicable (all except RESTORE)
  */
@@ -4737,7 +4737,7 @@ int LuaSyncedRead::GetUnitWorkerTask(lua_State* L)
  *
  * @function Spring.GetUnitEffectiveBuildRange
  * Useful for setting move goals manually.
- * @param unitID integer
+ * @param unitID UnitID
  * @param buildeeDefID integer or nil
  * @return number effectiveBuildRange counted to the center of prospective buildee; buildRange if buildee nil
  */
@@ -4792,7 +4792,7 @@ int LuaSyncedRead::GetUnitEffectiveBuildRange(lua_State* L)
 /***
  *
  * @function Spring.GetUnitCurrentBuildPower
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? buildPower `nil` if the unit is neither a builder nor a factory.
  */
 int LuaSyncedRead::GetUnitCurrentBuildPower(lua_State* L)
@@ -4829,7 +4829,7 @@ int LuaSyncedRead::GetUnitCurrentBuildPower(lua_State* L)
  *
  * Checks resources being carried internally by the unit.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return number storedMetal
  * @return number maxStoredMetal
  * @return number storedEnergy
@@ -4851,7 +4851,7 @@ int LuaSyncedRead::GetUnitHarvestStorage(lua_State* L)
 /***
  *
  * @function Spring.GetUnitBuildParams
- * @param unitID integer
+ * @param unitID UnitID
  * @param paramName "buildRange"|"buildDistance"|"buildRange3D" The build param to get
  * @return number|boolean|nil value number for `"buildRange"` or `"buildDistance"`,
  * boolean for `"buildRange3D"`, otherwise `nil` for unrecognized paramName or not
@@ -4892,7 +4892,7 @@ int LuaSyncedRead::GetUnitBuildParams(lua_State* L)
  * Checks if a builder is in build stance, i.e. can create nanoframes.
  * Returns nil for non-builders.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean inBuildStance
  */
 int LuaSyncedRead::GetUnitInBuildStance(lua_State* L)
@@ -4922,7 +4922,7 @@ int LuaSyncedRead::GetUnitInBuildStance(lua_State* L)
  * Only works on builders and factories, returns nil (NOT empty table)
  * for other units.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer[] pieceArray
  */
 int LuaSyncedRead::GetUnitNanoPieces(lua_State* L)
@@ -4973,8 +4973,8 @@ int LuaSyncedRead::GetUnitNanoPieces(lua_State* L)
  * Returns the unit ID of the transport, if any.
  * Returns nil if the unit is not being transported.
  *
- * @param unitID integer
- * @return integer? transportUnitID
+ * @param unitID UnitID
+ * @return UnitID? transportUnitID
  */
 int LuaSyncedRead::GetUnitTransporter(lua_State* L)
 {
@@ -4994,8 +4994,8 @@ int LuaSyncedRead::GetUnitTransporter(lua_State* L)
  * Get units being transported
  *
  * @function Spring.GetUnitIsTransporting
- * @param unitID integer
- * @return integer[]? transporteeArray
+ * @param unitID UnitID
+ * @return UnitID[]? transporteeArray
  * An array of unitIDs being transported by this unit, or `nil` if not a transport.
  */
 int LuaSyncedRead::GetUnitIsTransporting(lua_State* L)
@@ -5022,9 +5022,9 @@ int LuaSyncedRead::GetUnitIsTransporting(lua_State* L)
 /***
  *
  * @function Spring.GetUnitShieldState
- * @param unitID integer
- * @param weaponNum number? Optional if the unit has just one shield
- * @return number isEnabled Warning, number not boolean. 0 or 1
+ * @param unitID UnitID
+ * @param weaponNum integer? Optional if the unit has just one shield
+ * @return integer isEnabled Warning, number not boolean. 0 or 1
  * @return number currentPower
  */
 int LuaSyncedRead::GetUnitShieldState(lua_State* L)
@@ -5059,7 +5059,7 @@ int LuaSyncedRead::GetUnitShieldState(lua_State* L)
  * `"mode"`, `"moveFactor"`, `"minDamage"` or `"maxDamage"` returns just that
  * single number, and with `"dir"` returns just `dirX`, `dirY`, `dirZ`.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return number mode
  * @return number moveFactor
  * @return number minDamage
@@ -5133,7 +5133,7 @@ int LuaSyncedRead::GetUnitFlanking(lua_State* L)
  * By default this is the highest among the unit's weapon ranges (hence name),
  * but can be changed dynamically. Also note that unarmed units ignore this.
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return number maxRange
  */
 int LuaSyncedRead::GetUnitMaxRange(lua_State* L)
@@ -5181,8 +5181,8 @@ int LuaSyncedRead::GetUnitMaxRange(lua_State* L)
  * The state "salvoError" is an exception and returns a table: {x, y, z},
  * which represents the inaccuracy error of the ongoing burst.
  *
- * @param unitID integer
- * @param weaponNum number
+ * @param unitID UnitID
+ * @param weaponNum integer
  * @param stateName string?
  * @return number stateValue
  */
@@ -5367,7 +5367,7 @@ static inline int PushDamagesKey(lua_State* L, const DynDamageArray& damages, in
 /***
  *
  * @function Spring.GetUnitWeaponDamages
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitWeaponDamages(lua_State* L)
 {
@@ -5406,7 +5406,7 @@ int LuaSyncedRead::GetUnitWeaponDamages(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponVectors
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer 1-indexed weapon number
  * @return number? posX
  * @return number posY
@@ -5453,15 +5453,15 @@ int LuaSyncedRead::GetUnitWeaponVectors(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponTryTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
- * @param targetID integer
+ * @param targetID UnitID
  * @return boolean canTarget
  */
 /***
  *
  * @function Spring.GetUnitWeaponTryTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @param posX number
  * @param posY number
@@ -5511,15 +5511,15 @@ int LuaSyncedRead::GetUnitWeaponTryTarget(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponTestTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer weapon number (1-based Lua index)
- * @param targetUnitID integer enemy unit to test (when fewer than five arguments)
+ * @param targetUnitID UnitID enemy unit to test (when fewer than five arguments)
  * @return boolean validTarget
  */
 /***
  *
  * @function Spring.GetUnitWeaponTestTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponID integer weapon number (1-based Lua index)
  * @param targetX number world X to test (with `targetY`, `targetZ`; used when at least five arguments are passed)
  * @param targetY number
@@ -5562,15 +5562,15 @@ int LuaSyncedRead::GetUnitWeaponTestTarget(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponTestRange
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
- * @param targetID integer
+ * @param targetID UnitID
  * @return boolean inRange
  */
 /***
  *
  * @function Spring.GetUnitWeaponTestRange
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @param posX number
  * @param posY number
@@ -5613,36 +5613,36 @@ int LuaSyncedRead::GetUnitWeaponTestRange(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponHaveFreeLineOfFire
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
- * @param targetID integer
+ * @param targetID UnitID
  * @return boolean haveFreeLineOfFire
  */
 /***
  *
  * @function Spring.GetUnitWeaponHaveFreeLineOfFire
- * @param unitID integer
- * @param weaponNum integer
- * @param srcPosX number
- * @param srcPosY number
- * @param srcPosZ number
- * @return boolean haveFreeLineOfFire
- */
-/***
- *
- * @function Spring.GetUnitWeaponHaveFreeLineOfFire
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @param srcPosX number
  * @param srcPosY number
  * @param srcPosZ number
- * @param targetID integer
  * @return boolean haveFreeLineOfFire
  */
 /***
  *
  * @function Spring.GetUnitWeaponHaveFreeLineOfFire
- * @param unitID integer
+ * @param unitID UnitID
+ * @param weaponNum integer
+ * @param srcPosX number
+ * @param srcPosY number
+ * @param srcPosZ number
+ * @param targetID UnitID
+ * @return boolean haveFreeLineOfFire
+ */
+/***
+ *
+ * @function Spring.GetUnitWeaponHaveFreeLineOfFire
+ * @param unitID UnitID
  * @param weaponNum integer
  * @param srcPosX number
  * @param srcPosY number
@@ -5716,7 +5716,7 @@ int LuaSyncedRead::GetUnitWeaponHaveFreeLineOfFire(lua_State* L)
 /***
  *
  * @function Spring.GetUnitWeaponCanFire
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @param ignoreAngleGood boolean?
  * @param ignoreTargetType boolean?
@@ -5758,7 +5758,7 @@ int LuaSyncedRead::GetUnitWeaponCanFire(lua_State* L)
  * that weapons can aim individually unless slaved.
  *
  * @function Spring.GetUnitWeaponTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @return 0 TargetType none
  * @return boolean isUserTarget
@@ -5770,11 +5770,11 @@ int LuaSyncedRead::GetUnitWeaponCanFire(lua_State* L)
  * that weapons can aim individually unless slaved.
  *
  * @function Spring.GetUnitWeaponTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @return 1 TargetType unit
  * @return boolean isUserTarget
- * @return integer targetUnitID
+ * @return UnitID targetUnitID
  */
 /***
  * Checks a weapon's target
@@ -5783,7 +5783,7 @@ int LuaSyncedRead::GetUnitWeaponCanFire(lua_State* L)
  * that weapons can aim individually unless slaved.
  *
  * @function Spring.GetUnitWeaponTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @return 2 TargetType position
  * @return boolean isUserTarget
@@ -5796,11 +5796,11 @@ int LuaSyncedRead::GetUnitWeaponCanFire(lua_State* L)
  * that weapons can aim individually unless slaved.
  *
  * @function Spring.GetUnitWeaponTarget
- * @param unitID integer
+ * @param unitID UnitID
  * @param weaponNum integer
  * @return 3 TargetType projectileID
  * @return boolean isUserTarget
- * @return integer targetProjectileId
+ * @return ProjectileID targetProjectileId
  */
 int LuaSyncedRead::GetUnitWeaponTarget(lua_State* L)
 {
@@ -5861,7 +5861,7 @@ int LuaSyncedRead::GetUnitFuel(lua_State* L) { lua_pushnumber(L, 0.0f); return 1
 /***
  *
  * @function Spring.GetUnitEstimatedPath
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitEstimatedPath(lua_State* L)
 {
@@ -5881,7 +5881,7 @@ int LuaSyncedRead::GetUnitEstimatedPath(lua_State* L)
 /***
  *
  * @function Spring.GetUnitLastAttacker
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer? attackerUnitID `nil` if the unit has no last attacker or the attacker is not visible.
  */
 int LuaSyncedRead::GetUnitLastAttacker(lua_State* L)
@@ -5902,7 +5902,7 @@ int LuaSyncedRead::GetUnitLastAttacker(lua_State* L)
 /***
  *
  * @function Spring.GetUnitLastAttackedPiece
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitLastAttackedPiece(lua_State* L)
 {
@@ -5912,7 +5912,7 @@ int LuaSyncedRead::GetUnitLastAttackedPiece(lua_State* L)
 /***
  *
  * @function Spring.GetUnitCollisionVolumeData
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitCollisionVolumeData(lua_State* L)
 {
@@ -5927,7 +5927,7 @@ int LuaSyncedRead::GetUnitCollisionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.GetUnitPieceCollisionVolumeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer 1-based local-model piece index
  * @return number? scaleX
  * @return number? scaleY
@@ -5952,8 +5952,8 @@ int LuaSyncedRead::GetUnitPieceCollisionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.GetUnitSeparation
- * @param unitID1 number
- * @param unitID2 number
+ * @param unitID1 UnitID
+ * @param unitID2 UnitID
  * @param direction boolean? (Default: `false`) to subtract from, default unitID1 - unitID2
  * @param subtractRadii boolean? (Default: `false`) whether units radii should be subtracted from the total
  * @return number?
@@ -5994,8 +5994,8 @@ int LuaSyncedRead::GetUnitSeparation(lua_State* L)
 /***
  *
  * @function Spring.GetUnitFeatureSeparation
- * @param unitID integer
- * @param featureID integer
+ * @param unitID UnitID
+ * @param featureID FeatureID
  * @param flat boolean? (Default: `false`) if true, XZ (2D) distance; otherwise 3D distance
  * @return number distance
  */
@@ -6047,7 +6047,7 @@ int LuaSyncedRead::GetUnitFeatureSeparation(lua_State* L)
 /***
  *
  * @function Spring.GetUnitDefDimensions
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @return UnitDefDimensions? dimensions
  */
 int LuaSyncedRead::GetUnitDefDimensions(lua_State* L)
@@ -6094,7 +6094,7 @@ int LuaSyncedRead::GetCEGID(lua_State* L)
 /***
  *
  * @function Spring.GetUnitBlocking
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isBlocking
  * @return boolean isSolidObjectCollidable
  * @return boolean isProjectileCollidable
@@ -6112,7 +6112,7 @@ int LuaSyncedRead::GetUnitBlocking(lua_State* L)
 /***
  *
  * @function Spring.GetUnitMoveTypeData
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitMoveTypeData(lua_State* L)
 {
@@ -6350,7 +6350,7 @@ static void PackCommandQueue(lua_State* L, const CCommandQueue& commands, size_t
  *
  * @function Spring.GetUnitCurrentCommand
  *
- * @param unitID integer unitID when invalid this function returns nil.
+ * @param unitID UnitID unitID when invalid this function returns nil.
  * @param cmdIndex integer? (Default: `0`) Command index to get. If negative will count from the end of the queue, e.g. -1 will be the last command.
  * @return CMD? cmdID
  * @return integer|CommandOptionBit|nil options
@@ -6401,7 +6401,7 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
  *
  * Same as `Spring.GetCommandQueue`
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count integer Maximum amount of commands to return, `-1` returns all commands.
  * @return Command[] commands
  */
@@ -6411,7 +6411,7 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
  * @deprecated This overload is deprecated, use `Spring.GetUnitCommandCount(unitId)` instead.
  * @function Spring.GetUnitCommands
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count 0 Returns the number of commands in the units queue.
  * @return integer The number of commands in the unit queue.
  */
@@ -6446,7 +6446,7 @@ int LuaSyncedRead::GetUnitCommands(lua_State* L)
  *
  * @function Spring.GetFactoryCommands
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count integer Maximum amount of commands to return, `-1` returns all commands.
  * @return Command[] commands
  *
@@ -6459,7 +6459,7 @@ int LuaSyncedRead::GetUnitCommands(lua_State* L)
  * @deprecated This overload is deprecated, use `Spring.GetFactoryCommandCount(unitId)` instead.
  * @function Spring.GetFactoryCommands
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count 0 Returns the number of commands in the factory queue.
  * @return integer The number of commands in the factory queue.
  *
@@ -6497,7 +6497,7 @@ int LuaSyncedRead::GetFactoryCommands(lua_State* L)
 /*** Get the number of commands in a unit's queue.
  *
  * @function Spring.GetUnitCommandCount
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer The number of commands in the unit's queue.
  */
 int LuaSyncedRead::GetUnitCommandCount(lua_State* L)
@@ -6520,7 +6520,7 @@ int LuaSyncedRead::GetUnitCommandCount(lua_State* L)
 /*** Get the number of commands in a factory queue.
  *
  * @function Spring.GetFactoryCommandCount
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer The number of commands in the factory queue.
  *
  * @see Spring.GetFactoryCommands to get the factory commands.
@@ -6550,7 +6550,7 @@ int LuaSyncedRead::GetFactoryCommandCount(lua_State* L)
 /***
  *
  * @function Spring.GetFactoryBuggerOff
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? boPerform `nil` if the unit does not exist or is not a factory.
  * @return number boOffset
  * @return number boRadius
@@ -6636,7 +6636,7 @@ static void PackFactoryCounts(lua_State* L,
 /*** Gets the build queue of a factory
  *
  * @function Spring.GetFactoryCounts
- * @param unitID integer
+ * @param unitID UnitID
  * @param count integer? (Default: `-1`) Number of commands to retrieve, `-1` for all.
  * @param addCmds boolean? (Default: `false`) Retrieve commands other than buildunit
  *
@@ -6677,7 +6677,7 @@ int LuaSyncedRead::GetFactoryCounts(lua_State* L)
  *
  * Same as `Spring.GetUnitCommands`
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count integer Number of commands to return, `-1` returns all commands, `0` returns command count.
  * @return Command[] commands
  */
@@ -6689,7 +6689,7 @@ int LuaSyncedRead::GetFactoryCounts(lua_State* L)
  *
  * Same as `Spring.GetUnitCommands`
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param count 0 Returns the number of commands in the units queue.
  * @return integer cmdCount The number of commands in the unit queue.
  *
@@ -6777,7 +6777,7 @@ static int PackBuildQueue(lua_State* L, bool canBuild, const char* caller)
 /*** Returns the build queue
  *
  * @function Spring.GetFullBuildQueue
- * @param unitID integer
+ * @param unitID UnitID
  * @return table<number,number>? buildqueue indexed by unitDefID with count values
  */
 int LuaSyncedRead::GetFullBuildQueue(lua_State* L)
@@ -6789,7 +6789,7 @@ int LuaSyncedRead::GetFullBuildQueue(lua_State* L)
 /*** Returns the build queue cleaned of things the unit can't build itself
  *
  * @function Spring.GetRealBuildQueue
- * @param unitID integer
+ * @param unitID UnitID
  * @return table<number,number>? buildqueue indexed by unitDefID with count values
  */
 int LuaSyncedRead::GetRealBuildQueue(lua_State* L)
@@ -6804,7 +6804,7 @@ int LuaSyncedRead::GetRealBuildQueue(lua_State* L)
 /***
  *
  * @function Spring.GetUnitCmdDescs
- * @param unitID integer
+ * @param unitID UnitID
  */
 int LuaSyncedRead::GetUnitCmdDescs(lua_State* L)
 {
@@ -6843,7 +6843,7 @@ int LuaSyncedRead::GetUnitCmdDescs(lua_State* L)
 /***
  *
  * @function Spring.FindUnitCmdDesc
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdID integer
  * @return integer?
  */
@@ -6872,7 +6872,7 @@ int LuaSyncedRead::FindUnitCmdDesc(lua_State* L)
 /***
  *
  * @function Spring.ValidFeatureID
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean
  */
 int LuaSyncedRead::ValidFeatureID(lua_State* L)
@@ -6884,7 +6884,7 @@ int LuaSyncedRead::ValidFeatureID(lua_State* L)
 
 /***
  * @function Spring.GetAllFeatures
- * @return integer[] featureIDs
+ * @return FeatureID[] featureIDs
  */
 int LuaSyncedRead::GetAllFeatures(lua_State* L)
 {
@@ -6913,8 +6913,8 @@ int LuaSyncedRead::GetAllFeatures(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureDefID
- * @param featureID integer
- * @return number?
+ * @param featureID FeatureID
+ * @return FeatureDefID?
  */
 int LuaSyncedRead::GetFeatureDefID(lua_State* L)
 {
@@ -6930,8 +6930,8 @@ int LuaSyncedRead::GetFeatureDefID(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureTeam
- * @param featureID integer
- * @return number?
+ * @param featureID FeatureID
+ * @return TeamID?
  */
 int LuaSyncedRead::GetFeatureTeam(lua_State* L)
 {
@@ -6951,8 +6951,8 @@ int LuaSyncedRead::GetFeatureTeam(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureAllyTeam
- * @param featureID integer
- * @return number?
+ * @param featureID FeatureID
+ * @return AllyTeamID?
  */
 int LuaSyncedRead::GetFeatureAllyTeam(lua_State* L)
 {
@@ -6968,7 +6968,7 @@ int LuaSyncedRead::GetFeatureAllyTeam(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureHealth
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? health
  * @return number defHealth
  * @return number resurrectProgress
@@ -6989,7 +6989,7 @@ int LuaSyncedRead::GetFeatureHealth(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureHeight
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number?
  */
 int LuaSyncedRead::GetFeatureHeight(lua_State* L)
@@ -7006,7 +7006,7 @@ int LuaSyncedRead::GetFeatureHeight(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureRadius
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number?
  */
 int LuaSyncedRead::GetFeatureRadius(lua_State* L)
@@ -7022,7 +7022,7 @@ int LuaSyncedRead::GetFeatureRadius(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureMass
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number?
  */
 int LuaSyncedRead::GetFeatureMass(lua_State* L)
@@ -7033,7 +7033,7 @@ int LuaSyncedRead::GetFeatureMass(lua_State* L)
 /***
  *
  * @function Spring.GetFeaturePosition
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? x
  * @return number? y
  * @return number? z
@@ -7047,8 +7047,8 @@ int LuaSyncedRead::GetFeaturePosition(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureSeparation
- * @param featureID1 number
- * @param featureID2 number
+ * @param featureID1 FeatureID
+ * @param featureID2 FeatureID
  * @param direction boolean? (Default: `false`) to subtract from, default featureID1 - featureID2
  * @return number?
  */
@@ -7080,7 +7080,7 @@ int LuaSyncedRead::GetFeatureSeparation(lua_State* L)
  *
  * @function Spring.GetFeatureRotation
  * Note: PYR order
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? pitch Rotation in X axis
  * @return number? yaw Rotation in Y axis
  * @return number? roll Rotation in Z axis
@@ -7097,7 +7097,7 @@ int LuaSyncedRead::GetFeatureRotation(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureDirection
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? frontDirX
  * @return number? frontDirY
  * @return number? frontDirZ
@@ -7139,7 +7139,7 @@ int LuaSyncedRead::GetFeatureDirection(lua_State* L)
  *
  * @function Spring.GetFeatureVelocity
  * Returns nil if no feature found with ID.
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? x 
  * @return number? y
  * @return number? z
@@ -7154,7 +7154,7 @@ int LuaSyncedRead::GetFeatureVelocity(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureHeading
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? heading
  */
 int LuaSyncedRead::GetFeatureHeading(lua_State* L)
@@ -7171,7 +7171,7 @@ int LuaSyncedRead::GetFeatureHeading(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureResources
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? metal
  * @return number defMetal
  * @return number energy
@@ -7198,7 +7198,7 @@ int LuaSyncedRead::GetFeatureResources(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureBlocking
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean? isBlocking
  * @return boolean? isSolidObjectCollidable
  * @return boolean? isProjectileCollidable
@@ -7216,7 +7216,7 @@ int LuaSyncedRead::GetFeatureBlocking(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureNoSelect
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean?
  */
 int LuaSyncedRead::GetFeatureNoSelect(lua_State* L)
@@ -7235,7 +7235,7 @@ int LuaSyncedRead::GetFeatureNoSelect(lua_State* L)
  *
  * @function Spring.GetFeatureResurrect
  * Returns nil if no feature found with ID.
- * @param featureID integer
+ * @param featureID FeatureID
  * @return string|""|nil featureDefName
  * @return FacingInteger buildFacing facing of footprint, 0 - 3
  */
@@ -7260,7 +7260,7 @@ int LuaSyncedRead::GetFeatureResurrect(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureLastAttackedPiece
- * @param featureID integer
+ * @param featureID FeatureID
  * @return string|""|nil Last hit piece name
  * @return integer? frame it was last hit on, nil when featureID is not valid
  */
@@ -7290,7 +7290,7 @@ int LuaSyncedRead::GetFeatureLastAttackedPiece(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureCollisionVolumeData
- * @param featureID integer
+ * @param featureID FeatureID
  * @return CollisionVolumeData?
  */
 int LuaSyncedRead::GetFeatureCollisionVolumeData(lua_State* L)
@@ -7306,7 +7306,7 @@ int LuaSyncedRead::GetFeatureCollisionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.GetFeaturePieceCollisionVolumeData
- * @param featureID integer
+ * @param featureID FeatureID
  * @return CollisionVolumeData?
  */
 int LuaSyncedRead::GetFeaturePieceCollisionVolumeData(lua_State* L)
@@ -7319,7 +7319,7 @@ int LuaSyncedRead::GetFeaturePieceCollisionVolumeData(lua_State* L)
  *
  * @function Spring.GetFeatureFireTime
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? fireTime in seconds, nil when featureID is invalid.
  */
 int LuaSyncedRead::GetFeatureFireTime(lua_State* L)
@@ -7338,7 +7338,7 @@ int LuaSyncedRead::GetFeatureFireTime(lua_State* L)
  *
  * @function Spring.GetFeatureSmokeTime
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? smokeTime in seconds, nil when featureID is invalid.
  */
 int LuaSyncedRead::GetFeatureSmokeTime(lua_State* L)
@@ -7363,7 +7363,7 @@ int LuaSyncedRead::GetFeatureSmokeTime(lua_State* L)
 /***
  *
  * @function Spring.GetProjectilePosition
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return number? posX
  * @return number? posY
  * @return number? posZ
@@ -7384,7 +7384,7 @@ int LuaSyncedRead::GetProjectilePosition(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileDirection
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return number? dirX
  * @return number? dirY
  * @return number? dirZ
@@ -7405,7 +7405,7 @@ int LuaSyncedRead::GetProjectileDirection(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileVelocity
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return number? velX
  * @return number? velY
  * @return number? velZ
@@ -7420,7 +7420,7 @@ int LuaSyncedRead::GetProjectileVelocity(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileGravity
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return number?
  */
 int LuaSyncedRead::GetProjectileGravity(lua_State* L)
@@ -7439,8 +7439,8 @@ int LuaSyncedRead::GetProjectileGravity(lua_State* L)
 /***
  *
  * @function Spring.GetPieceProjectileParams
- * @param projectileID integer
- * @return number? explosionFlags encoded bitwise with SHATTER = 1, EXPLODE = 2, EXPLODE_ON_HIT = 2, FALL = 4, SMOKE = 8, FIRE = 16, NONE = 32, NO_CEG_TRAIL = 64, NO_HEATCLOUD = 128
+ * @param projectileID ProjectileID
+ * @return integer? explosionFlags encoded bitwise with SHATTER = 1, EXPLODE = 2, EXPLODE_ON_HIT = 2, FALL = 4, SMOKE = 8, FIRE = 16, NONE = 32, NO_CEG_TRAIL = 64, NO_HEATCLOUD = 128
  * @return number spinAngle
  * @return number spinSpeed
  * @return number spinVectorX
@@ -7469,13 +7469,13 @@ int LuaSyncedRead::GetPieceProjectileParams(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileTarget
- * @param projectileID integer
- * @return number? targetTypeInt where
+ * @param projectileID ProjectileID
+ * @return integer? targetTypeInt where
  * string.byte('g') := GROUND
  * string.byte('u') := UNIT
  * string.byte('f') := FEATURE
  * string.byte('p') := PROJECTILE
- * @return number|float3 target targetID or targetPos when targetTypeInt == string.byte('g')
+ * @return UnitID|FeatureID|ProjectileID|float3 target targetID or targetPos when targetTypeInt == string.byte('g')
  */
 int LuaSyncedRead::GetProjectileTarget(lua_State* L)
 {
@@ -7521,7 +7521,7 @@ int LuaSyncedRead::GetProjectileTarget(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileIsIntercepted
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return boolean?
  */
 int LuaSyncedRead::GetProjectileIsIntercepted(lua_State* L)
@@ -7541,8 +7541,8 @@ int LuaSyncedRead::GetProjectileIsIntercepted(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileTimeToLive
- * @param projectileID integer
- * @return number?
+ * @param projectileID ProjectileID
+ * @return integer?
  */
 int LuaSyncedRead::GetProjectileTimeToLive(lua_State* L)
 {
@@ -7561,8 +7561,8 @@ int LuaSyncedRead::GetProjectileTimeToLive(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileOwnerID
- * @param projectileID integer
- * @return number?
+ * @param projectileID ProjectileID
+ * @return UnitID?
  */
 int LuaSyncedRead::GetProjectileOwnerID(lua_State* L)
 {
@@ -7583,8 +7583,8 @@ int LuaSyncedRead::GetProjectileOwnerID(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileTeamID
- * @param projectileID integer
- * @return number?
+ * @param projectileID ProjectileID
+ * @return TeamID?
  */
 int LuaSyncedRead::GetProjectileTeamID(lua_State* L)
 {
@@ -7604,8 +7604,8 @@ int LuaSyncedRead::GetProjectileTeamID(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileAllyTeamID
- * @param projectileID integer
- * @return number?
+ * @param projectileID ProjectileID
+ * @return AllyTeamID?
  */
 int LuaSyncedRead::GetProjectileAllyTeamID(lua_State* L)
 {
@@ -7625,7 +7625,7 @@ int LuaSyncedRead::GetProjectileAllyTeamID(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileType
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return boolean? weapon
  * @return boolean piece
  */
@@ -7646,8 +7646,8 @@ int LuaSyncedRead::GetProjectileType(lua_State* L)
  *
  * @function Spring.GetProjectileDefID
  *
- * @param projectileID integer
- * @return number?
+ * @param projectileID ProjectileID
+ * @return WeaponDefID?
  */
 int LuaSyncedRead::GetProjectileDefID(lua_State* L)
 {
@@ -7671,7 +7671,7 @@ int LuaSyncedRead::GetProjectileDefID(lua_State* L)
 /*** Returns the name of the model piece from which a piece projectile was spawned. Returns nil for other projectiles including weapons
  *
  * @function Spring.GetPieceProjectileName
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @return string? pieceName
  */
 int LuaSyncedRead::GetPieceProjectileName(lua_State* L)
@@ -7696,7 +7696,7 @@ int LuaSyncedRead::GetPieceProjectileName(lua_State* L)
 /***
  *
  * @function Spring.GetProjectileDamages
- * @param projectileID integer
+ * @param projectileID ProjectileID
  * @param tag string one of:
  *     "paralyzeDamageTime"
  *     "impulseFactor"
@@ -7886,9 +7886,9 @@ int LuaSyncedRead::GetGroundNormal(lua_State* L)
  * @function Spring.GetGroundInfo
  * @param x number
  * @param z number
- * @return number ix
- * @return number iz
- * @return number terrainTypeIndex
+ * @return integer ix
+ * @return integer iz
+ * @return integer terrainTypeIndex
  * @return string name
  * @return number metalExtraction
  * @return number hardness
@@ -7960,7 +7960,7 @@ static void ParseMapCoords(lua_State* L, const char* caller,
  * @param x2 number? world xMax (4-arg rectangle form)
  * @param z2 number? world zMax (4-arg rectangle form)
  * @return string? objectType `"feature"` or `"unit"`
- * @return number? objectID the feature or unit ID
+ * @return ObjectID? objectID the feature or unit ID
  */
 int LuaSyncedRead::GetGroundBlocked(lua_State* L)
 {
@@ -8024,8 +8024,8 @@ int LuaSyncedRead::GetGroundExtremes(lua_State* L)
 /***
  *
  * @function Spring.GetTerrainTypeData
- * @param terrainTypeInfo number
- * @return number index
+ * @param terrainTypeInfo integer
+ * @return integer index
  * @return string name
  * @return number hardness
  * @return number tankSpeed
@@ -8088,7 +8088,7 @@ int LuaSyncedRead::GetSmoothMeshHeight(lua_State* L)
 /***
  *
  * @function Spring.TestMoveOrder
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -8152,13 +8152,13 @@ int LuaSyncedRead::TestMoveOrder(lua_State* L)
 
 /***
  * @function Spring.TestBuildOrder
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param x number
  * @param y number
  * @param z number
  * @param facing Facing
  * @return BuildOrderBlockedStatus blocking
- * @return integer? featureID A reclaimable feature in the way.
+ * @return FeatureID? featureID A reclaimable feature in the way.
  */
 int LuaSyncedRead::TestBuildOrder(lua_State* L)
 {
@@ -8203,7 +8203,7 @@ int LuaSyncedRead::TestBuildOrder(lua_State* L)
 /*** Snaps a position to the building grid
  *
  * @function Spring.Pos2BuildPos
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -8232,8 +8232,8 @@ int LuaSyncedRead::Pos2BuildPos(lua_State* L)
 /***
  *
  * @function Spring.ClosestBuildPos
- * @param teamID integer
- * @param unitDefID integer
+ * @param teamID TeamID
+ * @param unitDefID UnitDefID
  * @param posX number
  * @param posY number
  * @param posZ number
@@ -8303,7 +8303,7 @@ static int GetEffectiveLosAllyTeam(lua_State* L, int arg)
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param allyTeamID integer?
+ * @param allyTeamID AllyTeamID?
  * @return boolean inLosOrRadar
  * @return boolean inLos
  * @return boolean inRadar
@@ -8343,7 +8343,7 @@ int LuaSyncedRead::GetPositionLosState(lua_State* L)
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param allyTeamID integer?
+ * @param allyTeamID AllyTeamID?
  * @return boolean
  */
 int LuaSyncedRead::IsPosInLos(lua_State* L)
@@ -8369,7 +8369,7 @@ int LuaSyncedRead::IsPosInLos(lua_State* L)
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param allyTeamID integer?
+ * @param allyTeamID AllyTeamID?
  * @return boolean
  */
 int LuaSyncedRead::IsPosInRadar(lua_State* L)
@@ -8395,7 +8395,7 @@ int LuaSyncedRead::IsPosInRadar(lua_State* L)
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param allyTeamID integer?
+ * @param allyTeamID AllyTeamID?
  * @return boolean
  */
 int LuaSyncedRead::IsPosInAirLos(lua_State* L)
@@ -8417,8 +8417,8 @@ int LuaSyncedRead::IsPosInAirLos(lua_State* L)
 /*** Get unit los state (bitmask)
  *
  * @function Spring.GetUnitLosState
- * @param unitID integer
- * @param allyTeamID integer?
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID?
  * @param raw true Return a bitmask.
  * @return LosMask|integer? bitmask A bitmask of `LosMask` bits
  */
@@ -8426,8 +8426,8 @@ int LuaSyncedRead::IsPosInAirLos(lua_State* L)
 /*** Get unit los state (table)
  *
  * @function Spring.GetUnitLosState
- * @param unitID integer
- * @param allyTeamID integer?
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID?
  * @param raw false? (Default: `false`) Return a table.
  * @return table<"los"|"radar"|"typed",boolean>? los A table of LOS state names as keys and booleans as values, or `nil` if `unitID` is invalid.
  */
@@ -8476,8 +8476,8 @@ int LuaSyncedRead::GetUnitLosState(lua_State* L)
 /***
  *
  * @function Spring.IsUnitInLos
- * @param unitID integer
- * @param allyTeamID integer? defaults to the calling widget/gadget's ally team
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID? defaults to the calling widget/gadget's ally team
  * @return boolean inLos
  */
 int LuaSyncedRead::IsUnitInLos(lua_State* L)
@@ -8500,8 +8500,8 @@ int LuaSyncedRead::IsUnitInLos(lua_State* L)
 /***
  *
  * @function Spring.IsUnitInAirLos
- * @param unitID integer
- * @param allyTeamID integer? defaults to the calling widget/gadget's ally team
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID? defaults to the calling widget/gadget's ally team
  * @return boolean inAirLos
  */
 int LuaSyncedRead::IsUnitInAirLos(lua_State* L)
@@ -8524,8 +8524,8 @@ int LuaSyncedRead::IsUnitInAirLos(lua_State* L)
 /***
  *
  * @function Spring.IsUnitInRadar
- * @param unitID integer
- * @param allyTeamID integer? defaults to the calling widget/gadget's ally team
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID? defaults to the calling widget/gadget's ally team
  * @return boolean inRadar
  */
 int LuaSyncedRead::IsUnitInRadar(lua_State* L)
@@ -8548,8 +8548,8 @@ int LuaSyncedRead::IsUnitInRadar(lua_State* L)
 /***
  *
  * @function Spring.IsUnitInJammer
- * @param unitID integer
- * @param allyTeamID integer
+ * @param unitID UnitID
+ * @param allyTeamID AllyTeamID
  * @return boolean inJammer
  */
 int LuaSyncedRead::IsUnitInJammer(lua_State* L)
@@ -8847,7 +8847,7 @@ static int GetSolidObjectPieceMatrix(lua_State* L, const CSolidObject* o)
  *
  * @function Spring.GetModelRootPiece
  * @param modelName string
- * @return number index of the root piece
+ * @return integer index of the root piece
  */
 int LuaSyncedRead::GetModelRootPiece(lua_State* L) {
 	return ::GetModelRootPiece(L, luaL_optsstring(L, 1, ""));
@@ -8857,7 +8857,7 @@ int LuaSyncedRead::GetModelRootPiece(lua_State* L) {
  *
  * @function Spring.GetModelPieceMap
  * @param modelName string
- * @return table<string,number>? pieceInfos where keys are piece names and values are indices
+ * @return table<string,integer>? pieceInfos where keys are piece names and values are indices
  */
 int LuaSyncedRead::GetModelPieceMap(lua_State* L) {
 	return ::GetModelPieceMap(L, luaL_optsstring(L, 1, ""));
@@ -8878,8 +8878,8 @@ int LuaSyncedRead::GetModelPieceList(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitRootPiece
- * @param unitID integer
- * @return number index of the root piece
+ * @param unitID UnitID
+ * @return integer index of the root piece
  */
 int LuaSyncedRead::GetUnitRootPiece(lua_State* L) {
 	return (GetSolidObjectRootPiece(L, ParseTypedUnit(L, __func__, 1)));
@@ -8888,8 +8888,8 @@ int LuaSyncedRead::GetUnitRootPiece(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPieceMap
- * @param unitID integer
- * @return table<string,number>? pieceInfos where keys are piece names and values are indices
+ * @param unitID UnitID
+ * @return table<string,integer>? pieceInfos where keys are piece names and values are indices
  */
 int LuaSyncedRead::GetUnitPieceMap(lua_State* L) {
 	return (GetSolidObjectPieceMap(L, ParseTypedUnit(L, __func__, 1)));
@@ -8899,7 +8899,7 @@ int LuaSyncedRead::GetUnitPieceMap(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPieceList
- * @param unitID integer
+ * @param unitID UnitID
  * @return string[] pieceNames
  */
 int LuaSyncedRead::GetUnitPieceList(lua_State* L) {
@@ -8910,7 +8910,7 @@ int LuaSyncedRead::GetUnitPieceList(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPieceInfo
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer
  * @return PieceInfo? pieceInfo
  */
@@ -8922,7 +8922,7 @@ int LuaSyncedRead::GetUnitPieceInfo(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPiecePosDir
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer
  * @return number? posX
  * @return number     posY
@@ -8939,7 +8939,7 @@ int LuaSyncedRead::GetUnitPiecePosDir(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPiecePosition
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer
  * @return number? posX
  * @return number     posY
@@ -8953,7 +8953,7 @@ int LuaSyncedRead::GetUnitPiecePosition(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPieceDirection
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer
  * @return number? dirX
  * @return number     dirY
@@ -8967,7 +8967,7 @@ int LuaSyncedRead::GetUnitPieceDirection(lua_State* L) {
 /***
  *
  * @function Spring.GetUnitPieceMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @param pieceIndex integer
  * @return number? m11
  * @return number m12
@@ -8993,8 +8993,8 @@ int LuaSyncedRead::GetUnitPieceMatrix(lua_State* L) {
 /***
  *
  * @function Spring.GetFeatureRootPiece
- * @param featureID integer
- * @return number index of the root piece
+ * @param featureID FeatureID
+ * @return integer index of the root piece
  */
 int LuaSyncedRead::GetFeatureRootPiece(lua_State* L) {
 	return (GetSolidObjectRootPiece(L, ParseFeature(L, __func__, 1)));
@@ -9003,8 +9003,8 @@ int LuaSyncedRead::GetFeatureRootPiece(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePieceMap
- * @param featureID integer
- * @return table<string,number> pieceInfos where keys are piece names and values are indices
+ * @param featureID FeatureID
+ * @return table<string,integer> pieceInfos where keys are piece names and values are indices
  */
 int LuaSyncedRead::GetFeaturePieceMap(lua_State* L) {
 	return (GetSolidObjectPieceMap(L, ParseFeature(L, __func__, 1)));
@@ -9014,7 +9014,7 @@ int LuaSyncedRead::GetFeaturePieceMap(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePieceList
- * @param featureID integer
+ * @param featureID FeatureID
  * @return string[] pieceNames
  */
 int LuaSyncedRead::GetFeaturePieceList(lua_State* L) {
@@ -9025,7 +9025,7 @@ int LuaSyncedRead::GetFeaturePieceList(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePieceInfo
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceIndex integer
  * @return PieceInfo? pieceInfo
  */
@@ -9037,7 +9037,7 @@ int LuaSyncedRead::GetFeaturePieceInfo(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePiecePosDir
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceIndex integer
  * @return number? posX
  * @return number     posY
@@ -9054,7 +9054,7 @@ int LuaSyncedRead::GetFeaturePiecePosDir(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePiecePosition
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceIndex integer
  * @return number? posX
  * @return number     posY
@@ -9068,7 +9068,7 @@ int LuaSyncedRead::GetFeaturePiecePosition(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePieceDirection
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceIndex integer
  * @return number? dirX
  * @return number     dirY
@@ -9082,7 +9082,7 @@ int LuaSyncedRead::GetFeaturePieceDirection(lua_State* L) {
 /***
  *
  * @function Spring.GetFeaturePieceMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @param pieceIndex integer
  * @return number? m11
  * @return number m12
@@ -9109,14 +9109,14 @@ int LuaSyncedRead::GetFeaturePieceMatrix(lua_State* L) {
  *
  * @function Spring.GetUnitScriptPiece
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer[] pieceIndices
  */
 /***
  *
  * @function Spring.GetUnitScriptPiece
  *
- * @param unitID integer
+ * @param unitID UnitID
  * @param scriptPiece integer
  * @return integer pieceIndex
  */
@@ -9155,9 +9155,9 @@ int LuaSyncedRead::GetUnitScriptPiece(lua_State* L)
  *
  * @function Spring.GetUnitScriptNames
  *
- * @param unitID integer
+ * @param unitID UnitID
  *
- * @return table<string,number> where keys are piece names and values are piece indices
+ * @return table<string,integer> where keys are piece names and values are piece indices
  */
 int LuaSyncedRead::GetUnitScriptNames(lua_State* L)
 {
@@ -9402,7 +9402,7 @@ int LuaSyncedRead::TraceRayGroundBetweenPositions(lua_State* L)
  *
  * @function Spring.GetRadarErrorParams
  *
- * @param allyTeamID integer
+ * @param allyTeamID AllyTeamID
  *
  * @return number? radarErrorSize actual radar error size (when allyTeamID is allied to current team) or base radar error size
  * @return number baseRadarErrorSize

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -472,7 +472,7 @@ static inline CUnit* ParseSelectUnit(lua_State* L, const char* caller, int index
  *
  * @function Spring.Ping
  *
- * @param pingTag number?
+ * @param pingTag integer?
  *
  * @return nil
  */
@@ -634,7 +634,7 @@ int LuaUnsyncedCtrl::SendSpectatorChat(lua_State* L) {
  *
  * @function Spring.SendPrivateChat
  * @param message string
- * @param playerID integer
+ * @param playerID PlayerID
  * @return nil
  */
 int LuaUnsyncedCtrl::SendPrivateChat(lua_State* L) {
@@ -691,7 +691,7 @@ int LuaUnsyncedCtrl::SendMessageToSpectators(lua_State* L)
 
 
 /*** @function Spring.SendMessageToPlayer
- * @param playerID integer
+ * @param playerID PlayerID
  * @param message string
  * @return nil
  */
@@ -705,7 +705,7 @@ int LuaUnsyncedCtrl::SendMessageToPlayer(lua_State* L)
 
 
 /*** @function Spring.SendMessageToTeam
- * @param teamID integer
+ * @param teamID TeamID
  * @param message string
  * @return nil
  */
@@ -719,7 +719,7 @@ int LuaUnsyncedCtrl::SendMessageToTeam(lua_State* L)
 
 
 /*** @function Spring.SendMessageToAllyTeam
- * @param allyID integer
+ * @param allyID AllyTeamID
  * @param message string
  * @return nil
  */
@@ -1101,11 +1101,11 @@ int LuaUnsyncedCtrl::AddWorldText(lua_State* L)
 /***
  *
  * @function Spring.AddWorldUnit
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param posX number
  * @param posY number
  * @param posZ number
- * @param teamID integer
+ * @param teamID TeamID
  * @param facing FacingInteger
  * @return nil
  */
@@ -1133,16 +1133,16 @@ int LuaUnsyncedCtrl::AddWorldUnit(lua_State* L)
 
 /***
  * @function Spring.DrawUnitCommands
- * @param unitID integer
+ * @param unitID UnitID
  */
 /***
  * @function Spring.DrawUnitCommands
- * @param unitIDs integer[] Unit ids.
+ * @param unitIDs UnitID[] Unit ids.
  * @param tableOrArray false|nil Set to `true` if the unit IDs should be read from the keys of `unitIDs`.
  */
 /***
  * @function Spring.DrawUnitCommands
- * @param unitIDs table<integer, any> Table with unit IDs as keys.
+ * @param unitIDs table<UnitID, any> Table with unit IDs as keys.
  * @param tableOrArray true Set to `false` if the unit IDs should be read from the values of `unitIDs`.
  * @return nil
  */
@@ -1390,7 +1390,7 @@ int LuaUnsyncedCtrl::SetDollyCameraPosition(lua_State* L)
 /*** Sets Dolly Camera movement Curve
  *
  * @function Spring.SetDollyCameraCurve
- * @param degree number
+ * @param degree integer
  * @param cpoints ControlPoint[] NURBS control point positions.
  * @param knots table
  * @return nil
@@ -1428,7 +1428,7 @@ int LuaUnsyncedCtrl::SetDollyCameraMode(lua_State* L)
 /*** Sets Dolly Camera movement curve to world relative or look target relative
  *
  * @function Spring.SetDollyCameraRelativeMode
- * @param relativeMode number `1` world, `2` look target
+ * @param relativeMode integer `1` world, `2` look target
  * @return nil
  */
 int LuaUnsyncedCtrl::SetDollyCameraRelativeMode(lua_State* L)
@@ -1444,7 +1444,7 @@ int LuaUnsyncedCtrl::SetDollyCameraRelativeMode(lua_State* L)
 /*** Sets Dolly Camera Look Curve
  *
  * @function Spring.SetDollyCameraLookCurve
- * @param degree number
+ * @param degree integer
  * @param cpoints ControlPoint[] NURBS control point positions.
  * @param knots table
  * @return nil
@@ -1488,7 +1488,7 @@ int LuaUnsyncedCtrl::SetDollyCameraLookPosition(lua_State* L)
 /*** Sets target unit for Dolly Camera to look towards
  *
  * @function Spring.SetDollyCameraLookUnit
- * @param unitID integer The unit to look at.
+ * @param unitID UnitID The unit to look at.
  * @return nil
  */
 int LuaUnsyncedCtrl::SetDollyCameraLookUnit(lua_State* L)
@@ -1511,7 +1511,7 @@ int LuaUnsyncedCtrl::SetDollyCameraLookUnit(lua_State* L)
 /*** Selects a single unit
  *
  * @function Spring.SelectUnit
- * @param unitID integer?
+ * @param unitID UnitID?
  * @param append boolean? (Default: `false`) Append to current selection.
  * @return nil
  */
@@ -1535,7 +1535,7 @@ int LuaUnsyncedCtrl::SelectUnit(lua_State* L)
 /***
  *
  * @function Spring.DeselectUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @return nil
  */
 int LuaUnsyncedCtrl::DeselectUnit(lua_State* L)
@@ -1577,7 +1577,7 @@ static int TableSelectionCommonFunc(lua_State* L, int unitIndexInTable, bool isS
 /*** Deselects multiple units.
  *
  * @function Spring.DeselectUnitArray
- * @param unitIDs integer[] Table with unit IDs as values.
+ * @param unitIDs UnitID[] Table with unit IDs as values.
  * @return nil
  */
 int LuaUnsyncedCtrl::DeselectUnitArray(lua_State* L)
@@ -1588,7 +1588,7 @@ int LuaUnsyncedCtrl::DeselectUnitArray(lua_State* L)
 /*** Deselects multiple units.
  *
  * @function Spring.DeselectUnitMap
- * @param unitMap table<integer, any> Table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> Table with unit IDs as keys.
  * @return nil
  */
 int LuaUnsyncedCtrl::DeselectUnitMap(lua_State* L)
@@ -1599,7 +1599,7 @@ int LuaUnsyncedCtrl::DeselectUnitMap(lua_State* L)
 /*** Selects multiple units, or appends to selection. Accepts a table with unitIDs as values
  *
  * @function Spring.SelectUnitArray
- * @param unitIDs integer[] Table with unit IDs as values.
+ * @param unitIDs UnitID[] Table with unit IDs as values.
  * @param append boolean? (Default: `false`) append to current selection
  * @return nil
  */
@@ -1611,7 +1611,7 @@ int LuaUnsyncedCtrl::SelectUnitArray(lua_State* L)
 /*** Selects multiple units, or appends to selection. Accepts a table with unitIDs as keys
  *
  * @function Spring.SelectUnitMap
- * @param unitMap table<integer, any> Table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> Table with unit IDs as keys.
  * @param append boolean? (Default: `false`) append to current selection
  * @return nil
  */
@@ -1798,7 +1798,7 @@ int LuaUnsyncedCtrl::AddMapLight(lua_State* L)
  * requires MaxDynamicMapLights > 0
  *
  * @param lightParams LightParams
- * @return number lightHandle
+ * @return integer lightHandle
  */
 int LuaUnsyncedCtrl::AddModelLight(lua_State* L)
 {
@@ -1821,7 +1821,7 @@ int LuaUnsyncedCtrl::AddModelLight(lua_State* L)
 /***
  * @function Spring.UpdateMapLight
  *
- * @param lightHandle number
+ * @param lightHandle integer
  * @param lightParams LightParams
  * @return boolean success
  */
@@ -1843,7 +1843,7 @@ int LuaUnsyncedCtrl::UpdateMapLight(lua_State* L)
 /***
  * @function Spring.UpdateModelLight
  *
- * @param lightHandle number
+ * @param lightHandle integer
  * @param lightParams LightParams
  * @return boolean success
  */
@@ -1923,8 +1923,8 @@ static bool AddLightTrackingTarget(lua_State* L, GL::Light* light, bool trackEna
  *
  * @function Spring.SetMapLightTrackingState
  *
- * @param lightHandle number
- * @param unitOrProjectileID integer
+ * @param lightHandle integer
+ * @param unitOrProjectileID UnitID|ProjectileID
  * @param enableTracking boolean?
  * @param unitOrProjectile boolean?
  * @return boolean success
@@ -1959,8 +1959,8 @@ int LuaUnsyncedCtrl::SetMapLightTrackingState(lua_State* L)
  *
  * @function Spring.SetModelLightTrackingState
  *
- * @param lightHandle number
- * @param unitOrProjectileID integer
+ * @param lightHandle integer
+ * @param unitOrProjectileID UnitID|ProjectileID
  * @param enableTracking boolean?
  * @param unitOrProjectile boolean?
  * @return boolean success
@@ -2027,8 +2027,8 @@ int LuaUnsyncedCtrl::SetMapShader(lua_State* L)
 
 
 /*** @function Spring.SetMapSquareTexture
- * @param texSqrX number
- * @param texSqrY number
+ * @param texSqrX integer
+ * @param texSqrY integer
  * @param luaTexName string
  * @return boolean success
  */
@@ -2168,7 +2168,7 @@ int LuaUnsyncedCtrl::SetSkyBoxTexture(lua_State* L)
 /***
  *
  * @function Spring.SetUnitNoDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @param noDraw boolean
  * @return nil
  */
@@ -2187,7 +2187,7 @@ int LuaUnsyncedCtrl::SetUnitNoDraw(lua_State* L)
 /***
  *
  * @function Spring.SetUnitEngineDrawMask
- * @param unitID integer
+ * @param unitID UnitID
  * @param drawMask number
  * @return nil
  */
@@ -2206,7 +2206,7 @@ int LuaUnsyncedCtrl::SetUnitEngineDrawMask(lua_State* L)
 /***
  *
  * @function Spring.SetUnitAlwaysUpdateMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @param alwaysUpdateMatrix boolean
  * @return nil
  */
@@ -2225,7 +2225,7 @@ int LuaUnsyncedCtrl::SetUnitAlwaysUpdateMatrix(lua_State* L)
 /***
  *
  * @function Spring.SetUnitNoMinimap
- * @param unitID integer
+ * @param unitID UnitID
  * @param unitNoMinimap boolean
  * @return nil
  */
@@ -2273,7 +2273,7 @@ int LuaUnsyncedCtrl::SetMiniMapRotation(lua_State* L)
 /***
  *
  * @function Spring.SetUnitNoGroup
- * @param unitID integer
+ * @param unitID UnitID
  * @param unitNoGroup boolean Whether unit can be added to selection groups
  */
 int LuaUnsyncedCtrl::SetUnitNoGroup(lua_State* L)
@@ -2295,7 +2295,7 @@ int LuaUnsyncedCtrl::SetUnitNoGroup(lua_State* L)
 /***
  *
  * @function Spring.SetUnitNoSelect
- * @param unitID integer
+ * @param unitID UnitID
  * @param unitNoSelect boolean whether unit can be selected or not
  * @return nil
  */
@@ -2323,7 +2323,7 @@ int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
 /***
  *
  * @function Spring.SetUnitLeaveTracks
- * @param unitID integer
+ * @param unitID UnitID
  * @param unitLeaveTracks boolean whether unit leaves tracks on movement
  * @return nil
  */
@@ -2342,16 +2342,16 @@ int LuaUnsyncedCtrl::SetUnitLeaveTracks(lua_State* L)
 /***
  *
  * @function Spring.SetUnitSelectionVolumeData
- * @param unitID integer
+ * @param unitID UnitID
  * @param scaleX number
  * @param scaleY number
  * @param scaleZ number
  * @param offsetX number
  * @param offsetY number
  * @param offsetZ number
- * @param vType number
- * @param tType number
- * @param Axis number
+ * @param vType integer
+ * @param tType integer
+ * @param Axis integer
  * @return nil
  */
 int LuaUnsyncedCtrl::SetUnitSelectionVolumeData(lua_State* L)
@@ -2375,7 +2375,7 @@ int LuaUnsyncedCtrl::SetUnitSelectionVolumeData(lua_State* L)
  *
  * @function Spring.SetFeatureNoDraw
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param noDraw boolean
  *
  * @return nil
@@ -2395,7 +2395,7 @@ int LuaUnsyncedCtrl::SetFeatureNoDraw(lua_State* L)
 /***
  *
  * @function Spring.SetFeatureEngineDrawMask
- * @param featureID integer
+ * @param featureID FeatureID
  * @param engineDrawMask number
  * @return nil
  */
@@ -2414,7 +2414,7 @@ int LuaUnsyncedCtrl::SetFeatureEngineDrawMask(lua_State* L)
 /***
  *
  * @function Spring.SetFeatureAlwaysUpdateMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @param alwaysUpdateMat number
  * @return nil
  */
@@ -2434,7 +2434,7 @@ int LuaUnsyncedCtrl::SetFeatureAlwaysUpdateMatrix(lua_State* L)
  *
  * @function Spring.SetFeatureFade
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param allow boolean
  *
  * @return nil
@@ -2455,16 +2455,16 @@ int LuaUnsyncedCtrl::SetFeatureFade(lua_State* L)
  *
  * @function Spring.SetFeatureSelectionVolumeData
  *
- * @param featureID integer
+ * @param featureID FeatureID
  * @param scaleX number
  * @param scaleY number
  * @param scaleZ number
  * @param offsetX number
  * @param offsetY number
  * @param offsetZ number
- * @param vType number
- * @param tType number
- * @param Axis number
+ * @param vType integer
+ * @param tType integer
+ * @param Axis integer
  * @return nil
  */
 int LuaUnsyncedCtrl::SetFeatureSelectionVolumeData(lua_State* L)
@@ -2548,7 +2548,7 @@ int LuaUnsyncedCtrl::FreeUnitIcon(lua_State* L)
  * @function Spring.UnitIconSetDraw
  * Use Spring.SetUnitIconDraw instead.
  * @deprecated
- * @param unitID integer
+ * @param unitID UnitID
  * @param drawIcon boolean
  * @return nil
  */
@@ -2562,7 +2562,7 @@ int LuaUnsyncedCtrl::UnitIconSetDraw(lua_State* L)
 /***
  *
  * @function Spring.SetUnitIconDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @param drawIcon boolean
  * @return nil
  */
@@ -2580,7 +2580,7 @@ int LuaUnsyncedCtrl::SetUnitIconDraw(lua_State* L)
 /***
  *
  * @function Spring.SetUnitIcon
- * @param unitID integer
+ * @param unitID UnitID
  * @param iconName string? supply nil to reset to the default
  * @return nil
  */
@@ -2616,7 +2616,7 @@ int LuaUnsyncedCtrl::SetUnitIcon(lua_State* L)
  *
  * @function Spring.SetUnitDefIcon
  *
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param iconName string
  *
  * @return nil
@@ -2664,7 +2664,7 @@ int LuaUnsyncedCtrl::SetUnitDefIcon(lua_State* L)
  *
  * @function Spring.SetUnitDefImage
  *
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @param image string? luaTexture|texFile
  *
  * @return nil
@@ -2862,8 +2862,8 @@ static int SetActiveCommandByAction(lua_State* L)
  */
 
 /*** @function Spring.SetActiveCommand
- * @param cmdIndex number
- * @param button number? (Default: `1`)
+ * @param cmdIndex integer
+ * @param button integer? (Default: `1`)
  * @param leftClick boolean?
  * @param rightClick boolean?
  * @param alt boolean?
@@ -2963,7 +2963,7 @@ int LuaUnsyncedCtrl::SetBoxSelectionByEngine(lua_State* L)
 /***
  *
  * @function Spring.SetTeamColor
- * @param teamID integer
+ * @param teamID TeamID
  * @param r number
  * @param g number
  * @param b number
@@ -3014,7 +3014,7 @@ int LuaUnsyncedCtrl::SetCustomPaletteColor(lua_State* L)
  * Sets a custom color for a unit from the palette. Custom assignments are permanent
  * until explicitly reset by passing nil, and are NOT affected by team changes.
  * @function Spring.SetUnitPaletteIndex
- * @param unitID integer
+ * @param unitID UnitID
  * @param customIndex integer? [0..MAX_CUSTOM_COLORS) index into custom palette, or nil to reset to team color
  * @return nil
  */
@@ -3040,7 +3040,7 @@ int LuaUnsyncedCtrl::SetUnitPaletteIndex(lua_State* L)
  * Sets a custom color for a feature from the palette. Custom assignments are permanent
  * until explicitly reset by passing nil, and are NOT affected by team changes.
  * @function Spring.SetFeaturePaletteIndex
- * @param featureID integer
+ * @param featureID FeatureID
  * @param customIndex integer? [0..MAX_CUSTOM_COLORS) index into custom palette, or nil to reset to team color
  * @return nil
  */
@@ -3165,8 +3165,8 @@ int LuaUnsyncedCtrl::SetCustomCommandDrawData(lua_State* L)
 
 
 /*** @function Spring.WarpMouse
- * @param x number
- * @param y number
+ * @param x integer
+ * @param y integer
  * @return nil
  */
 int LuaUnsyncedCtrl::WarpMouse(lua_State* L)
@@ -3434,8 +3434,8 @@ int LuaUnsyncedCtrl::Quit(lua_State* L)
 /***
  *
  * @function Spring.SetUnitGroup
- * @param unitID integer
- * @param groupID integer the group number to be assigned, or -1 for deassignment
+ * @param unitID UnitID
+ * @param groupID GroupID the group number to be assigned, or -1 for deassignment
  * @return nil
  */
 int LuaUnsyncedCtrl::SetUnitGroup(lua_State* L)
@@ -3555,7 +3555,7 @@ int LuaUnsyncedCtrl::GiveOrder(lua_State* L)
  * Give order to specific unit.
  *
  * @function Spring.GiveOrderToUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -3589,7 +3589,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnit(lua_State* L)
  * Give order to multiple units, specified by table keys.
  *
  * @function Spring.GiveOrderToUnitMap
- * @param unitMap table<integer, any> A table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> A table with unit IDs as keys.
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -3623,7 +3623,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnitMap(lua_State* L)
  * Give order to an array of units.
  *
  * @function Spring.GiveOrderToUnitArray
- * @param unitIDs integer[] Array of unit IDs.
+ * @param unitIDs UnitID[] Array of unit IDs.
  * @param cmdID CMD|integer The command ID.
  * @param params CreateCommandParams? Parameters for the given command.
  * @param options CreateCommandOptions?
@@ -3655,7 +3655,7 @@ int LuaUnsyncedCtrl::GiveOrderToUnitArray(lua_State* L)
 /***
  *
  * @function Spring.GiveOrderArrayToUnit
- * @param unitID integer Unit ID.
+ * @param unitID UnitID Unit ID.
  * @param commands CreateCommand[]
  * @return boolean ordersGiven `true` if any orders were sent, otherwise `false`.
  */
@@ -3689,7 +3689,7 @@ int LuaUnsyncedCtrl::GiveOrderArrayToUnit(lua_State* L)
 /***
  *
  * @function Spring.GiveOrderArrayToUnitMap
- * @param unitMap table<integer, any> A table with unit IDs as keys.
+ * @param unitMap table<UnitID, any> A table with unit IDs as keys.
  * @param commands CreateCommand[]
  * @return boolean ordersGiven `true` if any orders were sent, otherwise `false`.
  */
@@ -3722,7 +3722,7 @@ int LuaUnsyncedCtrl::GiveOrderArrayToUnitMap(lua_State* L)
 
 /***
  * @function Spring.GiveOrderArrayToUnitArray
- * @param unitIDs integer[] Array of unit IDs.
+ * @param unitIDs UnitID[] Array of unit IDs.
  * @param commands CreateCommand[]
  * @param pairwise boolean? (Default: `false`) When `false`, assign all commands to each unit.
  *
@@ -3765,7 +3765,7 @@ int LuaUnsyncedCtrl::GiveOrderArrayToUnitArray(lua_State* L)
 /***
  *
  * @function Spring.SetBuildSpacing
- * @param spacing number
+ * @param spacing integer
  * @return nil
  */
 int LuaUnsyncedCtrl::SetBuildSpacing(lua_State* L)
@@ -3917,7 +3917,7 @@ int LuaUnsyncedCtrl::SetShareLevel(lua_State* L)
  *
  * @function Spring.ShareResources
  *
- * @param teamID integer
+ * @param teamID TeamID
  * @param units string
  * @return nil
  */
@@ -3926,7 +3926,7 @@ int LuaUnsyncedCtrl::SetShareLevel(lua_State* L)
  *
  * @function Spring.ShareResources
  *
- * @param teamID integer
+ * @param teamID TeamID
  * @param resource string metal | energy
  * @param amount number
  * @return nil
@@ -4007,7 +4007,7 @@ int LuaUnsyncedCtrl::SetLastMessagePosition(lua_State* L)
  * @param z number
  * @param text string? (Default: `""`)
  * @param localOnly boolean?
- * @param playerID number? Local labels pretend they are from this player
+ * @param playerID PlayerID? Local labels pretend they are from this player
  * @return nil
  */
 int LuaUnsyncedCtrl::MarkerAddPoint(lua_State* L)
@@ -4039,7 +4039,7 @@ int LuaUnsyncedCtrl::MarkerAddPoint(lua_State* L)
  * @param y2 number
  * @param z2 number
  * @param localOnly boolean? (Default: `false`)
- * @param playerId number?
+ * @param playerId PlayerID?
  * @return nil
  */
 int LuaUnsyncedCtrl::MarkerAddLine(lua_State* L)
@@ -4074,7 +4074,7 @@ int LuaUnsyncedCtrl::MarkerAddLine(lua_State* L)
  * @param z number
  * @param unused nil This argument is ignored.
  * @param localOnly boolean? (Default: `false`) do not issue a network message, erase only for the current player
- * @param playerId number? when not specified it uses the issuer playerId
+ * @param playerId PlayerID? when not specified it uses the issuer playerId
  * @param alwaysErase boolean? (Default: `false`) erase any marker when `localOnly` and current player is spectating. Allows spectators to erase players markers locally
  * @return nil
  */
@@ -4371,7 +4371,7 @@ int LuaUnsyncedCtrl::ForceTesselationUpdate(lua_State* L)
 
 
 /*** @function Spring.SendSkirmishAIMessage
- * @param aiTeam number
+ * @param aiTeam TeamID
  * @param message string
  * @return boolean? ai_processed
  */
@@ -4842,7 +4842,7 @@ int LuaUnsyncedCtrl::SetWaterParams(lua_State* L)
  * Allow the engine to load the unit's model (and texture) in a background thread.
  * Wreckages and buildOptions of a unit are automatically preloaded.
  *
- * @param unitDefID integer
+ * @param unitDefID UnitDefID
  * @return nil
  */
 int LuaUnsyncedCtrl::PreloadUnitDefModel(lua_State* L) {
@@ -4858,7 +4858,7 @@ int LuaUnsyncedCtrl::PreloadUnitDefModel(lua_State* L) {
 
 /*** @function Spring.PreloadFeatureDefModel
  *
- * @param featureDefID integer
+ * @param featureDefID FeatureDefID
  * @return nil
  */
 int LuaUnsyncedCtrl::PreloadFeatureDefModel(lua_State* L) {
@@ -4927,7 +4927,7 @@ int LuaUnsyncedCtrl::LoadModelTextures(lua_State* L)
 /***
  *
  * @function Spring.CreateGroundDecal
- * @return nil|number decalID
+ * @return DecalID? decalID
  */
 int LuaUnsyncedCtrl::CreateGroundDecal(lua_State* L)
 {
@@ -4943,7 +4943,7 @@ int LuaUnsyncedCtrl::CreateGroundDecal(lua_State* L)
 /***
  *
  * @function Spring.DestroyGroundDecal
- * @param decalID integer
+ * @param decalID DecalID
  * @return boolean delSuccess
  */
 int LuaUnsyncedCtrl::DestroyGroundDecal(lua_State* L)
@@ -4956,7 +4956,7 @@ int LuaUnsyncedCtrl::DestroyGroundDecal(lua_State* L)
 /***
  *
  * @function Spring.SetGroundDecalPosAndDims
- * @param decalID integer
+ * @param decalID DecalID
  * @param midPosX number? (Default: currMidPosX)
  * @param midPosZ number? (Default: currMidPosZ)
  * @param sizeX number? (Default: currSizeX)
@@ -5009,7 +5009,7 @@ int LuaUnsyncedCtrl::SetGroundDecalPosAndDims(lua_State* L)
  *
  * Use for non-rectangular decals
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @param posTL xz? (Default: currPosTL)
  * @param posTR xz? (Default: currPosTR)
  * @param posBR xz? (Default: currPosBR)
@@ -5042,7 +5042,7 @@ int LuaUnsyncedCtrl::SetGroundDecalQuadPosAndHeight(lua_State* L)
 /***
  *
  * @function Spring.SetGroundDecalRotation
- * @param decalID integer
+ * @param decalID DecalID
  * @param rot number? (Default: random) in radians
  * @return boolean decalSet
  */
@@ -5064,7 +5064,7 @@ int LuaUnsyncedCtrl::SetGroundDecalRotation(lua_State* L)
 /***
  *
  * @function Spring.SetGroundDecalTexture
- * @param decalID integer
+ * @param decalID DecalID
  * @param textureName string The texture has to be on the atlas which seems to mean it's defined as an explosion, unit tracks, or building plate decal on some unit already (no arbitrary textures)
  * @param isMainTex boolean? (Default: `true`) If false, it sets the normals/glow map
  * @return nil|boolean decalSet
@@ -5080,7 +5080,7 @@ int LuaUnsyncedCtrl::SetGroundDecalTexture(lua_State* L)
 /***
  *
  * @function Spring.SetGroundDecalTextureParams
- * @param decalID integer
+ * @param decalID DecalID
  * @param texWrapDistance number? (Default: currTexWrapDistance) if non-zero sets the mode to repeat the texture along the left-right direction of the decal every texWrapFactor elmos
  * @param texTraveledDistance number? (Default: currTexTraveledDistance) shifts the texture repetition defined by texWrapFactor so the texture of a next line in the continuous multiline can start where the previous finished. For that it should collect all elmo lengths of the previously set multiline segments.
  * @return nil|boolean decalSet
@@ -5104,7 +5104,7 @@ int LuaUnsyncedCtrl::SetGroundDecalTextureParams(lua_State* L)
 /***
  *
  * @function Spring.SetGroundDecalAlpha
- * @param decalID integer
+ * @param decalID DecalID
  * @param alpha number? (Default: currAlpha) Between 0 and 1
  * @param alphaFalloff number? (Default: currAlphaFalloff) Between 0 and 1, per second
  * @return boolean decalSet
@@ -5129,7 +5129,7 @@ int LuaUnsyncedCtrl::SetGroundDecalAlpha(lua_State* L)
  * @function Spring.SetGroundDecalNormal
  * Sets projection cube normal to orient in 3D space.
  * In case the normal (0,0,0) then normal is picked from the terrain
- * @param decalID integer
+ * @param decalID DecalID
  * @param normalX number? (Default: `0`)
  * @param normalY number? (Default: `0`)
  * @param normalZ number? (Default: `0`)
@@ -5161,7 +5161,7 @@ int LuaUnsyncedCtrl::SetGroundDecalNormal(lua_State* L)
  * @function Spring.SetGroundDecalTint
  * Sets the tint of the ground decal. Color = 2 * textureColor * tintColor
  * Respectively a color of (0.5, 0.5, 0.5, 0.5) is effectively no tint
- * @param decalID integer
+ * @param decalID DecalID
  * @param tintColR number? (Default: curTintColR)
  * @param tintColG number? (Default: curTintColG)
  * @param tintColB number? (Default: curTintColB)
@@ -5192,7 +5192,7 @@ int LuaUnsyncedCtrl::SetGroundDecalTint(lua_State* L)
  *
  * @function Spring.SetGroundDecalMisc
  * Sets varios secondary parameters of a decal
- * @param decalID integer
+ * @param decalID DecalID
  * @param dotElimExp number? (Default: curValue) pow(max(dot(decalProjVector, SurfaceNormal), 0.0), dotElimExp), used to reduce decal artifacts on surfaces non-collinear with the projection vector
  * @param refHeight number? (Default: curValue)
  * @param minHeight number? (Default: curValue)
@@ -5224,7 +5224,7 @@ int LuaUnsyncedCtrl::SetGroundDecalMisc(lua_State* L)
  *
  * Use separate min and max for "gradient" style decals such as tank tracks
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @param creationFrameMin number? (Default: currCreationFrameMin)
  * @param creationFrameMax number? (Default: currCreationFrameMax)
  * @return boolean decalSet
@@ -5250,7 +5250,7 @@ int LuaUnsyncedCtrl::SetGroundDecalCreationFrame(lua_State* L)
  *
  * Set decal glow parameters
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @param glow number? Between 0 and 1 (Default: currGlow)
  * @param glowFalloff number? Between 0 and 1, per second (Default: currGlowFallOff)
  * @return boolean decalSet
@@ -5276,7 +5276,7 @@ int LuaUnsyncedCtrl::SetGroundDecalGlowParams(lua_State* L)
  *
  * Set decal user data. Useful in conjunction with custom decal shaders
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @param udQuad integer vec4 index, must be within [0;1] for now
  * @param x number? Any valid Lua float number (Default: current data)
  * @param y number? Any valid Lua float number (Default: current data)
@@ -5315,10 +5315,10 @@ int LuaUnsyncedCtrl::SetGroundDecalUserData(lua_State* L)
 /***
  *
  * @function Spring.SDLSetTextInputRect
- * @param x number
- * @param y number
- * @param width number
- * @param height number
+ * @param x integer
+ * @param y integer
+ * @param width integer
+ * @param height integer
  * @return nil
  */
 int LuaUnsyncedCtrl::SDLSetTextInputRect(lua_State* L)
@@ -5363,11 +5363,11 @@ int LuaUnsyncedCtrl::SDLStopTextInput(lua_State* L)
 /***
  *
  * @function Spring.SetWindowGeometry
- * @param displayIndex number
- * @param winRelPosX number
- * @param winRelPosY number
- * @param winSizeX number
- * @param winSizeY number
+ * @param displayIndex integer
+ * @param winRelPosX integer
+ * @param winRelPosY integer
+ * @param winSizeX integer
+ * @param winSizeY integer
  * @param fullScreen boolean
  * @param borderless boolean
  * @return nil

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -610,7 +610,7 @@ int LuaUnsyncedRead::GetMenuName(lua_State* L)
  * @return number max_dt
  * @return number time_pct
  * @return number peak_pct
- * @return table<number,number>? frameData Table where key is the frame index and value is duration.
+ * @return table<integer,number>? frameData Table where key is the frame index and value is duration.
  */
 int LuaUnsyncedRead::GetProfilerTimeRecord(lua_State* L)
 {
@@ -871,7 +871,7 @@ int LuaUnsyncedRead::DiffTimers(lua_State* L)
  *
  * @function Spring.GetNumDisplays
  *
- * @return number numDisplays as returned by `SDL_GetNumVideoDisplays`
+ * @return integer numDisplays as returned by `SDL_GetNumVideoDisplays`
  */
 int LuaUnsyncedRead::GetNumDisplays(lua_State* L)
 {
@@ -884,10 +884,10 @@ int LuaUnsyncedRead::GetNumDisplays(lua_State* L)
  *
  * @function Spring.GetViewGeometry
  *
- * @return number viewSizeX in px
- * @return number viewSizeY in px
- * @return number viewPosX offset from leftmost screen left border in px
- * @return number viewPosY offset from bottommost screen bottom border in px
+ * @return integer viewSizeX in px
+ * @return integer viewSizeY in px
+ * @return integer viewPosX offset from leftmost screen left border in px
+ * @return integer viewPosY offset from bottommost screen bottom border in px
  */
 int LuaUnsyncedRead::GetViewGeometry(lua_State* L)
 {
@@ -903,10 +903,10 @@ int LuaUnsyncedRead::GetViewGeometry(lua_State* L)
  *
  * @function Spring.GetDualViewGeometry
  *
- * @return number dualViewSizeX in px
- * @return number dualViewSizeY in px
- * @return number dualViewPosX offset from leftmost screen left border in px
- * @return number dualViewPosY offset from bottommost screen bottom border in px
+ * @return integer dualViewSizeX in px
+ * @return integer dualViewSizeY in px
+ * @return integer dualViewPosX offset from leftmost screen left border in px
+ * @return integer dualViewPosY offset from bottommost screen bottom border in px
  */
 int LuaUnsyncedRead::GetDualViewGeometry(lua_State* L)
 {
@@ -922,14 +922,14 @@ int LuaUnsyncedRead::GetDualViewGeometry(lua_State* L)
  *
  * @function Spring.GetWindowGeometry
  *
- * @return number winSizeX in px
- * @return number winSizeY in px
- * @return number winPosX in px
- * @return number winPosY in px
- * @return number windowBorderTop in px
- * @return number windowBorderLeft in px
- * @return number windowBorderBottom in px
- * @return number windowBorderRight in px
+ * @return integer winSizeX in px
+ * @return integer winSizeY in px
+ * @return integer winPosX in px
+ * @return integer winPosY in px
+ * @return integer windowBorderTop in px
+ * @return integer windowBorderLeft in px
+ * @return integer windowBorderBottom in px
+ * @return integer windowBorderRight in px
  */
 int LuaUnsyncedRead::GetWindowGeometry(lua_State* L)
 {
@@ -951,10 +951,10 @@ int LuaUnsyncedRead::GetWindowGeometry(lua_State* L)
 /*** Get main window display mode
  *
  * @function Spring.GetWindowDisplayMode
- * @return number width in px
- * @return number height in px
- * @return number bits per pixel
- * @return number refresh rate in Hz
+ * @return integer width in px
+ * @return integer height in px
+ * @return integer bits per pixel
+ * @return integer refresh rate in Hz
  */
 int LuaUnsyncedRead::GetWindowDisplayMode(lua_State* L)
 {
@@ -975,21 +975,21 @@ int LuaUnsyncedRead::GetWindowDisplayMode(lua_State* L)
  *
  * @function Spring.GetScreenGeometry
  *
- * @param displayIndex number? (Default: `-1`)
+ * @param displayIndex integer? (Default: `-1`)
  * @param queryUsable boolean? (Default: `false`)
  *
- * @return number screenSizeX in px
- * @return number screenSizeY in px
- * @return number screenPosX in px
- * @return number screenPosY in px
- * @return number windowBorderTop in px
- * @return number windowBorderLeft in px
- * @return number windowBorderBottom in px
- * @return number windowBorderRight in px
- * @return number? screenUsableSizeX in px
- * @return number? screenUsableSizeY in px
- * @return number? screenUsablePosX in px
- * @return number? screenUsablePosY in px
+ * @return integer screenSizeX in px
+ * @return integer screenSizeY in px
+ * @return integer screenPosX in px
+ * @return integer screenPosY in px
+ * @return integer windowBorderTop in px
+ * @return integer windowBorderLeft in px
+ * @return integer windowBorderBottom in px
+ * @return integer windowBorderRight in px
+ * @return integer? screenUsableSizeX in px
+ * @return integer? screenUsableSizeY in px
+ * @return integer? screenUsablePosX in px
+ * @return integer? screenUsablePosY in px
  */
 int LuaUnsyncedRead::GetScreenGeometry(lua_State* L)
 {
@@ -1032,10 +1032,10 @@ int LuaUnsyncedRead::GetScreenGeometry(lua_State* L)
  *
  * @function Spring.GetMiniMapGeometry
  *
- * @return number minimapPosX in px
- * @return number minimapPosY in px
- * @return number minimapSizeX in px
- * @return number minimapSizeY in px
+ * @return integer minimapPosX in px
+ * @return integer minimapPosY in px
+ * @return integer minimapSizeX in px
+ * @return integer minimapSizeY in px
  * @return boolean minimized
  * @return boolean maximized
  */
@@ -1143,8 +1143,8 @@ int LuaUnsyncedRead::GetDrawSelectionInfo(lua_State* L)
  *
  * @function Spring.IsAboveMiniMap
  *
- * @param x number
- * @param y number
+ * @param x integer
+ * @param y integer
  *
  * @return boolean isAbove
  */
@@ -1175,8 +1175,8 @@ int LuaUnsyncedRead::IsAboveMiniMap(lua_State* L)
  *
  * @function Spring.GetDrawFrame
  *
- * @return number low_16bit
- * @return number high_16bit
+ * @return integer low_16bit
+ * @return integer high_16bit
  */
 int LuaUnsyncedRead::GetDrawFrame(lua_State* L)
 {
@@ -1282,7 +1282,7 @@ int LuaUnsyncedRead::GetPrevFrameSyncChecksum(lua_State* L)
 /***
  *
  * @function Spring.IsUnitAllied
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isAllied nil with unitID cannot be parsed
  */
 int LuaUnsyncedRead::IsUnitAllied(lua_State* L)
@@ -1306,7 +1306,7 @@ int LuaUnsyncedRead::IsUnitAllied(lua_State* L)
 /***
  *
  * @function Spring.IsUnitSelected
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isSelected nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::IsUnitSelected(lua_State* L)
@@ -1324,7 +1324,7 @@ int LuaUnsyncedRead::IsUnitSelected(lua_State* L)
 /***
  *
  * @function Spring.GetUnitLuaDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? draw nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitLuaDraw(lua_State* L)
@@ -1335,7 +1335,7 @@ int LuaUnsyncedRead::GetUnitLuaDraw(lua_State* L)
 /***
  *
  * @function Spring.GetUnitNoDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitNoDraw(lua_State* L)
@@ -1346,7 +1346,7 @@ int LuaUnsyncedRead::GetUnitNoDraw(lua_State* L)
 /***
  *
  * @function Spring.GetUnitEngineDrawMask
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitEngineDrawMask(lua_State* L)
@@ -1357,7 +1357,7 @@ int LuaUnsyncedRead::GetUnitEngineDrawMask(lua_State* L)
 /***
  *
  * @function Spring.GetUnitAlwaysUpdateMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitAlwaysUpdateMatrix(lua_State* L)
@@ -1374,7 +1374,7 @@ int LuaUnsyncedRead::GetUnitAlwaysUpdateMatrix(lua_State* L)
 /***
  *
  * @function Spring.GetUnitDrawFlag
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitDrawFlag(lua_State* L)
@@ -1391,7 +1391,7 @@ int LuaUnsyncedRead::GetUnitDrawFlag(lua_State* L)
 /***
  *
  * @function Spring.GetUnitNoMinimap
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::GetUnitNoMinimap(lua_State* L)
@@ -1409,7 +1409,7 @@ int LuaUnsyncedRead::GetUnitNoMinimap(lua_State* L)
  * Check if a unit is not allowed to be added to a group by a player.
  *
  * @function Spring.GetUnitNoGroup
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? noGroup `true` if the unit is not allowed to be added to a group, `false` if it is allowed to be added to a group, or `nil` when `unitID` is not valid.
  */
 int LuaUnsyncedRead::GetUnitNoGroup(lua_State* L)
@@ -1426,7 +1426,7 @@ int LuaUnsyncedRead::GetUnitNoGroup(lua_State* L)
 /***
  *
  * @function Spring.GetUnitNoSelect
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? noSelect `nil` when `unitID` cannot be parsed.
  */
 int LuaUnsyncedRead::GetUnitNoSelect(lua_State* L)
@@ -1444,7 +1444,7 @@ int LuaUnsyncedRead::GetUnitNoSelect(lua_State* L)
 /***
  *
  * @function Spring.UnitIconGetDraw
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? drawIcon
  * `true` if icon is being drawn, `nil` when unitID is invalid, otherwise `false`.
  */
@@ -1535,7 +1535,7 @@ namespace Impl {
 /*** Get unit icon data
  *
  * @function Spring.GetUnitIconData
- * @param unitID number
+ * @param unitID UnitID
  * @param fullData boolean? (Default: false) Whether additional information about the icon is returned, otherwise only `name` and `atlasTexCoords` are returned
  * @return IconData? `nil` if unit is not found or unit currentIconIndex is invalid
  * @see Spring.GetIconData
@@ -1557,7 +1557,7 @@ int LuaUnsyncedRead::GetUnitIconData(lua_State* L)
 /*** Get unit icon name
  *
  * @function Spring.GetUnitIcon
- * @param unitID number
+ * @param unitID UnitID
  * @return string iconName
  */
 int LuaUnsyncedRead::GetUnitIcon(lua_State* L)
@@ -1628,16 +1628,16 @@ int LuaUnsyncedRead::GetAllIconDataArray(lua_State* L)
 /***
  *
  * @function Spring.GetUnitSelectionVolumeData
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? scaleX nil when unitID cannot be parsed
  * @return number scaleY
  * @return number scaleZ
  * @return number offsetX
  * @return number offsetY
  * @return number offsetZ
- * @return number volumeType
- * @return number useContHitTest
- * @return number getPrimaryAxis
+ * @return integer volumeType
+ * @return integer useContHitTest
+ * @return integer getPrimaryAxis
  * @return boolean ignoreHits
  */
 int LuaUnsyncedRead::GetUnitSelectionVolumeData(lua_State* L)
@@ -1655,7 +1655,7 @@ int LuaUnsyncedRead::GetUnitSelectionVolumeData(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureLuaDraw
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean? nil when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureLuaDraw(lua_State* L)
@@ -1666,7 +1666,7 @@ int LuaUnsyncedRead::GetFeatureLuaDraw(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureNoDraw
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean? nil when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureNoDraw(lua_State* L)
@@ -1677,7 +1677,7 @@ int LuaUnsyncedRead::GetFeatureNoDraw(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureEngineDrawMask
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean? nil when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureEngineDrawMask(lua_State* L)
@@ -1688,7 +1688,7 @@ int LuaUnsyncedRead::GetFeatureEngineDrawMask(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureAlwaysUpdateMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @return boolean? nil when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureAlwaysUpdateMatrix(lua_State* L)
@@ -1705,7 +1705,7 @@ int LuaUnsyncedRead::GetFeatureAlwaysUpdateMatrix(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureDrawFlag
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? nil when featureID cannot be parsed
  */
 int LuaUnsyncedRead::GetFeatureDrawFlag(lua_State* L)
@@ -1722,16 +1722,16 @@ int LuaUnsyncedRead::GetFeatureDrawFlag(lua_State* L)
 /***
  *
  * @function Spring.GetFeatureSelectionVolumeData
- * @param featureID integer
- * @return number? scaleX nil when unitID cannot be parsed
+ * @param featureID FeatureID
+ * @return number? scaleX nil when featureID cannot be parsed
  * @return number scaleY
  * @return number scaleZ
  * @return number offsetX
  * @return number offsetY
  * @return number offsetZ
- * @return number volumeType
- * @return number useContHitTest
- * @return number getPrimaryAxis
+ * @return integer volumeType
+ * @return integer useContHitTest
+ * @return integer getPrimaryAxis
  * @return boolean ignoreHits
  */
 int LuaUnsyncedRead::GetFeatureSelectionVolumeData(lua_State* L)
@@ -1771,7 +1771,7 @@ static int GetObjectTransformMatrix(const CSolidObject* o, lua_State* L)
 /***
  *
  * @function Spring.GetUnitTransformMatrix
- * @param unitID integer
+ * @param unitID UnitID
  * @return number? m11 nil when unitID cannot be parsed
  * @return number m12
  * @return number m13
@@ -1795,7 +1795,7 @@ int LuaUnsyncedRead::GetUnitTransformMatrix(lua_State* L) { return (GetObjectTra
 /***
  *
  * @function Spring.GetFeatureTransformMatrix
- * @param featureID integer
+ * @param featureID FeatureID
  * @return number? m11 nil when featureID cannot be parsed
  * @return number m12
  * @return number m13
@@ -1825,7 +1825,7 @@ int LuaUnsyncedRead::GetFeatureTransformMatrix(lua_State* L) { return (GetObject
 /***
  *
  * @function Spring.IsUnitInView
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? inView nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::IsUnitInView(lua_State* L)
@@ -1843,7 +1843,7 @@ int LuaUnsyncedRead::IsUnitInView(lua_State* L)
 /***
  *
  * @function Spring.IsUnitVisible
- * @param unitID integer
+ * @param unitID UnitID
  * @param radius number? unitRadius when not specified
  * @param checkIcon boolean
  * @return boolean? isVisible nil when unitID cannot be parsed
@@ -1885,7 +1885,7 @@ int LuaUnsyncedRead::IsUnitVisible(lua_State* L)
 /***
  *
  * @function Spring.IsUnitIcon
- * @param unitID integer
+ * @param unitID UnitID
  * @return boolean? isUnitIcon nil when unitID cannot be parsed
  */
 int LuaUnsyncedRead::IsUnitIcon(lua_State* L)
@@ -1953,7 +1953,7 @@ int LuaUnsyncedRead::IsSphereInView(lua_State* L)
 /***
  *
  * @function Spring.GetUnitViewPosition
- * @param unitID integer
+ * @param unitID UnitID
  * @param midPos boolean? (Default: `false`)
  * @return number? x nil when unitID cannot be parsed
  * @return number y
@@ -2048,10 +2048,10 @@ public:
 /***
  *
  * @function Spring.GetVisibleUnits
- * @param teamID integer? (Default: `-1`)
+ * @param teamID TeamID? (Default: `-1`)
  * @param radius number? (Default: `30`)
  * @param icons boolean? (Default: `true`)
- * @return number[]? unitIDs
+ * @return UnitID[]? unitIDs
  */
 int LuaUnsyncedRead::GetVisibleUnits(lua_State* L)
 {
@@ -2146,11 +2146,11 @@ int LuaUnsyncedRead::GetVisibleUnits(lua_State* L)
 /***
  *
  * @function Spring.GetVisibleFeatures
- * @param teamID integer? (Default: `-1`)
+ * @param teamID TeamID? (Default: `-1`)
  * @param radius number? (Default: `30`)
  * @param icons boolean? (Default: `true`)
  * @param geos boolean? (Default: `true`)
- * @return number[]? featureIDs
+ * @return FeatureID[]? featureIDs
  */
 int LuaUnsyncedRead::GetVisibleFeatures(lua_State* L)
 {
@@ -2227,11 +2227,11 @@ int LuaUnsyncedRead::GetVisibleFeatures(lua_State* L)
 /***
  *
  * @function Spring.GetVisibleProjectiles
- * @param allyTeamID integer? (Default: `-1`)
+ * @param allyTeamID AllyTeamID? (Default: `-1`)
  * @param addSyncedProjectiles boolean? (Default: `true`)
  * @param addWeaponProjectiles boolean? (Default: `true`)
  * @param addPieceProjectiles boolean? (Default: `true`)
- * @return number[]? projectileIDs
+ * @return ProjectileID[]? projectileIDs
  */
 int LuaUnsyncedRead::GetVisibleProjectiles(lua_State* L)
 {
@@ -2423,7 +2423,7 @@ int LuaUnsyncedRead::GetRenderUnits(lua_State* L)
  * @function Spring.GetRenderUnitsDrawFlagChanged
  * Gets a list of IDs of units that have had their draw flags changed, and the corresponding flags.
  * @param sendMask true Whether to send objects draw flags as second return.
- * @return integer[] ids
+ * @return UnitID[] ids
  * @return DrawFlag[] unitDrawFlags
  */
 
@@ -2431,7 +2431,7 @@ int LuaUnsyncedRead::GetRenderUnits(lua_State* L)
  * @function Spring.GetRenderUnitsDrawFlagChanged
  * Gets a list of IDs of units that have had their draw flags changed, and the corresponding flags.
  * @param sendMask false? Whether to send objects draw flags as second return.
- * @return integer[] ids
+ * @return UnitID[] ids
  */
 int LuaUnsyncedRead::GetRenderUnitsDrawFlagChanged(lua_State* L)
 {
@@ -2443,7 +2443,7 @@ int LuaUnsyncedRead::GetRenderUnitsDrawFlagChanged(lua_State* L)
  * @function Spring.GetRenderFeatures
  * @param drawMask DrawMask (Default: `0`) Filter objects by their draw flags.
  * @param sendMask true Whether to send objects draw flags as second return
- * @return integer[] featureIDs
+ * @return FeatureID[] featureIDs
  * @return DrawFlag[] drawFlags
  */
 
@@ -2452,7 +2452,7 @@ int LuaUnsyncedRead::GetRenderUnitsDrawFlagChanged(lua_State* L)
  * @function Spring.GetRenderFeatures
  * @param drawMask DrawMask (Default: `0`) Filter objects by their draw flags.
  * @param sendMask false? Whether to send objects draw flags as second return
- * @return integer[] featureIDs
+ * @return FeatureID[] featureIDs
  */
 int LuaUnsyncedRead::GetRenderFeatures(lua_State* L)
 {
@@ -2463,15 +2463,15 @@ int LuaUnsyncedRead::GetRenderFeatures(lua_State* L)
  * @function Spring.GetRenderFeaturesDrawFlagChanged
  * Gets a list of IDs of features that have had their draw flags changed, and the corresponding flags.
  * @param sendMask true Whether to send objects draw flags as second return.
- * @return integer[] ids
- * @return DrawFlag[] unitDrawFlags
+ * @return FeatureID[] ids
+ * @return DrawFlag[] featureDrawFlags
  */
 
 /***
  * @function Spring.GetRenderFeaturesDrawFlagChanged
  * Gets a list of IDs of features that have had their draw flags changed, and the corresponding flags.
  * @param sendMask false? Whether to send objects draw flags as second return.
- * @return integer[] ids
+ * @return FeatureID[] ids
  */
 int LuaUnsyncedRead::GetRenderFeaturesDrawFlagChanged(lua_State* L)
 {
@@ -2505,8 +2505,8 @@ int LuaUnsyncedRead::ClearFeaturesPreviousDrawFlag(lua_State* L)
  * @param top number
  * @param right number
  * @param bottom number
- * @param allegiance number? (Default: `-1`) teamID when > 0, when < 0 one of AllUnits = -1, MyUnits = -2, AllyUnits = -3, EnemyUnits = -4
- * @return number[]? unitIDs
+ * @param allegiance integer? (Default: `-1`) teamID when > 0, when < 0 one of AllUnits = -1, MyUnits = -2, AllyUnits = -3, EnemyUnits = -4
+ * @return UnitID[]? unitIDs
  */
 int LuaUnsyncedRead::GetUnitsInScreenRectangle(lua_State* L)
 {
@@ -2590,7 +2590,7 @@ int LuaUnsyncedRead::GetUnitsInScreenRectangle(lua_State* L)
 	* @param top number
 	* @param right number
 	* @param bottom number
-	* @return number[]? featureIDs
+	* @return FeatureID[]? featureIDs
 	*/
 int LuaUnsyncedRead::GetFeaturesInScreenRectangle(lua_State* L)
 {
@@ -2643,7 +2643,7 @@ int LuaUnsyncedRead::GetFeaturesInScreenRectangle(lua_State* L)
  *
  * @function Spring.GetLocalPlayerID
  * @function Spring.GetMyPlayerID Alias of GetLocalPlayerID
- * @return integer playerID
+ * @return PlayerID playerID
  */
 int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
 {
@@ -2656,7 +2656,7 @@ int LuaUnsyncedRead::GetLocalPlayerID(lua_State* L)
  *
  * @function Spring.GetLocalTeamID
  * @function Spring.GetMyTeamID Alias of GetLocalTeamID
- * @return integer teamID
+ * @return TeamID teamID
  */
 int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
 {
@@ -2669,7 +2669,7 @@ int LuaUnsyncedRead::GetLocalTeamID(lua_State* L)
  *
  * @function Spring.GetLocalAllyTeamID
  * @function Spring.GetMyAllyTeamID Alias of GetLocalAllyTeamID
- * @return integer allyTeamID
+ * @return AllyTeamID allyTeamID
  */
 int LuaUnsyncedRead::GetLocalAllyTeamID(lua_State* L)
 {
@@ -2700,7 +2700,7 @@ int LuaUnsyncedRead::GetSpectatingState(lua_State* L)
 /***
  *
  * @function Spring.GetSelectedUnits
- * @return number[] unitIDs
+ * @return UnitID[] unitIDs
  */
 int LuaUnsyncedRead::GetSelectedUnits(lua_State* L)
 {
@@ -2711,7 +2711,7 @@ int LuaUnsyncedRead::GetSelectedUnits(lua_State* L)
 /*** Get selected units aggregated by unitDefID
  *
  * @function Spring.GetSelectedUnitsSorted
- * @return table<number,number[]> where keys are unitDefIDs and values are unitIDs
+ * @return table<UnitDefID,UnitID[]> where keys are unitDefIDs and values are unitIDs
  * @return integer the number of unitDefIDs
  */
 int LuaUnsyncedRead::GetSelectedUnitsSorted(lua_State* L)
@@ -2727,7 +2727,7 @@ int LuaUnsyncedRead::GetSelectedUnitsSorted(lua_State* L)
  *
  * @function Spring.GetSelectedUnitsCounts
  *
- * @return table<number,number> unitsCounts where keys are unitDefIDs and values are counts
+ * @return table<UnitDefID,integer> unitsCounts where keys are unitDefIDs and values are counts
  * @return integer the number of unitDefIDs
  */
 int LuaUnsyncedRead::GetSelectedUnitsCounts(lua_State* L)
@@ -2742,7 +2742,7 @@ int LuaUnsyncedRead::GetSelectedUnitsCounts(lua_State* L)
 /*** Returns the amount of selected units
  *
  * @function Spring.GetSelectedUnitsCount
- * @return number selectedUnitsCount
+ * @return integer selectedUnitsCount
  */
 int LuaUnsyncedRead::GetSelectedUnitsCount(lua_State* L)
 {
@@ -2855,11 +2855,11 @@ int LuaUnsyncedRead::GetMapDrawMode(lua_State* L)
 /***
  *
  * @function Spring.GetMapSquareTexture
- * @param texSquareX number
- * @param texSquareY number
- * @param lodMin number
+ * @param texSquareX integer
+ * @param texSquareY integer
+ * @param lodMin integer
  * @param luaTexName string
- * @param lodMax number? (Default: lodMin)
+ * @param lodMax integer? (Default: lodMin)
  * @return boolean? success
  */
 int LuaUnsyncedRead::GetMapSquareTexture(lua_State* L)
@@ -3187,16 +3187,16 @@ int LuaUnsyncedRead::WorldToScreenCoords(lua_State* L)
  *
  * The unit must be selectable, to appear to a screen trace ray.
  *
- * @param screenX number position on x axis in mouse coordinates (origin on left border of view)
- * @param screenY number position on y axis in mouse coordinates (origin on top border of view)
+ * @param screenX integer position on x axis in mouse coordinates (origin on left border of view)
+ * @param screenY integer position on y axis in mouse coordinates (origin on top border of view)
  * @param onlyCoords boolean? (Default: `false`) return only description (1st return value) and coordinates (2nd return value)
  * @param useMinimap boolean? (Default: `false`) if position arguments are contained by minimap, use the minimap corresponding world position
  * @param includeSky boolean? (Default: `false`)
  * @param ignoreWater boolean? (Default: `false`)
  * @param heightOffset number? (Default: `0`)
  * @return string? description of traced position
- * @return number|string|xyz|nil unitID or feature, position triple when onlyCoords=true
- * @return number|string|nil featureID or ground
+ * @return UnitID|FeatureID|string|xyz|nil unitID or feature, position triple when onlyCoords=true
+ * @return FeatureID|string|nil featureID or ground
  * @return xyz? coords
  */
 int LuaUnsyncedRead::TraceScreenRay(lua_State* L)
@@ -3304,8 +3304,8 @@ int LuaUnsyncedRead::TraceScreenRay(lua_State* L)
 /***
  *
  * @function Spring.GetPixelDir
- * @param x number
- * @param y number
+ * @param x integer
+ * @param y integer
  * @return number dirX
  * @return number dirY
  * @return number dirZ
@@ -3359,7 +3359,7 @@ static bool AddPlayerToRoster(lua_State* L, int playerID, bool onlyActivePlayers
 /***
  *
  * @function Spring.GetTeamColor
- * @param teamID integer
+ * @param teamID TeamID
  * @return number? r factor from 0 to 1
  * @return number? g factor from 0 to 1
  * @return number? b factor from 0 to 1
@@ -3386,7 +3386,7 @@ int LuaUnsyncedRead::GetTeamColor(lua_State* L)
 /***
  *
  * @function Spring.GetTeamOrigColor
- * @param teamID integer
+ * @param teamID TeamID
  * @return number? r factor from 0 to 1
  * @return number? g factor from 0 to 1
  * @return number? b factor from 0 to 1
@@ -3433,7 +3433,7 @@ int LuaUnsyncedRead::GetCustomPaletteColor(lua_State* L)
 /***
  * Returns the custom palette index for a unit, or nil if using team color.
  * @function Spring.GetUnitPaletteIndex
- * @param unitID integer
+ * @param unitID UnitID
  * @return integer? customIndex [0..MAX_CUSTOM_COLORS) if unit uses a custom color, nil if using team color
  */
 int LuaUnsyncedRead::GetUnitPaletteIndex(lua_State* L)
@@ -3455,7 +3455,7 @@ int LuaUnsyncedRead::GetUnitPaletteIndex(lua_State* L)
 /***
  * Returns the custom palette index for a feature, or nil if using team color.
  * @function Spring.GetFeaturePaletteIndex
- * @param featureID integer
+ * @param featureID FeatureID
  * @return integer? customIndex [0..MAX_CUSTOM_COLORS) if feature uses a custom color, nil if using team color
  */
 int LuaUnsyncedRead::GetFeaturePaletteIndex(lua_State* L)
@@ -3627,7 +3627,7 @@ int LuaUnsyncedRead::GetSoundEffectParams(lua_State* L)
 /***
  *
  * @function Spring.GetFPS
- * @return number fps
+ * @return integer fps
  */
 int LuaUnsyncedRead::GetFPS(lua_State* L)
 {
@@ -3683,9 +3683,9 @@ int LuaUnsyncedRead::GetGameState(lua_State* L)
 /***
  *
  * @function Spring.GetActiveCommand
- * @return number? cmdIndex
+ * @return integer? cmdIndex
  * @return integer? cmdID
- * @return number? cmdType
+ * @return integer? cmdType
  * @return string? cmdName
  */
 int LuaUnsyncedRead::GetActiveCommand(lua_State* L)
@@ -3848,7 +3848,7 @@ int LuaUnsyncedRead::GetBuildFacing(lua_State* L)
 /***
  *
  * @function Spring.GetBuildSpacing
- * @return number buildSpacing
+ * @return integer buildSpacing
  */
 int LuaUnsyncedRead::GetBuildSpacing(lua_State* L)
 {
@@ -3863,7 +3863,7 @@ int LuaUnsyncedRead::GetBuildSpacing(lua_State* L)
 /***
  *
  * @function Spring.GetGatherMode
- * @return number gatherMode
+ * @return integer gatherMode
  */
 int LuaUnsyncedRead::GetGatherMode(lua_State* L)
 {
@@ -3880,8 +3880,8 @@ int LuaUnsyncedRead::GetGatherMode(lua_State* L)
 /***
  *
  * @function Spring.GetActivePage
- * @return number activePage
- * @return number maxPage
+ * @return integer activePage
+ * @return integer maxPage
  */
 int LuaUnsyncedRead::GetActivePage(lua_State* L)
 {
@@ -3903,8 +3903,8 @@ int LuaUnsyncedRead::GetActivePage(lua_State* L)
 /***
  *
  * @function Spring.GetMouseState
- * @return number x
- * @return number y
+ * @return integer x
+ * @return integer y
  * @return boolean lmbPressed left mouse button pressed
  * @return boolean mmbPressed middle mouse button pressed
  * @return boolean rmbPressed right mouse button pressed
@@ -3947,9 +3947,9 @@ int LuaUnsyncedRead::GetMouseCursor(lua_State* L)
 /***
  *
  * @function Spring.GetMouseStartPosition
- * @param button number
- * @return number x
- * @return number y
+ * @param button integer
+ * @return integer x
+ * @return integer y
  * @return number camPosX
  * @return number camPosY
  * @return number camPosZ
@@ -4077,7 +4077,7 @@ int LuaUnsyncedRead::GetLastMessagePositions(lua_State* L)
 
 /***
  * @function Spring.GetConsoleBuffer
- * @param maxLines number
+ * @param maxLines integer
  * @return { text: string, priority: integer }[] buffer
  */
 int LuaUnsyncedRead::GetConsoleBuffer(lua_State* L)
@@ -4166,7 +4166,7 @@ int LuaUnsyncedRead::GetKeyFromScanSymbol(lua_State* L)
 /***
  *
  * @function Spring.GetKeyState
- * @param keyCode number
+ * @param keyCode integer
  * @return boolean pressed
  */
 int LuaUnsyncedRead::GetKeyState(lua_State* L)
@@ -4198,7 +4198,7 @@ int LuaUnsyncedRead::GetModKeyState(lua_State* L)
 /***
  *
  * @function Spring.GetPressedKeys
- * @return table<number|string,true> where keys are keyCodes or key names
+ * @return table<integer|string,true> where keys are keyCodes or key names
  */
 int LuaUnsyncedRead::GetPressedKeys(lua_State* L)
 {
@@ -4229,7 +4229,7 @@ int LuaUnsyncedRead::GetPressedKeys(lua_State* L)
 /***
  *
  * @function Spring.GetPressedScans
- * @return table<number|string,true> where keys are scanCodes or scan names
+ * @return table<integer|string,true> where keys are scanCodes or scan names
  */
 int LuaUnsyncedRead::GetPressedScans(lua_State* L)
 {
@@ -4276,7 +4276,7 @@ int LuaUnsyncedRead::GetInvertQueueKey(lua_State* L)
  *
  * @function Spring.GetKeyCode
  * @param keySym string
- * @return number keyCode
+ * @return integer keyCode
  */
 int LuaUnsyncedRead::GetKeyCode(lua_State* L)
 {
@@ -4288,7 +4288,7 @@ int LuaUnsyncedRead::GetKeyCode(lua_State* L)
 /***
  *
  * @function Spring.GetKeySymbol
- * @param keyCode number
+ * @param keyCode integer
  * @return string keyCodeName
  * @return string keyCodeDefaultName name when there are not aliases
  */
@@ -4304,7 +4304,7 @@ int LuaUnsyncedRead::GetKeySymbol(lua_State* L)
 /***
  *
  * @function Spring.GetScanSymbol
- * @param scanCode number
+ * @param scanCode integer
  * @return string scanCodeName
  * @return string scanCodeDefaultName name when there are not aliases
  */
@@ -4409,7 +4409,7 @@ int LuaUnsyncedRead::GetActionHotKeys(lua_State* L)
 /***
  *
  * @function Spring.GetGroupList
- * @return table<number,number>? where keys are groupIDs and values are counts
+ * @return table<GroupID,integer>? where keys are groupIDs and values are counts
  */
 int LuaUnsyncedRead::GetGroupList(lua_State* L)
 {
@@ -4437,7 +4437,7 @@ int LuaUnsyncedRead::GetGroupList(lua_State* L)
 /***
  *
  * @function Spring.GetSelectedGroup
- * @return integer groupID -1 when no group selected
+ * @return GroupID groupID -1 when no group selected
  */
 int LuaUnsyncedRead::GetSelectedGroup(lua_State* L)
 {
@@ -4449,8 +4449,8 @@ int LuaUnsyncedRead::GetSelectedGroup(lua_State* L)
 /***
  *
  * @function Spring.GetUnitGroup
- * @param unitID integer
- * @return integer? groupID
+ * @param unitID UnitID
+ * @return GroupID? groupID
  */
 int LuaUnsyncedRead::GetUnitGroup(lua_State* L)
 {
@@ -4484,8 +4484,8 @@ static inline const CGroup* GetGroupFromArg(lua_State* L, int arg)
 /***
  *
  * @function Spring.GetGroupUnits
- * @param groupID integer
- * @return number[]? unitIDs
+ * @param groupID GroupID
+ * @return UnitID[]? unitIDs
  */
 int LuaUnsyncedRead::GetGroupUnits(lua_State* L)
 {
@@ -4501,8 +4501,8 @@ int LuaUnsyncedRead::GetGroupUnits(lua_State* L)
 /***
  *
  * @function Spring.GetGroupUnitsSorted
- * @param groupID integer
- * @return table<number,number[]>? where keys are unitDefIDs and values are unitIDs
+ * @param groupID GroupID
+ * @return table<UnitDefID,UnitID[]>? where keys are unitDefIDs and values are unitIDs
  */
 int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
 {
@@ -4518,8 +4518,8 @@ int LuaUnsyncedRead::GetGroupUnitsSorted(lua_State* L)
 /***
  *
  * @function Spring.GetGroupUnitsCounts
- * @param groupID integer
- * @return table<number,number>? where keys are unitDefIDs and values are counts
+ * @param groupID GroupID
+ * @return table<UnitDefID,integer>? where keys are unitDefIDs and values are counts
  */
 int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
 {
@@ -4535,8 +4535,8 @@ int LuaUnsyncedRead::GetGroupUnitsCounts(lua_State* L)
 /***
  *
  * @function Spring.GetGroupUnitsCount
- * @param groupID integer
- * @return number? groupSize
+ * @param groupID GroupID
+ * @return integer? groupSize
  */
 int LuaUnsyncedRead::GetGroupUnitsCount(lua_State* L)
 {
@@ -4560,9 +4560,9 @@ int LuaUnsyncedRead::GetGroupUnitsCount(lua_State* L)
  * @class Roster
  * @x_helper
  * @field name string
- * @field playerID integer
- * @field teamID integer
- * @field allyTeamID integer
+ * @field playerID PlayerID
+ * @field teamID TeamID
+ * @field allyTeamID AllyTeamID
  * @field spectator boolean
  * @field cpuUsage number in order to find the progress, use: cpuUsage&0x1 if it's PC or BO, cpuUsage& 0xFE to get path res, (cpuUsage>>8)*1000 for the progress
  * @field pingTime number if -1, the player is pathfinding
@@ -4572,7 +4572,7 @@ int LuaUnsyncedRead::GetGroupUnitsCount(lua_State* L)
 /***
  *
  * @function Spring.GetPlayerRoster
- * @param sortType number? return unsorted if unspecified. Disabled = 0, Allies = 1, TeamID = 2, PlayerName = 3, PlayerCPU = 4, PlayerPing = 5
+ * @param sortType integer? return unsorted if unspecified. Disabled = 0, Allies = 1, TeamID = 2, PlayerName = 3, PlayerCPU = 4, PlayerPing = 5
  * @param showPathingPlayers boolean? (Default: `false`)
  * @return Roster[]? playerTable
  */
@@ -4608,9 +4608,9 @@ int LuaUnsyncedRead::GetPlayerRoster(lua_State* L)
 /***
  *
  * @function Spring.GetPlayerTraffic
- * @param playerID integer
+ * @param playerID PlayerID
  * @param packetID integer?
- * @return number traffic
+ * @return integer traffic
  */
 int LuaUnsyncedRead::GetPlayerTraffic(lua_State* L)
 {
@@ -4660,12 +4660,12 @@ int LuaUnsyncedRead::GetPlayerTraffic(lua_State* L)
 /***
  *
  * @function Spring.GetPlayerStatistics
- * @param playerID integer
- * @return number? mousePixels nil when invalid playerID
- * @return number mouseClicks
- * @return number keyPresses
- * @return number numCommands
- * @return number unitCommands
+ * @param playerID PlayerID
+ * @return integer? mousePixels nil when invalid playerID
+ * @return integer mouseClicks
+ * @return integer keyPresses
+ * @return integer numCommands
+ * @return integer unitCommands
  */
 int LuaUnsyncedRead::GetPlayerStatistics(lua_State* L)
 {
@@ -4855,7 +4855,7 @@ int LuaUnsyncedRead::GetConfigString(lua_State* L)
 /***
  *
  * @function Spring.GetLogSections
- * @return table<string,number> sections where keys are names and loglevel are values. E.g. `{ "KeyBindings" = LOG.INFO, "Font" = LOG.INFO, "Sound" = LOG.WARNING, ... }`
+ * @return table<string,integer> sections where keys are names and loglevel are values. E.g. `{ "KeyBindings" = LOG.INFO, "Font" = LOG.INFO, "Sound" = LOG.WARNING, ... }`
  */
 int LuaUnsyncedRead::GetLogSections(lua_State* L) {
 	const int numLogSections = log_filter_section_getNumRegisteredSections();
@@ -4884,7 +4884,7 @@ int LuaUnsyncedRead::GetLogSections(lua_State* L) {
  *
  * @function Spring.GetAllGroundDecals
  *
- * @return number[] decalIDs
+ * @return DecalID[] decalIDs
  */
 int LuaUnsyncedRead::GetAllGroundDecals(lua_State* L)
 {
@@ -4917,7 +4917,7 @@ int LuaUnsyncedRead::GetAllGroundDecals(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalMiddlePos
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? posX
  * @return number posZ
  */
@@ -4938,7 +4938,7 @@ int LuaUnsyncedRead::GetGroundDecalMiddlePos(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalQuadPos
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? posTL.x
  * @return number posTL.z
  * @return number posTR.x
@@ -4971,7 +4971,7 @@ int LuaUnsyncedRead::GetGroundDecalQuadPos(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalSizeAndHeight
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? sizeX
  * @return number sizeY
  * @return number projCubeHeight
@@ -4995,7 +4995,7 @@ int LuaUnsyncedRead::GetGroundDecalSizeAndHeight(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalRotation
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? rotation Rotation in radians.
  */
 int LuaUnsyncedRead::GetGroundDecalRotation(lua_State* L)
@@ -5014,7 +5014,7 @@ int LuaUnsyncedRead::GetGroundDecalRotation(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalTexture
- * @param decalID integer
+ * @param decalID DecalID
  * @param isMainTex boolean? (Default: `true`) If `false`, return the normal/glow map.
  * @return string? texture
  */
@@ -5057,7 +5057,7 @@ int LuaUnsyncedRead::GetGroundDecalTextures(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalTextureParams
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? texWrapDistance If non-zero, sets the mode to repeat the texture along the left-right direction of the decal every texWrapFactor elmos.
  * @return number texTraveledDistance Shifts the texture repetition defined by texWrapFactor so the texture of a next line in the continuous multiline can start where the previous finished. For that it should collect all elmo lengths of the previously set multiline segments.
  */
@@ -5078,7 +5078,7 @@ int LuaUnsyncedRead::GetGroundDecalTextureParams(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalAlpha
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? alpha Between 0 and 1
  * @return number alphaFalloff Between 0 and 1, per second
  */
@@ -5101,7 +5101,7 @@ int LuaUnsyncedRead::GetGroundDecalAlpha(lua_State* L)
  *
  * If all three equal 0, the decal follows the normals of ground at midpoint
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? normal.x
  * @return number normal.y
  * @return number normal.z
@@ -5125,7 +5125,7 @@ int LuaUnsyncedRead::GetGroundDecalNormal(lua_State* L)
  * @function Spring.GetGroundDecalTint
  * Gets the tint of the ground decal.
  * A color of (0.5, 0.5, 0.5, 0.5) is effectively no tint
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? tintR
  * @return number tintG
  * @return number tintB
@@ -5151,7 +5151,7 @@ int LuaUnsyncedRead::GetGroundDecalTint(lua_State* L)
  *
  * @function Spring.GetGroundDecalMisc
  * Returns less important parameters of a ground decal
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? dotElimExp
  * @return number refHeight
  * @return number minHeight
@@ -5179,7 +5179,7 @@ int LuaUnsyncedRead::GetGroundDecalMisc(lua_State* L)
  *
  * Min can be not equal to max for "gradient" style decals, e.g. unit tracks
  *
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? creationFrameMin
  * @return number creationFrameMax
  */
@@ -5199,7 +5199,7 @@ int LuaUnsyncedRead::GetGroundDecalCreationFrame(lua_State* L)
 
 /***
  * @function Spring.GetGroundDecalOwner
- * @param decalID integer
+ * @param decalID DecalID
  * @return integer? value If owner is a unit, then this is `unitID`, if owner is
  * a feature it is `featureID + MAX_UNITS`. If there is no owner, then `nil`.
  */
@@ -5221,7 +5221,7 @@ int LuaUnsyncedRead::GetGroundDecalOwner(lua_State* L)
  *
  * @function Spring.GetGroundDecalGlowParams
  * Gets the glow parameters of the ground decal.
- * @param decalID integer
+ * @param decalID DecalID
  * @return number? glow Between 0 and 1
  * @return number glowFalloff Between 0 and 1, per second
  */
@@ -5245,7 +5245,7 @@ int LuaUnsyncedRead::GetGroundDecalGlowParams(lua_State* L)
  *
  * @function Spring.GetGroundDecalUserData
  * Gets the user defined decal data.
- * @param decalID integer
+ * @param decalID DecalID
  * @param udQuad integer vec4 index, must be within [0;1] for now
  * @return number? x
  * @return number y
@@ -5275,7 +5275,7 @@ int LuaUnsyncedRead::GetGroundDecalUserData(lua_State* L)
 /***
  *
  * @function Spring.GetGroundDecalType
- * @param decalID integer
+ * @param decalID DecalID
  * @return "explosion"|"plate"|"lua"|"track"|"unknown"|nil type
  */
 int LuaUnsyncedRead::GetGroundDecalType(lua_State* L)
@@ -5318,7 +5318,7 @@ int LuaUnsyncedRead::GetGroundDecalType(lua_State* L)
  *
  * @function Spring.GetSyncedGCInfo
  * @param collectGC boolean? (Default: `false`) collect before returning metric
- * @return number? GC values are expressed in Kbytes: #bytes/2^10
+ * @return integer? GC values are expressed in Kbytes: #bytes/2^10
  */
 int LuaUnsyncedRead::GetSyncedGCInfo(lua_State* L) {
 	if (luaRules == nullptr)

--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -368,11 +368,11 @@ LuaVAOImpl::DrawCheckResult LuaVAOImpl::DrawCheck(GLenum mode, const DrawCheckIn
 /***
  *
  * @function VAO:DrawArrays
- * @param glEnum number primitivesMode
- * @param vertexCount number?
- * @param vertexFirst number?
- * @param instanceCount number?
- * @param instanceFirst number?
+ * @param glEnum GL primitivesMode
+ * @param vertexCount integer?
+ * @param vertexFirst integer?
+ * @param instanceCount integer?
+ * @param instanceFirst integer?
  * @return nil
  */
 void LuaVAOImpl::DrawArrays(GLenum mode, sol::optional<int> vertCountOpt, sol::optional<int> vertexFirstOpt, sol::optional<int> instanceCountOpt, sol::optional<int> instanceFirstOpt)
@@ -405,12 +405,12 @@ void LuaVAOImpl::DrawArrays(GLenum mode, sol::optional<int> vertCountOpt, sol::o
 /***
  *
  * @function VAO:DrawElements
- * @param glEnum number primitivesMode
- * @param drawCount number?
- * @param baseIndex number?
- * @param instanceCount number?
- * @param baseVertex number?
- * @param baseInstance number?
+ * @param glEnum GL primitivesMode
+ * @param drawCount integer?
+ * @param baseIndex integer?
+ * @param instanceCount integer?
+ * @param baseVertex integer?
+ * @param baseInstance integer?
  * @return nil
  */
 void LuaVAOImpl::DrawElements(GLenum mode, sol::optional<int> indCountOpt, sol::optional<int> indElemOffsetOpt, sol::optional<int> instanceCountOpt, sol::optional<int> baseVertexOpt, sol::optional<int> instanceFirstOpt)
@@ -467,8 +467,8 @@ void LuaVAOImpl::ClearSubmission()
 /***
  *
  * @function VAO:AddUnitsToSubmission
- * @param unitIDs number|number[]
- * @return number submittedCount
+ * @param unitIDs UnitID|UnitID[]
+ * @return integer submittedCount
  */
 int LuaVAOImpl::AddUnitsToSubmission(int id) { return AddObjectsToSubmissionImpl<CUnit>(id); }
 int LuaVAOImpl::AddUnitsToSubmission(const sol::stack_table& ids) { return  AddObjectsToSubmissionImpl<CUnit>(ids); }
@@ -477,8 +477,8 @@ int LuaVAOImpl::AddUnitsToSubmission(const sol::stack_table& ids) { return  AddO
 /***
  *
  * @function VAO:AddFeaturesToSubmission
- * @param featureIDs number|number[]
- * @return number submittedCount
+ * @param featureIDs FeatureID|FeatureID[]
+ * @return integer submittedCount
  */
 int LuaVAOImpl::AddFeaturesToSubmission(int id) { return AddObjectsToSubmissionImpl<CFeature>(id); }
 int LuaVAOImpl::AddFeaturesToSubmission(const sol::stack_table& ids) { return AddObjectsToSubmissionImpl<CFeature>(ids); }
@@ -487,8 +487,8 @@ int LuaVAOImpl::AddFeaturesToSubmission(const sol::stack_table& ids) { return Ad
 /***
  *
  * @function VAO:AddUnitDefsToSubmission
- * @param unitDefIDs number|number[]
- * @return number submittedCount
+ * @param unitDefIDs UnitDefID|UnitDefID[]
+ * @return integer submittedCount
  */
 int LuaVAOImpl::AddUnitDefsToSubmission(int id) { return AddObjectsToSubmissionImpl<UnitDef>(id); }
 int LuaVAOImpl::AddUnitDefsToSubmission(const sol::stack_table& ids) { return AddObjectsToSubmissionImpl<UnitDef>(ids); }
@@ -497,8 +497,8 @@ int LuaVAOImpl::AddUnitDefsToSubmission(const sol::stack_table& ids) { return Ad
 /***
  *
  * @function VAO:AddFeatureDefsToSubmission
- * @param featureDefIDs number|number[]
- * @return number submittedCount
+ * @param featureDefIDs FeatureDefID|FeatureDefID[]
+ * @return integer submittedCount
  */
 int LuaVAOImpl::AddFeatureDefsToSubmission(int id) { return AddObjectsToSubmissionImpl<FeatureDef>(id); }
 int LuaVAOImpl::AddFeatureDefsToSubmission(const sol::stack_table& ids) { return AddObjectsToSubmissionImpl<FeatureDef>(ids); }
@@ -507,7 +507,7 @@ int LuaVAOImpl::AddFeatureDefsToSubmission(const sol::stack_table& ids) { return
 /***
  *
  * @function VAO:RemoveFromSubmission
- * @param index number
+ * @param index integer
  * @return nil
  */
 void LuaVAOImpl::RemoveFromSubmission(int idx)

--- a/rts/Lua/LuaVBOImpl.cpp
+++ b/rts/Lua/LuaVBOImpl.cpp
@@ -524,10 +524,10 @@ bool LuaVBOImpl::DefineElementArray(const sol::optional<sol::object> attribDefAr
  * enter your data into the Lua array correctly.
  *
  * @function VBO:Define
- * @param size number The maximum number of elements this VBO can have.
- * @param attribs number|VBOAttributeDef[]
+ * @param size integer The maximum number of elements this VBO can have.
+ * @param attribs integer|VBOAttributeDef[]
  *
- * When number, the maximum number of elements this VBO can have.
+ * When integer, the maximum number of elements this VBO can have.
  *
  * Otherwise, an array of arrays specifying the layout.
  *
@@ -585,9 +585,9 @@ void LuaVBOImpl::Define(const int elementsCount, const sol::optional<sol::object
 /***
  *
  * @function VBO:GetBufferSize
- * @return number elementsCount
- * @return number bufferSizeInBytes
- * @return number size
+ * @return integer elementsCount
+ * @return integer bufferSizeInBytes
+ * @return integer size
  */
 std::tuple<uint32_t, uint32_t, uint32_t> LuaVBOImpl::GetBufferSize()
 {
@@ -670,7 +670,7 @@ size_t LuaVBOImpl::Upload(const sol::stack_table& luaTblData, sol::optional<int>
  * from specified attribute will be downloaded - otherwise all attributes are
  * downloaded
  * @param elementOffset integer? (Default: `0`) download data starting from this element
- * @param elementCount number? number of elements to download
+ * @param elementCount integer? number of elements to download
  * @param forceGPURead boolean? (Default: `false`) force downloading the data from GPU buffer as opposed
  * to using shadow RAM buffer
  * @return number[] vboData
@@ -1176,7 +1176,7 @@ size_t LuaVBOImpl::UploadImpl(const std::vector<TIn>& dataVec, uint32_t elemOffs
  *
  * Also fills in VBO definition data as they're set for engine models (no need to do VBO:Define()).
  *
- * @return nil|number buffer size in bytes
+ * @return integer? buffer size in bytes
  */
 size_t LuaVBOImpl::ModelsVBO()
 {
@@ -1207,11 +1207,11 @@ size_t LuaVBOImpl::ModelsVBO()
  *    , aux1 { 0u }
  * ```
  *
- * @param unitDefIDs number|number[]
+ * @param unitDefIDs UnitDefID|UnitDefID[]
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
- * @return [number,number,number,number] instanceData
+ * @return [integer,integer,integer,integer] instanceData
  * @return integer elementOffset
  * @return integer attrID
  */
@@ -1246,11 +1246,11 @@ size_t LuaVBOImpl::InstanceDataFromUnitDefIDs(const sol::stack_table& ids, int a
  *    , aux1 { 0u }
  * ```
  *
- * @param featureDefIDs number|number[]
+ * @param featureDefIDs FeatureDefID|FeatureDefID[]
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
- * @return [number,number,number,number] instanceData
+ * @return [integer,integer,integer,integer] instanceData
  * @return integer elementOffset
  * @return integer attrID 
  */
@@ -1286,11 +1286,11 @@ size_t LuaVBOImpl::InstanceDataFromFeatureDefIDs(const sol::stack_table& ids, in
  *    , aux1 { 0u }
  * ```
  *
- * @param unitIDs number|number[]
+ * @param unitIDs UnitID|UnitID[]
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
- * @return [number,number,number,number] instanceData
+ * @return [integer,integer,integer,integer] instanceData
  * @return integer elementOffset
  * @return integer attrID 
  */
@@ -1314,11 +1314,11 @@ size_t LuaVBOImpl::InstanceDataFromUnitIDs(const sol::stack_table& ids, int attr
  * global per unit/feature uniform SSBO (unused for Unit/FeatureDefs), as
  * well as some auxiliary data such as palette index and number of pieces.
  *
- * @param featureIDs number|number[]
+ * @param featureIDs FeatureID|FeatureID[]
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
- * @return [number,number,number,number] instanceData
+ * @return [integer,integer,integer,integer] instanceData
  * @return integer elementOffset
  * @return integer attrID
  */
@@ -1336,7 +1336,7 @@ size_t LuaVBOImpl::InstanceDataFromFeatureIDs(const sol::stack_table& ids, int a
 /***
  *
  * @function VBO:MatrixDataFromProjectileIDs
- * @param projectileIDs integer|integer[]
+ * @param projectileIDs ProjectileID|ProjectileID[]
  * @param attrID integer
  * @param teamIdOpt integer?
  * @param elementOffset integer?
@@ -1426,8 +1426,8 @@ int LuaVBOImpl::BindBufferRangeImpl(GLuint bindingIndex,  const sol::optional<in
  * @param index integer should be in the range between
  * `5 < index < GL_MAX_UNIFORM_BUFFER_BINDINGS` value (usually 31)
  * @param elementOffset integer?
- * @param elementCount number?
- * @param target number? glEnum
+ * @param elementCount integer?
+ * @param target GL? glEnum
  * @return integer bindingIndex when successful, -1 otherwise
  */
 int LuaVBOImpl::BindBufferRange(const GLuint index, const sol::optional<int> elemOffsetOpt, const sol::optional<int> elemCountOpt, const sol::optional<GLenum> targetOpt)
@@ -1441,9 +1441,9 @@ int LuaVBOImpl::BindBufferRange(const GLuint index, const sol::optional<int> ele
  * @function VBO:UnbindBufferRange
  * @param index integer
  * @param elementOffset integer?
- * @param elementCount number?
- * @param target number? glEnum
- * @return number bindingIndex when successful, -1 otherwise
+ * @param elementCount integer?
+ * @param target GL? glEnum
+ * @return integer bindingIndex when successful, -1 otherwise
  */
 int LuaVBOImpl::UnbindBufferRange(const GLuint index, const sol::optional<int> elemOffsetOpt, const sol::optional<int> elemCountOpt, const sol::optional<GLenum> targetOpt)
 {

--- a/rts/Lua/library/Types.lua
+++ b/rts/Lua/library/Types.lua
@@ -110,6 +110,94 @@
 ---@field oldHeight number? Camera distance from the ground, cannot be changed. (rot)
 
 --------------------------------------------------------------------------------
+-- Object IDs
+--------------------------------------------------------------------------------
+
+---Identifier of a unit currently present in the simulation.
+---
+---IDs are drawn from a pool and are recycled, so the ID of a dead unit may
+---later be handed out to a different unit.
+---
+---@alias UnitID integer
+
+---Identifier of a unit definition, i.e. an index into `UnitDefs`.
+---
+---Valid IDs start at `1`; `0` is not a valid unit definition.
+---
+---@alias UnitDefID integer
+
+---Identifier of a feature currently present in the simulation.
+---
+---IDs are drawn from a pool and are recycled, so the ID of a destroyed feature
+---may later be handed out to a different feature.
+---
+---@alias FeatureID integer
+
+---Identifier of a feature definition, i.e. an index into `FeatureDefs`.
+---
+---@alias FeatureDefID integer
+
+---Identifier of a solid object, i.e. either a unit or a feature.
+---
+---Unit and feature IDs live in separate ranges, so which of the two is meant
+---follows from context: `Spring.UnitRendering` functions take a unit ID where
+---`Spring.FeatureRendering` functions take a feature ID, and callins that pass
+---an object ID pass the type alongside it.
+---
+---@alias ObjectID UnitID|FeatureID
+
+---Identifier of a projectile currently present in the simulation.
+---
+---Synced and unsynced projectiles are numbered independently.
+---
+---@alias ProjectileID integer
+
+---Identifier of a weapon definition, i.e. an index into `WeaponDefs`,
+---or a negated `CSolidObject::DamageType`
+---
+---@alias WeaponDefID integer
+
+---Identifier of a ground decal.
+---
+---@alias DecalID integer
+
+--------------------------------------------------------------------------------
+-- Player and team IDs
+--------------------------------------------------------------------------------
+
+---Identifier of a team.
+---
+---Teams are numbered from `0`; `Spring.GetGaiaTeamID` returns the Gaia team.
+---
+---@alias TeamID integer
+
+---Identifier of an allyteam.
+---
+---Allyteams are numbered from `0`.
+---
+---@alias AllyTeamID integer
+
+---Identifier of a player.
+---
+---Players are numbered from `0`. Note that a player is a human client, which is
+---not the same thing as a team.
+---
+---@alias PlayerID integer
+
+--------------------------------------------------------------------------------
+-- Unit groups
+--------------------------------------------------------------------------------
+
+---Identifier of a unit (control) group.
+---
+---Groups are per-team. IDs `0` to `9` are the hot-key groups that players can
+---create and select directly; IDs from `10` up are "special" groups that can
+---only be created programmatically. Interfaces that accept or return a group
+---for a unit use `-1` to mean "no group".
+---
+---@alias GroupID integer
+
+--------------------------------------------------------------------------------
 -- Resources
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves #2438

This PR updates the lua annotation comments to replace `number` with `integer` where appropriate, and `integer` with new type aliases for the various distinct IDs that are used across the codebase and shouldn't be conflated (UnitID, UnitDefID, PlayerID, etc). The language servers don't prevent mistakes of that sort yet, however. A few small corrections to other types and comments are made along the way.

If the `number`->`integer` change is welcome but the aliases are not, it will be easy to break them out.

This PR was authored ~90% by Claude Opus 5. I used Perplexity Mistral Large 2 and ChatGPT GPT-5 to identify some of Claude's mistakes and oversights. I made those corrections myself, then reviewed the remainder of the PR and made further corrections and added additional annotation improvements.