### PR TITLE
Stop per-frame atlas log spam while the window is minimized

### DIFF
--- a/rts/Rendering/Textures/TextureRenderAtlas.cpp
+++ b/rts/Rendering/Textures/TextureRenderAtlas.cpp
@@ -356,10 +356,10 @@ bool CTextureRenderAtlas::CreateAtlasTexture()
 	if (atlasRendered)
 		return true;
 
-	LOG_L(L_INFO, "CTextureRenderAtlas::%s()[0] atlas=%s FBO::ready=%d", __func__, atlasName.c_str(), FBO::IsReady());
-
 	if (!FBO::IsReady())
 		return false;
+
+	LOG_L(L_INFO, "CTextureRenderAtlas::%s()[0] atlas=%s FBO::ready=%d", __func__, atlasName.c_str(), FBO::IsReady());
 
 	const auto numLevels = atlasAllocator->GetNumTexLevels();
 	const auto numPages = atlasAllocator->GetNumPages();


### PR DESCRIPTION
CTextureRenderAtlas::CreateAtlasTexture() logs a diagnostic line (added in d3482cc99e to help track #2661) before checking FBO::IsReady(). Since FBO::IsReady() is just globalRendering->active and callers like CIconHandler::Update() and CGroundDecalHandler::Draw() retry atlas creation every frame until it succeeds, a minimized/hidden window (e.g. alt-tabbed fullscreen) floods infolog with

  CTextureRenderAtlas::CreateAtlasTexture()[0] atlas=IconsAtlas_0 FBO::ready=0

roughly every 11 ms until the window is restored.

Move the log below the FBO::IsReady() early-out, so it is emitted once per atlas on the attempt that actually proceeds. The [1] atlasRendered= line is unaffected, keeping the diagnostic value for #2661.

Found and implemente with: Claude Fable 5