### PR TITLE
Fix Fight-assist repairs being dropped at elevation for 2D-range builders

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -751,7 +751,7 @@ void CBuilderCAI::ExecuteRepair(Command& c)
 
 		if (tempOrder && owner->moveState <= MOVESTATE_MANEUVER) {
 			// limit how far away we go when not roaming
-			if (LinePointDist(commandPos1, commandPos2, unit->pos) > std::max(500.0f, GetBuildRange(unit->buildeeRadius))) {
+			if (f3LinePointDist(commandPos1, commandPos2, unit->pos) > std::max(500.0f, GetBuildRange(unit->buildeeRadius))) {
 				StopMoveAndFinishCommand();
 				return;
 			}

--- a/rts/Sim/Units/CommandAI/BuilderCAI.h
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.h
@@ -6,6 +6,7 @@
 #include "MobileCAI.h"
 #include "Sim/Units/BuildInfo.h"
 #include "System/Misc/BitwiseEnum.h"
+#include "System/SpringMath.h"
 #include "System/UnorderedSet.hpp"
 
 #include <vector>
@@ -115,6 +116,15 @@ private:
 	}
 	inline float f3SqDist(const float3& a, const float3& b) const {
 		return range3D ? a.SqDistance(b) : a.SqDistance2D(b);
+	}
+	inline float f3LinePointDist(const float3& l1, const float3& l2, const float3& p) const {
+		if (range3D)
+			return LinePointDist(l1, l2, p);
+
+		return LinePointDist(
+			float3{l1.x, 0.0f, l1.z},
+			float3{l2.x, 0.0f, l2.z},
+			float3{p.x, 0.0f, p.z});
 	}
 	//inline float f3Len(const float3& a) const {
 	//	return range3D ? a.Length() : a.Length2D();


### PR DESCRIPTION
The Maneuver leash used 3D LinePointDist while IsInBuildRange is horizontal unless buildRange3D is set, so construction turrets on Maneuver cancelled in-range assists and stalled. Construction turrets use 2D build range not 3D so they were being incorrectly affected by this check. 


Repro: if you build anything near max range of a nano at high elevation, it'll try to build it, then get cancelled by this "moving too far" check. It also stops them from building anything else that is in range unless manually targeted. 

<img width="1786" height="1289" alt="image" src="https://github.com/user-attachments/assets/4304c20c-bab4-41d1-9c86-5af083dc923d" />

Now LinePointDist uses 2D range instead of 3D when appropriate.


Tested with fix: 
<img width="1906" height="973" alt="image" src="https://github.com/user-attachments/assets/5813a1b7-2221-4976-ab41-fa57000ed8c9" />


AI:
Cursor for pointing to relevant files, manual review & testing. 