### PR TITLE
Attack Command: keep moving towards target if static obstruction blocks shot

### DIFF
--- a/cont/base/springcontent/LuaGadgets/Gadgets/unit_script.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/unit_script.lua
@@ -596,15 +596,15 @@ local function Wrap_AimWeapon(unitID, callins)
 	--   therefore on the Lua side all weapon indices are ASSUMED to be
 	--   1-based and if LuaConfig::LUA_WEAPON_BASE_INDEX is changed to 0
 	--   no Lua code should need to be updated
-	local function AimWeaponThread(weaponNum, heading, pitch)
-		local bAimReady = AimWeapon(weaponNum, heading, pitch) or false
+	local function AimWeaponThread(weaponNum, heading, pitch, launchHeading)
+		local bAimReady = AimWeapon(weaponNum, heading, pitch, launchHeading) or false
 		local fAimReady = (bAimReady and 1.0) or 0.0
 
 		return sp_SetUnitWeaponState(unitID, weaponNum, "aimReady", fAimReady)
 	end
 
-	callins["AimWeapon"] = function(weaponNum, heading, pitch)
-		return StartThread(AimWeaponThread, weaponNum, heading, pitch)
+	callins["AimWeapon"] = function(weaponNum, heading, pitch, launchHeading)
+		return StartThread(AimWeaponThread, weaponNum, heading, pitch, launchHeading)
 	end
 end
 

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,6 +7,15 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
+# Caveats
+These are the entries which may require special attention when migrating:
+* Cannon, MissileLauncher and StarburstLauncher weapons no longer test line of fire from
+the current muzzle position before aiming. Like every other weapon type they now use the
+`AimFromWeapon` piece, or the new `aimFromEstimate` unit def tag when the unit provides one.
+* `Spring.GetUnitWeaponTryTarget(unitID, weaponNum, x, y, z)` used to test position (0, 0, 0)
+regardless of the given coordinates and therefore always returned `false`. It now tests the
+given position.
+
 # Fixes
 * Line-of-fire and other synced ground traces (`TraceRay`, `CWeapon::HaveFreeLineOfFire`,
 `Spring.GetUnitWeaponHaveFreeLineOfFire`) no longer report a free line when the ray starts
@@ -34,3 +43,14 @@ use it for turning the turret and keep arc checks on `heading`. LUS scripts get 
 an optional fourth argument, `AimWeapon(weaponNum, heading, pitch, launchHeading)`
 (radians); COB scripts via `get WEAPON_LAUNCH_HEADING(weaponNum)` (141, COB angle
 units). Existing scripts need no change.
+
+# Weapons
+* Added the `aimFromEstimate` tag to unit def weapon entries. It describes where the muzzle
+ends up once the script has aimed, so line-of-fire tests that run before the turret has
+turned (target selection and target re-validation) trace from the predicted muzzle instead of
+the `AimFromWeapon` piece. The value is a list of 7 numbers
+`{pivotX, pivotY, pivotZ, lateral, forward, barrelForward, barrelUp}` in unit space (yaw pivot,
+offsets turning with yaw only, offsets turning with yaw and pitch). Weapons that alternate
+between barrels use one estimate for the mean muzzle. Units without the tag behave as before.
+* Added `Spring.GetUnitWeaponAimFromPos(unitID, weaponNum, x, y, z) -> posX, posY, posZ, isEstimate`
+returning the position a weapon's pre-aim line-of-fire test towards the given target is traced from.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,4 +7,16 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-No changes as of yet.
+# Fixes
+* Line-of-fire and other synced ground traces (`TraceRay`, `CWeapon::HaveFreeLineOfFire`,
+`Spring.GetUnitWeaponHaveFreeLineOfFire`) no longer report a free line when the ray starts
+below the terrain. `LineGroundCol` returns a hit distance of 0 for such a ray and `TraceRay`
+discarded that as "no hit", so a weapon whose muzzle or aim-from piece was inside a cliff
+believed it could shoot through it, stopped, and never fired. Cannons had the same problem
+with their trajectory trace and now reject a source below the interpolated terrain height
+outright, the test the fire-time check already applies to the muzzle.
+* The underground test of `LineGroundCol` (also behind `Spring.TraceRayGround*`) compares the
+ray origin against the interpolated terrain height instead of the corner vertex of its
+heightmap square. Next to a steep cliff that vertex could sit far above an origin that was
+well clear of the ground, so the whole ground trace was skipped. A ray that starts exactly
+on the surface is no longer treated as underground.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -34,6 +34,16 @@ shot direction. Since 2026.06 it was the unit-frame azimuth of the full launch v
 which for steep (high-trajectory) shots on tilted ground swung by tens of degrees, so
 scripts with a yaw arc check rejected targets the engine considered in arc and the
 unit never fired (e.g. a Wolverine stopping on a slope during a ground attack).
+* Mobile units that are inside weapon range of their attack target but have no firing
+solution because terrain, a feature or an allied structure blocks the line of fire now keep
+closing in on the target (down to 20% of their range) instead of standing there and never
+firing. Units blocked only by allied mobile units stop and wait for them to move instead of
+walking on to the target, so a group does not creep forward unit by unit. `stopToAttack`
+units always wait; a unit whose approach fails (unreachable goal) waits and retries every
+10 seconds.
+* The pre-aim line-of-fire test rejects targets when the predicted muzzle (`aimFromEstimate`)
+is below the terrain, as the fire-time test already does for the real muzzle. A unit standing
+against a cliff no longer believes it can shoot through it.
 
 # Additions
 * `AimWeapon` additionally receives the unit-frame heading of the full shot direction,

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -20,3 +20,8 @@ ray origin against the interpolated terrain height instead of the corner vertex 
 heightmap square. Next to a steep cliff that vertex could sit far above an origin that was
 well clear of the ground, so the whole ground trace was skipped. A ray that starts exactly
 on the surface is no longer treated as underground.
+* The heading passed to `AimWeapon` is now derived from the horizontal part of the
+shot direction. Since 2026.02 it was the unit-frame azimuth of the full launch vector,
+which for steep (high-trajectory) shots on tilted ground swung by tens of degrees, so
+scripts with a yaw arc check rejected targets the engine considered in arc and the
+unit never fired (e.g. a Wolverine stopping on a slope during a ground attack).

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -21,7 +21,16 @@ heightmap square. Next to a steep cliff that vertex could sit far above an origi
 well clear of the ground, so the whole ground trace was skipped. A ray that starts exactly
 on the surface is no longer treated as underground.
 * The heading passed to `AimWeapon` is now derived from the horizontal part of the
-shot direction. Since 2026.02 it was the unit-frame azimuth of the full launch vector,
+shot direction. Since 2026.06 it was the unit-frame azimuth of the full launch vector,
 which for steep (high-trajectory) shots on tilted ground swung by tens of degrees, so
 scripts with a yaw arc check rejected targets the engine considered in arc and the
 unit never fired (e.g. a Wolverine stopping on a slope during a ground attack).
+
+# Additions
+* `AimWeapon` additionally receives the unit-frame heading of the full shot direction,
+the value 2026.06 passed as `heading`. It is the exact turret yaw that points the barrel
+along a steep shot on tilted ground, but it depends on hull tilt and launch pitch, so
+use it for turning the turret and keep arc checks on `heading`. LUS scripts get it as
+an optional fourth argument, `AimWeapon(weaponNum, heading, pitch, launchHeading)`
+(radians); COB scripts via `get WEAPON_LAUNCH_HEADING(weaponNum)` (141, COB angle
+units). Existing scripts need no change.

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -316,7 +316,9 @@ float TraceRay(
 		// ground intersection
 		const float groundLength = CGround::LineGroundCol(pos, pos + dir * traceLength);
 
-		if (traceLength > groundLength && groundLength > 0.0f) {
+		// a return value of 0 means the ray starts underground (or on the surface pointing into
+		// it), which blocks it at the origin; only -1 signals that the ground was not hit at all
+		if (traceLength > groundLength && groundLength >= 0.0f) {
 			traceLength = groundLength;
 
 			hitUnit = nullptr;

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -220,6 +220,7 @@ float TraceRay(
 	const bool scanForNeutrals = ((traceFlags & Collision::NONEUTRALS  ) == 0);
 	const bool scanForGround   = ((traceFlags & Collision::NOGROUND    ) == 0);
 	const bool scanForCloaked  = ((traceFlags & Collision::NOCLOAKED   ) == 0);
+	const bool skipMobileAllies = ((traceFlags & Collision::NOMOBILEFRIENDLIES) != 0);
 
 	const bool scanForAnyUnits = scanForEnemies || scanForAllies || scanForNeutrals || scanForCloaked;
 
@@ -282,7 +283,7 @@ float TraceRay(
 
 					bool doHitTest = false;
 
-					doHitTest |= (scanForAllies   && u->allyteam == owner->allyteam);
+					doHitTest |= (scanForAllies   && u->allyteam == owner->allyteam && !(skipMobileAllies && !u->immobile));
 					doHitTest |= (scanForEnemies  && u->allyteam != owner->allyteam);
 					doHitTest |= (scanForNeutrals && u->IsNeutral());
 					doHitTest |= (scanForCloaked  && u->IsCloaked());
@@ -545,6 +546,7 @@ bool TestCone(
 	const bool scanForAllies   = ((traceFlags & Collision::NOFRIENDLIES) == 0);
 	const bool scanForNeutrals = ((traceFlags & Collision::NONEUTRALS  ) == 0);
 	const bool scanForFeatures = ((traceFlags & Collision::NOFEATURES  ) == 0);
+	const bool skipMobileAllies = ((traceFlags & Collision::NOMOBILEFRIENDLIES) != 0);
 
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);
@@ -554,6 +556,8 @@ bool TestCone(
 				if (u == owner)
 					continue;
 				if (!u->HasCollidableStateBit(CSolidObject::CSTATE_BIT_QUADMAPRAYS))
+					continue;
+				if (skipMobileAllies && !u->immobile)
 					continue;
 
 				if (TestConeHelper(from, dir, length, spread, u))
@@ -612,6 +616,7 @@ bool TestTrajectoryCone(
 	const bool scanForAllies   = ((traceFlags & Collision::NOFRIENDLIES) == 0);
 	const bool scanForNeutrals = ((traceFlags & Collision::NONEUTRALS  ) == 0);
 	const bool scanForFeatures = ((traceFlags & Collision::NOFEATURES  ) == 0);
+	const bool skipMobileAllies = ((traceFlags & Collision::NOMOBILEFRIENDLIES) != 0);
 
 	for (const int quadIdx: *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);
@@ -622,6 +627,8 @@ bool TestTrajectoryCone(
 				if (u == owner)
 					continue;
 				if (!u->HasCollidableStateBit(CSolidObject::CSTATE_BIT_QUADMAPRAYS))
+					continue;
+				if (skipMobileAllies && !u->immobile)
 					continue;
 
 				if (TestTrajectoryConeHelper(from, dir, length, linear, quadratic, spread, 0.0f, u))

--- a/rts/Game/TraceRay.h
+++ b/rts/Game/TraceRay.h
@@ -23,6 +23,10 @@ namespace Collision {
 		NONONTARGETS = 1 << 5, // ignored by raytraces; not added to avoidFlags
 		NOGROUND     = 1 << 6,
 		NOCLOAKED    = 1 << 7,
+		// skip allied units that are able to move out of the way (mobile units); allied
+		// structures are still scanned; only set by callers that want to know whether a
+		// line of fire is blocked by something static, never part of a weapon's avoidFlags
+		NOMOBILEFRIENDLIES = 1 << 8,
 		NOUNITS      = NOENEMIES | NOFRIENDLIES | NONEUTRALS
 	};
 }

--- a/rts/Lua/LuaConstCOB.cpp
+++ b/rts/Lua/LuaConstCOB.cpp
@@ -184,6 +184,8 @@ bool LuaConstCOB::PushEntries(lua_State* L)
 	PUSH_COB(PIECE_HEADING);
 	/*** @field COB.PIECE_PITCH integer */
 	PUSH_COB(PIECE_PITCH);
+	/*** @field COB.WEAPON_LAUNCH_HEADING integer */
+	PUSH_COB(WEAPON_LAUNCH_HEADING);
 
 	// NOTE: shared variables use codes [1024 - 5119]
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -266,6 +266,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetUnitWeaponTestTarget);
 	REGISTER_LUA_CFUNC(GetUnitWeaponTestRange);
 	REGISTER_LUA_CFUNC(GetUnitWeaponHaveFreeLineOfFire);
+	REGISTER_LUA_CFUNC(GetUnitWeaponAimFromPos);
 	REGISTER_LUA_CFUNC(GetUnitWeaponCanFire);
 	REGISTER_LUA_CFUNC(GetUnitWeaponTarget);
 	REGISTER_LUA_CFUNC(GetUnitTravel);
@@ -5503,7 +5504,8 @@ int LuaSyncedRead::GetUnitWeaponTryTarget(lua_State* L)
 			return 0;
 	}
 
-	lua_pushboolean(L, weapon->TryTarget(SWeaponTarget(enemy, pos, true)));
+	// SWeaponTarget(unit, pos) discards <pos> when <unit> is null, so build the position target explicitly
+	lua_pushboolean(L, weapon->TryTarget((enemy != nullptr) ? SWeaponTarget(enemy, true) : SWeaponTarget(pos, true)));
 	return 1;
 }
 
@@ -5667,7 +5669,7 @@ int LuaSyncedRead::GetUnitWeaponHaveFreeLineOfFire(lua_State* L)
 	const CWeapon* weapon = unit->weapons[weaponNum];
 	const CUnit* enemy = nullptr;
 
-	float3 srcPos = weapon->GetAimFromPos();
+	float3 srcPos;
 	float3 tgtPos;
 
 	const auto ParsePos = [&L](int idx, int cnt, float* pos) {
@@ -5678,11 +5680,12 @@ int LuaSyncedRead::GetUnitWeaponHaveFreeLineOfFire(lua_State* L)
 
 	switch (lua_gettop(L)) {
 		case 3: {
-			// [3] := targetID
+			// [3] := targetID, source is what the engine itself would test from
 			if ((enemy = ParseUnit(L, __func__, 3)) == nullptr)
 				return 0;
 
 			tgtPos = weapon->GetUnitLeadTargetPos(enemy);
+			srcPos = weapon->GetAimFromPos(tgtPos);
 		} break;
 		case 5: {
 			// [3,4,5] := srcPos
@@ -5711,6 +5714,46 @@ int LuaSyncedRead::GetUnitWeaponHaveFreeLineOfFire(lua_State* L)
 
 	lua_pushboolean(L, weapon->HaveFreeLineOfFire(srcPos, tgtPos, SWeaponTarget(enemy, tgtPos, true)));
 	return 1;
+}
+
+/***
+ * Position a weapon's line-of-fire test towards a target would be traced from
+ * before the weapon has aimed: the estimated post-aim muzzle position when the
+ * unit def provides `aimFromEstimate` for this weapon, otherwise the AimFromWeapon
+ * piece position.
+ *
+ * @function Spring.GetUnitWeaponAimFromPos
+ * @param unitID integer
+ * @param weaponNum integer
+ * @param tgtPosX number
+ * @param tgtPosY number
+ * @param tgtPosZ number
+ * @return number? posX
+ * @return number posY
+ * @return number posZ
+ * @return boolean isEstimate whether the position came from `aimFromEstimate`
+ */
+int LuaSyncedRead::GetUnitWeaponAimFromPos(lua_State* L)
+{
+	const CUnit* unit = ParseAllyUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	const size_t weaponNum = luaL_checkint(L, 2) - LUA_WEAPON_BASE_INDEX;
+
+	if (weaponNum >= unit->weapons.size())
+		return 0;
+
+	const CWeapon* weapon = unit->weapons[weaponNum];
+	const float3 tgtPos(luaL_checkfloat(L, 3), luaL_checkfloat(L, 4), luaL_checkfloat(L, 5));
+	const float3 srcPos = weapon->GetAimFromPos(tgtPos);
+
+	lua_pushnumber(L, srcPos.x);
+	lua_pushnumber(L, srcPos.y);
+	lua_pushnumber(L, srcPos.z);
+	lua_pushboolean(L, weapon->HasAimFromEstimate());
+	return 4;
 }
 
 /***

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -162,6 +162,7 @@ class LuaSyncedRead {
 		static int GetUnitWeaponTestTarget(lua_State* L);
 		static int GetUnitWeaponTestRange(lua_State* L);
 		static int GetUnitWeaponHaveFreeLineOfFire(lua_State* L);
+		static int GetUnitWeaponAimFromPos(lua_State* L);
 		static int GetUnitWeaponCanFire(lua_State* L);
 		static int GetUnitWeaponTarget(lua_State* L);
 		static int GetUnitTravel(lua_State* L);

--- a/rts/Map/Ground.cpp
+++ b/rts/Map/Ground.cpp
@@ -242,10 +242,11 @@ float CGround::LineGroundCol(float3 from, float3 to, bool synced)
 	if (synced) {
 		// TODO: do this in unsynced too?
 		// check if our start position is underground (assume ground is unpassable for cannons etc.)
-		const int sx = from.x / SQUARE_SIZE;
-		const int sz = from.z / SQUARE_SIZE;
-
-		if (from.y <= hm[sz * mapDims.mapxp1 + sx])
+		// compare against the interpolated surface rather than the corner vertex of the square:
+		// next to a steep rise that vertex can sit far above a start point that is well clear of
+		// the ground, and a start exactly on the surface is not underground (LineGroundSquareCol
+		// reports a hit at distance 0 for it if the ray points into the ground)
+		if (from.y < InterpolateCornerHeight(from.x, from.z, hm))
 			return 0.0f + skippedDist;
 	}
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -6,6 +6,7 @@
 #include "Game/GameHelper.h"
 #include "Game/GlobalUnsynced.h"
 #include "Game/SelectedUnitsHandler.h"
+#include "Game/TraceRay.h"
 #include "Map/Ground.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/LosHandler.h"
@@ -793,8 +794,6 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 		}
 
 		// move sideways (i.e. strafe) to get a shot
-		// note that the close-enough assumption is flawed:
-		// unit may be aiming or otherwise unable to shoot
 		if (owner->unitDef->strafeToAttack) {
 			const int dirSign = Sign(int(moveDir ^= (owner->moveType->progressState == AMoveType::Failed)));
 
@@ -808,9 +807,28 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 			goalDiff += orderTarget->pos;
 
 			SetGoal(goalDiff, owner->pos);
+			return;
 		}
 
-		return;
+		// being in range does not mean we can shoot: no weapon has a firing
+		// solution from here, so decide whether to wait or to keep closing in
+		//
+		// wait if only an allied unit is in the way (it may move out of it, whereas
+		// walking past it would in turn block its shot and make the whole group
+		// creep forward), if we are close enough already or the approach failed
+		//
+		// waiting means stopping: the goal set when the order was given is the
+		// target itself and would otherwise carry us right up to it
+		if (owner->unitDef->stopToAttack || !CanCloseInOnBlockedTarget(targetMidPosDist2D) || !HasStaticallyBlockedLineOfFire(c, orderTgtInfo, targetHeading)) {
+			if (owner->moveType->progressState != AMoveType::Failed)
+				StopMove();
+
+			owner->moveType->KeepPointingTo(orderTarget->midPos, minPointingDist, true);
+			return;
+		}
+
+		// terrain, a feature or an allied structure blocks the shot: close in
+		// on the target like a unit that is still out of range would
 	}
 
 	// not a temporary order or not on hold-position; close in on target more
@@ -879,8 +897,60 @@ void CMobileCAI::ExecuteGroundAttack(Command& c)
 	if (attackVec.SqLength2D() >= Square(owner->maxRange * 0.9f))
 		return;
 
+	// in range, but no weapon has a firing solution from here
 	owner->AttackGround(attackTgtInfo.groundPos, attackTgtInfo.isUserTarget, false);
-	StopMoveAndKeepPointing(attackPos, owner->maxRange * 0.9f, true);
+
+	if (!owner->unitDef->stopToAttack && CanCloseInOnBlockedTarget(attackVec.Length2D()) && HasStaticallyBlockedLineOfFire(c, attackTgtInfo, attackHeading)) {
+		// terrain, a feature or an allied structure blocks the shot: keep
+		// closing in on the point until some weapon can fire at it
+		SetGoal(attackPos, owner->pos);
+		lastCloseInTry = gs->frameNum;
+		return;
+	}
+
+	// wait here (see ExecuteObjectAttack); a failed approach stays failed so
+	// that it is not retried every update
+	if (owner->moveType->progressState != AMoveType::Failed)
+		StopMove();
+
+	owner->moveType->KeepPointingTo(attackPos, std::max(owner->maxRange * 0.9f, 10.0f), true);
+}
+
+bool CMobileCAI::CanCloseInOnBlockedTarget(float targetDist2D) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	// gunships get their shot by pitching the nose, not by moving closer
+	if (owner->unitDef->IsHoveringAirUnit())
+		return false;
+
+	// the last approach ended against an obstacle (e.g. the very rock that
+	// blocks the shot); retry only occasionally instead of pushing into it
+	if (owner->moveType->progressState == AMoveType::Failed && gs->frameNum < (lastCloseInTry + BLOCKED_CLOSE_IN_FAILED_RETRY_TICKS))
+		return false;
+
+	// keep some distance so that e.g. artillery does not walk up to a target
+	// whose line of fire is blocked by a wall right around it
+	return (targetDist2D > (owner->maxRange * BLOCKED_CLOSE_IN_MIN_RANGE_FACTOR));
+}
+
+bool CMobileCAI::HasStaticallyBlockedLineOfFire(const Command& c, const SWeaponTarget& trg, short targetHeading) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	for (CWeapon* w: owner->weapons) {
+		if (c.GetID() == CMD_MANUALFIRE && !w->weaponDef->manualfire)
+			continue;
+
+		// same tests as the callers use to decide whether to stop, but with
+		// allied units that can move out of the way taken out of the trace
+		const bool freeLineOfFire = (trg.type == Target_Unit) ?
+			w->TryTargetRotate(trg.unit, trg.isUserTarget, trg.isManualFire, Collision::NOMOBILEFRIENDLIES):
+			w->TryTargetHeading(targetHeading, trg, Collision::NOMOBILEFRIENDLIES);
+
+		if (freeLineOfFire)
+			return false;
+	}
+
+	return true;
 }
 
 void CMobileCAI::ExecuteAttack(Command& c)

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -13,6 +13,7 @@ class CUnit;
 class CFeature;
 class CWeapon;
 struct Command;
+struct SWeaponTarget;
 
 class CMobileCAI : public CCommandAI
 {
@@ -108,6 +109,11 @@ protected:
 	static constexpr int MAX_CLOSE_IN_RETRY_TICKS = 30;
 	static constexpr int BUGGER_OFF_TTL = 200;
 
+	/// a unit inside range whose line of fire is blocked stops closing in below this fraction of maxRange
+	static constexpr float BLOCKED_CLOSE_IN_MIN_RANGE_FACTOR = 0.2f;
+	/// and retries an approach that failed (unreachable goal) only this often
+	static constexpr int BLOCKED_CLOSE_IN_FAILED_RETRY_TICKS = 10 * MAX_CLOSE_IN_RETRY_TICKS;
+
 	static constexpr float MAX_USERGOAL_TOLERANCE_DIST = 100.0f;
 	static constexpr float AIRTRANSPORT_DOCKING_RADIUS = 16.0f;
 	static constexpr float AIRTRANSPORT_DOCKING_ANGLE = 50.0f;
@@ -127,6 +133,19 @@ protected:
 private:
 	void ExecuteObjectAttack(Command& c);
 	void ExecuteGroundAttack(Command& c);
+
+	/**
+	 * whether a unit that is inside range of its target but has no firing
+	 * solution may keep closing in instead of stopping and waiting
+	 */
+	bool CanCloseInOnBlockedTarget(float targetDist2D) const;
+	/**
+	 * true iff every weapon eligible for <c> still has no firing solution when
+	 * allied mobile units are ignored, i.e. the line of fire is blocked by
+	 * terrain, features or allied structures rather than by a friend that may
+	 * move out of the way
+	 */
+	bool HasStaticallyBlockedLineOfFire(const Command& c, const SWeaponTarget& trg, short targetHeading) const;
 
 	bool MobileAutoGenerateTarget();
 	bool GenerateAttackCmd();

--- a/rts/Sim/Units/Scripts/CobDefines.h
+++ b/rts/Sim/Units/Scripts/CobDefines.h
@@ -116,4 +116,5 @@ static constexpr int KTAN                    = 137; // get (kiloTangent : 1024*t
 static constexpr int SQRT                    = 138; // get (square root)
 static constexpr int PIECE_HEADING			 = 139; // get
 static constexpr int PIECE_PITCH			 = 140; // get
+static constexpr int WEAPON_LAUNCH_HEADING   = 141; // get WEAPON_LAUNCH_HEADING(weaponNum): unit-frame heading of the full shot direction at the last AimWeapon
 // NOTE: shared variables use codes [1024 - 5119]

--- a/rts/Sim/Units/Scripts/CobInstance.cpp
+++ b/rts/Sim/Units/Scripts/CobInstance.cpp
@@ -447,9 +447,11 @@ int CCobInstance::QueryWeapon(int weaponNum)
 }
 
 
-void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch)
+void CCobInstance::AimWeapon(int weaponNum, float heading, float pitch, float launchHeading)
 {
 	ZoneScoped;
+	// COB arguments are positional, an extra one would shift the function's
+	// locals; scripts read launchHeading via get WEAPON_LAUNCH_HEADING(weaponNum)
 	std::array<int, 1 + MAX_COB_ARGS> callinArgs;
 
 	callinArgs[0] = 2;

--- a/rts/Sim/Units/Scripts/CobInstance.h
+++ b/rts/Sim/Units/Scripts/CobInstance.h
@@ -183,7 +183,7 @@ public:
 
 	// weapon callins
 	int   QueryWeapon(int weaponNum) override;
-	void  AimWeapon(int weaponNum, float heading, float pitch) override;
+	void  AimWeapon(int weaponNum, float heading, float pitch, float launchHeading) override;
 	void  AimShieldWeapon(CPlasmaRepulser* weapon) override;
 	int   AimFromWeapon(int weaponNum) override;
 	void  Shot(int weaponNum) override;

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -140,6 +140,9 @@ callIn notes:
   use 'local height = Spring.GetUnitHeight(unitID)' to get the height.
 - TransportDrop takes x,y,z instead of PACKXZ(x,z)
 - AimWeapon for a shield (plasma repulser) takes no arguments instead of 0,0
+- AimWeapon(weaponNum, heading, pitch, launchHeading): launchHeading is the
+  unit-frame heading of the full shot direction (radians), the exact turret yaw
+  for a steep shot on tilted ground; heading is the azimuth, use it for arc checks
 - Shot takes no arguments instead of 0
 - new callins MoveFinished and TurnFinished, see below
 
@@ -614,6 +617,25 @@ void CLuaUnitScript::Call(int fn, float arg1, float arg2, float arg3)
 }
 
 
+void CLuaUnitScript::Call(int fn, float arg1, float arg2, float arg3, float arg4)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	if (!HasFunction(fn))
+		return;
+
+	LUA_CALL_IN_CHECK(L);
+	lua_checkstack(L, 5);
+
+	PushFunction(fn);
+	lua_pushnumber(L, arg1);
+	lua_pushnumber(L, arg2);
+	lua_pushnumber(L, arg3);
+	lua_pushnumber(L, arg4);
+
+	RunCallIn(fn, 4, 0);
+}
+
+
 /******************************************************************************/
 /******************************************************************************/
 
@@ -854,10 +876,10 @@ int CLuaUnitScript::QueryWeapon(int weaponNum)
 }
 
 
-void CLuaUnitScript::AimWeapon(int weaponNum, float heading, float pitch)
+void CLuaUnitScript::AimWeapon(int weaponNum, float heading, float pitch, float launchHeading)
 {
 	ZoneScoped;
-	Call(LUAFN_AimWeapon, weaponNum + LUA_WEAPON_BASE_INDEX, heading, pitch);
+	Call(LUAFN_AimWeapon, weaponNum + LUA_WEAPON_BASE_INDEX, heading, pitch, launchHeading);
 }
 
 

--- a/rts/Sim/Units/Scripts/LuaUnitScript.h
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.h
@@ -64,6 +64,7 @@ protected:
 	void Call(int fn, float arg1);
 	void Call(int fn, float arg1, float arg2);
 	void Call(int fn, float arg1, float arg2, float arg3);
+	void Call(int fn, float arg1, float arg2, float arg3, float arg4);
 
 	void RawPushFunction(int functionId);
 	void PushFunction(int id);
@@ -125,7 +126,7 @@ public:
 
 	// weapon callins
 	int   QueryWeapon(int weaponNum) override;
-	void  AimWeapon(int weaponNum, float heading, float pitch) override;
+	void  AimWeapon(int weaponNum, float heading, float pitch, float launchHeading) override;
 	void  AimShieldWeapon(CPlasmaRepulser* weapon) override;
 	int   AimFromWeapon(int weaponNum) override;
 	void  Shot(int weaponNum) override;

--- a/rts/Sim/Units/Scripts/NullUnitScript.h
+++ b/rts/Sim/Units/Scripts/NullUnitScript.h
@@ -57,7 +57,7 @@ public:
 
 	// weapon callins
 	int   QueryWeapon(int weaponNum) override { return -1; }
-	void  AimWeapon(int weaponNum, float heading, float pitch) override {}
+	void  AimWeapon(int weaponNum, float heading, float pitch, float launchHeading) override {}
 	void  AimShieldWeapon(CPlasmaRepulser* weapon) override {}
 	int   AimFromWeapon(int weaponNum) override { return -1; }
 	void  Shot(int weaponNum) override {}

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -1505,6 +1505,17 @@ int CUnitScript::GetUnitVal(int val, int p1, int p2, int p3, int p4)
 		return -1;
 	} break;
 
+	case WEAPON_LAUNCH_HEADING: {
+		// get: unit-frame heading of the full shot direction at the last
+		// AimWeapon callin, in COB angle units with the same convention as
+		// AimWeapon's heading argument (see CWeapon::CallAimingScript); the
+		// int->short narrowing wraps deterministically, as in CobInstance
+		if (p1 > 0 && static_cast<size_t>(p1) <= unit->weapons.size())
+			return static_cast<short>(static_cast<int>(unit->weapons[p1 - 1]->launchHeading * RAD2TAANG));
+
+		return 0;
+	} break;
+
 	case WEAPON_PROJECTILE_SPEED: {
 		// get (+)
 		if (p1 > 0 && static_cast<size_t>(p1) <= unit->weapons.size())

--- a/rts/Sim/Units/Scripts/UnitScript.h
+++ b/rts/Sim/Units/Scripts/UnitScript.h
@@ -211,7 +211,7 @@ public:
 
 	// weapon callins
 	virtual int   QueryWeapon(int weaponNum) = 0; // returns piece, former QueryPrimary
-	virtual void  AimWeapon(int weaponNum, float heading, float pitch) = 0;
+	virtual void  AimWeapon(int weaponNum, float heading, float pitch, float launchHeading) = 0; // launchHeading: unit-frame heading of the full shot direction, see CWeapon::CallAimingScript
 	virtual void  AimShieldWeapon(CPlasmaRepulser* weapon) = 0;
 	virtual int   AimFromWeapon(int weaponNum) = 0; // returns piece, former AimFromPrimary
 	virtual void  Shot(int weaponNum) = 0;

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -24,6 +24,20 @@
 
 /******************************************************************************/
 
+// {pivotX, pivotY, pivotZ, lateral, forward, barrelForward, barrelUp}
+static bool ParseAimFromEstimate(const LuaTable& table, AimFromEstimate& estimate)
+{
+	if (table.GetLength() < 7)
+		return false;
+
+	estimate.pivot = float3(table.GetFloat(1, 0.0f), table.GetFloat(2, 0.0f), table.GetFloat(3, 0.0f));
+	estimate.lateral = table.GetFloat(4, 0.0f);
+	estimate.forward = table.GetFloat(5, 0.0f);
+	estimate.barrelForward = table.GetFloat(6, 0.0f);
+	estimate.barrelUp = table.GetFloat(7, 0.0f);
+	return true;
+}
+
 UnitDefWeapon::UnitDefWeapon(const WeaponDef* weaponDef) {
 	*this = UnitDefWeapon();
 	this->def = weaponDef;
@@ -67,6 +81,17 @@ UnitDefWeapon::UnitDefWeapon(const WeaponDef* weaponDef, const LuaTable& weaponT
 	// 1 = exact solution for non-parabolic shots and 1 accuracy iteration for parabolic shots
 	// 2+ = extra iterations for parabolic shots. Iterations terminate early once 1-frame accuracy is achieved. 
 	accurateLeading = weaponTable.GetInt("accurateLeading", accurateLeading);
+
+	// Where the muzzle will be once the script has aimed, for line-of-fire tests that run
+	// before aiming. Absent = keep testing from the AimFromWeapon piece.
+	const LuaTable& estimateTable = weaponTable.SubTable("aimFromEstimate");
+
+	if (estimateTable.IsValid()) {
+		hasAimFromEstimate = ParseAimFromEstimate(estimateTable, aimFromEstimate);
+
+		if (!hasAimFromEstimate)
+			LOG_L(L_WARNING, "[%s] aimFromEstimate for weapon \"%s\" needs 7 numbers {pivotX, pivotY, pivotZ, lateral, forward, barrelForward, barrelUp}", __func__, weaponDef->name.c_str());
+	}
 }
 
 

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef UNITDEF_H
-#define UNITDEF_H
+#pragma once
 
 #include <vector>
 
@@ -9,6 +8,7 @@
 #include "Sim/Misc/GuiSoundSet.h"
 #include "Sim/Objects/SolidObject.h"
 #include "Sim/Objects/SolidObjectDef.h"
+#include "Sim/Weapons/AimFromEstimate.h"
 #include "System/float3.h"
 #include "System/UnorderedMap.hpp"
 
@@ -47,6 +47,11 @@ struct UnitDefWeapon {
 	unsigned int accurateLeading = 0;	///< Accurately lead moving targets. The number controls how many calculation iterations are done. 0 = undershoot approaching or retreating targets (default), 1 = sufficient for exact solution for non-parabolic shots and improves parabolic shots, 2+ = extra iterations for parabolic shots
 	unsigned int burstControlWhenOutOfArc = 0; ///< Determines how to handle burst fire, when target is out of arc. 0 = no restrictions (default), 1 = don't fire, 2 = fire in current direction of weapon 
 	float weaponAimAdjustPriority = 1.f;		///< relative importance of picking enemy targets that are in front
+
+	/// predicted post-aim muzzle position used for line-of-fire tests before the weapon has aimed;
+	/// without it the AimFromWeapon piece is tested from as before (see AimFromEstimate.h)
+	AimFromEstimate aimFromEstimate;
+	bool hasAimFromEstimate = false;
 
 
 	static constexpr unsigned int BURST_CONTROL_OUT_OF_ARC_OFF = 0;
@@ -405,5 +410,3 @@ private:
 	SResourcePack realUpkeep;
 	float realBuildTime;
 };
-
-#endif /* UNITDEF_H */

--- a/rts/Sim/Weapons/AimFromEstimate.h
+++ b/rts/Sim/Weapons/AimFromEstimate.h
@@ -1,0 +1,62 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include "System/float3.h"
+
+/**
+ * @brief Predicts where a weapon's muzzle ends up once its script has aimed.
+ *
+ * Line-of-fire tests that run before the turret has turned (target selection,
+ * SlowUpdate re-validation) have to guess the muzzle position. This models the
+ * muzzle as a yaw pivot plus an offset that turns with yaw only plus an offset
+ * that turns with yaw and pitch:
+ *
+ *   m = pivot + lateral*R + forward*H + barrelForward*(k*H + s*U) + barrelUp*(k*U - s*H)
+ *
+ * where H is the horizontal aim direction, R = (H.z, 0, -H.x) its perpendicular,
+ * U is up, k = cos(pitch) and s = sin(pitch). All vectors are in unit-local space
+ * (rightdir, updir, frontdir components), the frame CWeapon::CallAimingScript
+ * derives heading and pitch in. Evaluation needs one sqrt and no trigonometry,
+ * and the expression is linear in the five offsets, so they can be fitted from
+ * observed (aim direction, muzzle position) pairs with plain least squares.
+ *
+ * Weapons that alternate between several muzzle pieces get one estimate for the
+ * mean muzzle: which barrel fires next depends on where the script advances its
+ * counter relative to the engine's QueryWeapon re-query (measured: Storm fires
+ * the current piece, AK mostly the other one, Pawn alternates), so at aiming
+ * time the barrel cannot be predicted from the current piece.
+ */
+struct AimFromEstimate {
+	/// yaw axis position relative to the unit origin
+	float3 pivot;
+	/// offset perpendicular to the aim direction (positive along rightdir when aiming forward), turns with yaw only
+	float lateral = 0.0f;
+	/// offset along the horizontal aim direction, turns with yaw only
+	float forward = 0.0f;
+	/// offset along the barrel, turns with yaw and pitch
+	float barrelForward = 0.0f;
+	/// offset perpendicular to the barrel (upwards at zero pitch), turns with yaw and pitch
+	float barrelUp = 0.0f;
+
+	/// unit-local muzzle position for a unit-local aim direction (need not be normalised)
+	float3 Eval(const float3& dir) const
+	{
+		const float hSq = dir.x * dir.x + dir.z * dir.z;
+		const float len = math::sqrt(hSq + dir.y * dir.y);
+
+		if (len <= 0.0f)
+			return pivot;
+
+		const float h = math::sqrt(hSq);
+		const float3 H = (h > 1e-6f) ? float3(dir.x / h, 0.0f, dir.z / h) : FwdVector;
+		const float3 R(H.z, 0.0f, -H.x);
+		const float s = dir.y / len; // sin(pitch)
+		const float k = h / len;     // cos(pitch)
+
+		return pivot
+			+ R * lateral
+			+ H * (forward + barrelForward * k - barrelUp * s)
+			+ UpVector * (barrelForward * s + barrelUp * k);
+	}
+};

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -77,6 +77,12 @@ bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 
 	const float xzTargetDist = targetVec.LengthNormalize();
 
+	// a source below the terrain (e.g. a muzzle inside a cliff) blocks the shot at its origin;
+	// TrajectoryGroundCol reports this as distance 0 too, but against GetApproximateHeight, which
+	// on rough ground can lie above a source that is clear of the interpolated surface
+	if ((avoidFlags & Collision::NOGROUND) == 0 && srcPos.y < CGround::GetHeightReal(srcPos))
+		return false;
+
 	// linear parabolic coefficient is the ratio of vertical velocity to horizontal velocity, with slight adjustment due to acceleration being applied in discrete steps.
 	// quadratic parabolic coefficient is the ratio of gravity to (horizontal velocity)^2
 	const float projectileSpeedHorizontal = std::max(0.001f,projectileSpeed * launchDir.Length2D()); //ensure projectileSpeedHorizontal cannot be zero

--- a/rts/Sim/Weapons/Cannon.h
+++ b/rts/Sim/Weapons/Cannon.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef _CANNON_H
-#define _CANNON_H
+#pragma once
 
 #include "Weapon.h"
 #include "System/type2.h"
@@ -45,11 +44,8 @@ private:
 	/// tells where to point the gun to hit the point at pos+diff
 	float3 GetWantedDir(const float3& diff);
 	float3 CalcWantedDir(const float3& diff) const;
-
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
+	float3 GetWantedDirFor(const float3& targetVec) const override final { return CalcWantedDir(targetVec); }
 
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;
 };
-
-#endif // _CANNON_H

--- a/rts/Sim/Weapons/MissileLauncher.cpp
+++ b/rts/Sim/Weapons/MissileLauncher.cpp
@@ -226,6 +226,7 @@ bool CMissileLauncher::HaveFreeLineOfFire(const float3& srcPos, const float3& tg
 	const bool scanForAllies = ((avoidFlags & Collision::NOFRIENDLIES) == 0);
 	const bool scanForNeutrals = ((avoidFlags & Collision::NONEUTRALS) == 0);
 	const bool scanForFeatures = ((avoidFlags & Collision::NOFEATURES) == 0);
+	const bool skipMobileAllies = ((avoidFlags & Collision::NOMOBILEFRIENDLIES) != 0);
 	for (const int quadIdx : *qfQuery.quads) {
 		const CQuadField::Quad& quad = quadField.GetQuad(quadIdx);
 
@@ -235,6 +236,8 @@ bool CMissileLauncher::HaveFreeLineOfFire(const float3& srcPos, const float3& tg
 				if (u == owner)
 					continue;
 				if (!u->HasCollidableStateBit(CSolidObject::CSTATE_BIT_QUADMAPRAYS))
+					continue;
+				if (skipMobileAllies && !u->immobile)
 					continue;
 
 				// chord check here

--- a/rts/Sim/Weapons/MissileLauncher.cpp
+++ b/rts/Sim/Weapons/MissileLauncher.cpp
@@ -35,6 +35,18 @@ void CMissileLauncher::UpdateWantedDir()
 	}
 }
 
+float3 CMissileLauncher::GetWantedDirFor(const float3& targetVec) const
+{
+	float3 dir = CWeapon::GetWantedDirFor(targetVec);
+
+	if (weaponDef->trajectoryHeight > 0.0f) {
+		dir.y += weaponDef->trajectoryHeight;
+		dir.Normalize();
+	}
+
+	return dir;
+}
+
 void CMissileLauncher::FireImpl(const bool scriptCall)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Sim/Weapons/MissileLauncher.h
+++ b/rts/Sim/Weapons/MissileLauncher.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef MISSILELAUNCHER_H
-#define MISSILELAUNCHER_H
+#pragma once
 
 #include "Weapon.h"
 
@@ -12,13 +11,9 @@ public:
 	CMissileLauncher(CUnit* owner = nullptr, const WeaponDef* def = nullptr): CWeapon(owner, def) {}
 
 	void UpdateWantedDir() override final;
+	float3 GetWantedDirFor(const float3& targetVec) const override final;
 
 private:
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
-
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;
 };
-
-
-#endif /* MISSILELAUNCHER_H */

--- a/rts/Sim/Weapons/StarburstLauncher.h
+++ b/rts/Sim/Weapons/StarburstLauncher.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef STARBURSTLAUNCHER_H
-#define STARBURSTLAUNCHER_H
+#pragma once
 
 #include "Weapon.h"
 
@@ -14,8 +13,6 @@ public:
 	float GetRange2D(float boost, float ydiff) const override final;
 
 private:
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
-
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;
 
@@ -23,5 +20,3 @@ private:
 	float tracking;
 	float uptime;
 };
-
-#endif /* STARBURSTLAUNCHER_H */

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1027,12 +1027,18 @@ bool CWeapon::TryTarget(const float3& tgtPos, const SWeaponTarget& trg, bool pre
 	if (!trg.isAutoTarget && !TestRange(tgtPos, trg))
 		return false;
 
+	const float3 srcPos = GetAimFromPos(tgtPos, preFire);
+
 	// no LOF if aim-position is below ground (not in HFLOF, is overridden)
-	if (preFire && (weaponMuzzlePos.y < CGround::GetHeightReal(weaponMuzzlePos.x, weaponMuzzlePos.z)))
+	// before aiming this only applies to the predicted muzzle: like the real
+	// muzzle it ends up inside the terrain when the unit stands against a
+	// cliff, whereas the AimFromWeapon piece may legitimately sit below the
+	// surface inside the hull of a unit on a slope
+	if ((preFire || HasAimFromEstimate()) && (srcPos.y < CGround::GetHeightReal(srcPos.x, srcPos.z)))
 		return false;
 
 	// TODO: add a forcedUserTarget (forced-fire mode enabled with CTRL e.g.) and skip the tests below
-	return (HaveFreeLineOfFire(GetAimFromPos(tgtPos, preFire), tgtPos, trg));
+	return (HaveFreeLineOfFire(srcPos, tgtPos, trg));
 }
 
 float CWeapon::GetShapedWeaponRange(const float3& dir, float maxLength) const

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1221,7 +1221,7 @@ bool CWeapon::TryTarget(const SWeaponTarget& trg) const {
 }
 
 
-bool CWeapon::TryTargetRotate(const CUnit* unit, bool userTarget, bool manualFire)
+bool CWeapon::TryTargetRotate(const CUnit* unit, bool userTarget, bool manualFire, unsigned int extraAvoidFlags)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float3 tempTargetPos = GetUnitLeadTargetPos(unit);
@@ -1238,15 +1238,15 @@ bool CWeapon::TryTargetRotate(const CUnit* unit, bool userTarget, bool manualFir
 	// if the aimToTgt is (close to) degenerate then enemyHeading value makes no sense,
 	// use the owner's heading instead
 	if unlikely(aimToTgt.SqLength2D() < 1.0f) {
-		return TryTargetHeading(owner->heading - weaponHeading, trg);
+		return TryTargetHeading(owner->heading - weaponHeading, trg, extraAvoidFlags);
 	}
 
 	const short enemyHeading = GetHeadingFromVector(aimToTgt.x, aimToTgt.z);
-	return TryTargetHeading(enemyHeading - weaponHeading, trg);
+	return TryTargetHeading(enemyHeading - weaponHeading, trg, extraAvoidFlags);
 }
 
 
-bool CWeapon::TryTargetRotate(float3 pos, bool userTarget, bool manualFire)
+bool CWeapon::TryTargetRotate(float3 pos, bool userTarget, bool manualFire, unsigned int extraAvoidFlags)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	AdjustTargetPosToWater(pos, true);
@@ -1255,25 +1255,28 @@ bool CWeapon::TryTargetRotate(float3 pos, bool userTarget, bool manualFire)
 	SWeaponTarget trg(pos, userTarget);
 	trg.isManualFire = manualFire;
 
-	return TryTargetHeading(enemyHeading - weaponHeading, trg);
+	return TryTargetHeading(enemyHeading - weaponHeading, trg, extraAvoidFlags);
 }
 
 
-bool CWeapon::TryTargetHeading(short heading, const SWeaponTarget& trg)
+bool CWeapon::TryTargetHeading(short heading, const SWeaponTarget& trg, unsigned int extraAvoidFlags)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	const float3 tempfrontdir(owner->frontdir);
 	const float3 temprightdir(owner->rightdir);
 	const short tempHeading = owner->heading;
+	const unsigned int tempAvoidFlags = avoidFlags;
 
 	owner->heading = heading;
 	owner->frontdir = GetVectorFromHeading(owner->heading);
 	owner->rightdir = owner->frontdir.cross(owner->updir);
 	auto wvs = SaveWeaponVectors();
 	UpdateWeaponVectors();
+	avoidFlags |= extraAvoidFlags;
 
 	const bool val = TryTarget(trg);
 
+	avoidFlags = tempAvoidFlags;
 	owner->frontdir = tempfrontdir;
 	owner->rightdir = temprightdir;
 	owner->heading = tempHeading;

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1138,7 +1138,8 @@ bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		const float tgtDst = tgtPos.SqDistance(srcPos + tgtDir * gndDst);
 
 		// true iff ground does not block the ray of length <length> from <srcPos> along <tgtDir>
-		if ((gndDst > 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
+		// (a distance of 0 means <srcPos> itself is underground; -1 is not possible since length > 0)
+		if ((gndDst >= 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
 			return false;
 
 		unit = nullptr;

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -102,6 +102,7 @@ CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(mainDir),
 	CR_MEMBER(wantedDir),
 	CR_MEMBER(lastRequestedDir),
+	CR_MEMBER(launchHeading),
 	CR_MEMBER(salvoError),
 	CR_MEMBER(errorVector),
 	CR_MEMBER(errorVectorAdd),
@@ -188,6 +189,7 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	mainDir(FwdVector),
 	wantedDir(UpVector),
 	lastRequestedDir(-UpVector),
+	launchHeading(0.0f),
 	salvoError(ZeroVector),
 	errorVector(ZeroVector),
 	errorVectorAdd(ZeroVector),
@@ -433,10 +435,17 @@ bool CWeapon::CallAimingScript(bool waitForAim)
 	const float heading = GetHeadingFromVectorF(localX, localZ);
 	const float pitch = math::asin(std::clamp(localY, -1.0f, 1.0f));
 
+	// the unit-frame heading of the full shot direction is the exact turret yaw
+	// that points the barrel along the shot on tilted ground, but it is not
+	// usable for arc checks (see above); offer it to scripts as an optional
+	// extra value, the fourth AimWeapon argument for LUS and the
+	// WEAPON_LAUNCH_HEADING getter for COB, and keep <heading> the azimuth
+	launchHeading = ClampRadPi(-GetHeadingFromVectorF(wantedDir.dot(owner->rightdir), wantedDir.dot(owner->frontdir)));
+
 	// for COB, this sets <angleGood> to AimWeapon's return value when finished
 	// for LUS, there exists a callout to set the <angleGood> member directly
 	// FIXME: convert CSolidObject::heading to radians too.
-	owner->script->AimWeapon(weaponNum, ClampRadPi(-heading), pitch);
+	owner->script->AimWeapon(weaponNum, ClampRadPi(-heading), pitch, launchHeading);
 	return true;
 }
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -407,12 +407,28 @@ bool CWeapon::CallAimingScript(bool waitForAim)
 	lastRequestedDir = wantedDir;
 	lastAimedFrame = gs->frameNum;
 
-	// transform wantedDir into unit's local coordinate frame so that
-	// heading and pitch are relative to the unit's current orientation,
-	// correctly handling units on sloped terrain
-	const float localX = wantedDir.dot(owner->rightdir);
+	// heading and pitch are given in the unit's frame so that turrets on sloped
+	// terrain aim correctly; the heading is derived from the horizontal part of
+	// the shot direction only. For a steep launch (high-trajectory cannons) the
+	// horizontal part of wantedDir is small and the hull's tilt would otherwise
+	// dominate the yaw, swinging it tens of degrees away from the target azimuth
+	// that CheckTargetAngleConstraint and the scripts' own arc checks reason
+	// about; the script then rejects a target the engine considers in arc and
+	// the unit never fires
+	float3 flatDir = wantedDir;
+	flatDir.y = 0.0f;
+
+	if (flatDir.SqLength() < 1e-6f) {
+		// shooting straight up or down, fall back to the target's azimuth
+		flatDir = currentTargetPos - aimFromPos;
+		flatDir.y = 0.0f;
+	}
+	if (flatDir.SqLength() < 1e-6f)
+		flatDir = owner->frontdir;
+
+	const float localX = flatDir.dot(owner->rightdir);
+	const float localZ = flatDir.dot(owner->frontdir);
 	const float localY = wantedDir.dot(owner->updir);
-	const float localZ = wantedDir.dot(owner->frontdir);
 
 	const float heading = GetHeadingFromVectorF(localX, localZ);
 	const float pitch = math::asin(std::clamp(localY, -1.0f, 1.0f));

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -73,6 +73,7 @@ CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(doTargetGroundPos),
 	CR_MEMBER(noAutoTarget),
 	CR_MEMBER(alreadyWarnedAboutMissingPieces),
+	CR_MEMBER(hasAimFromEstimate),
 
 	CR_MEMBER(badTargetCategory),
 	CR_MEMBER(onlyTargetCategory),
@@ -161,6 +162,7 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	doTargetGroundPos(false),
 	noAutoTarget(false),
 	alreadyWarnedAboutMissingPieces(false),
+	hasAimFromEstimate(false),
 
 	badTargetCategory(0),
 	onlyTargetCategory(0xffffffff),
@@ -307,6 +309,36 @@ void CWeapon::UpdateWantedDir()
 	} else {
 		wantedDir = owner->frontdir;
 	}
+}
+
+float3 CWeapon::GetWantedDirFor(const float3& targetVec) const
+{
+	float3 dir = targetVec;
+	return dir.SafeNormalize();
+}
+
+
+float3 CWeapon::EstimateMuzzlePos(const float3& tgtPos) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(HasAimFromEstimate());
+	const AimFromEstimate& estimate = owner->unitDef->GetWeapon(weaponNum).aimFromEstimate;
+
+	// the direction the aiming script would be asked for, in the unit's frame
+	const float3 worldDir = GetWantedDirFor(tgtPos - owner->GetObjectSpacePos(estimate.pivot));
+	const float3 localDir(worldDir.dot(owner->rightdir), worldDir.dot(owner->updir), worldDir.dot(owner->frontdir));
+
+	return owner->GetObjectSpacePos(estimate.Eval(localDir));
+}
+
+float3 CWeapon::GetAimFromPos(const float3& tgtPos, bool useMuzzle) const
+{
+	if (useMuzzle)
+		return weaponMuzzlePos;
+	if (HasAimFromEstimate())
+		return EstimateMuzzlePos(tgtPos);
+
+	return aimFromPos;
 }
 
 
@@ -1000,7 +1032,7 @@ bool CWeapon::TryTarget(const float3& tgtPos, const SWeaponTarget& trg, bool pre
 		return false;
 
 	// TODO: add a forcedUserTarget (forced-fire mode enabled with CTRL e.g.) and skip the tests below
-	return (HaveFreeLineOfFire(GetAimFromPos(preFire), tgtPos, trg));
+	return (HaveFreeLineOfFire(GetAimFromPos(tgtPos, preFire), tgtPos, trg));
 }
 
 float CWeapon::GetShapedWeaponRange(const float3& dir, float maxLength) const

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -207,6 +207,7 @@ public:
 	float3 mainDir;                         // main aiming-direction of weapon
 	float3 wantedDir;                       // norm(currentTargetPos - weaponMuzzlePos)
 	float3 lastRequestedDir;                // last angle we called the script with
+	float launchHeading;                    // unit-frame heading of wantedDir at the last AimWeapon callin (radians, script convention)
 
 	float3 salvoError;                      // error vector for the whole salvo
 	float3 errorVector;

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -74,9 +74,16 @@ public:
 	virtual bool CanFire(bool ignoreAngleGood, bool ignoreTargetType, bool ignoreRequestedDir) const;
 
 	bool TryTarget(const SWeaponTarget& trg) const;
-	bool TryTargetRotate(const CUnit* unit, bool userTarget, bool manualFire);
-	bool TryTargetRotate(float3 tgtPos, bool userTarget, bool manualFire);
-	bool TryTargetHeading(short heading, const SWeaponTarget& trg);
+	/**
+	 * test the target as if the owner had turned to face it
+	 *
+	 * <extraAvoidFlags> are added to the weapon's avoidFlags for this test only; the
+	 * CommandAI passes Collision::NOMOBILEFRIENDLIES to find out whether a failing
+	 * line of fire is blocked by something that will not move out of the way
+	 */
+	bool TryTargetRotate(const CUnit* unit, bool userTarget, bool manualFire, unsigned int extraAvoidFlags = 0);
+	bool TryTargetRotate(float3 tgtPos, bool userTarget, bool manualFire, unsigned int extraAvoidFlags = 0);
+	bool TryTargetHeading(short heading, const SWeaponTarget& trg, unsigned int extraAvoidFlags = 0);
 
 	bool WantOwnerRotation() const { return onlyForward; }
 public:

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef WEAPON_H
-#define WEAPON_H
+#pragma once
 
 #include <functional>
 #include <vector>
@@ -51,7 +50,15 @@ public:
 	const SWeaponTarget& GetCurrentTarget() const { return currentTarget; }
 	const float3& GetCurrentTargetPos() const { return currentTargetPos; }
 
-	virtual const float3& GetAimFromPos(bool useMuzzle = false) const { return (useMuzzle? weaponMuzzlePos: aimFromPos); }
+	/**
+	 * position line-of-fire tests towards <tgtPos> are traced from: the muzzle when
+	 * about to fire, otherwise the estimated post-aim muzzle position if the unit
+	 * defines one for this weapon (UnitDefWeapon::aimFromEstimate), else aimFromPos
+	 */
+	float3 GetAimFromPos(const float3& tgtPos, bool useMuzzle = false) const;
+	bool HasAimFromEstimate() const { return hasAimFromEstimate; }
+	/// where the muzzle is predicted to be once the script has aimed at <tgtPos>
+	float3 EstimateMuzzlePos(const float3& tgtPos) const;
 
 	bool HasIncomingProjectile(int projID) const { return (std::find(incomingProjectileIDs.begin(), incomingProjectileIDs.end(), projID) != incomingProjectileIDs.end()); }
 	void AddIncomingProjectile(int projID) { incomingProjectileIDs.push_back(projID); }
@@ -109,6 +116,8 @@ public:
 protected:
 	virtual void FireImpl(const bool scriptCall) {}
 	virtual void UpdateWantedDir();
+	/// direction the aiming script would be asked for to hit <targetVec> (relative to the aim position)
+	virtual float3 GetWantedDirFor(const float3& targetVec) const;
 	virtual float GetPredictedImpactTime(const float3& p) const; //< how long time we predict it take for a projectile to reach target
 
 	ProjectileParams GetProjectileParams();
@@ -179,6 +188,7 @@ public:
 	bool doTargetGroundPos;                 // (used for bombers) target the ground pos under the unit instead of the center aimPos
 	bool noAutoTarget;
 	bool alreadyWarnedAboutMissingPieces;
+	bool hasAimFromEstimate;                // UnitDefWeapon::aimFromEstimate is set for this weapon
 
 	unsigned int badTargetCategory;         // targets in this category get a lot lower targeting priority
 	unsigned int onlyTargetCategory;        // only targets in this category can be targeted (default 0xffffffff)
@@ -229,5 +239,3 @@ protected:
 	// (eg. nuke toward a repulsor, or missile toward a shield)
 	std::vector<int> incomingProjectileIDs;
 };
-
-#endif /* WEAPON_H */

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -206,6 +206,7 @@ void CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefWeapo
 	weapon->fastQueryPointUpdate = defWeapon->fastQueryPointUpdate;
 	weapon->accurateLeading = defWeapon->accurateLeading;
 	weapon->burstControlWhenOutOfArc = defWeapon->burstControlWhenOutOfArc;
+	weapon->hasAimFromEstimate = defWeapon->hasAimFromEstimate;
 	weapon->ttl = weaponDef->flighttime;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,6 +176,26 @@ endif()
 	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DNOT_USING_CREG")
 
 ################################################################################
+### AimFromEstimate
+	set(test_name AimFromEstimate)
+	set(test_src
+			"${CMAKE_CURRENT_SOURCE_DIR}/engine/Sim/Weapons/testAimFromEstimate.cpp"
+			"${ENGINE_SOURCE_DIR}/System/float3.cpp"
+			"${ENGINE_SOURCE_DIR}/System/float4.cpp"
+			"${ENGINE_SOURCE_DIR}/System/Misc/SpringTime.cpp"
+			"${ENGINE_SOURCE_DIR}/System/TimeProfiler.cpp"
+			${sources_engine_System_Threading}
+			${test_Common_sources}
+		)
+
+	set(test_libs
+			streflop
+			${WINMM_LIBRARY}
+		)
+
+	add_spring_test(${test_name} "${test_src}" "${test_libs}" "-DNOT_USING_CREG -DBUILDING_AI")
+
+################################################################################
 ### Float3
 	set(test_name Float3)
 	set(test_src

--- a/test/engine/Sim/Weapons/testAimFromEstimate.cpp
+++ b/test/engine/Sim/Weapons/testAimFromEstimate.cpp
@@ -1,0 +1,115 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include <catch_amalgamated.hpp>
+
+#include <cmath>
+
+#include "Sim/Weapons/AimFromEstimate.h"
+#include "System/float3.h"
+
+namespace {
+	// reference model built with explicit rotations: a turret that yaws around a
+	// vertical axis through <pivot>, carrying a barrel that pitches around the
+	// turret's local right axis at <turretOffset>
+	struct ReferenceTurret {
+		float3 pivot;
+		float3 turretOffset; // (lateral, 0, forward) in turret space
+		float3 barrelOffset; // (0, up, forward) in barrel space
+
+		static float3 Yaw(const float3& v, float yaw) {
+			const float c = std::cos(yaw);
+			const float s = std::sin(yaw);
+			// local frame: x = right, z = front; yaw 0 aims along +z, positive yaw turns towards +x
+			return float3(v.x * c + v.z * s, v.y, -v.x * s + v.z * c);
+		}
+		static float3 Pitch(const float3& v, float pitch) {
+			const float c = std::cos(pitch);
+			const float s = std::sin(pitch);
+			// rotate in the (front, up) plane, positive pitch lifts the front
+			return float3(v.x, v.y * c + v.z * s, -v.y * s + v.z * c);
+		}
+
+		float3 AimDir(float yaw, float pitch) const {
+			return Yaw(Pitch(FwdVector, pitch), yaw);
+		}
+		float3 Muzzle(float yaw, float pitch) const {
+			return pivot + Yaw(turretOffset + Pitch(barrelOffset, pitch), yaw);
+		}
+		AimFromEstimate Estimate() const {
+			AimFromEstimate e;
+			e.pivot = pivot;
+			e.lateral = turretOffset.x;
+			e.forward = turretOffset.z;
+			e.barrelForward = barrelOffset.z;
+			e.barrelUp = barrelOffset.y;
+			return e;
+		}
+	};
+
+	bool Near(const float3& a, const float3& b, float eps = 1e-3f) {
+		return (a - b).SqLength() <= (eps * eps);
+	}
+}
+
+TEST_CASE("AimFromEstimate matches an explicitly rotated two-axis turret")
+{
+	const ReferenceTurret turrets[] = {
+		{ float3(0.0f, 20.0f, 0.0f), float3(0.0f, 0.0f, 0.0f), float3(0.0f, 0.0f, 25.0f) },   // plain barrel on the yaw axis
+		{ float3(-1.0f, 21.8f, -8.5f), float3(-6.3f, 0.0f, 0.0f), float3(0.0f, -4.0f, 19.4f) },   // Stumpy-like: barrel beside the yaw axis
+		{ float3(0.4f, 23.4f, 0.1f), float3(-0.4f, 0.0f, 1.3f), float3(0.0f, -1.0f, 26.4f) },  // Mart-like: long pitching barrel
+		{ float3(0.0f, 66.7f, 0.0f), float3(0.0f, 0.0f, 0.0f), float3(0.0f, -2.3f, 26.4f) },  // LLT-like: tall pivot
+	};
+
+	for (const auto& t : turrets) {
+		const AimFromEstimate e = t.Estimate();
+
+		for (int yi = 0; yi < 16; yi++) {
+			for (int pi = -3; pi <= 3; pi++) {
+				const float yaw = yi * (2.0f * 3.14159265f / 16.0f);
+				const float pitch = pi * 0.25f; // -0.75 .. 0.75 rad
+
+				const float3 dir = t.AimDir(yaw, pitch);
+				const float3 want = t.Muzzle(yaw, pitch);
+
+				CHECK(Near(e.Eval(dir), want));
+				// direction length must not matter
+				CHECK(Near(e.Eval(dir * 137.0f), want));
+			}
+		}
+	}
+}
+
+TEST_CASE("AimFromEstimate degenerate inputs")
+{
+	AimFromEstimate e;
+	e.pivot = float3(1.0f, 2.0f, 3.0f);
+	e.lateral = 4.0f;
+	e.forward = 5.0f;
+	e.barrelForward = 6.0f;
+	e.barrelUp = 7.0f;
+
+	SECTION("zero direction returns the pivot") {
+		CHECK(Near(e.Eval(ZeroVector), e.pivot));
+	}
+
+	SECTION("straight up falls back to aiming forward, barrel pitched 90 degrees") {
+		// H = front, R = right, k = 0, s = 1
+		const float3 want = e.pivot + float3(e.lateral, e.barrelForward, e.forward - e.barrelUp);
+		CHECK(Near(e.Eval(UpVector), want));
+	}
+
+	SECTION("only the pivot set reproduces a fixed point for every direction") {
+		AimFromEstimate fixedPoint;
+		fixedPoint.pivot = float3(-3.0f, 40.0f, 8.0f);
+		CHECK(Near(fixedPoint.Eval(FwdVector), fixedPoint.pivot));
+		CHECK(Near(fixedPoint.Eval(float3(1.0f, -0.5f, -1.0f)), fixedPoint.pivot));
+	}
+
+	SECTION("lateral offset points along +x when aiming forward") {
+		AimFromEstimate lat;
+		lat.lateral = 3.0f;
+		CHECK(Near(lat.Eval(FwdVector), float3(3.0f, 0.0f, 0.0f)));
+		// and along -z when aiming towards +x (turned by 90 degrees)
+		CHECK(Near(lat.Eval(float3(1.0f, 0.0f, 0.0f)), float3(0.0f, 0.0f, -3.0f)));
+	}
+}


### PR DESCRIPTION
Fixes #3242.

Stacked on #3328 (rays that start below the terrain), #3325 (AimWeapon heading) and #3327 (`aimFromEstimate`): the first four commits are theirs and disappear from this diff once they land. The fix itself is the last two commits.

## Problem

In current game, units with an attack command that are within 90% of their weapons range will stop moving towards the target, even if terrain obstructs the shot.

This results in units disobeying a players attack command and just cowardly hiding behind a rock.

`CMobileCAI` decides whether an attacker stops or keeps moving with the preliminary line-of-fire test (`TryTargetRotate` for unit targets, `TryTargetHeading` for ground targets). When the target is inside `0.9 * maxRange` and no weapon passes that test, the CAI does nothing useful: it plain-returns (unit target) or stops and keeps pointing (ground target), and retries from the same spot every SlowUpdate.

Video of the issue on master (five Sheldons, two stuck behind the rock, one not shooting behind another Sheldon):

https://github.com/user-attachments/assets/7eab142d-acba-4be2-ace3-0675c06602fc

## Earlier attempts (kept for reference)

1. Re-check the muzzle-below-ground condition in the pre-aim test: small improvement only.
2. Fall back to the `strafeToAttack` code when there is no solution — best results at the time, preserved in `archive/attack-obstacle-close-in-original`. @sprunk pointed out that a solution found by rotating can become invalid again after the rotation.
3. Detect the blocked state and keep moving towards the target: the rear Sheldons of a group walk to the front, block the ones they passed, and the whole ball creeps forward.
4. Detect the blocked state, sidestep first, then move closer (`FindBlockedAttackSidestepGoal`): works in the reproducers but a lot of code. Preserved in `archive/attack-obstacle-close-in-sidestep`.

## Idea

The current AI does nothing at 90% of weapons range if there's no shot, causing units to stay behind rocks or blindly continue walking depending on the unit state. 

If we tell the unit to continue closing in when the shot is blocked, it causes the creep behavior in groups of units, where the back of the pack tries to move to the front and then the other units get block and they try to get to the front. 

So the simple boolean test, blocked or not, is not enough. A unit in firing range should continue moving if terrain or buildings obstruct a shot but they should stop moving if a friendly unit is in the way. 

The core idea of this PR is to differentiate between the two obstruction types.


## Implementation

* **TraceRay**: new `Collision::NOMOBILEFRIENDLIES`, a trace-only flag (never part of a weapon's `avoidFlags`) that skips allied units that are able to move. Allied structures, features and terrain are still scanned. Honoured by `TraceRay`, `TestCone`, `TestTrajectoryCone` and the MissileLauncher trajectory scan.
* **CWeapon**: `TryTargetRotate` / `TryTargetHeading` take optional extra avoid flags for one test.
* **CMobileCAI**: when the target is in range but no weapon has a solution, test again with mobile allies ignored.
  * still no solution: the blocker is static (terrain, feature, allied wall or building) and the unit keeps closing in like an out-of-range unit would, for unit and ground targets;
  * solution: only an allied unit is in the way and it may move out of it, so the unit **stops** and waits (`StopMove` + `KeepPointingTo`) instead of walking past it.
  * Bounds: the approach stops at 20% of `maxRange` (artillery does not walk up to a target that sits behind a wall); an approach that fails (unreachable goal, e.g. the rock itself) is not retried for 10 seconds; `stopToAttack` units always wait; the `strafeToAttack` sidestep and the gunship / very-close / owner-rotation branches are unchanged. Hold-position units follow the same logic: an explicit attack order already makes them approach an out-of-range target, and the temp-order case is cancelled earlier as before.
* **CWeapon::TryTarget**: the "aim position below ground" rejection, so far only applied at fire time to the real muzzle, is also applied to the predicted muzzle (`aimFromEstimate`). Without it a Sheldon standing against a cliff (muzzle 60 elmo inside the rock) passes the pre-aim test, stops, and can never fire; with it the CAI sees a static blocker and moves the unit out. The `AimFromWeapon` piece is deliberately not checked: it may legitimately sit inside the hull below the surface on slopes. With #3328 an underground predicted muzzle is also caught by `HaveFreeLineOfFire` itself; this check stays because it covers weapons that skip ground checks (`avoidGround = false`) and mirrors the fire-time test.

Why stopping matters: the plain `return` of the old code has the creep problem of attempt 3 already. The goal set with the attack order is the target itself, so a unit that enters range without a solution simply keeps walking; the false positives of the old pre-aim test hid that. With the honest test a column of five Sheldons ordered to attack a Fatboy 600 elmo away walks all the way up to it.

## Performance consideration

Cost: For every units that are within 90% range of their target and have no firing solution we make one extra `TryTargetRotate` per weapon per SlowUpdate.


## Validation

Headless runs of BAR overlays (gadgets, start scripts and runner: https://github.com/eun-ice/bar-attack-reproducers), BAR `feature/aim-from-estimate` (beyond-all-reason/Beyond-All-Reason#9090). "baseline" = #3325 + #3327 without the fix commits. Five Sheldons per run, `targetHits` and `moved` (elmos) per unit at frame 800:

| scenario | baseline | this branch |
|---|---|---|
| rock, maneuver: five Sheldons behind the rock, one of them against the cliff | 2 stall (moved 11–15, 0 hits), 3 walk ~350–400 and hit | all 5 walk out (moved 340–400), 3 hit 7–9×, 2 fire but hit only the Fleas around the Fatboy; all stand still afterwards (`movedLast60Frames=0`) |
| rock, hold position | 1 stalls against the cliff (moved 14, 0 hits) | all 5 reposition, same as maneuver |
| wall, mobile: five Sheldons abreast behind seven allied Banthas (100 elmo high), Fatboy 450 beyond | shooters push 45–70 elmo into the Bantha row, 1 slips through and hits 13× | **no shooter moves** (0.0 elmo), none fires; they wait for the Banthas |
| wall, static: same with seven allied fortification walls | shooters walk 60–207, 4 hit (they were walking to the target anyway) | 3 walk around the walls (56–138) and hit 12–13×, 2 stop behind the Sheldons that went first and wait |
| Rocko on the crest, plain attack order | fires without moving (fixed by #3325/#3327) | unchanged |

Two reproducers built from player reports, plus one more wall variant, run against **master** (not the #3325 + #3327 baseline) and the current branch stacked on #3328:

| scenario | master | this branch |
|---|---|---|
| missile cruisers vs. plateau geo, far ([Crd]gunseng's replay, Supreme Isthmus): four `cormship` 1396–1630 elmo from an advanced geo on the 304 elmo plateau, ground attack on it | all 4 stop (`moveState=done`), `tryTarget=false`, 0 rockets in 60 s | all 4 close in (139–359 elmo) and fire, 7–8 rockets each |
| missile cruisers, close: 1268–1441 elmo | the 2 nearest fire (8 each), the 2 farthest sit in range without a solution, 0 rockets | all 4 fire; the two farthest move 144 and 171 elmo first |
| missile cruisers, far, **unit**-target attack on the geo | all 4 fire | all 4 fire (unchanged) |
| wall, mobile: five Sheldons behind seven allied Korgoths | shooters walk 121–156 around the Korgoths, all 5 hit | **no shooter moves**, none fires; they wait for the Korgoths |
| Cortex commander vs. three Ticks (replay 2026-09-05, All That Glitters): area attack on Ticks 335 elmo away, commander stops 320 elmo short of its 300-range laser | stalls, 0 shots | stalls, 0 shots (**not covered**, see below) |

The commander case is the unit-target sibling of #3242 but this change cannot see it: the commander's sea laser (never aims on land) passes `TryTargetRotate` from its forward muzzle piece while the land laser is out of range, so the CAI is told there *is* a solution and stops. Only a "no weapon has a solution" state triggers the re-test added here. It needs its own fix (a weapon the script refuses to aim should not count as a solution); reproducer and analysis are in the repo above.

The two waiting units in the static-wall row are the price of the "wait for allies" rule: the allies in the way are their own group mates, which now stand and fire. A sidestep for that case (lateral goal instead of waiting) is a possible follow-up; it is a different problem from #3242 and was left out on purpose.

## Videos

Same scenarios as above, recorded fullscreen at 1x; baseline = #3325 + #3327 without the fix commits. Each video opens with a two-second still of the end state, then runs from game start to the result at frame 800.

**Rock, maneuver: baseline.** Two Sheldons stay behind the rock, one of them with its muzzle inside the cliff.

https://github.com/user-attachments/assets/c8cb56d3-66ad-4379-b5be-825527eb1fec

**Rock, maneuver: this branch.** All five walk out and stop once they have a shot. (Re-recorded with the branch stacked on #3328.)

https://github.com/user-attachments/assets/61d1334a-3430-4565-9b43-986fbe10efad

**Rock, hold position: baseline.**

https://github.com/user-attachments/assets/a646f45f-b697-49dc-bea0-289f930bdd76

**Rock, hold position: this branch.**

https://github.com/user-attachments/assets/832fc55f-a0e3-4371-a638-f034269718be

**Bantha row (mobile allies): baseline.** The Sheldons push into the row of allied Banthas that blocks their shot.

https://github.com/user-attachments/assets/eddcf44a-6f82-4e6f-8c89-963bdb30b27d

**Bantha row (mobile allies): this branch.** Nobody moves; they wait for the Banthas.

https://github.com/user-attachments/assets/66164951-bc25-429d-8d55-68bacc013a05

**Fortification row (allied structures): baseline.**

https://github.com/user-attachments/assets/fd3638b1-5708-4de0-9353-1dad60898ab6

**Fortification row (allied structures): this branch.** Three walk around the wall and fire, two wait behind the Sheldons that went first.

https://github.com/user-attachments/assets/98747aa5-55e1-4eec-8485-2d7b48edb39c

**Rocko on the crest, plain attack order: this branch.** Fires from where it stands (#3325 + #3327 already fixed this; unchanged here).

https://github.com/user-attachments/assets/460b4a71-ffbc-4c4f-a490-83d34babd68b

**Missile cruisers vs. plateau geo, far layout: master.** All four sit at 1396–1630 elmo, aim at the geo, and never fire (cut at 32 s, nothing happens afterwards).

https://github.com/user-attachments/assets/a3a96820-22e1-41ae-8ce9-6a3f465ca187

**Missile cruisers, far layout: this branch.** All four close in and shell the geo (cut at 32 s).

https://github.com/user-attachments/assets/cef83d5d-73b7-4fa8-b4f0-6d39a73ee512

**Missile cruisers, close layout: master.** The two nearest fire, the two farthest never do.

https://github.com/user-attachments/assets/c613d0af-699c-4b80-a99c-9833f49caeed

**Missile cruisers, close layout: this branch.** The two farthest move up and all four fire.

https://github.com/user-attachments/assets/6ed3bf27-5fa5-4136-b073-ddcbd05054ab

**Commander vs. Ticks: master.** Stops 320 elmo from the Ticks with the attack order and never fires.

https://github.com/user-attachments/assets/d906aabf-7996-4b0e-a942-98c044b2c831

**Commander vs. Ticks: this branch.** Unchanged, see above.

https://github.com/user-attachments/assets/effd87a4-3b40-452c-992a-e0d0e060f6ef

Known residual visible in the rock videos: a Sheldon can stop at a spot where the pre-aim test from the estimated muzzle says "clear" but the real muzzle is a few elmo above the terrain and the fire-time test says "blocked". The CommandAI is then told there is a solution and stays; that is an estimate-accuracy question for #3327 / the BAR values, not something this change can see.

## AI disclosure

OpenAI Codex assisted with the earlier attempts; Claude Code (Fable 5.1) assisted with diagnosis, implementation, the reproducers and this description of the current approach. I directed the iterations and reviewed the diff and in-game behaviour.




