### PR TITLE
Gpu draw elements indirect

### DIFF
--- a/cont/examples/Widgets/api_compute_indirect_draw.lua
+++ b/cont/examples/Widgets/api_compute_indirect_draw.lua
@@ -2,13 +2,16 @@
 --------------------------------------------------------------------------------
 --
 --  file:    api_compute_indirect_draw.lua
---  brief:   Compute-written instance and indirect command buffer example
+--  brief:   Compute-culled sphere grid, drawn via indirect draw
 --  author:  RecoilEngine contributors
 --
 --  Demonstrates:
---    - Writing instance data and DrawElementsIndirectCommand from a compute shader
---    - Applying command and shader-storage memory barriers before drawing
---    - Drawing indexed instances without a conventional instance attribute VBO
+--    - A static world-space grid of spheres, frustum-culled by a compute shader
+--    - The compute shader appends surviving instances into a compacted SSBO
+--      with an atomic counter, and writes that count into the indirect
+--      draw command, so only the surviving instances are actually drawn
+--    - Applying shader-storage and command memory barriers between compute
+--      and the indirect draw
 --
 --  License: GNU GPL, v2 or later
 --
@@ -17,8 +20,8 @@
 
 function widget:GetInfo()
 	return {
-		name = "Compute Indirect Draw API Example",
-		desc = "Validates compute-written instance data and indexed indirect drawing",
+		name = "Compute Frustum Culling Grid",
+		desc = "Sphere grid culled and compacted by a compute-shader view frustum test",
 		author = "RecoilEngine contributors",
 		date = "2026",
 		license = "GNU GPL, v2 or later",
@@ -27,6 +30,8 @@ function widget:GetInfo()
 	}
 end
 
+local spGetGroundHeight = Spring.GetGroundHeight
+
 local glCreateShader = gl.CreateShader
 local glDeleteShader = gl.DeleteShader
 local glDispatchCompute = gl.DispatchCompute
@@ -34,102 +39,158 @@ local glGetShaderLog = gl.GetShaderLog
 local glGetVAO = gl.GetVAO
 local glGetVBO = gl.GetVBO
 local glUseShader = gl.UseShader
+local glCulling = gl.Culling
+local glDepthTest = gl.DepthTest
+local glDepthMask = gl.DepthMask
+local glBlending = gl.Blending
 
-local GL_ARRAY_BUFFER = GL.ARRAY_BUFFER
-local GL_COMMAND_BARRIER_BIT = GL.COMMAND_BARRIER_BIT
-local GL_ELEMENT_ARRAY_BUFFER = GL.ELEMENT_ARRAY_BUFFER
-local GL_FLOAT_VEC4 = GL.FLOAT_VEC4
 local GL_SHADER_STORAGE_BARRIER_BIT = GL.SHADER_STORAGE_BARRIER_BIT
+local GL_COMMAND_BARRIER_BIT = GL.COMMAND_BARRIER_BIT
 local GL_SHADER_STORAGE_BUFFER = GL.SHADER_STORAGE_BUFFER
 local GL_TRIANGLES = GL.TRIANGLES
 local GL_UNSIGNED_INT_VEC4 = GL.UNSIGNED_INT_VEC4
-local GL_UNSIGNED_SHORT = GL.UNSIGNED_SHORT
 
-local INSTANCE_BUFFER_BINDING = 4
-local COMMAND_BUFFER_BINDING = 5
-local INSTANCE_COUNT = 4
+-- Grid layout: spheres are spaced along the X and Z axes, centered on the map
+local GRID_RADIUS = 8 -- instances extend this many steps outward on each side
+local GRID_SIDE = GRID_RADIUS * 2 + 1
+local INSTANCE_COUNT = GRID_SIDE * GRID_SIDE
+local GRID_SPACING = 220 -- elmos between adjacent sphere centers
+local SPHERE_RADIUS = 50
+local SPHERE_HEIGHT_OFFSET = 80 -- elmos above the ground at each sphere's XZ
+
+local INSTANCE_BUFFER_BINDING = 4 -- static full grid, readonly
+local VISIBLE_BUFFER_BINDING = 5 -- compacted survivors, written by the compute shader
+local COMMAND_BUFFER_BINDING = 6 -- indirect draw command, instanceCount is an atomic counter
+
+local COMPUTE_LOCAL_SIZE = 64
+local computeGroups = math.ceil(INSTANCE_COUNT / COMPUTE_LOCAL_SIZE)
 
 local renderShader = nil
 local computeShader = nil
-local vertexVBO = nil
-local indexVBO = nil
-local instanceVBO = nil
+local sphereVBO = nil
+local sphereIndexVBO = nil
+local sphereNumIndices = nil
+local posRadiusVBO = nil
+local visibleVBO = nil
 local commandVBO = nil
 local vao = nil
 
 local renderVertexSource = [[
 #version 430 core
 
-layout(location = 0) in vec2 vertexPosition;
+layout(location = 0) in vec3 vertexPosition;
+layout(location = 1) in vec3 vertexNormal;
+layout(location = 2) in vec2 vertexUV;
 
-layout(std430, binding = 4) readonly buffer InstanceBuffer {
-	vec4 instanceOffsets[];
+layout(std430, binding = 5) readonly buffer VisibleBuffer {
+	vec4 visibleInstances[]; // xyz = world center, w = radius; compacted by the compute shader
 };
 
-flat out vec3 instanceColor;
+//__ENGINEUNIFORMBUFFERDEFS__
 
-const vec3 colors[4] = vec3[4](
-	vec3(0.95, 0.25, 0.20),
-	vec3(0.20, 0.80, 0.35),
-	vec3(0.25, 0.55, 1.00),
-	vec3(0.95, 0.75, 0.15)
-);
+out vec3 worldNormal;
 
 void main()
 {
-	vec2 position = vertexPosition * 0.45 + instanceOffsets[gl_InstanceID].xy;
-	gl_Position = vec4(position, 0.0, 1.0);
-	instanceColor = colors[gl_InstanceID];
+	vec4 posRadius = visibleInstances[gl_InstanceID];
+	vec3 worldPos = vertexPosition * posRadius.w + posRadius.xyz;
+
+	gl_Position = cameraViewProj * vec4(worldPos, 1.0);
+	worldNormal = vertexNormal;
 }
 ]]
 
 local renderFragmentSource = [[
 #version 430 core
 
-flat in vec3 instanceColor;
+in vec3 worldNormal;
+
 out vec4 fragmentColor;
 
 void main()
 {
-	fragmentColor = vec4(instanceColor, 1.0);
+	// constant tint: seeing red confirms this instance survived the compute shader's culling pass
+	const vec3 keptColor = vec3(1.0, 0.15, 0.1);
+	float shading = clamp(dot(normalize(worldNormal), normalize(vec3(0.4, 0.8, 0.4))), 0.35, 1.0);
+	fragmentColor = vec4(keptColor * shading, 1.0);
 }
 ]]
 
 local computeSource = [[
 #version 430 core
 
-layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x = ]] .. COMPUTE_LOCAL_SIZE .. [[, local_size_y = 1, local_size_z = 1) in;
 
-layout(std430, binding = 4) writeonly buffer InstanceBuffer {
-	vec4 instanceOffsets[];
+layout(std430, binding = 4) readonly buffer InstanceBuffer {
+	vec4 instancePosRadius[]; // xyz = world center, w = radius
 };
 
-layout(std430, binding = 5) buffer CommandBuffer {
+layout(std430, binding = 5) writeonly buffer VisibleBuffer {
+	vec4 visibleInstances[];
+};
+
+layout(std430, binding = 6) buffer CommandBuffer {
 	uint count;
-	uint instanceCount;
+	uint instanceCount; // reset to 0 by Lua each frame, then used as an atomic append counter
 	uint firstIndex;
 	int baseVertex;
 	uint baseInstance;
 };
 
-const vec2 offsets[4] = vec2[4](
-	vec2(-0.55, -0.35),
-	vec2( 0.10, -0.35),
-	vec2(-0.55,  0.30),
-	vec2( 0.10,  0.30)
-);
+//__ENGINEUNIFORMBUFFERDEFS__
+
+const uint instanceCountTotal = ]] .. INSTANCE_COUNT .. [[u;
+
+shared vec4 sharedPlanes[6];
+
+// Gribb/Hartmann plane extraction from the combined view-projection matrix
+void ExtractFrustumPlanes(out vec4 planes[6])
+{
+	mat4 m = cameraViewProj;
+	planes[0] = vec4(m[0][3] + m[0][0], m[1][3] + m[1][0], m[2][3] + m[2][0], m[3][3] + m[3][0]); // left
+	planes[1] = vec4(m[0][3] - m[0][0], m[1][3] - m[1][0], m[2][3] - m[2][0], m[3][3] - m[3][0]); // right
+	planes[2] = vec4(m[0][3] + m[0][1], m[1][3] + m[1][1], m[2][3] + m[2][1], m[3][3] + m[3][1]); // bottom
+	planes[3] = vec4(m[0][3] - m[0][1], m[1][3] - m[1][1], m[2][3] - m[2][1], m[3][3] - m[3][1]); // top
+	planes[4] = vec4(m[0][3] + m[0][2], m[1][3] + m[1][2], m[2][3] + m[2][2], m[3][3] + m[3][2]); // near
+	planes[5] = vec4(m[0][3] - m[0][2], m[1][3] - m[1][2], m[2][3] - m[2][2], m[3][3] - m[3][2]); // far
+
+	for (int i = 0; i < 6; i++) {
+		planes[i] /= length(planes[i].xyz);
+	}
+}
 
 void main()
 {
-	uint instanceID = gl_GlobalInvocationID.x;
-	instanceOffsets[instanceID] = vec4(offsets[instanceID], 0.0, 0.0);
+	if (gl_LocalInvocationIndex == 0u) {
+		vec4 planes[6];
+		ExtractFrustumPlanes(planes);
+		for (int i = 0; i < 6; i++) {
+			sharedPlanes[i] = planes[i];
+		}
+	}
+	barrier();
 
-	if (instanceID == 0u) {
-		count = 3u;
-		instanceCount = 4u;
-		firstIndex = 0u;
-		baseVertex = 0;
-		baseInstance = 0u;
+	uint index = gl_GlobalInvocationID.x;
+	if (index >= instanceCountTotal) {
+		return;
+	}
+
+	vec4 posRadius = instancePosRadius[index];
+
+	bool visible = true;
+	for (int i = 0; i < 6; i++) {
+		float distance = dot(sharedPlanes[i].xyz, posRadius.xyz) + sharedPlanes[i].w;
+		if (distance < -posRadius.w) {
+			visible = false;
+			break;
+		}
+	}
+
+	// culled instances are simply never appended, so only survivors get drawn
+	if (visible) {
+		uint slot = atomicAdd(instanceCount, 1u);
+		visibleInstances[slot] = posRadius;
+		visibleInstances[slot].w = posRadius.w * fract(float(slot) * 135.021);
 	}
 }
 ]]
@@ -143,19 +204,23 @@ local function freeResources()
 	if commandVBO then
 		commandVBO:Delete()
 	end
-	if instanceVBO then
-		instanceVBO:Delete()
+	if visibleVBO then
+		visibleVBO:Delete()
 	end
-	if indexVBO then
-		indexVBO:Delete()
+	if posRadiusVBO then
+		posRadiusVBO:Delete()
 	end
-	if vertexVBO then
-		vertexVBO:Delete()
+	if sphereIndexVBO then
+		sphereIndexVBO:Delete()
+	end
+	if sphereVBO then
+		sphereVBO:Delete()
 	end
 	commandVBO = nil
-	instanceVBO = nil
-	indexVBO = nil
-	vertexVBO = nil
+	visibleVBO = nil
+	posRadiusVBO = nil
+	sphereIndexVBO = nil
+	sphereVBO = nil
 
 	if computeShader then
 		glDeleteShader(computeShader)
@@ -168,64 +233,93 @@ local function freeResources()
 end
 
 local function fail(reason)
-	Spring.Echo("Compute Indirect Draw API Example: " .. reason)
+	Spring.Echo("Compute Frustum Culling Grid: " .. reason)
 	freeResources()
 	widgetHandler:RemoveWidget()
 end
 
+local function buildInstanceGrid()
+	local mapCenterX = Game.mapSizeX * 0.5
+	local mapCenterZ = Game.mapSizeZ * 0.5
+	local data = {}
+	local n = 0
+	for gz = -GRID_RADIUS, GRID_RADIUS do
+		for gx = -GRID_RADIUS, GRID_RADIUS do
+			local worldX = mapCenterX + gx * GRID_SPACING
+			local worldZ = mapCenterZ + gz * GRID_SPACING
+			local worldY = spGetGroundHeight(worldX, worldZ) + SPHERE_HEIGHT_OFFSET
+			data[n + 1] = worldX
+			data[n + 2] = worldY
+			data[n + 3] = worldZ
+			data[n + 4] = SPHERE_RADIUS
+			n = n + 4
+		end
+	end
+	return data
+end
+
 local function initResources()
+	local engineUniformBufferDefs = gl.LuaShader.GetEngineUniformBufferDefs()
+	local vertexSource = renderVertexSource:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+	local fragmentSource = renderFragmentSource
+	local finalComputeSource = computeSource:gsub("//__ENGINEUNIFORMBUFFERDEFS__", engineUniformBufferDefs)
+
 	renderShader = glCreateShader({
-		vertex = renderVertexSource,
-		fragment = renderFragmentSource,
+		vertex = vertexSource,
+		fragment = fragmentSource,
 	})
 	if not renderShader then
 		return false, "render shader failed: " .. (glGetShaderLog() or "unknown error")
 	end
 
-	computeShader = glCreateShader({ compute = computeSource })
+	computeShader = glCreateShader({ compute = finalComputeSource })
 	if not computeShader then
 		return false, "compute shader failed: " .. (glGetShaderLog() or "unknown error")
 	end
 
-	vertexVBO = glGetVBO(GL_ARRAY_BUFFER, false)
-	indexVBO = glGetVBO(GL_ELEMENT_ARRAY_BUFFER, false)
-	instanceVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
+	sphereVBO, _, sphereIndexVBO, sphereNumIndices = gl.InstanceVBOTable.makeSphereVBO(16, 12, 1)
+	posRadiusVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
+	visibleVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
 	commandVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
 	vao = glGetVAO()
 
-	if not (vertexVBO and indexVBO and instanceVBO and commandVBO and vao) then
+	if not (sphereVBO and sphereIndexVBO and posRadiusVBO and visibleVBO and commandVBO and vao) then
 		return false, "required GL4 VAO/VBO functionality is unavailable"
 	end
 
-	vertexVBO:Define(3, {
-		{ id = 0, name = "vertexPosition", size = 2 },
+	posRadiusVBO:Define(INSTANCE_COUNT, {
+		{ id = 0, name = "instancePosRadius", size = 1, type = GL.FLOAT_VEC4 },
 	})
-	vertexVBO:Upload({
-		-0.50, -0.40,
-		 0.50, -0.40,
-		 0.00,  0.50,
-	})
+	posRadiusVBO:Upload(buildInstanceGrid())
 
-	indexVBO:Define(3, GL_UNSIGNED_SHORT)
-	indexVBO:Upload({ 0, 1, 2 })
-
-	instanceVBO:Define(INSTANCE_COUNT, {
-		{ id = 0, name = "instanceOffsets", size = 1, type = GL_FLOAT_VEC4 },
+	-- capacity for the worst case where every instance survives culling
+	visibleVBO:Define(INSTANCE_COUNT, {
+		{ id = 0, name = "visibleInstances", size = 1, type = GL.FLOAT_VEC4 },
 	})
 
 	-- Two uvec4 elements provide 32 bytes. The command occupies the first 20.
 	commandVBO:Define(2, {
 		{ id = 0, name = "indirectCommand", size = 1, type = GL_UNSIGNED_INT_VEC4 },
 	})
+	commandVBO:Upload({
+		sphereNumIndices, -- count
+		0, -- instanceCount, filled in every frame by the compute shader
+		0, -- firstIndex
+		0, -- baseVertex
+		0, -- baseInstance
+		0,
+		0,
+		0,
+	})
 
-	vao:AttachVertexBuffer(vertexVBO)
-	vao:AttachIndexBuffer(indexVBO)
+	vao:AttachVertexBuffer(sphereVBO)
+	vao:AttachIndexBuffer(sphereIndexVBO)
 
 	return true
 end
 
 function widget:Initialize()
-	if not (glCreateShader and glDispatchCompute and glGetVAO and glGetVBO) then
+	if not (glCreateShader and glDispatchCompute and glGetVAO and glGetVBO and gl.InstanceVBOTable) then
 		fail("required GL4 API is unavailable")
 		return
 	end
@@ -240,23 +334,32 @@ function widget:Shutdown()
 	freeResources()
 end
 
-function widget:DrawScreen()
-	instanceVBO:BindBufferRange(INSTANCE_BUFFER_BINDING)
+function widget:DrawWorld()
+	-- reset the atomic append counter but keep the fixed mesh index count
+	commandVBO:Upload({ sphereNumIndices, 0, 0, 0, 0, 0, 0, 0 })
+
+	posRadiusVBO:BindBufferRange(INSTANCE_BUFFER_BINDING)
+	visibleVBO:BindBufferRange(VISIBLE_BUFFER_BINDING)
 	commandVBO:BindBufferRange(COMMAND_BUFFER_BINDING)
 
 	glUseShader(computeShader)
-	glDispatchCompute(
-		1, 1, 1,
-		GL_COMMAND_BARRIER_BIT + GL_SHADER_STORAGE_BARRIER_BIT
-	)
+	glDispatchCompute(computeGroups, 1, 1, GL_SHADER_STORAGE_BARRIER_BIT + GL_COMMAND_BARRIER_BIT)
 	glUseShader(0)
 
-	gl.DepthTest(false)
-	gl.Blending(false)
+	glDepthTest(true)
+	glDepthMask(true)
+	glBlending(false)
+	glCulling(GL.BACK)
+
 	glUseShader(renderShader)
 	vao:DrawElementsIndirect(GL_TRIANGLES, commandVBO)
 	glUseShader(0)
 
+	glCulling(false)
+	glDepthMask(false)
+	glDepthTest(false)
+
 	commandVBO:UnbindBufferRange(COMMAND_BUFFER_BINDING)
-	instanceVBO:UnbindBufferRange(INSTANCE_BUFFER_BINDING)
+	visibleVBO:UnbindBufferRange(VISIBLE_BUFFER_BINDING)
+	posRadiusVBO:UnbindBufferRange(INSTANCE_BUFFER_BINDING)
 end

--- a/cont/examples/Widgets/api_compute_indirect_draw.lua
+++ b/cont/examples/Widgets/api_compute_indirect_draw.lua
@@ -1,0 +1,262 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+--
+--  file:    api_compute_indirect_draw.lua
+--  brief:   Compute-written instance and indirect command buffer example
+--  author:  RecoilEngine contributors
+--
+--  Demonstrates:
+--    - Writing instance data and DrawElementsIndirectCommand from a compute shader
+--    - Applying command and shader-storage memory barriers before drawing
+--    - Drawing indexed instances without a conventional instance attribute VBO
+--
+--  License: GNU GPL, v2 or later
+--
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+	return {
+		name = "Compute Indirect Draw API Example",
+		desc = "Validates compute-written instance data and indexed indirect drawing",
+		author = "RecoilEngine contributors",
+		date = "2026",
+		license = "GNU GPL, v2 or later",
+		layer = 0,
+		enabled = false,
+	}
+end
+
+local glCreateShader = gl.CreateShader
+local glDeleteShader = gl.DeleteShader
+local glDispatchCompute = gl.DispatchCompute
+local glGetShaderLog = gl.GetShaderLog
+local glGetVAO = gl.GetVAO
+local glGetVBO = gl.GetVBO
+local glUseShader = gl.UseShader
+
+local GL_ARRAY_BUFFER = GL.ARRAY_BUFFER
+local GL_COMMAND_BARRIER_BIT = GL.COMMAND_BARRIER_BIT
+local GL_ELEMENT_ARRAY_BUFFER = GL.ELEMENT_ARRAY_BUFFER
+local GL_FLOAT_VEC4 = GL.FLOAT_VEC4
+local GL_SHADER_STORAGE_BARRIER_BIT = GL.SHADER_STORAGE_BARRIER_BIT
+local GL_SHADER_STORAGE_BUFFER = GL.SHADER_STORAGE_BUFFER
+local GL_TRIANGLES = GL.TRIANGLES
+local GL_UNSIGNED_INT_VEC4 = GL.UNSIGNED_INT_VEC4
+local GL_UNSIGNED_SHORT = GL.UNSIGNED_SHORT
+
+local INSTANCE_BUFFER_BINDING = 4
+local COMMAND_BUFFER_BINDING = 5
+local INSTANCE_COUNT = 4
+
+local renderShader = nil
+local computeShader = nil
+local vertexVBO = nil
+local indexVBO = nil
+local instanceVBO = nil
+local commandVBO = nil
+local vao = nil
+
+local renderVertexSource = [[
+#version 430 core
+
+layout(location = 0) in vec2 vertexPosition;
+
+layout(std430, binding = 4) readonly buffer InstanceBuffer {
+	vec4 instanceOffsets[];
+};
+
+flat out vec3 instanceColor;
+
+const vec3 colors[4] = vec3[4](
+	vec3(0.95, 0.25, 0.20),
+	vec3(0.20, 0.80, 0.35),
+	vec3(0.25, 0.55, 1.00),
+	vec3(0.95, 0.75, 0.15)
+);
+
+void main()
+{
+	vec2 position = vertexPosition * 0.45 + instanceOffsets[gl_InstanceID].xy;
+	gl_Position = vec4(position, 0.0, 1.0);
+	instanceColor = colors[gl_InstanceID];
+}
+]]
+
+local renderFragmentSource = [[
+#version 430 core
+
+flat in vec3 instanceColor;
+out vec4 fragmentColor;
+
+void main()
+{
+	fragmentColor = vec4(instanceColor, 1.0);
+}
+]]
+
+local computeSource = [[
+#version 430 core
+
+layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
+
+layout(std430, binding = 4) writeonly buffer InstanceBuffer {
+	vec4 instanceOffsets[];
+};
+
+layout(std430, binding = 5) buffer CommandBuffer {
+	uint count;
+	uint instanceCount;
+	uint firstIndex;
+	int baseVertex;
+	uint baseInstance;
+};
+
+const vec2 offsets[4] = vec2[4](
+	vec2(-0.55, -0.35),
+	vec2( 0.10, -0.35),
+	vec2(-0.55,  0.30),
+	vec2( 0.10,  0.30)
+);
+
+void main()
+{
+	uint instanceID = gl_GlobalInvocationID.x;
+	instanceOffsets[instanceID] = vec4(offsets[instanceID], 0.0, 0.0);
+
+	if (instanceID == 0u) {
+		count = 3u;
+		instanceCount = 4u;
+		firstIndex = 0u;
+		baseVertex = 0;
+		baseInstance = 0u;
+	}
+}
+]]
+
+local function freeResources()
+	if vao then
+		vao:Delete()
+		vao = nil
+	end
+
+	if commandVBO then
+		commandVBO:Delete()
+	end
+	if instanceVBO then
+		instanceVBO:Delete()
+	end
+	if indexVBO then
+		indexVBO:Delete()
+	end
+	if vertexVBO then
+		vertexVBO:Delete()
+	end
+	commandVBO = nil
+	instanceVBO = nil
+	indexVBO = nil
+	vertexVBO = nil
+
+	if computeShader then
+		glDeleteShader(computeShader)
+		computeShader = nil
+	end
+	if renderShader then
+		glDeleteShader(renderShader)
+		renderShader = nil
+	end
+end
+
+local function fail(reason)
+	Spring.Echo("Compute Indirect Draw API Example: " .. reason)
+	freeResources()
+	widgetHandler:RemoveWidget()
+end
+
+local function initResources()
+	renderShader = glCreateShader({
+		vertex = renderVertexSource,
+		fragment = renderFragmentSource,
+	})
+	if not renderShader then
+		return false, "render shader failed: " .. (glGetShaderLog() or "unknown error")
+	end
+
+	computeShader = glCreateShader({ compute = computeSource })
+	if not computeShader then
+		return false, "compute shader failed: " .. (glGetShaderLog() or "unknown error")
+	end
+
+	vertexVBO = glGetVBO(GL_ARRAY_BUFFER, false)
+	indexVBO = glGetVBO(GL_ELEMENT_ARRAY_BUFFER, false)
+	instanceVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
+	commandVBO = glGetVBO(GL_SHADER_STORAGE_BUFFER, true)
+	vao = glGetVAO()
+
+	if not (vertexVBO and indexVBO and instanceVBO and commandVBO and vao) then
+		return false, "required GL4 VAO/VBO functionality is unavailable"
+	end
+
+	vertexVBO:Define(3, {
+		{ id = 0, name = "vertexPosition", size = 2 },
+	})
+	vertexVBO:Upload({
+		-0.50, -0.40,
+		 0.50, -0.40,
+		 0.00,  0.50,
+	})
+
+	indexVBO:Define(3, GL_UNSIGNED_SHORT)
+	indexVBO:Upload({ 0, 1, 2 })
+
+	instanceVBO:Define(INSTANCE_COUNT, {
+		{ id = 0, name = "instanceOffsets", size = 1, type = GL_FLOAT_VEC4 },
+	})
+
+	-- Two uvec4 elements provide 32 bytes. The command occupies the first 20.
+	commandVBO:Define(2, {
+		{ id = 0, name = "indirectCommand", size = 1, type = GL_UNSIGNED_INT_VEC4 },
+	})
+
+	vao:AttachVertexBuffer(vertexVBO)
+	vao:AttachIndexBuffer(indexVBO)
+
+	return true
+end
+
+function widget:Initialize()
+	if not (glCreateShader and glDispatchCompute and glGetVAO and glGetVBO) then
+		fail("required GL4 API is unavailable")
+		return
+	end
+
+	local success, reason = initResources()
+	if not success then
+		fail(reason)
+	end
+end
+
+function widget:Shutdown()
+	freeResources()
+end
+
+function widget:DrawScreen()
+	instanceVBO:BindBufferRange(INSTANCE_BUFFER_BINDING)
+	commandVBO:BindBufferRange(COMMAND_BUFFER_BINDING)
+
+	glUseShader(computeShader)
+	glDispatchCompute(
+		1, 1, 1,
+		GL_COMMAND_BARRIER_BIT + GL_SHADER_STORAGE_BARRIER_BIT
+	)
+	glUseShader(0)
+
+	gl.DepthTest(false)
+	gl.Blending(false)
+	glUseShader(renderShader)
+	vao:DrawElementsIndirect(GL_TRIANGLES, commandVBO)
+	glUseShader(0)
+
+	commandVBO:UnbindBufferRange(COMMAND_BUFFER_BINDING)
+	instanceVBO:UnbindBufferRange(INSTANCE_BUFFER_BINDING)
+end

--- a/rts/Lua/LuaVAO.cpp
+++ b/rts/Lua/LuaVAO.cpp
@@ -32,6 +32,7 @@ bool LuaVAOs::PushEntries(lua_State* L)
 
 		"DrawArrays", &LuaVAOImpl::DrawArrays,
 		"DrawElements", &LuaVAOImpl::DrawElements,
+		"DrawElementsIndirect", &LuaVAOImpl::DrawElementsIndirect,
 
 		"ClearSubmission", &LuaVAOImpl::ClearSubmission,
 		"AddUnitsToSubmission", sol::overload(

--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -1,6 +1,7 @@
 #include "LuaVAOImpl.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <type_traits>
 
 #include <fmt/format.h>
@@ -15,6 +16,8 @@
 #include "LuaVBOImpl.h"
 
 #include "LuaUtils.h"
+
+static_assert(sizeof(SDrawElementsIndirectCommand) == 5 * sizeof(uint32_t));
 
 /***
  * Vertex Array Object
@@ -224,9 +227,9 @@ void LuaVAOImpl::CheckDrawPrimitiveType(GLenum mode) const
 void LuaVAOImpl::CondInitVAO()
 {
 	if (vao &&
-		(vertLuaVBO && vertLuaVBO->GetId() == oldVertVBOId) &&
-		(indxLuaVBO && indxLuaVBO->GetId() == oldIndxVBOId) &&
-		(instLuaVBO && instLuaVBO->GetId() == oldInstVBOId))
+		(!vertLuaVBO || vertLuaVBO->GetId() == oldVertVBOId) &&
+		(!indxLuaVBO || indxLuaVBO->GetId() == oldIndxVBOId) &&
+		(!instLuaVBO || instLuaVBO->GetId() == oldInstVBOId))
 		return; //already init and all VBOs still have same IDs
 
 	vao = nullptr;
@@ -452,6 +455,85 @@ void LuaVAOImpl::DrawElements(GLenum mode, sol::optional<int> indCountOpt, sol::
 	}
 	#undef INT2PTR
 
+	vao->Unbind();
+
+	glDisable(GL_PRIMITIVE_RESTART);
+}
+
+
+/***
+ * Draws indexed primitives using commands read directly from a GPU buffer.
+ *
+ * Each command has the OpenGL `DrawElementsIndirectCommand` layout:
+ * `{ uint count, uint instanceCount, uint firstIndex, int baseVertex, uint baseInstance }`.
+ * `firstIndex` is an element offset into the attached index buffer, not a byte offset.
+ *
+ * If a compute shader wrote the command buffer, call `gl.MemoryBarrier` or pass
+ * `GL.COMMAND_BARRIER_BIT` to `gl.DispatchCompute` before drawing. If compute
+ * also wrote instance data, include `GL.SHADER_STORAGE_BARRIER_BIT` when the
+ * vertex shader reads it as an SSBO, or `GL.VERTEX_ATTRIB_ARRAY_BARRIER_BIT`
+ * when the VAO reads it as vertex attributes.
+ *
+ * @function VAO:DrawElementsIndirect
+ * @param glEnum number primitivesMode
+ * @param commandVBO VBO
+ * @param commandOffsetBytes number? Byte offset of the first command. Defaults to 0.
+ * @param drawCount number? Number of commands to execute. Defaults to 1.
+ * @param strideBytes number? Byte stride between commands. 0 means tightly packed. Defaults to 0.
+ * @return nil
+ */
+void LuaVAOImpl::DrawElementsIndirect(GLenum mode, const LuaVBOImplSP& commandLuaVBO, sol::optional<int> commandOffsetBytesOpt, sol::optional<int> drawCountOpt, sol::optional<int> strideBytesOpt)
+{
+	if (!commandLuaVBO || !commandLuaVBO->vbo)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: The command VBO is undefined", __func__);
+
+	if (!indxLuaVBO)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: No index buffer is attached. Did you successfully call vao:AttachIndexBuffer()?", __func__);
+
+	const int commandOffsetBytes = commandOffsetBytesOpt.value_or(0);
+	const int drawCount = drawCountOpt.value_or(1);
+	const int strideBytes = strideBytesOpt.value_or(0);
+	constexpr uint32_t commandAlignment = sizeof(uint32_t);
+	constexpr uint64_t commandSize = sizeof(SDrawElementsIndirectCommand);
+
+	if (commandOffsetBytes < 0)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Negative command buffer byte offset %d is requested", __func__, commandOffsetBytes);
+
+	if ((commandOffsetBytes % commandAlignment) != 0)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Command buffer byte offset %d is not aligned to %u bytes", __func__, commandOffsetBytes, commandAlignment);
+
+	if (drawCount <= 0)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Non-positive command count %d is requested", __func__, drawCount);
+
+	if (strideBytes < 0)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Negative command stride %d is requested", __func__, strideBytes);
+
+	if (strideBytes != 0 && (strideBytes < commandSize || (strideBytes % commandAlignment) != 0))
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Command stride %d must be at least %llu bytes and aligned to %u bytes", __func__, strideBytes, static_cast<unsigned long long>(commandSize), commandAlignment);
+
+	const uint64_t effectiveStride = (strideBytes == 0) ? commandSize : strideBytes;
+	const uint64_t requiredBufferSize = static_cast<uint64_t>(commandOffsetBytes) + (static_cast<uint64_t>(drawCount) - 1u) * effectiveStride + commandSize;
+
+	if (requiredBufferSize > commandLuaVBO->bufferSizeInBytes)
+		LuaUtils::SolLuaError("[LuaVAOImpl::%s]: Indirect commands require %llu bytes, exceeding the command buffer size of %u bytes", __func__, static_cast<unsigned long long>(requiredBufferSize), commandLuaVBO->bufferSizeInBytes);
+
+	if (vertLuaVBO)
+		vertLuaVBO->UpdateModelsVBOElementCount();
+	indxLuaVBO->UpdateModelsVBOElementCount();
+
+	CheckDrawPrimitiveType(mode);
+	CondInitVAO();
+
+	const GLenum indexType = indxLuaVBO->bufferAttribDefsVec[0].second.type;
+	const auto commandOffset = reinterpret_cast<const void*>(static_cast<uintptr_t>(commandOffsetBytes));
+
+	glEnable(GL_PRIMITIVE_RESTART);
+	glPrimitiveRestartIndex(indxLuaVBO->primitiveRestartIndex);
+
+	vao->Bind();
+	glBindBuffer(GL_DRAW_INDIRECT_BUFFER, commandLuaVBO->GetId());
+	glMultiDrawElementsIndirect(mode, indexType, commandOffset, drawCount, strideBytes);
+	glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
 	vao->Unbind();
 
 	glDisable(GL_PRIMITIVE_RESTART);

--- a/rts/Lua/LuaVAOImpl.cpp
+++ b/rts/Lua/LuaVAOImpl.cpp
@@ -17,8 +17,6 @@
 
 #include "LuaUtils.h"
 
-static_assert(sizeof(SDrawElementsIndirectCommand) == 5 * sizeof(uint32_t));
-
 /***
  * Vertex Array Object
  * 

--- a/rts/Lua/LuaVAOImpl.h
+++ b/rts/Lua/LuaVAOImpl.h
@@ -35,6 +35,7 @@ public:
 
 	void DrawArrays(GLenum mode, sol::optional<int> vertCountOpt, sol::optional<int> vertexFirstOpt, sol::optional<int> instanceCountOpt, sol::optional<int> instanceFirstOpt);
 	void DrawElements(GLenum mode, sol::optional<int> indCountOpt, sol::optional<int> indElemOffsetOpt, sol::optional<int> instanceCountOpt, sol::optional<int> baseVertexOpt, sol::optional<int> instanceFirstOpt);
+	void DrawElementsIndirect(GLenum mode, const LuaVBOImplSP& commandLuaVBO, sol::optional<int> commandOffsetBytesOpt, sol::optional<int> drawCountOpt, sol::optional<int> strideBytesOpt);
 
 	void ClearSubmission();
 	int AddUnitsToSubmission(int id);

--- a/rts/Rendering/GL/myGL.h
+++ b/rts/Rendering/GL/myGL.h
@@ -140,6 +140,8 @@ struct SDrawElementsIndirectCommand {
 	uint32_t baseVertex;
 	uint32_t baseInstance;
 };
+// Layout must match OpenGL's DrawElementsIndirectCommand
+static_assert(sizeof(SDrawElementsIndirectCommand) == 5 * sizeof(uint32_t));
 
 struct SInstanceData {
 	SInstanceData() = default;


### PR DESCRIPTION
Draws indexed primitives using commands read directly from a GPU buffer.

 Each command has the OpenGL `DrawElementsIndirectCommand` layout:
 * `{ uint count, uint instanceCount, uint firstIndex, int baseVertex, uint baseInstance }`.
 * `firstIndex` is an element offset into the attached index buffer, not a byte offset.
 *
 * If a compute shader wrote the command buffer, call `gl.MemoryBarrier` or pass
 * `GL.COMMAND_BARRIER_BIT` to `gl.DispatchCompute` before drawing. If compute
 * also wrote instance data, include `GL.SHADER_STORAGE_BARRIER_BIT` when the
 * vertex shader reads it as an SSBO, or `GL.VERTEX_ATTRIB_ARRAY_BARRIER_BIT`
 * when the VAO reads it as vertex attributes. 
 
 Example test widget included.