### PR TITLE
Particle draw optimizations

### DIFF
--- a/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/ShieldSegmentProjectile.cpp
@@ -232,6 +232,9 @@ ShieldSegmentProjectile::ShieldSegmentProjectile(
 	useAirLos     = true;
 	drawRadius    = shieldWeaponDef->shieldRadius * 0.4f;
 	mygravity     = 0.0f;
+	// Draw() mutates the shared segment collection and can fire the DrawShield
+	// Lua callin, neither of which may run off the main thread
+	mtDrawSafe    = false;
 
 	vertices = GetSegmentVertices(xpart, ypart);
 	texCoors = GetSegmentTexCoords(collection->GetShieldTexture(), xpart, ypart);

--- a/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
+++ b/rts/Rendering/Env/Particles/Classes/SimpleParticleSystem.cpp
@@ -159,16 +159,16 @@ void CSimpleParticleSystem::Draw()
 	}
 
 	// !directional
+	zdir = camera->GetForward();
+	xdir = camera->GetRight();
+	ydir = camera->GetUp();
+
 	for (int i = 0; i < numParticles; i++) {
 		const Particle* p = &particles[i];
 
 		if (p->life >= 1.0f)
 			continue;
 
-		zdir = camera->GetForward();
-		xdir = camera->GetRight();
-		ydir = camera->GetUp();
-		
 		DoParticleDraw(xdir, ydir, zdir, p);
 	}
 }

--- a/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
+++ b/rts/Rendering/Env/Particles/Classes/TracerProjectile.cpp
@@ -26,6 +26,7 @@ CTracerProjectile::CTracerProjectile()
 	, drawLength(0.0f)
 {
 	checkCol = false;
+	mtDrawSafe = false; // Draw() issues immediate GL calls on its own buffer
 }
 
 CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const float3& spd, const float range)
@@ -36,6 +37,7 @@ CTracerProjectile::CTracerProjectile(CUnit* owner, const float3& pos, const floa
 	SetRadiusAndHeight(1.0f, 0.0f);
 
 	checkCol = false;
+	mtDrawSafe = false; // Draw() issues immediate GL calls on its own buffer
 	// Projectile::Init has been called by base ctor, so .w is defined
 	// FIXME: constant, assumes |speed| never changes after creation
 	speedf = this->speed.w;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -45,6 +45,7 @@
 #include "System/Misc/TracyDefs.h"
 
 CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften up CEG particles on clipping edges");
+CONFIG(int, ProjectileDrawReuseWaterPasses).defaultValue(1).safemodeValue(0).description("When water is visible, reuse the below-water pass' alpha particle geometry for the above-water pass instead of regenerating and re-uploading it. The two passes contain identical geometry by construction; disable to force a full refill per pass.");
 
 static uint32_t sortCamType = 0;
 static bool CProjectileDrawOrderSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
@@ -753,45 +754,59 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	};
 	const auto& clipPlane = clipPlanes[1U * drawBelowWater + 2U * drawAboveWater];
 
-	const uint8_t thisPassMask =
-		(1 - (drawReflection || drawRefraction)) * DrawFlags::SO_ALPHAF_FLAG +
-		(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
-		(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
+	// The main view draws alpha particles twice per frame when water is
+	// visible: a below-water pass, then an above-water pass once the water
+	// surface has been drawn. Both passes contain the same particles viewed
+	// from the same camera; only the clip plane differs. Fill and upload the
+	// geometry once in the below-water pass and re-submit the saved range in
+	// the above-water pass. The water reflection/refraction passes that run
+	// in between fill the buffer for their own camera/mask and consume their
+	// own ranges, so the saved range stays valid for the whole frame.
+	const bool mainPass = !drawReflection && !drawRefraction;
+	const bool reuseWanted = (configHandler->GetInt("ProjectileDrawReuseWaterPasses") != 0);
+	const bool reusePass = reuseWanted && mainPass && drawAboveWater && !drawBelowWater && (alphaRangeDrawFrame == globalRendering->drawFrame);
 
-	for (auto& dp : drawParticles)
-		dp.clear();
+	if (!reusePass) {
+		const uint8_t thisPassMask =
+			(1 - (drawReflection || drawRefraction)) * DrawFlags::SO_ALPHAF_FLAG +
+			(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
+			(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
-		for (CProjectile* p : renderProjectiles) {
-			if (!ShouldDrawProjectile(p, thisPassMask))
-				continue;
+		for (auto& dp : drawParticles)
+			dp.clear();
 
-			drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
+			for (CProjectile* p : renderProjectiles) {
+				if (!ShouldDrawProjectile(p, thisPassMask))
+					continue;
+
+				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+			}
 		}
-	}
 
-	// set static variable to facilite sorting
-	sortCamType = camera->GetCamType();
+		// set static variable to facilite sorting
+		sortCamType = camera->GetCamType();
 
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-		if (wantDrawOrder)
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
-		else
-			std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
-	}
-
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-		for (auto p : drawParticles[ true]) {
-			p->Draw();
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
+			if (wantDrawOrder)
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
+			else
+				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
 		}
-	}
-	{
-		ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-		for (auto p : drawParticles[false]) {
-			p->Draw();
+
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
+			for (auto p : drawParticles[ true]) {
+				p->Draw();
+			}
+		}
+		{
+			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
+			for (auto p : drawParticles[false]) {
+				p->Draw();
+			}
 		}
 	}
 
@@ -810,7 +825,18 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		eventHandler.DrawWorldPreParticles(drawAboveWater, drawBelowWater, drawReflection, drawRefraction);
 
 		auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
-		if (!rb.ShouldSubmit())
+
+		if (reuseWanted && mainPass && drawBelowWater && !drawAboveWater) {
+			// an above-water pass will follow this frame; remember what to re-draw
+			const auto pendingRange = rb.GetPendingElemsRange();
+			alphaRangeStart = pendingRange.first;
+			alphaRangeCount = pendingRange.second;
+			alphaRangeDrawFrame = globalRendering->drawFrame;
+		}
+
+		const bool haveRangeToRedraw = (reusePass && alphaRangeCount > 0);
+
+		if (!haveRangeToRedraw && !rb.ShouldSubmit())
 			return;
 
 		const bool needSoften = (wantSoften > 0) && !drawReflection && !drawRefraction;
@@ -835,7 +861,16 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		fxShader->SetUniform("fogColor", sky->fogColor.x, sky->fogColor.y, sky->fogColor.z);
 		fxShader->SetUniform("fogParams", sky->fogStart * camPlayer->GetFarPlaneDist(), sky->fogEnd * camPlayer->GetFarPlaneDist());
 
-		rb.DrawElements(GL_TRIANGLES);
+		if (reusePass) {
+			rb.DrawElementsRange(GL_TRIANGLES, alphaRangeStart, alphaRangeCount);
+			// consume anything appended since the range was saved (e.g. by the
+			// DrawWorldPreParticles handlers above), so it cannot leak into a
+			// later submit running a different shader
+			if (rb.ShouldSubmit())
+				rb.DrawElements(GL_TRIANGLES);
+		} else {
+			rb.DrawElements(GL_TRIANGLES);
+		}
 
 		fxShader->Disable();
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -45,16 +45,98 @@
 #include "System/Misc/TracyDefs.h"
 
 CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften up CEG particles on clipping edges");
+CONFIG(float, ProjectileReflectionMinRadius).defaultValue(0.0f).minimumValue(0.0f).description("Alpha particles with a draw radius (in elmos) smaller than this are skipped in water reflection passes; 0 draws all of them. Small particles are barely visible in reflections, so culling them there is cheap visually and saves a large part of the reflection pass on effect-heavy frames.");
+CONFIG(int, ProjectileDrawThreadedFill).defaultValue(1).safemodeValue(0).description("Generate alpha-particle geometry on the ThreadPool workers instead of the render thread. Draw order is preserved; the few particle types whose Draw is not thread-safe stay on the render thread.");
 CONFIG(int, ProjectileDrawReuseWaterPasses).defaultValue(1).safemodeValue(0).description("When water is visible, reuse the below-water pass' alpha particle geometry for the above-water pass instead of regenerating and re-uploading it. The two passes contain identical geometry by construction; disable to force a full refill per pass.");
 
-static uint32_t sortCamType = 0;
-static bool CProjectileDrawOrderSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::forward_as_tuple(p2->drawOrder, p1->GetSortDist(sortCamType), p1) > std::forward_as_tuple(p1->drawOrder, p2->GetSortDist(sortCamType), p2);
+// sort keys are snapshotted into SortableParticle at fill time, so the
+// comparators run on a contiguous array instead of dereferencing two
+// CProjectile pointers (= two likely cache misses) per comparison
+using SortableParticle = CProjectileDrawer::SortableParticle;
+
+static bool CProjectileDrawOrderSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
+	return std::forward_as_tuple(b.drawOrder, a.sortDist, a.proj) > std::forward_as_tuple(a.drawOrder, b.sortDist, b.proj);
 }
 
-static bool CProjectileSortingPredicate(const CProjectile* p1, const CProjectile* p2) noexcept {
-	return std::forward_as_tuple(p1->GetSortDist(sortCamType), p1) > std::forward_as_tuple(p2->GetSortDist(sortCamType), p2);
+static bool CProjectileSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
+	return std::forward_as_tuple(a.sortDist, a.proj) > std::forward_as_tuple(b.sortDist, b.proj);
 };
+
+// with fewer particles per chunk the for_mt dispatch overhead exceeds the
+// quad-generation work being distributed
+static constexpr size_t MT_FILL_MIN_CHUNK_SIZE = 96;
+
+// Runs p->Draw() over a particle list, generating quads on the ThreadPool
+// workers: the list is split into contiguous chunks, each chunk fills its own
+// scratch buffer, and the scratch buffers are merged into the primary buffer
+// in chunk order, so the emitted geometry is byte-identical to a serial fill.
+// Particles with mtDrawSafe == false (immediate GL calls, Lua callins) split
+// the list into segments and are drawn serially, in their exact position.
+template<typename GetParticle>
+static void FillParticleGeometry(std::vector<TypedRenderBuffer<VA_TYPE_PROJ>>& scratchBufs, size_t count, bool threaded, GetParticle&& getParticle)
+{
+	auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();
+
+	size_t segStart = 0;
+	for (size_t i = 0; i <= count; ++i) {
+		CProjectile* boundaryProj = (i < count) ? getParticle(i) : nullptr;
+		if (boundaryProj != nullptr && boundaryProj->mtDrawSafe)
+			continue;
+
+		// [segStart, i) is a contiguous run of MT-safe particles
+		const size_t segLen = i - segStart;
+		const size_t numChunks = threaded ? std::min<size_t>(ThreadPool::GetNumThreads(), segLen / MT_FILL_MIN_CHUNK_SIZE) : 1;
+
+		if (numChunks < 2) {
+			for (size_t j = segStart; j < i; ++j)
+				getParticle(j)->Draw();
+		} else {
+			// main thread only: buffer (de)registration is not thread-safe
+			if (scratchBufs.size() < numChunks)
+				scratchBufs.resize(numChunks);
+
+			const size_t chunkSize = (segLen + numChunks - 1) / numChunks;
+			const size_t segEnd = i;
+
+			for_mt(0, static_cast<int>(numChunks), [&scratchBufs, &getParticle, segStart, segEnd, chunkSize](int ci) {
+				ZoneScopedN("ProjectileDrawer::DrawAlpha(MTChunk)");
+				auto& scratch = scratchBufs[ci];
+				scratch.Clear();
+
+				CExpGenSpawnable::SetGeomFillTarget(&scratch);
+				const size_t jb = segStart + ci * chunkSize;
+				const size_t je = std::min(jb + chunkSize, segEnd);
+				for (size_t j = jb; j < je; ++j)
+					getParticle(j)->Draw();
+				CExpGenSpawnable::SetGeomFillTarget(nullptr);
+			});
+
+			{
+				// merge in chunk order to preserve the back-to-front particle order
+				ZoneScopedN("ProjectileDrawer::DrawAlpha(MTMerge)");
+				for (size_t ci = 0; ci < numChunks; ++ci) {
+					auto& scratch = scratchBufs[ci];
+					const auto& verts = scratch.GetElems();
+					const auto& indcs = scratch.GetIndcs();
+
+					if (verts.empty())
+						continue;
+
+					const auto vertBias = static_cast<int32_t>(rb.GetBaseVertex());
+					rb.AddVertices(verts.begin(), verts.end());
+					rb.AddIndices(indcs.begin(), indcs.end(), vertBias);
+				}
+			}
+		}
+
+		// the boundary particle itself is not MT-safe; draw it serially in its
+		// exact sorted position
+		if (boundaryProj != nullptr)
+			boundaryProj->Draw();
+
+		segStart = i + 1;
+	}
+}
 
 CProjectileDrawer* projectileDrawer = nullptr;
 
@@ -351,8 +433,9 @@ void CProjectileDrawer::Kill() {
 
 	renderProjectiles.clear();
 
-	for (auto& dp : drawParticles)
-		dp.clear();
+	sortedParticles.clear();
+	unsortedParticles.clear();
+	mtFillBuffers.clear();
 
 	perlinFB.Kill();
 
@@ -373,7 +456,12 @@ void CProjectileDrawer::UpdateDrawFlags()
 {
 	ZoneScopedN("ProjectileDrawer::UpdateDrawFlags");
 
-	for_mt(0, renderProjectiles.size(), [this](int i) {
+	// water reflections are distorted enough that small particles contribute
+	// next to nothing visually; skipping them avoids most of the reflection
+	// pass' fill/sort/quad-generation cost on effect-heavy frames
+	const float reflMinRadius = configHandler->GetFloat("ProjectileReflectionMinRadius");
+
+	for_mt(0, renderProjectiles.size(), [this, reflMinRadius](int i) {
 		CProjectile* p = renderProjectiles[i];
 		const bool hasModel = (p->model != nullptr);
 
@@ -389,6 +477,9 @@ void CProjectileDrawer::UpdateDrawFlags()
 
 		for (uint32_t camType = CCamera::CAMTYPE_PLAYER; camType < CCamera::CAMTYPE_ENVMAP; ++camType) {
 			if (camType == CCamera::CAMTYPE_UWREFL && !IWater::GetWater()->CanDrawReflectionPass())
+				continue;
+
+			if (camType == CCamera::CAMTYPE_UWREFL && !hasModel && p->GetDrawRadius() < reflMinRadius)
 				continue;
 
 			if (camType == CCamera::CAMTYPE_SHADOW && !p->castShadow)
@@ -772,8 +863,10 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 			(drawReflection * DrawFlags::SO_REFLEC_FLAG) +
 			(drawRefraction * DrawFlags::SO_REFRAC_FLAG);
 
-		for (auto& dp : drawParticles)
-			dp.clear();
+		sortedParticles.clear();
+		unsortedParticles.clear();
+
+		const uint32_t sortCamType = camera->GetCamType();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
@@ -781,32 +874,30 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 				if (!ShouldDrawProjectile(p, thisPassMask))
 					continue;
 
-				drawParticles[drawSorted && p->drawSorted].emplace_back(p);
+				if (drawSorted && p->drawSorted)
+					sortedParticles.emplace_back(SortableParticle{ p->drawOrder, p->GetSortDist(sortCamType), p });
+				else
+					unsortedParticles.emplace_back(p);
 			}
 		}
-
-		// set static variable to facilite sorting
-		sortCamType = camera->GetCamType();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
 			if (wantDrawOrder)
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileDrawOrderSortingPredicate);
+				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileDrawOrderSortingPredicate);
 			else
-				std::sort(drawParticles[true].begin(), drawParticles[true].end(), CProjectileSortingPredicate);
+				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileSortingPredicate);
 		}
+
+		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
-			for (auto p : drawParticles[ true]) {
-				p->Draw();
-			}
+			FillParticleGeometry(mtFillBuffers, sortedParticles.size(), threadedFill, [this](size_t j) { return sortedParticles[j].proj; });
 		}
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DU)");
-			for (auto p : drawParticles[false]) {
-				p->Draw();
-			}
+			FillParticleGeometry(mtFillBuffers, unsortedParticles.size(), threadedFill, [this](size_t j) { return unsortedParticles[j]; });
 		}
 	}
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -47,8 +47,8 @@
 
 CONFIG(int, SoftParticles).defaultValue(1).safemodeValue(0).description("Soften up CEG particles on clipping edges");
 CONFIG(float, ProjectileReflectionMinRadius).defaultValue(0.0f).minimumValue(0.0f).description("Alpha particles with a draw radius (in elmos) smaller than this are skipped in water reflection passes; 0 draws all of them. Small particles are barely visible in reflections, so culling them there is cheap visually and saves a large part of the reflection pass on effect-heavy frames.");
-CONFIG(int, ProjectileDrawThreadedFill).defaultValue(1).safemodeValue(0).description("Generate alpha-particle geometry on the ThreadPool workers instead of the render thread. Draw order is preserved; the few particle types whose Draw is not thread-safe stay on the render thread.");
-CONFIG(int, ProjectileDrawReuseWaterPasses).defaultValue(1).safemodeValue(0).description("When water is visible, reuse the below-water pass' alpha particle geometry for the above-water pass instead of regenerating and re-uploading it. The two passes contain identical geometry by construction; disable to force a full refill per pass.");
+CONFIG(bool, ProjectileDrawThreadedFill).defaultValue(true).safemodeValue(false).description("Generate alpha-particle geometry on the ThreadPool workers instead of the render thread. Draw order is preserved; the few particle types whose Draw is not thread-safe stay on the render thread.");
+CONFIG(bool, ProjectileDrawReuseWaterPasses).defaultValue(true).safemodeValue(false).description("When water is visible, reuse the below-water pass' alpha particle geometry for the above-water pass instead of regenerating and re-uploading it. The two passes contain identical geometry by construction; disable to force a full refill per pass.");
 
 // sort keys are snapshotted into SortableParticle at fill time, so sorting
 // works on a contiguous array instead of dereferencing two CProjectile
@@ -872,7 +872,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	// in between fill the buffer for their own camera/mask and consume their
 	// own ranges, so the saved range stays valid for the whole frame.
 	const bool mainPass = !drawReflection && !drawRefraction;
-	const bool reuseWanted = (configHandler->GetInt("ProjectileDrawReuseWaterPasses") != 0);
+	const bool reuseWanted = configHandler->GetBool("ProjectileDrawReuseWaterPasses");
 
 	// the above-water main pass and the water refraction pass both view the
 	// same particles from the player camera; both can re-submit the geometry
@@ -915,7 +915,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 			RadixSortByKey(sortedParticles, sortScratch, [](const SortableParticle& sp) noexcept { return sp.sortKey; });
 		}
 
-		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();
+		const bool threadedFill = configHandler->GetBool("ProjectileDrawThreadedFill") && ThreadPool::HasThreads();
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DS)");
@@ -1056,7 +1056,7 @@ void CProjectileDrawer::DrawShadowTransparent()
 
 	{
 		ZoneScopedN("ProjectileDrawer::DrawShadowTransparent(Fill)");
-		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();
+		const bool threadedFill = configHandler->GetBool("ProjectileDrawThreadedFill") && ThreadPool::HasThreads();
 		FillParticleGeometry(mtFillBuffers, unsortedParticles.size(), threadedFill, [this](size_t j) { return unsortedParticles[j]; });
 	}
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -1044,12 +1044,22 @@ void CProjectileDrawer::DrawShadowTransparent()
 
 	// 1) Render opaque objects into depth stencil texture from light's point of view - done elsewhere
 
-	// draw the model-less projectiles
+	// draw the model-less projectiles; the multiplicative shadow blend is
+	// order-independent, so the list needs no sorting. unsortedParticles is
+	// only otherwise used inside DrawAlpha, which runs later in the frame and
+	// clears it first.
+	unsortedParticles.clear();
 	for (CProjectile* p : renderProjectiles) {
 		if (!ShouldDrawProjectile(p, DrawFlags::SO_SHTRAN_FLAG))
 			continue;
 
-		p->Draw();
+		unsortedParticles.emplace_back(p);
+	}
+
+	{
+		ZoneScopedN("ProjectileDrawer::DrawShadowTransparent(Fill)");
+		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();
+		FillParticleGeometry(mtFillBuffers, unsortedParticles.size(), threadedFill, [this](size_t j) { return unsortedParticles[j]; });
 	}
 
 	auto& rb = CExpGenSpawnable::GetPrimaryRenderBuffer();

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -36,6 +36,7 @@
 #include "Sim/Weapons/WeaponDef.h"
 #include "System/Config/ConfigHandler.h"
 #include "System/EventHandler.h"
+#include "System/RadixSort.h"
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
 #include "System/SafeUtil.h"
@@ -71,54 +72,10 @@ static inline uint64_t ParticleSortKey(const CProjectile* p, uint32_t camType, b
 	return (orderKey << 32) | DistanceSortKey(p->GetSortDist(camType));
 }
 
-// Stable LSD radix sort on sortKey; O(n) with a deterministic per-frame cost,
-// unlike a comparison sort whose runtime varies with the input distribution.
-// Passes whose key byte is identical across all elements (e.g. the drawOrder
-// half when no particle uses it) are skipped. Stability means equal-key
+// The actual ordering is done by RadixSortByKey (System/RadixSort.h) on the
+// packed key: linear, input-independent cost, and stable, so equal-key
 // particles (exactly coincident ones) keep their fill order, which is frame
-// coherent; the previous comparison sort tiebroke them by pointer address.
-static void SortParticles(std::vector<SortableParticle>& elems, std::vector<SortableParticle>& scratch)
-{
-	const size_t n = elems.size();
-
-	// below this the O(n log n) sort wins over 8x histogram+scatter passes
-	if (n < 1024) {
-		std::sort(elems.begin(), elems.end(), [](const SortableParticle& a, const SortableParticle& b) noexcept { return a.sortKey < b.sortKey; });
-		return;
-	}
-
-	scratch.resize(n);
-
-	SortableParticle* src = elems.data();
-	SortableParticle* dst = scratch.data();
-
-	for (uint32_t shift = 0; shift < 64; shift += 8) {
-		size_t bucketOffsets[256] = { 0 };
-
-		for (size_t i = 0; i < n; ++i)
-			bucketOffsets[(src[i].sortKey >> shift) & 0xFF] += 1;
-
-		// this byte is identical across all keys; nothing to reorder
-		if (std::any_of(std::begin(bucketOffsets), std::end(bucketOffsets), [n](size_t c) { return c == n; }))
-			continue;
-
-		// exclusive prefix sum: counts -> output offsets
-		size_t sum = 0;
-		for (size_t b = 0; b < 256; ++b) {
-			const size_t count = bucketOffsets[b];
-			bucketOffsets[b] = sum;
-			sum += count;
-		}
-
-		for (size_t i = 0; i < n; ++i)
-			dst[bucketOffsets[(src[i].sortKey >> shift) & 0xFF]++] = src[i];
-
-		std::swap(src, dst);
-	}
-
-	if (src != elems.data())
-		std::copy(src, src + n, elems.data());
-}
+// coherent. The previous comparison sort tiebroke them by pointer address.
 
 // with fewer particles per chunk the for_mt dispatch overhead exceeds the
 // quad-generation work being distributed
@@ -957,7 +914,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-			SortParticles(sortedParticles, sortScratch);
+			RadixSortByKey(sortedParticles, sortScratch, [](const SortableParticle& sp) noexcept { return sp.sortKey; });
 		}
 
 		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -141,9 +141,13 @@ static void FillParticleGeometry(std::vector<TypedRenderBuffer<VA_TYPE_PROJ>>& s
 		if (boundaryProj != nullptr && boundaryProj->mtDrawSafe)
 			continue;
 
-		// [segStart, i) is a contiguous run of MT-safe particles
+		// [segStart, i) is a contiguous run of MT-safe particles.
+		// Per-particle draw cost varies wildly (a smoke trail emits dozens of
+		// quads, a small flash one), so oversubscribe chunks 4x relative to
+		// the worker count; the pool load-balances them and no single heavy
+		// chunk gates the whole dispatch.
 		const size_t segLen = i - segStart;
-		const size_t numChunks = threaded ? std::min<size_t>(ThreadPool::GetNumThreads(), segLen / MT_FILL_MIN_CHUNK_SIZE) : 1;
+		const size_t numChunks = threaded ? std::min<size_t>(ThreadPool::GetNumThreads() * 4, segLen / MT_FILL_MIN_CHUNK_SIZE) : 1;
 
 		if (numChunks < 2) {
 			for (size_t j = segStart; j < i; ++j)
@@ -914,7 +918,17 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 	// own ranges, so the saved range stays valid for the whole frame.
 	const bool mainPass = !drawReflection && !drawRefraction;
 	const bool reuseWanted = (configHandler->GetInt("ProjectileDrawReuseWaterPasses") != 0);
-	const bool reusePass = reuseWanted && mainPass && drawAboveWater && !drawBelowWater && (alphaRangeDrawFrame == globalRendering->drawFrame);
+
+	// the above-water main pass and the water refraction pass both view the
+	// same particles from the player camera; both can re-submit the geometry
+	// saved by the below-water pass with their own clip plane instead of
+	// refilling. (Refraction previously filled only the underwater-flagged
+	// subset; submitting the full range is visually equivalent because the
+	// clip plane discards everything above the surface.) The reflection pass
+	// uses the mirrored camera and must keep building its own billboards.
+	const bool reuseAbove = mainPass && drawAboveWater && !drawBelowWater;
+	const bool reuseRefraction = drawRefraction && !drawReflection;
+	const bool reusePass = reuseWanted && (reuseAbove || reuseRefraction) && (alphaRangeDrawFrame == globalRendering->drawFrame);
 
 	if (!reusePass) {
 		const uint8_t thisPassMask =

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -49,18 +49,76 @@ CONFIG(float, ProjectileReflectionMinRadius).defaultValue(0.0f).minimumValue(0.0
 CONFIG(int, ProjectileDrawThreadedFill).defaultValue(1).safemodeValue(0).description("Generate alpha-particle geometry on the ThreadPool workers instead of the render thread. Draw order is preserved; the few particle types whose Draw is not thread-safe stay on the render thread.");
 CONFIG(int, ProjectileDrawReuseWaterPasses).defaultValue(1).safemodeValue(0).description("When water is visible, reuse the below-water pass' alpha particle geometry for the above-water pass instead of regenerating and re-uploading it. The two passes contain identical geometry by construction; disable to force a full refill per pass.");
 
-// sort keys are snapshotted into SortableParticle at fill time, so the
-// comparators run on a contiguous array instead of dereferencing two
-// CProjectile pointers (= two likely cache misses) per comparison
+// sort keys are snapshotted into SortableParticle at fill time, so sorting
+// works on a contiguous array instead of dereferencing two CProjectile
+// pointers (= two likely cache misses) per comparison
 using SortableParticle = CProjectileDrawer::SortableParticle;
 
-static bool CProjectileDrawOrderSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
-	return std::forward_as_tuple(b.drawOrder, a.sortDist, a.proj) > std::forward_as_tuple(a.drawOrder, b.sortDist, b.proj);
+// maps a float to an unsigned int with the same ordering (for non-NaN),
+// inverted so that LARGER distances get SMALLER keys (back-to-front when
+// sorting ascending)
+static inline uint32_t DistanceSortKey(float dist) noexcept
+{
+	uint32_t u = std::bit_cast<uint32_t>(dist);
+	u ^= static_cast<uint32_t>(static_cast<int32_t>(u) >> 31) | 0x80000000u;
+	return ~u;
 }
 
-static bool CProjectileSortingPredicate(const SortableParticle& a, const SortableParticle& b) noexcept {
-	return std::forward_as_tuple(a.sortDist, a.proj) > std::forward_as_tuple(b.sortDist, b.proj);
-};
+// ascending == draw order: drawOrder asc (high 32 bits), distance desc
+static inline uint64_t ParticleSortKey(const CProjectile* p, uint32_t camType, bool useDrawOrder) noexcept
+{
+	const uint64_t orderKey = useDrawOrder ? (static_cast<uint32_t>(p->drawOrder) ^ 0x80000000u) : 0u;
+	return (orderKey << 32) | DistanceSortKey(p->GetSortDist(camType));
+}
+
+// Stable LSD radix sort on sortKey; O(n) with a deterministic per-frame cost,
+// unlike a comparison sort whose runtime varies with the input distribution.
+// Passes whose key byte is identical across all elements (e.g. the drawOrder
+// half when no particle uses it) are skipped. Stability means equal-key
+// particles (exactly coincident ones) keep their fill order, which is frame
+// coherent; the previous comparison sort tiebroke them by pointer address.
+static void SortParticles(std::vector<SortableParticle>& elems, std::vector<SortableParticle>& scratch)
+{
+	const size_t n = elems.size();
+
+	// below this the O(n log n) sort wins over 8x histogram+scatter passes
+	if (n < 1024) {
+		std::sort(elems.begin(), elems.end(), [](const SortableParticle& a, const SortableParticle& b) noexcept { return a.sortKey < b.sortKey; });
+		return;
+	}
+
+	scratch.resize(n);
+
+	SortableParticle* src = elems.data();
+	SortableParticle* dst = scratch.data();
+
+	for (uint32_t shift = 0; shift < 64; shift += 8) {
+		size_t bucketOffsets[256] = { 0 };
+
+		for (size_t i = 0; i < n; ++i)
+			bucketOffsets[(src[i].sortKey >> shift) & 0xFF] += 1;
+
+		// this byte is identical across all keys; nothing to reorder
+		if (std::any_of(std::begin(bucketOffsets), std::end(bucketOffsets), [n](size_t c) { return c == n; }))
+			continue;
+
+		// exclusive prefix sum: counts -> output offsets
+		size_t sum = 0;
+		for (size_t b = 0; b < 256; ++b) {
+			const size_t count = bucketOffsets[b];
+			bucketOffsets[b] = sum;
+			sum += count;
+		}
+
+		for (size_t i = 0; i < n; ++i)
+			dst[bucketOffsets[(src[i].sortKey >> shift) & 0xFF]++] = src[i];
+
+		std::swap(src, dst);
+	}
+
+	if (src != elems.data())
+		std::copy(src, src + n, elems.data());
+}
 
 // with fewer particles per chunk the for_mt dispatch overhead exceeds the
 // quad-generation work being distributed
@@ -434,6 +492,7 @@ void CProjectileDrawer::Kill() {
 	renderProjectiles.clear();
 
 	sortedParticles.clear();
+	sortScratch.clear();
 	unsortedParticles.clear();
 	mtFillBuffers.clear();
 
@@ -867,6 +926,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 		unsortedParticles.clear();
 
 		const uint32_t sortCamType = camera->GetCamType();
+		const bool useDrawOrder = wantDrawOrder;
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(DP)");
@@ -875,7 +935,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 					continue;
 
 				if (drawSorted && p->drawSorted)
-					sortedParticles.emplace_back(SortableParticle{ p->drawOrder, p->GetSortDist(sortCamType), p });
+					sortedParticles.emplace_back(SortableParticle{ ParticleSortKey(p, sortCamType, useDrawOrder), p });
 				else
 					unsortedParticles.emplace_back(p);
 			}
@@ -883,10 +943,7 @@ void CProjectileDrawer::DrawAlpha(bool drawAboveWater, bool drawBelowWater, bool
 
 		{
 			ZoneScopedN("ProjectileDrawer::DrawAlpha(SO)");
-			if (wantDrawOrder)
-				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileDrawOrderSortingPredicate);
-			else
-				std::sort(sortedParticles.begin(), sortedParticles.end(), CProjectileSortingPredicate);
+			SortParticles(sortedParticles, sortScratch);
 		}
 
 		const bool threadedFill = (configHandler->GetInt("ProjectileDrawThreadedFill") != 0) && ThreadPool::HasThreads();

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -481,11 +481,22 @@ void CProjectileDrawer::UpdateDrawFlags()
 	// pass' fill/sort/quad-generation cost on effect-heavy frames
 	const float reflMinRadius = configHandler->GetFloat("ProjectileReflectionMinRadius");
 
-	for_mt(0, renderProjectiles.size(), [this, reflMinRadius](int i) {
+	// per-frame invariants, hoisted out of the per-particle loop (notably
+	// IWater::GetWater()->CanDrawReflectionPass(), a virtual call that was
+	// previously made once per particle)
+	const bool drawReflPass = IWater::GetWater()->CanDrawReflectionPass();
+	const bool drawShadowPass = (shadowHandler.shadowGenBits & CShadowHandler::SHADOWGEN_BIT_PROJ) != 0;
+	const float timeOffset = globalRendering->timeOffset;
+
+	const CCamera* camPlayer = CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER);
+	const CCamera* camUWRefl = CCameraHandler::GetCamera(CCamera::CAMTYPE_UWREFL);
+	const CCamera* camShadow = CCameraHandler::GetCamera(CCamera::CAMTYPE_SHADOW);
+
+	for_mt(0, renderProjectiles.size(), [this, reflMinRadius, drawReflPass, drawShadowPass, timeOffset, camPlayer, camUWRefl, camShadow](int i) {
 		CProjectile* p = renderProjectiles[i];
 		const bool hasModel = (p->model != nullptr);
 
-		p->drawPos = p->GetDrawPos(globalRendering->timeOffset);
+		p->drawPos = p->GetDrawPos(timeOffset);
 
 		p->previousDrawFlag = p->drawFlag;
 		p->ResetDrawFlag();
@@ -495,55 +506,42 @@ void CProjectileDrawer::UpdateDrawFlags()
 
 		p->SetDrawFlag(DrawFlags::SO_DRICON_FLAG); //reuse as a minimap draw indication
 
-		for (uint32_t camType = CCamera::CAMTYPE_PLAYER; camType < CCamera::CAMTYPE_ENVMAP; ++camType) {
-			if (camType == CCamera::CAMTYPE_UWREFL && !IWater::GetWater()->CanDrawReflectionPass())
-				continue;
+		const float drawRadius = p->GetDrawRadius();
 
-			if (camType == CCamera::CAMTYPE_UWREFL && !hasModel && p->GetDrawRadius() < reflMinRadius)
-				continue;
+		if (camPlayer->InView(p->drawPos, drawRadius)) {
+			p->SetSortDist(CCamera::CAMTYPE_PLAYER, camPlayer->ProjectedDistance(p->drawPos));
 
-			if (camType == CCamera::CAMTYPE_SHADOW && !p->castShadow)
-				continue;
+			if (hasModel)
+				p->AddDrawFlag(DrawFlags::SO_OPAQUE_FLAG);
+			else
+				p->AddDrawFlag(DrawFlags::SO_ALPHAF_FLAG);
 
-			if (camType == CCamera::CAMTYPE_SHADOW && ((shadowHandler.shadowGenBits & CShadowHandler::SHADOWGEN_BIT_PROJ) == 0))
-				continue;
+			if (p->drawPos.y - drawRadius < 0.0f)
+				p->AddDrawFlag(DrawFlags::SO_REFRAC_FLAG);
 
-			const CCamera* cam = CCameraHandler::GetCamera(camType);
-			if (!cam->InView(p->drawPos, p->GetDrawRadius()))
-				continue;
+			// Special case of piece projectile, since it has a model and fire particle
+			if (p->piece)
+				p->AddDrawFlag(DrawFlags::SO_ALPHAF_FLAG);
+		}
 
-			p->SetSortDist(camType, cam->ProjectedDistance(p->drawPos));
+		if (drawReflPass && (hasModel || drawRadius >= reflMinRadius) && camUWRefl->InView(p->drawPos, drawRadius)) {
+			p->SetSortDist(CCamera::CAMTYPE_UWREFL, camUWRefl->ProjectedDistance(p->drawPos));
 
-			switch (camType)
-			{
-				case CCamera::CAMTYPE_PLAYER: {
-					if (hasModel)
-						p->AddDrawFlag(DrawFlags::SO_OPAQUE_FLAG);
-					else
-						p->AddDrawFlag(DrawFlags::SO_ALPHAF_FLAG);
+			if (CModelDrawerHelper::ObjectVisibleReflection(p->drawPos, camUWRefl->GetPos(), drawRadius))
+				p->AddDrawFlag(DrawFlags::SO_REFLEC_FLAG);
+		}
 
-					if (p->drawPos.y - p->GetDrawRadius() < 0.0f)
-						p->AddDrawFlag(DrawFlags::SO_REFRAC_FLAG);
+		if (drawShadowPass && p->castShadow && camShadow->InView(p->drawPos, drawRadius)) {
+			p->SetSortDist(CCamera::CAMTYPE_SHADOW, camShadow->ProjectedDistance(p->drawPos));
 
-					// Special case of piece projectile, since it has a model and fire particle
-					if (p->piece)
-						p->AddDrawFlag(DrawFlags::SO_ALPHAF_FLAG);
-				} break;
-				case CCamera::CAMTYPE_UWREFL: {
-					if (CModelDrawerHelper::ObjectVisibleReflection(p->drawPos, cam->GetPos(), p->GetDrawRadius()))
-						p->AddDrawFlag(DrawFlags::SO_REFLEC_FLAG);
-				} break;
-				case CCamera::CAMTYPE_SHADOW: {
-					if unlikely(hasModel)
-						p->AddDrawFlag(DrawFlags::SO_SHOPAQ_FLAG);
-					else
-						p->AddDrawFlag(DrawFlags::SO_SHTRAN_FLAG);
+			if unlikely(hasModel)
+				p->AddDrawFlag(DrawFlags::SO_SHOPAQ_FLAG);
+			else
+				p->AddDrawFlag(DrawFlags::SO_SHTRAN_FLAG);
 
-					// Special case of piece projectile, since it has a model and fire particle
-					if (p->piece)
-						p->AddDrawFlag(DrawFlags::SO_SHTRAN_FLAG);
-				} break;
-			}
+			// Special case of piece projectile, since it has a model and fire particle
+			if (p->piece)
+				p->AddDrawFlag(DrawFlags::SO_SHTRAN_FLAG);
 		}
 	});
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -169,16 +169,19 @@ private:
 
 public:
 	struct SortableParticle {
-		int drawOrder;
-		float sortDist;
+		// drawOrder and view distance packed into one integer so that an
+		// ascending sort yields the draw order (drawOrder asc, distance desc)
+		uint64_t sortKey;
 		CProjectile* proj;
 	};
 
 private:
 	/// alpha particles drawn back-to-front; sort keys are snapshotted at fill
-	/// time so sorting compares a contiguous 16-byte array instead of chasing
+	/// time so sorting works on a contiguous 16-byte array instead of chasing
 	/// projectile pointers
 	std::vector<SortableParticle> sortedParticles;
+	/// ping-pong buffer for the radix sort passes
+	std::vector<SortableParticle> sortScratch;
 	/// alpha particles that opt out of sorting, drawn after the sorted ones
 	std::vector<CProjectile*> unsortedParticles;
 

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -170,6 +170,12 @@ private:
 	/// used to render particle effects in back-to-front order. {unsorted, sorted}
 	std::array<std::vector<CProjectile*>, 2> drawParticles;
 
+	/// geometry range submitted by the below-water alpha pass, re-drawn by the
+	/// above-water pass of the same frame instead of refilling the buffer
+	size_t alphaRangeStart = 0;
+	size_t alphaRangeCount = 0;
+	unsigned int alphaRangeDrawFrame = 0;
+
 	bool drawSorted = true;
 
 	Shader::IProgramObject* fxShader = nullptr;

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -167,8 +167,26 @@ private:
 	/// projectiles with a model, binned by model type and textures
 	std::array<ModelRenderContainer<CProjectile>, MODELTYPE_CNT> modelRenderers;
 
-	/// used to render particle effects in back-to-front order. {unsorted, sorted}
-	std::array<std::vector<CProjectile*>, 2> drawParticles;
+public:
+	struct SortableParticle {
+		int drawOrder;
+		float sortDist;
+		CProjectile* proj;
+	};
+
+private:
+	/// alpha particles drawn back-to-front; sort keys are snapshotted at fill
+	/// time so sorting compares a contiguous 16-byte array instead of chasing
+	/// projectile pointers
+	std::vector<SortableParticle> sortedParticles;
+	/// alpha particles that opt out of sorting, drawn after the sorted ones
+	std::vector<CProjectile*> unsortedParticles;
+
+	/// per-chunk scratch buffers for the multithreaded alpha-pass geometry
+	/// fill; only their CPU-side arrays are ever used (no GL objects). Grown
+	/// on the main thread only, since (de)registration in the RenderBuffer
+	/// registry is not thread-safe.
+	std::vector<TypedRenderBuffer<VA_TYPE_PROJ>> mtFillBuffers;
 
 	/// geometry range submitted by the below-water alpha pass, re-drawn by the
 	/// above-water pass of the same frame instead of refilling the buffer

--- a/rts/Rendering/GL/RenderBuffers.h
+++ b/rts/Rendering/GL/RenderBuffers.h
@@ -587,7 +587,15 @@ public:
 	void AssertBoundShader() const;
 	void DrawArrays(uint32_t mode, bool rewind = true);
 	void DrawElements(uint32_t mode, bool rewind = true);
+	void DrawElementsRange(uint32_t mode, size_t eboRangeStart, size_t eboRangeCount);
 	void DropCurrent();
+
+	// the index range the next DrawElements() call would submit; capture before
+	// submitting to later re-draw the same geometry via DrawElementsRange()
+	// (valid until the next SwapBuffer(), i.e. within the current draw frame)
+	std::pair<size_t, size_t> GetPendingElemsRange() const {
+		return { eboStartIndex, indcs.size() - eboStartIndex };
+	}
 
 	TypedRenderBuffer<T> CopyCurrent(bool readOnly) const;
 
@@ -907,6 +915,29 @@ inline void TypedRenderBuffer<T>::DrawElements(uint32_t mode, bool rewind)
 	}
 
 	vboStartIndex = verts.size();
+
+	numSubmits[1] += 1;
+}
+
+// re-draws an already uploaded and submitted index range of the current frame,
+// without touching the consume/rewind bookkeeping. The range must come from
+// GetPendingElemsRange() captured earlier in the same draw frame.
+template<typename T>
+inline void TypedRenderBuffer<T>::DrawElementsRange(uint32_t mode, size_t eboRangeStart, size_t eboRangeCount)
+{
+	AssertBoundShader();
+
+	if (eboRangeCount == 0)
+		return;
+
+	assert(eboRangeStart + eboRangeCount <= indcs.size());
+	assert(eboRangeStart + eboRangeCount <= eboUploadIndex);
+#ifndef HEADLESS
+	assert(vao.GetIdRaw() > 0);
+#endif
+	vao.Bind();
+	glDrawElements(mode, static_cast<GLsizei>(eboRangeCount), GL_UNSIGNED_INT, reinterpret_cast<void*>(sizeof(uint32_t) * (ebo->BufferElemOffset() + eboRangeStart)));
+	vao.Unbind();
 
 	numSubmits[1] += 1;
 }

--- a/rts/Sim/Projectiles/ExpGenSpawnable.cpp
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.cpp
@@ -138,9 +138,21 @@ bool CExpGenSpawnable::GetMemberInfo(SExpGenSpawnableMemberInfo& memberInfo)
 	return false;
 }
 
+// per-thread geometry destination override for the multithreaded alpha-pass
+// fill; null (the default) routes everything to the shared primary buffer
+static thread_local TypedRenderBuffer<VA_TYPE_PROJ>* geomFillTarget = nullptr;
+
+void CExpGenSpawnable::SetGeomFillTarget(TypedRenderBuffer<VA_TYPE_PROJ>* target)
+{
+	geomFillTarget = target;
+}
+
 TypedRenderBuffer<VA_TYPE_PROJ>& CExpGenSpawnable::GetPrimaryRenderBuffer()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (geomFillTarget != nullptr)
+		return *geomFillTarget;
+
 	return RenderBuffer::GetTypedRenderBuffer<VA_TYPE_PROJ>();
 }
 

--- a/rts/Sim/Projectiles/ExpGenSpawnable.h
+++ b/rts/Sim/Projectiles/ExpGenSpawnable.h
@@ -35,6 +35,11 @@ public:
 	//Memory handled in projectileHandler
 	static CExpGenSpawnable* CreateSpawnable(int spawnableID);
 	static TypedRenderBuffer<VA_TYPE_PROJ>& GetPrimaryRenderBuffer();
+
+	// while set (per thread), AddEffectsQuad geometry lands in the given
+	// buffer instead of the shared primary one; used by the multithreaded
+	// alpha-pass fill in CProjectileDrawer. Pass nullptr to restore.
+	static void SetGeomFillTarget(TypedRenderBuffer<VA_TYPE_PROJ>* target);
 protected:
 	CExpGenSpawnable();
 

--- a/rts/Sim/Projectiles/Projectile.h
+++ b/rts/Sim/Projectiles/Projectile.h
@@ -116,6 +116,10 @@ public:
 
 	bool castShadow = false;
 	bool drawSorted = true;
+	// false for the few classes whose Draw() touches shared state (immediate
+	// GL calls, Lua callins); they are drawn serially by the alpha pass while
+	// everything else fills geometry multithreaded
+	bool mtDrawSafe = true;
 
 	bool blockPreciseCol = false;
 

--- a/rts/System/RadixSort.h
+++ b/rts/System/RadixSort.h
@@ -1,0 +1,72 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+
+// Sorts elems ascending by an unsigned integer key, using a least-significant
+// digit radix sort: linear, input-independent cost, no comparison predicate.
+// keyOf maps an element to its key; pack composite orderings into one integer
+// (see e.g. the alpha-particle sort in ProjectileDrawer for a float-distance
+// packing example). Key bytes that are identical across all elements cost one
+// counting pass and no scatter, so sparse keys sort proportionally faster.
+//
+// The radix path is stable (equal keys keep their input order). Arrays below
+// smallNThreshold fall back to std::sort on the key, which is faster at that
+// size but not stable; both paths are deterministic for identical input.
+//
+// scratch is a caller-owned ping-pong buffer, kept as a parameter so repeated
+// sorts (e.g. once per frame) can reuse its capacity.
+template<typename T, typename KeyFunc>
+inline void RadixSortByKey(std::vector<T>& elems, std::vector<T>& scratch, KeyFunc keyOf, size_t smallNThreshold = 1024)
+{
+	using KeyType = std::decay_t<std::invoke_result_t<KeyFunc, const T&>>;
+	static_assert(std::is_unsigned_v<KeyType>, "radix sort key must be an unsigned integer type");
+
+	const size_t n = elems.size();
+
+	if (n < 2)
+		return;
+
+	if (n < smallNThreshold) {
+		std::sort(elems.begin(), elems.end(), [&keyOf](const T& a, const T& b) { return keyOf(a) < keyOf(b); });
+		return;
+	}
+
+	scratch.resize(n);
+
+	T* src = elems.data();
+	T* dst = scratch.data();
+
+	for (uint32_t shift = 0; shift < sizeof(KeyType) * 8; shift += 8) {
+		size_t bucketOffsets[256] = { 0 };
+
+		for (size_t i = 0; i < n; ++i)
+			bucketOffsets[(keyOf(src[i]) >> shift) & 0xFF] += 1;
+
+		// this byte is identical across all keys; nothing to reorder
+		if (std::any_of(std::begin(bucketOffsets), std::end(bucketOffsets), [n](size_t c) { return c == n; }))
+			continue;
+
+		// exclusive prefix sum: counts -> output offsets
+		size_t sum = 0;
+		for (size_t b = 0; b < 256; ++b) {
+			const size_t count = bucketOffsets[b];
+			bucketOffsets[b] = sum;
+			sum += count;
+		}
+
+		for (size_t i = 0; i < n; ++i)
+			dst[bucketOffsets[(keyOf(src[i]) >> shift) & 0xFF]++] = src[i];
+
+		std::swap(src, dst);
+	}
+
+	if (src != elems.data())
+		std::copy(src, src + n, elems.data());
+}


### PR DESCRIPTION
On water maps the alpha-particle pipeline built its geometry up to four times per frame (below-water, reflection, refraction, above-water), each time re-filtering, re-sorting, re-running every particle's Draw() and re-uploading the result — all on the render thread. At battle-level particle counts this made ProjectileDrawer::DrawAlpha one of the largest CPU blocks in the frame. This PR eliminates the redundant builds and parallelizes/speeds up what remains. Every change is either config-gated or geometry-byte-identical by construction, and none of it can affect sync (details below).

# Relationship to #3037
This branch and @bruno-dasilva's draft #3037 arrived at the same overall design independently — pass geometry reuse, threaded fill (with the same two serial-exception classes found by separate audits), and a keyed radix sort — which is good evidence for the design itself. Two refinements here are adopted directly from #3037 and credited in the commit message: the refraction-pass reuse and the fill-chunk oversubscription. The radix sort lives in a templated utility header per the review feedback given there. The #3037 replay-based numbers (late-game ultra) complement the deterministic benchmark used here.

# Measurement
Numbers are from a deterministic benchmark: a synced gadget spawning a fixed, seeded, map-wide mix of CEGs, weapon explosions, in-flight projectiles and beams (~20k sortable alpha particles at the tested intensity), so back-to-back runs draw identical scenes. Measured with Tracy on a water map (Tabula), same-session A/B via the config toggles. 
Benchmark executed in via: /luarules particlebench mix 300 3

Metric	before	after
Frame average	7.51 ms (133 fps)	4.98 ms (201 fps)
1%-low fps	111	125
Alpha builds per frame (water map)	4	2 (main + mirrored reflection)
Above-water pass	1.16 ms	65 µs
Quad generation DrawAlpha(DS)	~390 µs	~130 µs
Sorting DrawAlpha(SO)	~184 µs mean / ~470 µs max	~31 µs mean / ~75 µs max

# Implementation
Reuse alpha geometry across the water passes. Below/above-water passes contain identical geometry (same camera, same particles, same interpolation time — only the clip plane differs). The below-water pass records its submitted index range (TypedRenderBuffer::GetPendingElemsRange); the above-water pass re-issues it via the new DrawElementsRange instead of refilling. Config ProjectileDrawReuseWaterPasses (default 1, safemode 0) restores the old refill-per-pass behavior.
Sort-key snapshot + threaded quad generation. Keys are snapshotted at filter time instead of dereferencing two CProjectile* per comparison. The Draw() loops fan out over the ThreadPool into per-chunk scratch buffers via a thread-local redirect of CExpGenSpawnable::GetPrimaryRenderBuffer(), merged in chunk order — submitted geometry is byte-identical to a serial fill, including back-to-front order. All reachable Draw() overrides were audited for shared state; the two exceptions (CTracerProjectile: immediate GL, ShieldSegmentProjectile: shared latch + DrawShield Lua callin) carry mtDrawSafe = false and draw serially at their exact sorted position. Config ProjectileDrawThreadedFill (default 1, safemode 0). Worker chunks are Tracy-zoned (MTChunk/MTMerge). Also adds ProjectileReflectionMinRadius (default 0 = off) for optionally culling small particles from reflections.

# Radix sort. 
drawOrder + distance packed into one 64-bit key; stable LSD radix with constant-byte pass skipping, std::sort-on-key below 1024 elements. Linear, input-independent cost — the worst-case sort spikes disappear. Stable ordering also removes a latent UB path (NaN distances fed to a comparison predicate violate strict weak ordering).
Refraction reuse + chunk balancing (both from #3037). The refraction pass views the same particles from the player camera, so it re-submits the saved below-water range with its clip plane instead of filling the underwater subset — visually equivalent, one full build eliminated. Fill chunks oversubscribe 4× vs. worker count so no single heavy chunk (smoke trails) gates the dispatch: MTChunk mean 68 → 26 µs, 1%-lows 111 → 125 fps.
System/RadixSort.h. The sort extracted into a reusable utility templated on element type and key projection, per review feedback on #3037. No functional change.

# UpdateDrawFlags
Hoist per-frame invariants out of UpdateDrawFlags. The per-particle camera loop re-evaluated per-frame constants for every projectile — most notably IWater::GetWater()->CanDrawReflectionPass(), a virtual call made ~once per particle per frame — plus the shadow-gen bit, camera pointer lookups, and repeated GetDrawRadius() calls. They're hoisted ahead of the for_mt and the three-camera loop is unrolled into straight-line blocks. Flag results and sort distances are unchanged.
measured 254µs→176µs, -31%

# Sync safety
Damage and particle spawning live exclusively in synced sim paths: a targeted sweep confirmed every guRNG call and every chained projMemPool.alloc sits in a ctor/Init()/Update(), gsRNG is never referenced by particle code, and Draw() bodies write only render-side members that sim code never reads. The draw path cannot reach synced state, so deduplicating, reordering, or threading it cannot diverge the simulation. (Full analysis in commit 2's message.)

Review aids
Three runtime toggles allow live bisection without rebuilding: ProjectileDrawReuseWaterPasses, ProjectileDrawThreadedFill (both read per frame, safemode-off), and ProjectileReflectionMinRadius. Setting the first two to 0 restores the pre-PR code path exactly

Before:
<img width="2270" height="796" alt="2026-08-15 20_53_25-NVIDIA GeForce Overlay" src="https://github.com/user-attachments/assets/24c291eb-fe87-4b13-a89a-62d0970c234f" />
After:
<img width="1314" height="1150" alt="2026-08-16 01_18_03-spring exe @ 2026-08-16 01_00_26 - Tracy Profiler 0 11 1" src="https://github.com/user-attachments/assets/0a9d12a6-a471-4ee8-8009-1780c478e951" />


Coded by: Claude Fable 5