### PR TITLE
Revert gitignore deletion from 6a14e4a0155ba9ce403d970478952a2255bf1c0f

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ build-*
 # IDE
 /.idea
 .kilo
+
+/.i-understand-git-submodules.txt


### PR DESCRIPTION
For undocumented uknown reason, that commit dropped /.i-understand-git-submodules.txt from .gitignore, restoring it.