### PR TITLE
feat(metrics): add a base Prometheus metrics implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "rts/lib/streflop"]
 	path = rts/lib/streflop
 	url = https://github.com/RecoilEngine/streflop.git
+[submodule "rts/lib/prometheus-cpp"]
+	path = rts/lib/prometheus-cpp
+	url = https://github.com/jupp0r/prometheus-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,10 @@ endif (NO_CREG)
 
 option(NO_SOUND "No sound output support" FALSE)
 
+# Pulls in prometheus-cpp and the civetweb HTTP server it vendors. Applies to
+# every target that can host a game, ie. both normal client and dedicated.
+option(ENABLE_METRICS "Build the Prometheus /metrics endpoint" TRUE)
+
 if    (WIN32)
 	## internal AVI recorder (w/o sound atm)
 	option(NO_AVI "Disable in-game video recording" FALSE)

--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -55,6 +55,12 @@ list(APPEND engineCommonLibraries "prd::base64")
 ### smmalloc
 list(APPEND engineCommonLibraries "smmalloc")
 
+### prometheus metrics subsystem
+if    (ENABLE_METRICS)
+	add_subdirectory(System/Metrics)
+	list(APPEND engineCommonLibraries "engineMetrics")
+endif (ENABLE_METRICS)
+
 ### Assemble common libraries
 add_subdirectory(System/Sound)
 if    (NO_SOUND)

--- a/rts/Net/CMakeLists.txt
+++ b/rts/Net/CMakeLists.txt
@@ -1,4 +1,12 @@
 
+if    (ENABLE_METRICS)
+	make_global_var(sources_engine_ServerMetrics
+			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/GameServerMetrics.cpp"
+		)
+else  (ENABLE_METRICS)
+	make_global_var(sources_engine_ServerMetrics "${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/GameServerMetricsNull.cpp")
+endif (ENABLE_METRICS)
+
 make_global_var(sources_engine_NetServer
 		"${CMAKE_CURRENT_SOURCE_DIR}/AutohostInterface.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/GameServer.cpp"
@@ -13,5 +21,6 @@ set(sources_engine_NetClient
 make_global_var(sources_engine_Net
 		${sources_engine_NetServer}
 		${sources_engine_NetClient}
+		${sources_engine_ServerMetrics}
 	)
 

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -12,6 +12,7 @@
 #include "GameServer.h"
 
 #include "GameParticipant.h"
+#include "ServerMetrics/GameServerMetrics.h"
 #include "GameSkirmishAI.h"
 #include "AutohostInterface.h"
 
@@ -135,6 +136,8 @@ CGameServer::CGameServer(
 	lastPlayerInfo = serverStartTime;
 	lastUpdate = serverStartTime;
 
+	serverMetrics = std::make_unique<ServerMetrics>();
+
 	myClientSetup = newClientSetup;
 	myGameData = newGameData;
 	myGameSetup = newGameSetup;
@@ -149,6 +152,10 @@ CGameServer::~CGameServer()
 	LOG_L(L_INFO, "[%s][1]", __func__);
 	thread.join();
 	LOG_L(L_INFO, "[%s][2]", __func__);
+
+	// Shutdown() invalidates every metric pointer, so this is only safe once the netcode thread is gone
+	// ie. this must come after thread.join() above
+	serverMetrics->Shutdown();
 
 	// after this, demoRecorder goes out of scope and its dtor is called
 	WriteDemoData();
@@ -259,6 +266,9 @@ void CGameServer::Initialize()
 
 	lastNewFrameTick = spring_gettime();
 	lastBandwidthUpdate = spring_gettime();
+
+	// this should come before `thread` is started, as netcode thread would otherwise use metrics uninitialized
+	serverMetrics->Init();
 
 	thread = spring::thread(std::bind(&CGameServer::UpdateLoop, this));
 
@@ -874,6 +884,8 @@ void CGameServer::Update()
 		if ((quitServer = (quitServer || !hasPlayers)))
 			Message(NoClientsExit);
 	}
+
+	serverMetrics->Update(*this);
 }
 
 

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -42,6 +42,7 @@ class CGameSetup;
 class ChatMessage;
 class GameParticipant;
 class GameSkirmishAI;
+class ServerMetrics;
 
 class GameTeam : public TeamBase
 {
@@ -65,6 +66,8 @@ private:
 class CGameServer
 {
 	friend class CCregLoadSaveHandler; // For initializing server state after load
+	// the metrics classes only ever *read* server state to publish, never write
+	friend class ServerMetrics;
 public:
 	CGameServer(
 		const std::shared_ptr<const ClientSetup> newClientSetup,
@@ -223,6 +226,8 @@ private:
 	std::pair<std::string, std::string> refClientVersion;
 
 	std::deque< std::shared_ptr<const netcode::RawPacket> > packetCache;
+
+	std::unique_ptr<ServerMetrics> serverMetrics;
 
 	/////////////////// sync stuff ///////////////////
 #ifdef SYNCCHECK

--- a/rts/Net/ServerMetrics/GameServerMetrics.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetrics.cpp
@@ -1,0 +1,49 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "GameServerMetrics.h"
+
+#include "Net/GameServer.h"
+#include "System/Metrics/Metrics.h"
+#include "System/Net/ConnectionStats.h"
+
+// how often metric values are republished, well below any sane scrape interval
+static const spring_time metricsPublishInterval = spring_secs(1);
+
+
+void ServerMetrics::Init()
+{
+	metrics::Init();
+
+	netcode::SetStatsSampling(metrics::Enabled());
+
+	if (!metrics::Enabled())
+		return;
+
+	registered = true;
+}
+
+
+void ServerMetrics::Shutdown()
+{
+	netcode::SetStatsSampling(false);
+
+	metrics::Shutdown();
+
+	// the registry is gone, so every metric pointer cached in this object now
+	// dangles. Assigning a default-constructed instance clears all of them at
+	// once.
+	*this = ServerMetrics{};
+}
+
+
+void ServerMetrics::Update(const CGameServer& server)
+{
+	if (!registered)
+		return;
+
+	if (lastPublishTime > (server.lastUpdate - metricsPublishInterval))
+		return;
+
+	// code to publish metrics goes here
+	lastPublishTime = server.lastUpdate;
+}

--- a/rts/Net/ServerMetrics/GameServerMetrics.h
+++ b/rts/Net/ServerMetrics/GameServerMetrics.h
@@ -1,0 +1,47 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include "System/Misc/SpringTime.h"
+
+class CGameServer;
+
+/**
+ * @brief every prometheus series the game server exports
+ *
+ * This is a facade over groups of metrics. It owns the metric endpoint's
+ * lifetime and the publish interval, and passes everything else to the metric
+ * groups.
+ *
+ * Every method no-ops when metrics are disabled (the default) at runtime,
+ * so callers don't have to test for it.
+ *
+ * Entry points are called from both the netcode and the game thread, but always
+ * under CGameServer::gameServerMutex.
+ */
+class ServerMetrics
+{
+public:
+	void Init();
+
+	/**
+	 * @brief stop the endpoint and drop the registry
+	 *
+	 * There is one registry per process, not per game, so a finished game's series
+	 * will go on being served until this drops them. This method invalidates every metric
+	 * pointer held here, so any callers must make sure they clear their refs.
+	 */
+	void Shutdown();
+
+	/// re-publish every value. This is rate-limited internally, so it's cheap to
+	/// call per loop
+	void Update(const CGameServer& server);
+
+private:
+	/// while false (during startup or metrics disabled), Update() is a no-op
+	bool registered = false;
+
+	/// when Update() last republished. This must be the *server's update clock*
+	/// (CGameServer::lastUpdate) rather than wall time
+	spring_time lastPublishTime = spring_notime;
+};

--- a/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
@@ -1,0 +1,16 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+/*
+ * ServerMetrics for a build without the endpoint, i.e. ENABLE_METRICS=OFF
+ *
+ * NOTE: Make sure you define every method the real implementation does, as
+ * a missing one breaks this build at link time.
+ */
+
+#include "GameServerMetrics.h"
+
+void ServerMetrics::Init() {}
+
+void ServerMetrics::Shutdown() {}
+
+void ServerMetrics::Update(const CGameServer&) {}

--- a/rts/System/Metrics/CMakeLists.txt
+++ b/rts/System/Metrics/CMakeLists.txt
@@ -1,0 +1,8 @@
+include_directories(${Spring_SOURCE_DIR}/rts)
+add_library(engineMetrics STATIC
+		"${CMAKE_CURRENT_SOURCE_DIR}/Metrics.cpp"
+	)
+
+# PUBLIC because the metric groups that build the families live engine-side, in
+# rts/Net.
+target_link_libraries(engineMetrics PUBLIC prometheus-cpp::core prometheus-cpp::pull)

--- a/rts/System/Metrics/Metrics.cpp
+++ b/rts/System/Metrics/Metrics.cpp
@@ -1,0 +1,79 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "Metrics.h"
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+#include "System/Config/ConfigHandler.h"
+#include "System/Log/ILog.h"
+
+CONFIG(int, MetricsPort)
+	.defaultValue(0)
+	.minimumValue(0)
+	.maximumValue(65535)
+	.description("Port for the Prometheus /metrics HTTP endpoint. 0, the default, disables it. One port per process, so hosts running several instances must assign a distinct one to each.");
+
+CONFIG(std::string, MetricsBindAddress)
+	.defaultValue("127.0.0.1")
+	.description("Address the Prometheus /metrics HTTP endpoint binds to. The endpoint has no authentication and no TLS, so bind it to a routable address only behind something that does access control.");
+
+namespace {
+	std::shared_ptr<prometheus::Registry> registry;
+	std::unique_ptr<prometheus::Exposer> exposer;
+
+	bool initialized = false;
+	bool enabled = false;
+}
+
+void metrics::Init()
+{
+	if (initialized)
+		return;
+
+	initialized = true;
+
+	const int port = configHandler->GetInt("MetricsPort");
+
+	if (port == 0)
+		return;
+
+	const std::string endpoint = configHandler->GetString("MetricsBindAddress") + ":" + std::to_string(port);
+
+	try {
+		registry = std::make_shared<prometheus::Registry>();
+		exposer = std::make_unique<prometheus::Exposer>(endpoint);
+		exposer->RegisterCollectable(registry);
+		enabled = true;
+		LOG("[Metrics] serving metrics on http://%s/metrics", endpoint.c_str());
+	} catch (const std::exception& ex) {
+		LOG_L(L_ERROR, "[Metrics] failed to start /metrics endpoint on %s: %s", endpoint.c_str(), ex.what());
+		exposer.reset();
+		registry.reset();
+	}
+}
+
+void metrics::Shutdown()
+{
+	enabled = false;
+
+	exposer.reset();
+	registry.reset();
+
+	initialized = false;
+}
+
+bool metrics::Enabled()
+{
+	return enabled;
+}
+
+prometheus::Registry& metrics::GetRegistry()
+{
+	assert(registry != nullptr);
+	return *registry;
+}

--- a/rts/System/Metrics/Metrics.h
+++ b/rts/System/Metrics/Metrics.h
@@ -1,0 +1,27 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+namespace prometheus {
+	class Registry;
+}
+
+/// the process-wide Prometheus registry and its /metrics endpoint
+namespace metrics {
+	/**
+	 * @brief start the embedded Prometheus /metrics endpoint
+	 *
+	 * Reads MetricsPort / MetricsBindAddress. An unset port keeps the endpoint
+	 * off. Idempotent until the next Shutdown().
+	 */
+	void Init();
+
+	/// stop serving and drop the registry, invalidating every metric pointer in it
+	void Shutdown();
+
+	/// true iff the /metrics endpoint is being served
+	bool Enabled();
+
+	/// registry to Register() metric families in, only valid when Enabled()
+	prometheus::Registry& GetRegistry();
+}

--- a/rts/System/Net/ConnectionStats.cpp
+++ b/rts/System/Net/ConnectionStats.cpp
@@ -17,15 +17,15 @@ std::string FormatConnectionStats(const UdpStats& s)
 {
 	std::string msg = spring::format("\t%u bytes sent\n\t%u bytes recv'd\n", s.sentBytes, s.receivedBytes);
 	msg += spring::format("\t%u packets sent   (%.3f bytes/packet)\n",
-		s.sentPackets, spring::SafeDivide(s.sentBytes * 1.0f, s.sentPackets * 1.0f));
+		s.accumulated.sentPackets, spring::SafeDivide(s.sentBytes * 1.0f, s.accumulated.sentPackets * 1.0f));
 	msg += spring::format("\t%u packets recv'd (%.3f bytes/packet)\n",
-		s.receivedPackets, spring::SafeDivide(s.receivedBytes * 1.0f, s.receivedPackets * 1.0f));
+		s.accumulated.receivedPackets, spring::SafeDivide(s.receivedBytes * 1.0f, s.accumulated.receivedPackets * 1.0f));
 	msg += spring::format("\t{%.3fx, %.3fx} relative protocol overhead {up, down}\n",
-		spring::SafeDivide(s.sentOverheadBytes * 1.0f, s.sentBytes * 1.0f),
-		spring::SafeDivide(s.receivedOverheadBytes * 1.0f, s.receivedBytes * 1.0f));
+		spring::SafeDivide(s.accumulated.sentOverheadBytes * 1.0f, s.sentBytes * 1.0f),
+		spring::SafeDivide(s.accumulated.receivedOverheadBytes * 1.0f, s.receivedBytes * 1.0f));
 	msg += spring::format("\t%u incoming chunks dropped, %u outgoing chunks resent\n",
-		s.duplicateIncomingChunks, s.resentOutgoingChunks);
-	msg += spring::format("\t%u incoming chunks processed\n", s.processedIncomingChunks);
+		s.accumulated.duplicateIncomingChunks, s.accumulated.resentOutgoingChunks);
+	msg += spring::format("\t%u incoming chunks processed\n", s.live.processedIncomingChunks);
 	return msg;
 }
 

--- a/rts/System/Net/ConnectionStats.h
+++ b/rts/System/Net/ConnectionStats.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <variant>
 
@@ -26,22 +27,49 @@ struct BasicStats {
  * If you add a field here, fill it in UDPConnection::GetStats().
  */
 struct UdpStats {
+	/// byte totals every connection keeps, whatever its transport
 	unsigned int sentBytes = 0;
 	unsigned int receivedBytes = 0;
-	unsigned int sentPackets = 0;
-	unsigned int receivedPackets = 0;
-	/// chunks put back on the wire after having been sent once
-	unsigned int resentOutgoingChunks = 0;
-	/// chunks discarded on arrival because the same chunk had already been received
-	unsigned int duplicateIncomingChunks = 0;
-	/// cumulative protocol header bytes
-	unsigned int sentOverheadBytes = 0;
-	unsigned int receivedOverheadBytes = 0;
-	/// inbound chunks delivered in order so far
-	unsigned int processedIncomingChunks = 0;
+
+	/**
+	 * @brief stats the connection accumulates inline as events happen
+	 */
+	struct Accumulated {
+		unsigned int sentPackets = 0;
+		unsigned int receivedPackets = 0;
+		/// chunks put back on the wire after having been sent once
+		unsigned int resentOutgoingChunks = 0;
+		/// chunks discarded on arrival because the same chunk had already been received
+		unsigned int duplicateIncomingChunks = 0;
+		/// cumulative protocol header bytes
+		unsigned int sentOverheadBytes = 0;
+		unsigned int receivedOverheadBytes = 0;
+	} accumulated;
+
+	/**
+	 * @brief stats read off *periodically* from live state
+	 */
+	struct Live {
+		/// inbound chunks delivered in order so far
+		unsigned int processedIncomingChunks = 0;
+	} live;
 };
 
 using ConnectionStats = std::variant<BasicStats, UdpStats>;
+
+/**
+ * @brief whether links should collect the optional telemetry in ConnectionStats
+ *
+ * Byte and packet counters are always kept, the rest exists purely to be
+ * exported, so the rest are off unless the stats need to be exported somewhere.
+ *
+ * Atomic because a host client's own CNetProtocol link is already alive
+ * when the server it just started flips this.
+ */
+inline std::atomic<bool> statsSampling = false;
+
+inline void SetStatsSampling(bool enable) { statsSampling.store(enable, std::memory_order_relaxed); }
+inline bool StatsSampling() { return statsSampling.load(std::memory_order_relaxed); }
 
 std::string FormatConnectionStats(const BasicStats& stats);
 std::string FormatConnectionStats(const UdpStats& stats);

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -300,13 +300,7 @@ void UDPConnection::Init()
 	currentPacketChunkNum = 0;
 
 	lastNak = -1;
-	sentOverhead = 0;
-	recvOverhead = 0;
-
-	resentOutgoingChunks = 0;
-	sentPackets = 0;
-	recvPackets = 0;
-	duplicateIncomingChunks = 0;
+	accumulatedStats = {};
 	mtu = globalConfig.mtu;
 	reconnectTime = globalConfig.reconnectTimeout;
 
@@ -530,8 +524,8 @@ void UDPConnection::ProcessRawPacket(Packet& incoming)
 
 	lastPacketRecvTime = spring_gettime();
 	dataRecv += incoming.GetSize();
-	recvOverhead += Packet::headerSize;
-	recvPackets += 1;
+	accumulatedStats.receivedOverheadBytes += Packet::headerSize;
+	accumulatedStats.receivedPackets += 1;
 
 //	if (EMULATE_PACKET_LOSS(lossCounter))
 //		return;
@@ -596,7 +590,7 @@ void UDPConnection::ProcessRawPacket(Packet& incoming)
 
 	for (const std::shared_ptr<netcode::Chunk>& c: incoming.chunks) {
 		if ((lastInOrder >= c->chunkNumber) || incomingChunkNums.find(c->chunkNumber) != incomingChunkNums.end()) {
-			++duplicateIncomingChunks;
+			++accumulatedStats.duplicateIncomingChunks;
 			continue;
 		}
 
@@ -743,7 +737,7 @@ void UDPConnection::Flush(const bool forced)
 					memcpy(buffer + pos, packet->data, numBytes);
 
 					pos += numBytes;
-					sentOverhead += Packet::headerSize;
+					accumulatedStats.sentOverheadBytes += Packet::headerSize;
 
 					outgoing.DataSent(numBytes, true);
 
@@ -806,13 +800,8 @@ ConnectionStats UDPConnection::GetStats() const
 	UdpStats stats;
 	stats.sentBytes = dataSent;
 	stats.receivedBytes = dataRecv;
-	stats.sentPackets = sentPackets;
-	stats.receivedPackets = recvPackets;
-	stats.resentOutgoingChunks = resentOutgoingChunks;
-	stats.duplicateIncomingChunks = duplicateIncomingChunks;
-	stats.sentOverheadBytes = sentOverhead;
-	stats.receivedOverheadBytes = recvOverhead;
-	stats.processedIncomingChunks = lastInOrder + 1;
+	stats.accumulated = accumulatedStats;
+	stats.live.processedIncomingChunks = lastInOrder + 1;
 	return stats;
 }
 
@@ -1007,7 +996,7 @@ void UDPConnection::SendIfNecessary(bool flushed)
 					rev = (rev + 1) % 4;
 				}
 
-				resentOutgoingChunks += 1;
+				accumulatedStats.resentOutgoingChunks += 1;
 				maxResend -= 1;
 
 				sent = true;
@@ -1060,7 +1049,7 @@ void UDPConnection::SendPacket(Packet& pkt)
 		return;
 
 	dataSent += sendBuffer.size();
-	sentPackets += 1;
+	accumulatedStats.sentPackets += 1;
 }
 
 void UDPConnection::AckChunks(int lastAck)

--- a/rts/System/Net/UDPConnection.h
+++ b/rts/System/Net/UDPConnection.h
@@ -237,12 +237,7 @@ private:
 	#endif
 	unsigned int currentPacketChunkNum;
 
-	/// packets that are resent
-	unsigned int resentOutgoingChunks;
-	unsigned int duplicateIncomingChunks;
-
-	unsigned int sentOverhead, recvOverhead;
-	unsigned int sentPackets, recvPackets;
+	UdpStats::Accumulated accumulatedStats;
 
 	class BandwidthUsage {
 	public:

--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -24,6 +24,9 @@ list(APPEND engineDedicatedLibraries ${Boost_REGEX_LIBRARY})
 list(APPEND engineDedicatedLibraries lua archives_nothreadpool 7zip prd::jsoncpp
 	${SPRING_MINIZIP_LIBRARY} ZLIB::ZLIB gflags_nothreads_static Tracy::TracyClient)
 list(APPEND engineDedicatedLibraries headlessStubs engineSystemNet)
+if    (ENABLE_METRICS)
+	list(APPEND engineDedicatedLibraries engineMetrics)
+endif (ENABLE_METRICS)
 if(UNIX AND NOT (CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	list(APPEND engineDedicatedLibraries libunwind::libunwind)
 endif()
@@ -148,6 +151,7 @@ endif ()
 set(engineDedicatedSources
 	${system_files}
 	${sources_engine_NetServer}
+	${sources_engine_ServerMetrics}
 	${sources_engine_System_Log}
 	${ENGINE_SRC_ROOT_DIR}/Game/ClientSetup.cpp
 	${ENGINE_SRC_ROOT_DIR}/Game/GameSetup.cpp

--- a/rts/lib/CMakeLists.txt
+++ b/rts/lib/CMakeLists.txt
@@ -180,6 +180,23 @@ option(TRACY_PROFILE_MEMORY "Profile memory allocations" OFF)
 
 add_subdirectory(tracy)
 
+# prometheus-cpp: metrics registry + embedded /metrics HTTP endpoint (pull mode).
+# civetweb is vendored inside it as a submodule. "push" (-gateway) support would
+# require libcurl, so it stays off.
+if (ENABLE_METRICS)
+	# block() so none of this leaks, given that ENABLE_TESTING, etc. are generic names
+	block()
+		set(ENABLE_PULL ON)
+		set(ENABLE_PUSH OFF)
+		set(ENABLE_COMPRESSION OFF)
+		set(ENABLE_TESTING OFF)
+		set(GENERATE_PKGCONFIG OFF)
+		# Metric values are doubles, so keep its FP constants double-precision
+		string(REPLACE "-fsingle-precision-constant" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+		add_subdirectory(prometheus-cpp)
+	endblock()
+endif()
+
 if (TRACY_ENABLE)
 	option(RMLUI_TRACY_PROFILING "Enable RmlUi profiling with Tracy." ON)
 	# We have our own memory profiling, never enable RmlUi one.


### PR DESCRIPTION
See https://github.com/beyond-all-reason/RecoilEngine/issues/3263
### What

Add a new `rts/System/Metrics` library that pulls in `prometheus-cpp` and serves a `/metrics` scrape endpoint. We also scaffold out a `ServerMetrics` facade under `rts/Net/ServerMetrics` tied to `CGameServer`.

Gated at compile time behind a new `ENABLE_METRICS` cmake option and off at runtime unless a port is configured.

The general idea is that we separate the concerns into:
1. the existing logic layer, which we try to minimally change.
2. a stats layer, which is independent of metrics and can be used for other purposes.
3. a metrics layer, which is directly attached to prometheus and reads from the stats layer.

### Why

We want to track metrics particularly from dedicated engine instances in BAR, so we can better track/identify issues with servers and their connections to clients.

This PR sets up the endpoint, config, and server-side lifecycle scaffolding so later PRs can register and publish actual metrics.

### AI disclosure

The whole stack was written with Claude Code, but very heavily iterated on and reviewed by me, a human.
