### PR TITLE
perf: skip exit-only footprint scans

### DIFF
--- a/rts/Sim/Misc/YardmapStatusEffectsMap.cpp
+++ b/rts/Sim/Misc/YardmapStatusEffectsMap.cpp
@@ -13,6 +13,8 @@ CR_BIND(YardmapStatusEffectsMap, )
 CR_REG_METADATA(YardmapStatusEffectsMap, (
 	CR_MEMBER(stateMap),
 	CR_IGNORED(tileStride),   // rebuilt from stateMap size on PostLoad
+	CR_IGNORED(eoStride),     // derived from stateMap, rebuilt on PostLoad
+	CR_IGNORED(eoBlocks),     // ditto — never the source of truth
 	CR_POSTLOAD(PostLoad)
 ))
 
@@ -24,7 +26,38 @@ CR_REG_METADATA(YardmapStatusEffectsMap::Tile, (
 
 void YardmapStatusEffectsMap::ClearTile(int tileId) {
 	assert(tileId >= 0 && tileId < static_cast<int>(stateMap.size()));
+
+	// A tile spans 8x8 squares and a coarse block 16x16, both aligned, so every
+	// square of a tile lives in the same block: count the EXIT_ONLY squares
+	// about to be erased and correct that block once.
+	const Tile& tile = stateMap[tileId];
+	int erased = 0;
+	for (int i = 0; i < TILE_AREA; ++i)
+		erased += ((tile.squares[i] & EXIT_ONLY) != 0);
+
+	if (erased != 0) {
+		const int tx = (tileId % tileStride) * TILE_SIZE;
+		const int tz = (tileId / tileStride) * TILE_SIZE;
+		eoBlocks[EOBlockIdx(tx, tz)] -= erased;
+	}
+
 	memset(&stateMap[tileId], 0, sizeof(Tile));
+}
+
+// Recompute the coarse EXIT_ONLY grid from the fine map. Called on map init
+// (where it just sizes and zeroes it) and after deserialization, since the grid
+// is derived state and is not serialized.
+void YardmapStatusEffectsMap::RebuildExitOnlyBlocks() {
+	eoStride = ((mapDims.mapx - 1) >> EO_BLOCK_SHIFT) + 1;
+	const int blocksZ = ((mapDims.mapy - 1) >> EO_BLOCK_SHIFT) + 1;
+	eoBlocks.assign(eoStride * blocksZ, 0);
+
+	for (int z = 0; z < mapDims.mapy; ++z) {
+		for (int x = 0; x < mapDims.mapx; ++x) {
+			if (GetMapState(x, z) & EXIT_ONLY)
+				++eoBlocks[EOBlockIdx(x, z)];
+		}
+	}
 }
 
 void YardmapStatusEffectsMap::InitNewYardmapStatusEffectsMap() {
@@ -35,8 +68,12 @@ void YardmapStatusEffectsMap::InitNewYardmapStatusEffectsMap() {
 
 	stateMap.clear();
 	stateMap.resize(tilesX * tilesZ); // value-initialises: squares are zeroed
+
+	RebuildExitOnlyBlocks();
 }
 
 void YardmapStatusEffectsMap::PostLoad() {
 	tileStride = (mapDims.mapx + TILE_SIZE - 1) / TILE_SIZE;
+
+	RebuildExitOnlyBlocks();
 }

--- a/rts/Sim/Misc/YardmapStatusEffectsMap.h
+++ b/rts/Sim/Misc/YardmapStatusEffectsMap.h
@@ -41,8 +41,43 @@ public:
 	bool AreAllFlagsSet(int x, int z, uint8_t flags) const { return (GetMapState(x, z) & flags) == flags; }
 	bool AreAnyFlagsSet(int x, int z, uint8_t flags) const { return (GetMapState(x, z) & flags) != 0; }
 
-	void SetFlags  (int x, int z, uint8_t flags) { GetMapState(x, z) |=  flags; }
-	void ClearFlags(int x, int z, uint8_t flags) { GetMapState(x, z) &= ~flags; }
+	// Set/ClearFlags additionally maintain the coarse EXIT_ONLY presence grid
+	// (see eoBlocks below), so RangeMayHaveExitOnly can reject a footprint scan
+	// without touching the fine map.
+	void SetFlags(int x, int z, uint8_t flags) {
+		const int cx = std::clamp(x, 0, mapDims.mapxm1);
+		const int cz = std::clamp(z, 0, mapDims.mapym1);
+		uint8_t& st = GetMapState(cx, cz);
+		if ((flags & EXIT_ONLY) && !(st & EXIT_ONLY))
+			++eoBlocks[EOBlockIdx(cx, cz)];
+		st |= flags;
+	}
+	void ClearFlags(int x, int z, uint8_t flags) {
+		const int cx = std::clamp(x, 0, mapDims.mapxm1);
+		const int cz = std::clamp(z, 0, mapDims.mapym1);
+		uint8_t& st = GetMapState(cx, cz);
+		if ((flags & EXIT_ONLY) && (st & EXIT_ONLY))
+			--eoBlocks[EOBlockIdx(cx, cz)];
+		st &= ~flags;
+	}
+
+	// True when some square in [xmin,xmax]x[zmin,zmax] may carry EXIT_ONLY.
+	// Conservative by construction: a block counts > 0 whenever any square in
+	// it is exit-only, so this never answers false while a real exit-only
+	// square is in range — a caller that skips its scan on false therefore
+	// returns exactly what the scan would have returned.
+	bool RangeMayHaveExitOnly(int xmin, int xmax, int zmin, int zmax) const {
+		const int bx0 = std::clamp(xmin, 0, mapDims.mapxm1) >> EO_BLOCK_SHIFT;
+		const int bx1 = std::clamp(xmax, 0, mapDims.mapxm1) >> EO_BLOCK_SHIFT;
+		const int bz0 = std::clamp(zmin, 0, mapDims.mapym1) >> EO_BLOCK_SHIFT;
+		const int bz1 = std::clamp(zmax, 0, mapDims.mapym1) >> EO_BLOCK_SHIFT;
+		for (int bz = bz0; bz <= bz1; ++bz) {
+			const int row = bz * eoStride;
+			for (int bx = bx0; bx <= bx1; ++bx)
+				if (eoBlocks[row + bx] != 0) return true;
+		}
+		return false;
+	}
 
 	void ClearTile(int tileId);
 
@@ -68,6 +103,30 @@ private:
 	              "Tile must be trivially default constructible for resize() zero-init to hold");
 
 	int tileStride = 0; // tiles per map row, set by Init / PostLoad
+
+	// Coarse EXIT_ONLY presence grid: one counter per 16x16-square block,
+	// holding how many squares in that block carry the flag.
+	//
+	// EXIT_ONLY is written in exactly one place (GroundBlockingObjectMap's
+	// Add/RemoveGroundBlockingObject, for yardmaps declaring YARDMAP_EXITONLY),
+	// so on a real map the flag exists only under a handful of factories while
+	// CMoveMath::RangeHasExitOnly scans a whole unit footprint for it on every
+	// collision query. The counter grid lets that scan be skipped wherever no
+	// overlapping block holds any exit-only square at all, which is nearly
+	// everywhere and nearly always.
+	//
+	// 1/256th of the map (a few KB, so permanently cache-resident) and still
+	// finer than the footprints querying it. The shift also makes a status
+	// tile (8x8, aligned) fall entirely inside one block, which is what lets
+	// ClearTile correct the counter with a single subtraction.
+	static constexpr int EO_BLOCK_SHIFT = 4;
+	int EOBlockIdx(int cx, int cz) const {
+		return (cz >> EO_BLOCK_SHIFT) * eoStride + (cx >> EO_BLOCK_SHIFT);
+	}
+	void RebuildExitOnlyBlocks();
+
+	int eoStride = 0;
+	std::vector<uint16_t> eoBlocks;
 
 	typedef std::vector<Tile> TileMapType;
 	TileMapType stateMap;

--- a/rts/Sim/MoveTypes/MoveMath/MoveMath.cpp
+++ b/rts/Sim/MoveTypes/MoveMath/MoveMath.cpp
@@ -486,6 +486,12 @@ void CMoveMath::FloodFillRangeIsBlocked(const MoveDef& moveDef, const CSolidObje
 }
 
 bool CMoveMath::RangeHasExitOnly(int xmin, int xmax, int zmin, int zmax, const ObjectCollisionMapHelper& object) {
+	// Reject the scan outright when no coarse block overlapping the footprint
+	// holds an exit-only square — the overwhelmingly common case, since
+	// EXIT_ONLY only ever exists under a factory yardmap.
+	if (!yardmapStatusEffectsMap.RangeMayHaveExitOnly(xmin, xmax, zmin, zmax))
+		return false;
+
 	for (int z = zmin; z <= zmax; z += FOOTPRINT_ZSTEP) {
 		for (int x = xmin; x <= xmax; x += FOOTPRINT_XSTEP)
 			if (object.IsExitOnlyAt(x, z)) return true;


### PR DESCRIPTION
Fixes #3252

Disclaimer: the patch was AI-generated (Claude Code, Fable) while running headless simulations with AI-generated patches. I'm also not familiar with the engine but the gains seem interesting enough to submit a PR.

The idea: RangeHasExitOnly scans all coordinates in a search area but EXIT_ONLY squares are rare. We can keep count of EXIT_ONLY squares in larger blocks and have a fast check if the search area intersects with any block that has EXIT_ONLY square. If not - there's no need to do the scan, we can return "false" early.

What is this assumption is incorrect and EXIT_ONLY squares are common? Well, in this case the added code does the same work (can potentially exit earlier) - it doesn't slow down with more EXIT_ONLY squares.
Since the benchmark shows significant reduction in cpu instructions the additional overhead from ClearTile, SetFlags and ClearFlags shouldn't be noticeable in such case - but I'm not familiar with the engine so it's not really an educated opinion.

I've put the benchmark code and a doc with more details here: https://github.com/mabn/RecoilEngine/pull/1/changes#top (not included in this PR)

I also was running these changes (separately from the benchmark) with a widget that dumps all unit positions/velocities/hp every second and they matched with the unpatched version. Althought not sure if this is required since I've seen some code that calculates checksums to detect desyncs.

**Benchmark**

Measured by re-simulating multiple times 2 demos, headless on 4-core cloud VM. Used one worker thread:
- 13min 8v8 Glitters [demo](https://www.beyondallreason.info/replays?gameId=4936896a8b258d038cbd28f55eb15ed2) 
- 27min 8v8 Supreme Isthmus [demo](https://www.beyondallreason.info/replays?gameId=6122896ac3328104d12093d975c61214)


| | glitters| isthmus |
|---|---|---|
| instructions, baseline | 623.6e9 (1.1%) | 2118.9e9 (1.5%) |
| instructions, with change | 525.1e9 (3.0%) | 1884.3e9 (1.4%) |
| | **-15.8%** | **-11.1%** |
| cycles | -11.7% (spread 13-15%) | -4.2% (spread 3-5%) |
| CPU in `SimFrame` | -10.2% (spread 13-15%) | -4.1% (spread 2-5%) |

(spread is the variability of the re-runs with the same build)


Wall clock, whole re-simulation pairs (pair = one baseline and one patched simulation)

| demo | worker threads | baseline | with the change | |
|---|---|---|---|---|
| glitters| default | 125.8s | 120.2s | -4.4%, faster in 3 of 4 pairs |
| glitters| 1 | 145.3s | 141.7s | -2.5%, faster in 2 of 3 pairs |
| isthmus | default | 496.3s | 481.3s | -3.0%, faster in 3 of 3 pairs |





**Details (AI generated)**

`CMoveMath::RangeHasExitOnly` scans a unit's whole footprint for the EXIT_ONLY yardmap flag on every collision query. The flag is written in exactly one place - GroundBlockingObjectMap's Add/RemoveGroundBlockingObject, for yardmaps declaring YARDMAP_EXITONLY - so on a real map it exists only under a handful of factories, and essentially every one of those scans walks squares that cannot possibly carry it.

The idea here is to maintain a coarse presence grid alongside the status map: one counter per 16x16-square block, holding how many squares in that block are exit-only, updated in Set/ClearFlags on the EXIT_ONLY bit. RangeHasExitOnly first asks whether any block overlapping the footprint has a non-zero count, and returns false immediately when none does.

The grid is a conservative superset of the fine map — a block counts > 0 whenever any square in it is flagged — so a skipped scan returns exactly what the scan would have returned. Positions are clamped the same way GetMapState clamps them, and the coarse range covers every square in [xmin,xmax]x[zmin,zmax] while the scan only samples every FOOTPRINT_XSTEP'th, so the check can never be false while the scan would have found something.

Notes:

- The grid is derived state: CR_IGNORED, rebuilt from the status map by PostLoad, exactly like tileStride.
- A status tile (8x8, aligned) never straddles a 16x16 block, so ClearTile corrects the affected counter with one subtraction rather than a rebuild.
- Counters are uint16_t; a block holds at most 256 squares.
- The threading model is unchanged: writes still come from synced single-threaded object blocking, reads from the same multi-threaded collision queries that already read the status map itself.