### PR TITLE
Fix miscalculation in GetHeadingFromVector()

### DIFF
--- a/doc/pr-changelogs/pr3240.md
+++ b/doc/pr-changelogs/pr3240.md
@@ -1,0 +1,1 @@
+Fix miscalculation in GetHeadingFromVector(), where near zero values get the sign flipped and EAST ends up pointing WEST and vice versa.

--- a/rts/System/SpringMath.h
+++ b/rts/System/SpringMath.h
@@ -15,6 +15,7 @@
 
 static constexpr int SPRING_MAX_HEADING = 32768;
 static constexpr int SPRING_CIRCLE_DIVS = (SPRING_MAX_HEADING << 1);
+static constexpr float SPRING_HEADING_EPSILON = 0.000001f;
 
 #define HEADING_CHECKSUM_1024 0x617a9968
 #define HEADING_CHECKSUM_4096 0x3d51b476

--- a/rts/System/SpringMath.inl
+++ b/rts/System/SpringMath.inl
@@ -40,10 +40,10 @@ inline float GetHeadingFromVectorF(const float dx, const float dz)
 	float h = 0.0f;
 
 	if (dz != 0.0f) {
-		// ensure a minimum distance between dz and 0 such that
-		// sqr(dx/dz) never exceeds abs(num_limits<float>::max)
-		const float sz = dz * 2.0f - 1.0f;
-		const float d  = dx / (dz + 0.000001f * sz);
+		// FIX: Use a tiny, sign-preserving offset to ensure dz never flips signs
+		// while protecting against division overflows.
+		const float safe_dz = dz + (std::copysign(0.000001f, dz));
+		const float d  = dx / safe_dz;
 		const float dd = d * d;
 
 		if (math::fabs(d) > 1.0f) {

--- a/rts/System/SpringMath.inl
+++ b/rts/System/SpringMath.inl
@@ -39,10 +39,10 @@ inline float GetHeadingFromVectorF(const float dx, const float dz)
 {
 	float h = 0.0f;
 
-	if (dz != 0.0f) {
+	if (std::fabs(dz) > SPRING_HEADING_EPSILON) {
 		// FIX: Use a tiny, sign-preserving offset to ensure dz never flips signs
 		// while protecting against division overflows.
-		const float safe_dz = dz + (std::copysign(0.000001f, dz));
+		const float safe_dz = dz + (std::copysign(SPRING_HEADING_EPSILON, dz));
 		const float d  = dx / safe_dz;
 		const float dd = d * d;
 


### PR DESCRIPTION
This fixes a miscalculation in GetHeadingFromVector(), where near zero values get the sign flipped and EAST ends up pointing WEST and vice versa.