### PR TITLE
Fix test_SerializeLuaState unit test crashing on OpenBSD/aarch64

### DIFF
--- a/rts/System/creg/SerializeLuaState.cpp
+++ b/rts/System/creg/SerializeLuaState.cpp
@@ -1042,7 +1042,7 @@ void creg_lua_State::PostLoad()
 	}
 
 	size_t savedpc_offset = * (size_t *) &savedpc;
-	savedpc = GetProtoFromCallInfo(ci)->code + savedpc_offset;
+	savedpc = GetProtoFromCallInfo(ci - 1)->code + savedpc_offset;
 }
 
 


### PR DESCRIPTION
Changed PostLoad() to restore savedpc from ci - 1 (the suspended
Lua frame), not ci (the C luaB_yield frame).

Fixes #3179