### PR TITLE
Add ordered attack target-list command

### DIFF
--- a/rts/Game/UI/CursorIcons.cpp
+++ b/rts/Game/UI/CursorIcons.cpp
@@ -200,6 +200,7 @@ const CMouseCursor* CCursorIcons::GetCursor(int cmd) const
 		case CMD_FIGHT:           cursorName = "Fight";        break;
 		case CMD_ATTACK:          cursorName = "Attack";       break;
 		case CMD_AREA_ATTACK:     cursorName = "Area attack";  break;
+		case CMD_ATTACK_TARGETS:  cursorName = "Attack";       break;
 		case CMD_GUARD:           cursorName = "Guard";        break;
 		case CMD_REPAIR:          cursorName = "Repair";       break;
 		case CMD_LOAD_ONTO:       cursorName = "Load units";   break;

--- a/rts/Lua/LuaConstCMD.cpp
+++ b/rts/Lua/LuaConstCMD.cpp
@@ -290,6 +290,12 @@ bool LuaConstCMD::PushEntries(lua_State* L)
 	PUSH_CMD(ATTACK);
 	/*** @field CMD.AREA_ATTACK 21 */
 	PUSH_CMD(AREA_ATTACK);
+	/***
+	 * @field CMD.ATTACK_TARGETS 22
+	 * Sequentially attacks each unit ID in the command parameters. Each receiving
+	 * unit keeps an independent cursor and skips targets that are no longer valid.
+	 */
+	PUSH_CMD(ATTACK_TARGETS);
 	/*** @field CMD.GUARD 25 */
 	PUSH_CMD(GUARD);
 	/*** @field CMD.GROUPSELECT 35 */

--- a/rts/Rendering/CommandDrawer.cpp
+++ b/rts/Rendering/CommandDrawer.cpp
@@ -34,6 +34,16 @@ static const CUnit* GetTrackableUnit(const CUnit* caiOwner, const CUnit* cmdUnit
 	return cmdUnit;
 }
 
+static void DrawAttackTargets(const Command& command, const CUnit* owner, unsigned int firstTargetIndex = 0)
+{
+	for (unsigned int p = firstTargetIndex; p < command.GetNumParams(); ++p) {
+		const CUnit* unit = GetTrackableUnit(owner, unitHandler.GetUnit(command.GetParam(p)));
+
+		if (unit != nullptr)
+			lineDrawer.DrawLineAndIcon(CMD_ATTACK_TARGETS, unit->GetObjDrawErrorPos(owner->allyteam), cmdColors.attack);
+	}
+}
+
 CommandDrawer* CommandDrawer::GetInstance() {
 	// luaQueuedUnitSet gets cleared each frame, so this is fine wrt. reloading
 	static CommandDrawer drawer;
@@ -112,6 +122,10 @@ void CommandDrawer::DrawCommands(const CCommandAI* cai, int queueDrawDepth) cons
 		const int cmdID = ci->GetID();
 
 		switch (cmdID) {
+			case CMD_ATTACK_TARGETS: {
+				const unsigned int firstTargetIndex = (ci == commandQue.begin()) ? cai->GetAttackTargetDrawIndex() : 0;
+				DrawAttackTargets(*ci, owner, firstTargetIndex);
+			} break;
 			case CMD_ATTACK:
 			case CMD_MANUALFIRE: {
 				if (ci->GetNumParams() == 1) {
@@ -169,6 +183,10 @@ void CommandDrawer::DrawAirCAICommands(const CAirCAI* cai, int queueDrawDepth) c
 		const int cmdID = ci->GetID();
 
 		switch (cmdID) {
+			case CMD_ATTACK_TARGETS: {
+				const unsigned int firstTargetIndex = (ci == commandQue.begin()) ? cai->GetAttackTargetDrawIndex() : 0;
+				DrawAttackTargets(*ci, owner, firstTargetIndex);
+			} break;
 			case CMD_MOVE: {
 				lineDrawer.DrawLineAndIcon(cmdID, ci->GetPos(0), cmdColors.move);
 			} break;
@@ -274,6 +292,10 @@ void CommandDrawer::DrawBuilderCAICommands(const CBuilderCAI* cai, int queueDraw
 		}
 
 		switch (cmdID) {
+			case CMD_ATTACK_TARGETS: {
+				const unsigned int firstTargetIndex = (ci == commandQue.begin()) ? cai->GetAttackTargetDrawIndex() : 0;
+				DrawAttackTargets(*ci, owner, firstTargetIndex);
+			} break;
 			case CMD_MOVE: {
 				lineDrawer.DrawLineAndIcon(cmdID, ci->GetPos(0), cmdColors.move);
 			} break;
@@ -426,6 +448,9 @@ void CommandDrawer::DrawFactoryCAICommands(const CFactoryCAI* cai, int queueDraw
 		const int cmdID = ci->GetID();
 
 		switch (cmdID) {
+			case CMD_ATTACK_TARGETS: {
+				DrawAttackTargets(*ci, owner);
+			} break;
 			case CMD_MOVE: {
 				lineDrawer.DrawLineAndIcon(cmdID, ci->GetPos(0) + UpVector * 3.0f, cmdColors.move);
 			} break;
@@ -514,6 +539,10 @@ void CommandDrawer::DrawMobileCAICommands(const CMobileCAI* cai, int queueDrawDe
 		const int cmdID = ci->GetID();
 
 		switch (cmdID) {
+			case CMD_ATTACK_TARGETS: {
+				const unsigned int firstTargetIndex = (ci == commandQue.begin()) ? cai->GetAttackTargetDrawIndex() : 0;
+				DrawAttackTargets(*ci, owner, firstTargetIndex);
+			} break;
 			case CMD_MOVE: {
 				lineDrawer.DrawLineAndIcon(cmdID, ci->GetPos(0), cmdColors.move);
 			} break;
@@ -797,4 +826,3 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		glDisableClientState(GL_VERTEX_ARRAY);
 	}
 }
-

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -105,6 +105,9 @@ void CModInfo::ResetState()
 		targetableTransportedUnits = 0;
 	}
 	{
+		attackTargetListPreferListedTargets = false;
+	}
+	{
 		fireAtKilled   = false;
 		fireAtCrashing = false;
 	}
@@ -320,6 +323,13 @@ void CModInfo::Init(const std::string& modFileName)
 	}
 
 	{
+		// targeting
+		const LuaTable& targetingTbl = root.SubTable("targeting");
+
+		attackTargetListPreferListedTargets = targetingTbl.GetBool("attackTargetListPreferListedTargets", attackTargetListPreferListedTargets);
+	}
+
+	{
 		// fire-at-dead-units
 		const LuaTable& fireAtDeadTbl = root.SubTable("fireAtDead");
 
@@ -420,4 +430,3 @@ void CModInfo::Init(const std::string& modFileName)
 	smoothMeshSmoothRadius                   = std::max  (smoothMeshSmoothRadius                  ,    1          );
 	unitQuadPositionUpdateRate               = std::clamp(unitQuadPositionUpdateRate              ,    1    ,   15);
 }
-

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -155,6 +155,10 @@ public:
 	/// If false, transported units cannot be manually or automatically targeted
 	bool targetableTransportedUnits;
 
+	// Targeting behaviour
+	/// Restrict opportunity targets to units named by an active CMD_ATTACK_TARGETS command.
+	bool attackTargetListPreferListedTargets;
+
 	// Fire-on-dying-units behaviour
 	/// Do units fire at enemies running Killed() script?
 	bool fireAtKilled;

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -446,6 +446,29 @@ void CAirCAI::ExecuteAttack(Command& c)
 	}
 }
 
+bool CAirCAI::ExecuteAttackTargets(Command& c)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	const CUnit* previousTarget = orderTarget;
+
+	if (!CCommandAI::ExecuteAttackTargets(c))
+		return false;
+	targetAge = (orderTarget == previousTarget) ? targetAge + 1 : 0;
+
+	if (orderTarget->unitDef->canfly && orderTarget->IsCrashing()) {
+		targetDied = true;
+		previousTarget = orderTarget;
+
+		if (!CCommandAI::ExecuteAttackTargets(c))
+			return false;
+		targetAge = (orderTarget == previousTarget) ? targetAge + 1 : 0;
+	}
+
+	SetGoal(orderTarget->pos, owner->pos, cancelDistance);
+	return true;
+}
+
+
 void CAirCAI::ExecuteAreaAttack(Command& c)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -596,4 +619,3 @@ bool CAirCAI::SelectNewAreaAttackTargetOrPos(const Command& ac)
 
 	return true;
 }
-

--- a/rts/Sim/Units/CommandAI/AirCAI.h
+++ b/rts/Sim/Units/CommandAI/AirCAI.h
@@ -29,6 +29,7 @@ public:
 	void ExecuteGuard(Command& c) override;
 	void ExecuteAreaAttack(Command& c);
 	void ExecuteAttack(Command& c) override;
+	bool ExecuteAttackTargets(Command& c) override;
 	void ExecuteFight(Command& c) override;
 	void ExecuteMove(Command& c) override;
 

--- a/rts/Sim/Units/CommandAI/Command.h
+++ b/rts/Sim/Units/CommandAI/Command.h
@@ -24,6 +24,7 @@ static constexpr int CMD_PATROL              =  15;
 static constexpr int CMD_FIGHT               =  16;
 static constexpr int CMD_ATTACK              =  20;
 static constexpr int CMD_AREA_ATTACK         =  21;
+static constexpr int CMD_ATTACK_TARGETS      =  22;
 static constexpr int CMD_GUARD               =  25;
 static constexpr int CMD_GROUPSELECT         =  35;
 static constexpr int CMD_GROUPADD            =  36;
@@ -310,6 +311,7 @@ public:
 		switch (GetID()) {
 			case CMD_AREA_ATTACK:
 			case CMD_ATTACK:
+			case CMD_ATTACK_TARGETS:
 			case CMD_CAPTURE:
 			case CMD_FIGHT:
 			case CMD_GUARD:
@@ -344,7 +346,7 @@ public:
 	}
 
 	bool IsAttackCommand() const {
-		return (GetID() == CMD_ATTACK || GetID() == CMD_AREA_ATTACK || GetID() == CMD_FIGHT);
+		return (GetID() == CMD_ATTACK || GetID() == CMD_AREA_ATTACK || GetID() == CMD_ATTACK_TARGETS || GetID() == CMD_FIGHT);
 	}
 
 	bool IsAreaCommand() const {
@@ -454,4 +456,3 @@ private:
 };
 
 #endif // COMMAND_H
-

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -4,6 +4,7 @@
 #include "CommandAI.h"
 
 #include "BuilderCAI.h"
+#include "CommandTargetList.h"
 #include "FactoryCAI.h"
 #include "ExternalAI/EngineOutHandler.h"
 #include "ExternalAI/SkirmishAIHandler.h"
@@ -76,6 +77,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(repeatOrders),
 	CR_MEMBER(lastSelectedCommandPage),
 	CR_MEMBER(inCommand),
+	CR_MEMBER(attackTargetIndex),
 	CR_MEMBER(commandDeathDependences),
 	CR_MEMBER(targetLostTimer),
 
@@ -93,7 +95,8 @@ CCommandAI::CCommandAI():
 	inCommand(CMD_STOP),
 	repeatOrders(false),
 	lastSelectedCommandPage(0),
-	targetLostTimer(TARGET_LOST_TIMER)
+	targetLostTimer(TARGET_LOST_TIMER),
+	attackTargetIndex(0)
 {}
 
 CCommandAI::CCommandAI(CUnit* owner):
@@ -107,7 +110,8 @@ CCommandAI::CCommandAI(CUnit* owner):
 	inCommand(CMD_STOP),
 	repeatOrders(false),
 	lastSelectedCommandPage(0),
-	targetLostTimer(TARGET_LOST_TIMER)
+	targetLostTimer(TARGET_LOST_TIMER),
+	attackTargetIndex(0)
 {
 	{
 		SCommandDescription c;
@@ -710,6 +714,20 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 			}
 		} break;
 
+		case CMD_ATTACK_TARGETS: {
+			if (!IsAttackCapable() || c.IsEmptyCommand())
+				return false;
+
+			for (unsigned int p = 0; p < c.GetNumParams(); ++p) {
+				const CUnit* attackee = GetCommandUnit(c, p);
+
+				if (attackee != nullptr && attackee != owner)
+					return true;
+			}
+
+			return false;
+		} break;
+
 		case CMD_MOVE: {
 			if (!ud->canmove)
 				return false;
@@ -821,11 +839,69 @@ void CCommandAI::GiveCommand(const Command& c, bool fromSynced)
 void CCommandAI::GiveCommand(const Command& c, int playerNum, bool fromSynced, bool fromLua)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!eventHandler.AllowCommand(owner, c, playerNum, fromSynced, fromLua))
+
+	const bool directTargetList = (c.GetID() == CMD_ATTACK_TARGETS);
+	const bool insertedTargetList = (
+		c.GetID() == CMD_INSERT &&
+		c.GetNumParams() >= 3 &&
+		static_cast<int>(c.GetParam(1)) == CMD_ATTACK_TARGETS
+	);
+
+	if (!directTargetList && !insertedTargetList) {
+		if (!eventHandler.AllowCommand(owner, c, playerNum, fromSynced, fromLua))
+			return;
+
+		eventHandler.UnitCommand(owner, c, playerNum, fromSynced, fromLua);
+		GiveCommandReal(c, fromSynced); // send to the sub-classes
+		return;
+	}
+
+	// Preserve the AllowCommand behavior of the equivalent series of ordinary
+	// unit-target attack commands. This lets games reject or transform targets
+	// individually while retaining one command in the engine queue.
+	Command filteredCommand(c.GetID(), c.GetOpts());
+	filteredCommand.SetAICmdID(c.GetID(true));
+	filteredCommand.SetFlags(c.GetTimeOut(), c.GetTag(), c.GetOpts());
+
+	const unsigned int firstTargetParam = insertedTargetList ? 3 : 0;
+	if (insertedTargetList) {
+		filteredCommand.PushParam(c.GetParam(0));
+		filteredCommand.PushParam(c.GetParam(1));
+		filteredCommand.PushParam(c.GetParam(2));
+	}
+
+	for (unsigned int p = firstTargetParam; p < c.GetNumParams(); ++p) {
+		Command attackCommand(CMD_ATTACK, c.GetOpts(), c.GetParam(p));
+
+		if (insertedTargetList) {
+			Command insertCommand(CMD_INSERT, c.GetOpts());
+			insertCommand.PushParam(c.GetParam(0));
+			insertCommand.PushParam(CMD_ATTACK);
+			insertCommand.PushParam(c.GetParam(2));
+			insertCommand.PushParam(c.GetParam(p));
+
+			if (!eventHandler.AllowCommand(owner, insertCommand, playerNum, fromSynced, fromLua))
+				continue;
+		} else {
+			// A non-queued list represents an immediate first attack followed by
+			// queued attacks, matching how area-attack widgets issued the series.
+			if (p != firstTargetParam)
+				attackCommand.SetOpts(attackCommand.GetOpts() | SHIFT_KEY);
+
+			if (!eventHandler.AllowCommand(owner, attackCommand, playerNum, fromSynced, fromLua))
+				continue;
+		}
+
+		filteredCommand.PushParam(c.GetParam(p));
+	}
+
+	if (filteredCommand.GetNumParams() == firstTargetParam)
+		return;
+	if (!eventHandler.AllowCommand(owner, filteredCommand, playerNum, fromSynced, fromLua))
 		return;
 
-	eventHandler.UnitCommand(owner, c, playerNum, fromSynced, fromLua);
-	GiveCommandReal(c, fromSynced); // send to the sub-classes
+	eventHandler.UnitCommand(owner, filteredCommand, playerNum, fromSynced, fromLua);
+	GiveCommandReal(filteredCommand, fromSynced); // send to the sub-classes
 }
 
 
@@ -950,7 +1026,7 @@ bool CCommandAI::ExecuteStateCommand(const Command& c)
 void CCommandAI::ClearTargetLock(const Command &c) {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// if no meta-bit attack lock, clear the order
-	if (((c.GetID() == CMD_ATTACK) || (c.GetID() == CMD_MANUALFIRE)) && (c.GetOpts() & META_KEY) == 0)
+	if (((c.GetID() == CMD_ATTACK) || (c.GetID() == CMD_ATTACK_TARGETS) || (c.GetID() == CMD_MANUALFIRE)) && (c.GetOpts() & META_KEY) == 0)
 		owner->DropCurrentAttackTarget();
 }
 
@@ -1053,7 +1129,7 @@ void CCommandAI::GiveAllowedCommand(const Command& c, bool fromSynced)
 	if (!GetOverlapQueued(c).empty())
 		return;
 
-	if (c.GetID() == CMD_ATTACK) {
+	if (c.GetID() == CMD_ATTACK || c.GetID() == CMD_ATTACK_TARGETS) {
 		// avoid weaponless units moving to 0 distance when given attack order
 		if (owner->weapons.empty() && (!owner->unitDef->canKamikaze)) {
 			commandQue.push_back(Command(CMD_STOP));
@@ -1324,6 +1400,12 @@ CCommandQueue::const_iterator CCommandAI::GetCancelQueued(const Command& c, cons
 
 		if (c2.GetNumParams() != c.GetNumParams())
 			continue;
+		if (cmdID == CMD_ATTACK_TARGETS && cmd2ID == CMD_ATTACK_TARGETS) {
+			if (CommandTargetList::HaveSameTargets(c, c2))
+				return ci;
+
+			continue;
+		}
 
 		if ((cmdID == cmd2ID) || (cmdID < 0 && cmd2ID < 0) || attackAndFight) {
 			if (c.GetNumParams() == 1) {
@@ -1422,6 +1504,8 @@ std::vector<Command> CCommandAI::GetOverlapQueued(const Command& c, const CComma
 			const Command& t = *ci;
 
 			if (t.GetNumParams() != c.GetNumParams())
+				continue;
+			if (c.GetID() == CMD_ATTACK_TARGETS)
 				continue;
 
 			if (t.GetID() == c.GetID() || (c.GetID() < 0 && t.GetID() < 0)) {
@@ -1528,6 +1612,51 @@ void CCommandAI::ExecuteAttack(Command& c)
 }
 
 
+bool CCommandAI::ExecuteAttackTargets(Command& c)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(owner->unitDef->canAttack);
+	assert(c.GetID() == CMD_ATTACK_TARGETS);
+
+	if (inCommand != CMD_ATTACK_TARGETS) {
+		attackTargetIndex = 0;
+	} else if (!targetDied && orderTarget != nullptr) {
+		const bool targetLost = (UpdateTargetLostTimer(orderTarget->id) == 0);
+		const bool skipParalyzed = !(c.GetOpts() & ALT_KEY) && IsParalyzeTargetSkippable(orderTarget)
+			&& (attackTargetIndex < c.GetNumParams() || HasMoreMoveCommands());
+
+		if (!targetLost && !skipParalyzed)
+			return true;
+	}
+
+	SetOrderTarget(nullptr);
+	owner->DropCurrentAttackTarget();
+	targetDied = false;
+
+	while (const std::optional<int> targetID = CommandTargetList::NextTargetID(c, attackTargetIndex)) {
+		CUnit* targetUnit = unitHandler.GetUnit(*targetID);
+
+		if (targetUnit == nullptr || targetUnit == owner)
+			continue;
+		if (targetUnit->GetTransporter() != nullptr && !modInfo.targetableTransportedUnits)
+			continue;
+		if (!(c.GetOpts() & ALT_KEY) && IsParalyzeTargetSkippable(targetUnit)
+		    && (attackTargetIndex < c.GetNumParams() || HasMoreMoveCommands()))
+			continue;
+
+		SetOrderTarget(targetUnit);
+		owner->AttackUnit(targetUnit, !c.IsInternalOrder(), false);
+		inCommand = CMD_ATTACK_TARGETS;
+		targetLostTimer = TARGET_LOST_TIMER;
+		return true;
+	}
+
+	StopMove();
+	FinishCommand();
+	return false;
+}
+
+
 void CCommandAI::ExecuteStop(Command& c)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -1571,6 +1700,10 @@ void CCommandAI::SlowUpdate()
 		}
 		case CMD_ATTACK: {
 			ExecuteAttack(c);
+			return;
+		}
+		case CMD_ATTACK_TARGETS: {
+			ExecuteAttackTargets(c);
 			return;
 		}
 		case CMD_MANUALFIRE: {
@@ -1674,6 +1807,7 @@ void CCommandAI::FinishCommand()
 
 	inCommand = CMD_STOP;
 	targetDied = false;
+	attackTargetIndex = 0;
 
 	SetOrderTarget(nullptr);
 	eoh->CommandFinished(*owner, cmd);
@@ -1743,7 +1877,7 @@ void CCommandAI::UpdateStockpileIcon()
 void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (inCommand != CMD_ATTACK || commandQue.empty())
+	if ((inCommand != CMD_ATTACK && inCommand != CMD_ATTACK_TARGETS) || commandQue.empty())
 		return;
 
 	const Command& c = commandQue.front();
@@ -1830,8 +1964,19 @@ bool CCommandAI::HasMoreMoveCommands(bool skipFirstCmd) const
 }
 
 
+bool CCommandAI::CanWeaponAutoTargetUnit(const CWeapon*, const CUnit* target) const
+{
+	if (!modInfo.attackTargetListPreferListedTargets || inCommand != CMD_ATTACK_TARGETS)
+		return true;
+	if (commandQue.empty() || commandQue.front().GetID() != CMD_ATTACK_TARGETS)
+		return true;
+
+	return CommandTargetList::ContainsTarget(commandQue.front(), target->id);
+}
+
+
 bool CCommandAI::CanChangeFireState() const { return (owner->unitDef->CanChangeFireState()); }
-bool CCommandAI::SkipParalyzeTarget(const CUnit* target) const
+bool CCommandAI::IsParalyzeTargetSkippable(const CUnit* target) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if ((target == nullptr) || (owner->weapons.empty()))
@@ -1843,7 +1988,12 @@ bool CCommandAI::SkipParalyzeTarget(const CUnit* target) const
 		return false;
 
 	// skip units that are visible and already stunned
-	return ((target->losStatus[owner->allyteam] & LOS_INLOS) && target->IsStunned() && HasMoreMoveCommands());
+	return ((target->losStatus[owner->allyteam] & LOS_INLOS) && target->IsStunned());
+}
+
+bool CCommandAI::SkipParalyzeTarget(const CUnit* target) const
+{
+	return (IsParalyzeTargetSkippable(target) && HasMoreMoveCommands());
 }
 
 
@@ -1854,6 +2004,19 @@ void CCommandAI::StopAttackingTargetIf(const std::function<bool(const CUnit*)>& 
 	const auto removeCmd = [&](const Command& c) { return (hasTarget(c) && pred(unitHandler.GetUnit(c.GetParam(0)))); };
 
 	commandQue.erase(std::remove_if(commandQue.begin(), commandQue.end(), removeCmd), commandQue.end());
+
+	for (Command& c: commandQue) {
+		if (c.GetID() != CMD_ATTACK_TARGETS)
+			continue;
+
+		for (unsigned int p = 0; p < c.GetNumParams(); ++p) {
+			if (pred(unitHandler.GetUnit(c.GetParam(p))))
+				c.SetParam(p, -1.0f);
+		}
+	}
+
+	if (inCommand == CMD_ATTACK_TARGETS && pred(orderTarget))
+		targetDied = true;
 }
 
 void CCommandAI::StopAttackingAllyTeam(int ally)
@@ -1861,4 +2024,3 @@ void CCommandAI::StopAttackingAllyTeam(int ally)
 	RECOIL_DETAILED_TRACY_ZONE;
 	StopAttackingTargetIf([&](const CUnit* t) { return (t != nullptr && t->allyteam == ally); });
 }
-

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -48,6 +48,7 @@ public:
 	void WeaponFired(CWeapon* weapon, const bool searchForNewTarget, bool raiseEvent = true);
 
 	virtual bool CanWeaponAutoTarget(const CWeapon* weapon) const { return true; }
+	virtual bool CanWeaponAutoTargetUnit(const CWeapon* weapon, const CUnit* target) const;
 	virtual int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
 	virtual void SlowUpdate();
 	virtual void GiveCommandReal(const Command& c, bool fromSynced = true);
@@ -88,6 +89,13 @@ public:
 	 * @brief Causes this CommandAI to execute the attack order c
 	 */
 	virtual void ExecuteAttack(Command& c);
+	virtual bool ExecuteAttackTargets(Command& c);
+	unsigned int GetAttackTargetDrawIndex() const {
+		if (inCommand != CMD_ATTACK_TARGETS || attackTargetIndex == 0)
+			return 0;
+
+		return attackTargetIndex - 1;
+	}
 
 	/**
 	 * @brief executes the stop command c
@@ -139,6 +147,7 @@ protected:
 	virtual bool SelectNewAreaAttackTargetOrPos(const Command& ac) { return true; }
 
 	bool IsAttackCapable() const;
+	bool IsParalyzeTargetSkippable(const CUnit* target) const;
 	bool SkipParalyzeTarget(const CUnit* target) const;
 
 	void GiveAllowedCommand(const Command& c, bool fromSynced = true);
@@ -162,6 +171,7 @@ private:
 	 * timer reaches 0
 	 */
 	int targetLostTimer;
+	unsigned int attackTargetIndex;
 };
 
 inline void CCommandAI::SetOrderTarget(CUnit* o) {

--- a/rts/Sim/Units/CommandAI/CommandTargetList.h
+++ b/rts/Sim/Units/CommandAI/CommandTargetList.h
@@ -1,0 +1,42 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <optional>
+
+#include "Command.h"
+
+namespace CommandTargetList {
+
+inline bool HaveSameTargets(const Command& lhs, const Command& rhs)
+{
+	if (lhs.GetNumParams() != rhs.GetNumParams())
+		return false;
+
+	for (unsigned int p = 0; p < lhs.GetNumParams(); ++p) {
+		if (lhs.GetParam(p) != rhs.GetParam(p))
+			return false;
+	}
+
+	return true;
+}
+
+inline bool ContainsTarget(const Command& command, int targetID)
+{
+	for (unsigned int p = 0; p < command.GetNumParams(); ++p) {
+		if (static_cast<int>(command.GetParam(p)) == targetID)
+			return true;
+	}
+
+	return false;
+}
+
+inline std::optional<int> NextTargetID(const Command& command, unsigned int& nextTargetIndex)
+{
+	if (nextTargetIndex >= command.GetNumParams())
+		return std::nullopt;
+
+	return static_cast<int>(command.GetParam(nextTargetIndex++));
+}
+
+} // namespace CommandTargetList

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -969,6 +969,23 @@ void CMobileCAI::ExecuteAttack(Command& c)
 }
 
 
+bool CMobileCAI::ExecuteAttackTargets(Command& c)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	const CUnit* previousTarget = orderTarget;
+
+	if (!CCommandAI::ExecuteAttackTargets(c))
+		return false;
+
+	if (orderTarget != previousTarget) {
+		const float3 targetErrorPos = orderTarget->GetErrorPos(owner->allyteam, false);
+		const float3 targetDirection = (targetErrorPos - owner->pos).Normalize();
+		SetGoal(targetErrorPos - targetDirection * CalcTargetRadius(orderTarget, orderTarget->radius, 1.0f), owner->pos);
+	}
+
+	ExecuteObjectAttack(c);
+	return true;
+}
 
 
 int CMobileCAI::GetDefaultCmd(const CUnit* pointed, const CFeature*)

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -44,6 +44,7 @@ public:
 	void StopSlowGuard();
 	void StartSlowGuard(float speed);
 	void ExecuteAttack(Command& c) override;
+	bool ExecuteAttackTargets(Command& c) override;
 	void ExecuteStop(Command& c) override;
 
 	virtual void Execute();

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -739,6 +739,8 @@ bool CWeapon::AutoTarget()
 	//   end, but Lua can mess with the ordering arbitrarily
 	for (size_t i = 0, n = CGameHelper::GenerateWeaponTargets(this, avoidUnit, targetPairs); i < n; i++, assert(n == targetPairs.size())) {
 		CUnit* unit = targetPairs[i].second;
+		if (!owner->commandAI->CanWeaponAutoTargetUnit(this, unit))
+			continue;
 
 		// save the "best" bad target in case we have no other
 		// good targets (of higher priority) left in <targets>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,21 @@ macro (add_spring_test target sources libraries flags)
 endmacro()
 
 ################################################################################
+### CommandTargetList
+	set(test_name CommandTargetList)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/engine/Sim/Units/CommandAI/TestCommandTargetList.cpp"
+			"${ENGINE_SOURCE_DIR}/Sim/Units/CommandAI/Command.cpp"
+			${test_Common_sources}
+		)
+
+	set(test_libs
+			""
+		)
+
+	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DNOT_USING_CREG -DNOT_USING_STREFLOP -DBUILDING_AI")
+
+################################################################################
 ### UDPListener
 # disabled for travis: https://springrts.com/mantis/view.php?id=5014
 if(NOT DEFINED ENV{CI})

--- a/test/engine/Sim/Units/CommandAI/TestCommandTargetList.cpp
+++ b/test/engine/Sim/Units/CommandAI/TestCommandTargetList.cpp
@@ -1,0 +1,81 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <catch_amalgamated.hpp>
+
+#include "Sim/Units/CommandAI/Command.h"
+#include "Sim/Units/CommandAI/CommandTargetList.h"
+
+TEST_CASE("Attack target lists retain their ordered parameters")
+{
+	Command command(CMD_ATTACK_TARGETS);
+
+	for (int targetID = 10; targetID < 30; ++targetID)
+		command.PushParam(targetID);
+
+	REQUIRE(command.GetNumParams() == 20);
+	CHECK(command.IsPooledCommand());
+	CHECK(command.IsAttackCommand());
+	CHECK(command.IsMoveCommand());
+	CHECK_FALSE(command.IsAreaCommand());
+
+	int objectParam = -1;
+	CHECK_FALSE(command.IsObjectCommand(objectParam));
+
+	unsigned int firstSourceIndex = 0;
+	unsigned int secondSourceIndex = 0;
+
+	CHECK(CommandTargetList::NextTargetID(command, firstSourceIndex) == 10);
+	CHECK(CommandTargetList::NextTargetID(command, firstSourceIndex) == 11);
+	CHECK(CommandTargetList::NextTargetID(command, secondSourceIndex) == 10);
+
+	for (int expectedID = 12; expectedID < 30; ++expectedID)
+		CHECK(CommandTargetList::NextTargetID(command, firstSourceIndex) == expectedID);
+
+	CHECK_FALSE(CommandTargetList::NextTargetID(command, firstSourceIndex).has_value());
+	CHECK(CommandTargetList::NextTargetID(command, secondSourceIndex) == 11);
+	CHECK(CommandTargetList::ContainsTarget(command, 10));
+	CHECK(CommandTargetList::ContainsTarget(command, 29));
+	CHECK_FALSE(CommandTargetList::ContainsTarget(command, 30));
+}
+
+TEST_CASE("Copied attack target lists retain independent traversal state")
+{
+	Command original(CMD_ATTACK_TARGETS);
+	original.PushParam(101);
+	original.PushParam(202);
+	original.PushParam(303);
+
+	const Command firstSourceCommand = original;
+	const Command secondSourceCommand = original;
+	unsigned int firstSourceIndex = 0;
+	unsigned int secondSourceIndex = 0;
+
+	CHECK(CommandTargetList::NextTargetID(firstSourceCommand, firstSourceIndex) == 101);
+	CHECK(CommandTargetList::NextTargetID(firstSourceCommand, firstSourceIndex) == 202);
+	CHECK(CommandTargetList::NextTargetID(secondSourceCommand, secondSourceIndex) == 101);
+
+	firstSourceIndex = 0;
+	CHECK(CommandTargetList::NextTargetID(firstSourceCommand, firstSourceIndex) == 101);
+}
+
+TEST_CASE("Only identical ordered target lists match")
+{
+	Command original(CMD_ATTACK_TARGETS);
+	original.PushParam(101);
+	original.PushParam(202);
+	original.PushParam(303);
+
+	Command identical = original;
+	CHECK(CommandTargetList::HaveSameTargets(original, identical));
+
+	Command reordered(CMD_ATTACK_TARGETS);
+	reordered.PushParam(101);
+	reordered.PushParam(303);
+	reordered.PushParam(202);
+	CHECK_FALSE(CommandTargetList::HaveSameTargets(original, reordered));
+
+	Command shorter(CMD_ATTACK_TARGETS);
+	shorter.PushParam(101);
+	shorter.PushParam(202);
+	CHECK_FALSE(CommandTargetList::HaveSameTargets(original, shorter));
+}


### PR DESCRIPTION
## Outdated

This PR is outdated, as the companion LUA only implementation https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8935 is now broader in scope and offers more optimizations than this.

For this to be considered, these features have to be inserted here.

## Summary

Adds an ordered `CMD_ATTACK_TARGETS` engine command so one queued command can represent a list of unit targets.

This is the engine-side alternative being evaluated in beyond-all-reason/Beyond-All-Reason#8790.

## Behavior

- Processes target IDs in the supplied order, matching a sequence of ordinary queued attack commands.
- Keeps one queue entry per source unit instead of one entry per source/target pair.
- Supports mobile and aircraft command AIs.
- Removes invalid or destroyed targets while processing the list.
- Renders the actual target sequence in the command drawer.
- Exposes an optional modrule that makes units prefer listed targets while approaching the first target.
- Exposes the command to Lua as `CMD.ATTACK_TARGETS`.

## Validation

- Adds focused engine tests for list parsing and target progression.
- BAR integration scenario: 600 fighters attacking a selected list of 200 bombers.
- Measured queue cancellation: 8 simulation frames, compared with 30 frames for the Lua `CommandFallback` prototype containing 120,000 ordinary attack queue entries.

## Related work

- BAR comparison issue: beyond-all-reason/Beyond-All-Reason#8790
- BAR engine integration: beyond-all-reason/Beyond-All-Reason#8792
- Alternative Lua fallback: beyond-all-reason/Beyond-All-Reason#8791

## Status

Draft for design and performance comparison.
