### PR TITLE
feat(metrics): export basic server health metrics

### DIFF
--- a/rts/Net/CMakeLists.txt
+++ b/rts/Net/CMakeLists.txt
@@ -2,6 +2,7 @@
 if    (ENABLE_METRICS)
 	make_global_var(sources_engine_ServerMetrics
 			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/GameServerMetrics.cpp"
+			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/ServerHealthMetrics.cpp"
 		)
 else  (ENABLE_METRICS)
 	make_global_var(sources_engine_ServerMetrics "${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/GameServerMetricsNull.cpp")

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -44,6 +44,7 @@
 #include "System/SpringExitCode.h"
 #include "System/SpringFormat.h"
 #include "System/TdfParser.h"
+#include "System/TimeUtil.h"
 #include "System/StringHash.h"
 #include "System/StringUtil.h"
 #include "System/Config/ConfigHandler.h"
@@ -267,8 +268,11 @@ void CGameServer::Initialize()
 	lastNewFrameTick = spring_gettime();
 	lastBandwidthUpdate = spring_gettime();
 
+	if (!demoReader)
+		ComputeGameID();
+
 	// this should come before `thread` is started, as netcode thread would otherwise use metrics uninitialized
-	serverMetrics->Init();
+	serverMetrics->Init(GetGameIDHex());
 
 	thread = spring::thread(std::bind(&CGameServer::UpdateLoop, this));
 
@@ -280,7 +284,8 @@ void CGameServer::Initialize()
 	streflop::streflop_init<streflop::Simple>();
 
 	if (!demoReader) {
-		GenerateAndSendGameID();
+		ComputeGameID();
+		SendGameID();
 		if (myGameSetup->fixedRNGSeed == 0) {
 			rng.Seed(gameID.intArray[0] ^ gameID.intArray[1] ^ gameID.intArray[2] ^ gameID.intArray[3]);
 			Broadcast(CBaseNetProtocol::Get().SendRandSeed(rng()));
@@ -2149,7 +2154,7 @@ void CGameServer::ServerReadNet()
 }
 
 
-void CGameServer::GenerateAndSendGameID()
+void CGameServer::ComputeGameID()
 {
 	// First and second dword are time based (current time and load time).
 	gameID.intArray[0] = (unsigned) time(nullptr);
@@ -2168,25 +2173,42 @@ void CGameServer::GenerateAndSendGameID()
 	// fixed gameID?
 	if (!myGameSetup->gameID.empty()) {
 		unsigned char p[16];
+	bool parsedFixedID = false;
 	#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
 		// workaround missing C99 support in a msvc lib with %2hhx
-		generatedGameID = (sscanf(myGameSetup->gameID.c_str(),
+		parsedFixedID = (sscanf(myGameSetup->gameID.c_str(),
 		      "%02hc%02hc%02hc%02hc%02hc%02hc%02hc%02hc"
 		      "%02hc%02hc%02hc%02hc%02hc%02hc%02hc%02hc",
 		      &p[ 0], &p[ 1], &p[ 2], &p[ 3], &p[ 4], &p[ 5], &p[ 6], &p[ 7],
 		      &p[ 8], &p[ 9], &p[10], &p[11], &p[12], &p[13], &p[14], &p[15]) == 16);
 	#else
-		generatedGameID = (sscanf(myGameSetup->gameID.c_str(),
+		parsedFixedID = (sscanf(myGameSetup->gameID.c_str(),
 		       "%hhx%hhx%hhx%hhx%hhx%hhx%hhx%hhx"
 		       "%hhx%hhx%hhx%hhx%hhx%hhx%hhx%hhx",
 		       &p[ 0], &p[ 1], &p[ 2], &p[ 3], &p[ 4], &p[ 5], &p[ 6], &p[ 7],
 		       &p[ 8], &p[ 9], &p[10], &p[11], &p[12], &p[13], &p[14], &p[15]) == 16);
 	#endif
-		if (generatedGameID)
+		if (parsedFixedID)
 			for (int i = 0; i<16; ++i)
 				gameID.charArray[i] = p[i];
 	}
 
+}
+
+
+std::string CGameServer::GetGameIDHex() const
+{
+	std::string hex;
+
+	for (const unsigned char b: gameID.charArray)
+		hex += spring::format("%02x", b);
+
+	return hex;
+}
+
+
+void CGameServer::SendGameID()
+{
 	Broadcast(CBaseNetProtocol::Get().SendGameID(gameID.charArray));
 
 	if (demoRecorder != nullptr) {
@@ -2246,6 +2268,8 @@ void CGameServer::StartGame(bool forced)
 	assert(!gameHasStarted);
 	gameHasStarted = true;
 	startTime = gameTime;
+
+	serverMetrics->SetGameStartTime(CTimeUtil::GetCurrentTime());
 
 	if (!canReconnect && !allowSpecJoin)
 		packetCache.clear(); // free memory

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -68,6 +68,7 @@ class CGameServer
 	friend class CCregLoadSaveHandler; // For initializing server state after load
 	// the metrics classes only ever *read* server state to publish, never write
 	friend class ServerMetrics;
+	friend class ServerHealthMetrics;
 public:
 	CGameServer(
 		const std::shared_ptr<const ClientSetup> newClientSetup,
@@ -170,8 +171,12 @@ private:
 
 	void LagProtection();
 
-	/** @brief Generate a unique game identifier and send it to all clients. */
-	void GenerateAndSendGameID();
+	/// derive this game's unique identifier
+	void ComputeGameID();
+	/// the game id as 32 lowercase hex chars
+	std::string GetGameIDHex() const;
+	/// send the game identifier to all clients
+	void SendGameID();
 
 	void WriteDemoData();
 	/// read data from demo and send it to clients
@@ -309,7 +314,7 @@ private:
 	union {
 		unsigned char charArray[16];
 		unsigned int intArray[4];
-	} gameID;
+	} gameID = {};
 };
 
 extern CGameServer* gameServer;

--- a/rts/Net/ServerMetrics/GameServerMetrics.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetrics.cpp
@@ -10,7 +10,7 @@
 static const spring_time metricsPublishInterval = spring_secs(1);
 
 
-void ServerMetrics::Init()
+void ServerMetrics::Init(const std::string& gameIDHex)
 {
 	metrics::Init();
 
@@ -19,6 +19,9 @@ void ServerMetrics::Init()
 	if (!metrics::Enabled())
 		return;
 
+	auto& registry = metrics::GetRegistry();
+
+	healthMetrics.Init(registry, gameIDHex);
 	registered = true;
 }
 
@@ -46,4 +49,10 @@ void ServerMetrics::Update(const CGameServer& server)
 
 	// code to publish metrics goes here
 	lastPublishTime = server.lastUpdate;
+
+	healthMetrics.Update(server);
+}
+
+void ServerMetrics::SetGameStartTime(double unixSecs) {
+	healthMetrics.SetGameStartTime(unixSecs);
 }

--- a/rts/Net/ServerMetrics/GameServerMetrics.h
+++ b/rts/Net/ServerMetrics/GameServerMetrics.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <string>
+
+#include "ServerHealthMetrics.h"
 #include "System/Misc/SpringTime.h"
 
 class CGameServer;
@@ -22,7 +25,10 @@ class CGameServer;
 class ServerMetrics
 {
 public:
-	void Init();
+	/**
+	 * @param gameIDHex identity label for recoil_server_info.
+	 */
+	void Init(const std::string& gameIDHex);
 
 	/**
 	 * @brief stop the endpoint and drop the registry
@@ -37,7 +43,11 @@ public:
 	/// call per loop
 	void Update(const CGameServer& server);
 
+	void SetGameStartTime(double unixSecs);
+
 private:
+	ServerHealthMetrics healthMetrics;
+
 	/// while false (during startup or metrics disabled), Update() is a no-op
 	bool registered = false;
 

--- a/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
@@ -7,10 +7,14 @@
  * a missing one breaks this build at link time.
  */
 
+#include <string>
+
 #include "GameServerMetrics.h"
 
-void ServerMetrics::Init() {}
+void ServerMetrics::Init(const std::string&) {}
 
 void ServerMetrics::Shutdown() {}
 
 void ServerMetrics::Update(const CGameServer&) {}
+
+void ServerMetrics::SetGameStartTime(double) {}

--- a/rts/Net/ServerMetrics/ServerHealthMetrics.cpp
+++ b/rts/Net/ServerMetrics/ServerHealthMetrics.cpp
@@ -1,0 +1,159 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "ServerHealthMetrics.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+
+#include <prometheus/gauge.h>
+#include <prometheus/registry.h>
+
+#include "Game/GameVersion.h"
+#include "Net/GameParticipant.h"
+#include "Net/GameServer.h"
+#include "Sim/Misc/GlobalConstants.h"
+#include "System/Metrics/Helpers.h"
+#include "System/Metrics/Metrics.h"
+
+using metrics::msToSecs;
+
+
+void ServerHealthMetrics::Init(prometheus::Registry& registry, const std::string& gameIDHex)
+{
+	const auto gaugeFamily = [&](const char* name, const char* help) {
+		return &prometheus::BuildGauge().Name(name).Help(help).Register(registry);
+	};
+	const auto gauge = [&](const char* name, const char* help) { return &gaugeFamily(name, help)->Add({}); };
+
+	metricServerFrame = gauge("recoil_server_frame",
+		"Current server simulation frame");
+	metricMaxLag = gauge("recoil_server_max_lag_seconds",
+		"Worst player lag in seconds: how far behind the server the most-behind player's last acked sim frame is. Derived from the frame backlog priced at the current speed, so a speed change rescales it even when the connection is unchanged. recoil_server_max_lag_frames is the speed-invariant alternative");
+	metricMaxLagFrames = gauge("recoil_server_max_lag_frames",
+		"Worst player lag in sim frames");
+	metricMaxCpu = gauge("recoil_server_max_cpu_usage",
+		"Highest client-reported cpu usage in [0,1] across players");
+	metricMedianLag = gauge("recoil_server_median_lag_seconds",
+		"Median player lag in seconds. Only computed when SpeedControl=1. Note: a speed change rescales this metric even if the connection is unchanged");
+	metricMedianCpu = gauge("recoil_server_median_cpu_usage",
+		"Median client cpu usage used as input to lag protection. Only computed when SpeedControl=1");
+
+	auto& participants = *gaugeFamily("recoil_server_participants",
+		"Connected participants by type. Includes local loopback clients.");
+	metricPlayers = &participants.Add({{"type", "player"}});
+	metricSpectators = &participants.Add({{"type", "spectator"}});
+
+	metricInternalSpeed = gauge("recoil_server_speed_factor",
+		"Speed the simulation is actually running at (1.0 = normal), lowered by lag protection");
+	metricWantedSpeed = gauge("recoil_server_wanted_speed_factor",
+		"Speed requested by the users (1.0 = normal)");
+	metricPaused = gauge("recoil_server_paused",
+		"1 while the game is paused");
+
+	metricGameStartTs = gauge("recoil_server_game_start_timestamp_seconds",
+		"Unix time the game started");
+
+	// The game id is a label here on an info metric rather than a constant label
+	// on every family. This is a prometheus convention, because it isolates churn
+	// to a single metric series.
+	gaugeFamily("recoil_server_info", "Constant 1, labels carry engine build and game identity")
+		->Add({{"engine_version", SpringVersion::GetFull()}, {"gameid", gameIDHex}}).Set(1);
+
+	if (!metrics::PerPlayerEnabled())
+		return;
+
+	metricPlayerLag = gaugeFamily("recoil_server_per_player_lag_seconds",
+		"How far behind the server the player's last acked sim frame is, in seconds. Derived from the frame backlog priced at the current speed, so a speed change rescales it even when the connection is unchanged. recoil_server_per_player_lag_frames is the speed-invariant alternative");
+	metricPlayerLagFrames = gaugeFamily("recoil_server_per_player_lag_frames",
+		"How far the player's last acked sim frame is behind the server, in sim frames");
+	metricPlayerCpu = gaugeFamily("recoil_server_per_player_cpu_usage",
+		"Client-reported cpu usage in [0,1]");
+}
+
+
+void ServerHealthMetrics::SetGameStartTime(double unixSecs)
+{
+	if (metricGameStartTs != nullptr)
+		metricGameStartTs->Set(unixSecs);
+}
+
+
+ServerHealthMetrics::PlayerMetrics& ServerHealthMetrics::GetPlayerSlot(int playerId)
+{
+	if (playerMetrics.size() <= static_cast<size_t>(playerId))
+		playerMetrics.resize(playerId + 1);
+
+	return playerMetrics[playerId];
+}
+
+
+void ServerHealthMetrics::Update(const CGameServer& server)
+{
+	int numPlayers = 0;
+	int numSpectators = 0;
+	float maxLag = 0.0f;
+	int maxLagFrames = 0;
+	float maxCpu = 0.0f;
+
+	for (const GameParticipant& p: server.players) {
+		if (p.clientLink == nullptr)
+			continue;
+
+		if (p.spectator)
+			numSpectators++;
+		else
+			numPlayers++;
+
+		PlayerMetrics& pm = GetPlayerSlot(p.id);
+
+		if (server.gameHasStarted && p.myState == GameParticipant::INGAME) {
+			const int lagFrames = std::max(0, server.serverFrameNum - p.lastFrameResponse);
+
+			// clamped to avoid a divide by zero
+			const float simSpeed = std::max(0.1f, server.internalSpeed);
+			const float lagMs = (lagFrames * 1000.0f) / (GAME_SPEED * simSpeed);
+			const float cpu = std::clamp(p.cpuUsage, 0.0f, 1.0f);
+
+			maxLag = std::max(maxLag, lagMs);
+			maxLagFrames = std::max(maxLagFrames, lagFrames);
+			maxCpu = std::max(maxCpu, cpu);
+
+			if (metrics::PerPlayerEnabled()) {
+				if (pm.lagSeconds == nullptr) {
+					const std::map<std::string, std::string> labels = {{"playerid", std::to_string(p.id)}};
+
+					pm.lagSeconds = &metricPlayerLag->Add(labels);
+					pm.lagFrames = &metricPlayerLagFrames->Add(labels);
+					pm.cpuUsage = &metricPlayerCpu->Add(labels);
+				}
+
+				pm.lagSeconds->Set(lagMs * msToSecs);
+				pm.lagFrames->Set(lagFrames);
+				pm.cpuUsage->Set(cpu);
+			}
+		} else if (pm.lagSeconds != nullptr) {
+			// dropped so we don't have a frozen gauge scrapes like a live one
+			metricPlayerLag->Remove(pm.lagSeconds);
+			metricPlayerLagFrames->Remove(pm.lagFrames);
+			metricPlayerCpu->Remove(pm.cpuUsage);
+
+			pm.lagSeconds = nullptr;
+			pm.lagFrames = nullptr;
+			pm.cpuUsage = nullptr;
+		}
+	}
+
+	metricMaxLag->Set(maxLag * msToSecs);
+	metricMaxLagFrames->Set(maxLagFrames);
+	metricMaxCpu->Set(maxCpu);
+	metricServerFrame->Set(server.serverFrameNum);
+	// medianPing is LagProtection's per-player lag, in milliseconds
+	metricMedianLag->Set(server.medianPing * msToSecs);
+	metricMedianCpu->Set(server.medianCpu);
+	metricPlayers->Set(numPlayers);
+	metricSpectators->Set(numSpectators);
+	metricInternalSpeed->Set(server.internalSpeed);
+	metricWantedSpeed->Set(server.userSpeedFactor);
+	metricPaused->Set(server.isPaused ? 1 : 0);
+}

--- a/rts/Net/ServerMetrics/ServerHealthMetrics.h
+++ b/rts/Net/ServerMetrics/ServerHealthMetrics.h
@@ -1,0 +1,61 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace prometheus
+{
+	template<typename T> class Family;
+	class Gauge;
+	class Registry;
+}
+
+class CGameServer;
+
+/**
+ * @brief the recoil_server_ series: game info, frame progress, speed, participants
+ *
+ * Owned by ServerMetrics. Participant-level rather than conn-level,
+ * because a local host lags like any other player even though the
+ * loopback connection has no network to describe.
+ */
+class ServerHealthMetrics
+{
+public:
+	void Init(prometheus::Registry& registry, const std::string& gameIDHex);
+	void Update(const CGameServer& server);
+
+	void SetGameStartTime(double unixSecs);
+
+private:
+	struct PlayerMetrics {
+		prometheus::Gauge* lagSeconds = nullptr;
+		prometheus::Gauge* lagFrames = nullptr;
+		prometheus::Gauge* cpuUsage = nullptr;
+	};
+
+	/// get this player's metric slot, created on first use
+	PlayerMetrics& GetPlayerSlot(int playerId);
+
+	std::vector<PlayerMetrics> playerMetrics;
+
+	prometheus::Gauge* metricServerFrame = nullptr;
+	prometheus::Gauge* metricMaxLag = nullptr;
+	prometheus::Gauge* metricMaxLagFrames = nullptr;
+	prometheus::Gauge* metricMaxCpu = nullptr;
+	prometheus::Gauge* metricMedianLag = nullptr;
+	prometheus::Gauge* metricMedianCpu = nullptr;
+	prometheus::Gauge* metricPlayers = nullptr;
+	prometheus::Gauge* metricSpectators = nullptr;
+	prometheus::Gauge* metricInternalSpeed = nullptr;
+	prometheus::Gauge* metricWantedSpeed = nullptr;
+	prometheus::Gauge* metricPaused = nullptr;
+	prometheus::Gauge* metricGameStartTs = nullptr;
+
+	// per-player families. always null unless MetricsPerPlayer is on
+	prometheus::Family<prometheus::Gauge>* metricPlayerLag = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricPlayerLagFrames = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricPlayerCpu = nullptr;
+};

--- a/rts/System/Metrics/Helpers.h
+++ b/rts/System/Metrics/Helpers.h
@@ -1,0 +1,12 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+/// Deliberately free of prometheus, so the pure-logic parts of the metrics
+/// path stay reachable from unit tests without needing the prom dependency.
+namespace metrics {
+
+/// the netcode works in milliseconds, prometheus wants base units
+inline constexpr double msToSecs = 0.001;
+
+}

--- a/rts/System/Metrics/Metrics.cpp
+++ b/rts/System/Metrics/Metrics.cpp
@@ -22,12 +22,17 @@ CONFIG(std::string, MetricsBindAddress)
 	.defaultValue("127.0.0.1")
 	.description("Address the Prometheus /metrics HTTP endpoint binds to. The endpoint has no authentication and no TLS, so bind it to a routable address only behind something that does access control.");
 
+CONFIG(bool, MetricsPerPlayer)
+	.defaultValue(false)
+	.description("Also export per-player metrics, not just server-wide aggregates. Multiplies the number of exported time series by the number of participants.");
+
 namespace {
 	std::shared_ptr<prometheus::Registry> registry;
 	std::unique_ptr<prometheus::Exposer> exposer;
 
 	bool initialized = false;
 	bool enabled = false;
+	bool perPlayerEnabled = false;
 }
 
 void metrics::Init()
@@ -48,8 +53,10 @@ void metrics::Init()
 		registry = std::make_shared<prometheus::Registry>();
 		exposer = std::make_unique<prometheus::Exposer>(endpoint);
 		exposer->RegisterCollectable(registry);
+		perPlayerEnabled = configHandler->GetBool("MetricsPerPlayer");
 		enabled = true;
-		LOG("[Metrics] serving metrics on http://%s/metrics", endpoint.c_str());
+		LOG("[Metrics] serving metrics on http://%s/metrics (per-player metrics %s)",
+			endpoint.c_str(), perPlayerEnabled ? "enabled" : "disabled");
 	} catch (const std::exception& ex) {
 		LOG_L(L_ERROR, "[Metrics] failed to start /metrics endpoint on %s: %s", endpoint.c_str(), ex.what());
 		exposer.reset();
@@ -60,6 +67,7 @@ void metrics::Init()
 void metrics::Shutdown()
 {
 	enabled = false;
+	perPlayerEnabled = false;
 
 	exposer.reset();
 	registry.reset();
@@ -70,6 +78,11 @@ void metrics::Shutdown()
 bool metrics::Enabled()
 {
 	return enabled;
+}
+
+bool metrics::PerPlayerEnabled()
+{
+	return perPlayerEnabled;
 }
 
 prometheus::Registry& metrics::GetRegistry()

--- a/rts/System/Metrics/Metrics.h
+++ b/rts/System/Metrics/Metrics.h
@@ -22,6 +22,11 @@ namespace metrics {
 	/// true iff the /metrics endpoint is being served
 	bool Enabled();
 
+	/// true iff per-player metrics should be exported alongside the
+	/// server-wide aggregates. These multiply the series count by the
+	/// number of participants
+	bool PerPlayerEnabled();
+
 	/// registry to Register() metric families in, only valid when Enabled()
 	prometheus::Registry& GetRegistry();
 }


### PR DESCRIPTION
See https://github.com/beyond-all-reason/RecoilEngine/issues/3263
### What

Adds the first real set of metrics, `ServerHealthMetrics`, which exports the `recoil_server_*` series. This includes frame progress, speed/pause state, participant counts, and speedcontrol player CPU/lag.

### Why

We need a base set of metrics to index against, eg. the game id and which frame the server is on will let us correlate with user reported issues.

### AI disclosure

The whole stack was written with Claude Code, but very heavily iterated on and reviewed by me, a human.
