### PR TITLE
feat(metrics): export per-connection byte and packet metrics

### DIFF
--- a/rts/Net/CMakeLists.txt
+++ b/rts/Net/CMakeLists.txt
@@ -2,6 +2,7 @@
 if    (ENABLE_METRICS)
 	make_global_var(sources_engine_ServerMetrics
 			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/GameServerMetrics.cpp"
+			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/NetworkMetrics.cpp"
 			"${CMAKE_CURRENT_SOURCE_DIR}/ServerMetrics/ServerHealthMetrics.cpp"
 		)
 else  (ENABLE_METRICS)

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -3134,6 +3134,10 @@ unsigned CGameServer::BindConnection(
 	for (const std::shared_ptr<const netcode::RawPacket>& p: packetCache)
 		newPlayer.SendData(p);
 
+	// a fresh connection restarts its counters at zero, so the exported metrics
+	// need a reset, too.
+	serverMetrics->ResetConnectionDeltas(newPlayerNumber);
+
 	// new connection established
 	Message(spring::format(" -> Connection established (given id %i)", newPlayerNumber));
 	clientLink->SetLossFactor(netloss);

--- a/rts/Net/GameServer.h
+++ b/rts/Net/GameServer.h
@@ -68,6 +68,7 @@ class CGameServer
 	friend class CCregLoadSaveHandler; // For initializing server state after load
 	// the metrics classes only ever *read* server state to publish, never write
 	friend class ServerMetrics;
+	friend class NetworkMetrics;
 	friend class ServerHealthMetrics;
 public:
 	CGameServer(

--- a/rts/Net/ServerMetrics/GameServerMetrics.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetrics.cpp
@@ -21,6 +21,7 @@ void ServerMetrics::Init(const std::string& gameIDHex)
 
 	auto& registry = metrics::GetRegistry();
 
+	networkMetrics.Init(registry);
 	healthMetrics.Init(registry, gameIDHex);
 	registered = true;
 }
@@ -50,9 +51,13 @@ void ServerMetrics::Update(const CGameServer& server)
 	// code to publish metrics goes here
 	lastPublishTime = server.lastUpdate;
 
+	networkMetrics.Update(server);
 	healthMetrics.Update(server);
 }
 
 void ServerMetrics::SetGameStartTime(double unixSecs) {
 	healthMetrics.SetGameStartTime(unixSecs);
+}
+void ServerMetrics::ResetConnectionDeltas(int playerId) {
+	networkMetrics.ResetConnectionDeltas(playerId);
 }

--- a/rts/Net/ServerMetrics/GameServerMetrics.h
+++ b/rts/Net/ServerMetrics/GameServerMetrics.h
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#include "NetworkMetrics.h"
 #include "ServerHealthMetrics.h"
 #include "System/Misc/SpringTime.h"
 
@@ -45,7 +46,10 @@ public:
 
 	void SetGameStartTime(double unixSecs);
 
+	void ResetConnectionDeltas(int playerId);
+
 private:
+	NetworkMetrics networkMetrics;
 	ServerHealthMetrics healthMetrics;
 
 	/// while false (during startup or metrics disabled), Update() is a no-op

--- a/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
+++ b/rts/Net/ServerMetrics/GameServerMetricsNull.cpp
@@ -18,3 +18,5 @@ void ServerMetrics::Shutdown() {}
 void ServerMetrics::Update(const CGameServer&) {}
 
 void ServerMetrics::SetGameStartTime(double) {}
+
+void ServerMetrics::ResetConnectionDeltas(int) {}

--- a/rts/Net/ServerMetrics/NetworkMetrics.cpp
+++ b/rts/Net/ServerMetrics/NetworkMetrics.cpp
@@ -1,0 +1,109 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#include "NetworkMetrics.h"
+
+#include <map>
+#include <string>
+#include <variant>
+
+#include <prometheus/counter.h>
+#include <prometheus/registry.h>
+
+#include "Net/GameParticipant.h"
+#include "Net/GameServer.h"
+#include "System/Metrics/Helpers.h"
+#include "System/Metrics/Metrics.h"
+#include "System/Net/ConnectionStats.h"
+
+using metrics::DeltaSince;
+
+
+void NetworkMetrics::Init(prometheus::Registry& registry)
+{
+	const auto counterFamily = [&](const char* name, const char* help) {
+		return &prometheus::BuildCounter().Name(name).Help(help).Register(registry);
+	};
+
+	// direction is a label rather than part of the name, to make querying
+	// more intuitive
+	auto& bytes = *counterFamily("recoil_network_bytes_total",
+		"Bytes over all client connections, by direction");
+	metricTotalSentBytes = &bytes.Add({{"direction", "outgoing"}});
+	metricTotalRecvBytes = &bytes.Add({{"direction", "incoming"}});
+
+	auto& packets = *counterFamily("recoil_network_packets_total",
+		"UDP packets over all client connections, by direction");
+	metricTotalSentPackets = &packets.Add({{"direction", "outgoing"}});
+	metricTotalRecvPackets = &packets.Add({{"direction", "incoming"}});
+
+	perPlayerEnabled = metrics::PerPlayerEnabled();
+	if (!perPlayerEnabled)
+		return;
+
+	metricBytes = counterFamily("recoil_network_per_connection_bytes_total",
+		"Bytes over this client connection, by direction. No series exists for local loopback connections");
+	metricPackets = counterFamily("recoil_network_per_connection_packets_total",
+		"UDP packets over this client connection, by direction");
+}
+
+
+NetworkMetrics::ConnectionMetrics& NetworkMetrics::ConnectionSlot(int playerId)
+{
+	if (connectionMetrics.size() <= static_cast<size_t>(playerId))
+		connectionMetrics.resize(playerId + 1);
+
+	return connectionMetrics[playerId];
+}
+
+
+void NetworkMetrics::ResetConnectionDeltas(int playerId)
+{
+	ConnectionSlot(playerId) = ConnectionMetrics{};
+}
+
+
+void NetworkMetrics::Update(const CGameServer& server)
+{
+	const auto publishDelta = [this](
+		prometheus::Counter* total, ConnectionMetrics::DeltaCounter& dc, double cur, double scale = 1.0
+	) {
+		const double delta = DeltaSince(cur, dc.last) * scale;
+
+		total->Increment(delta);
+
+		if (perPlayerEnabled)
+			dc.player->Increment(delta);
+	};
+
+	for (const GameParticipant& p: server.players) {
+		ConnectionMetrics& cm = ConnectionSlot(p.id);
+
+		if (p.clientLink == nullptr) {
+			cm = ConnectionMetrics{};
+			continue;
+		}
+
+		const netcode::ConnectionStats linkStats = p.clientLink->GetStats();
+		const auto* udp = std::get_if<netcode::UdpStats>(&linkStats);
+
+		// skip for loopback connections
+		if (udp == nullptr)
+			continue;
+
+		const netcode::UdpStats& stats = *udp;
+
+		// Label by player slot id. See recoil_server_per_player_info to resolve to names.
+		if (perPlayerEnabled && cm.sentBytes.player == nullptr) {
+			const std::string playerId = std::to_string(p.id);
+			cm.sentBytes.player   = &metricBytes->Add({{"playerid", playerId}, {"direction", "outgoing"}});
+			cm.recvBytes.player   = &metricBytes->Add({{"playerid", playerId}, {"direction", "incoming"}});
+			cm.sentPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "outgoing"}});
+			cm.recvPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "incoming"}});
+		}
+
+		publishDelta(metricTotalSentBytes, cm.sentBytes, stats.sentBytes);
+		publishDelta(metricTotalRecvBytes, cm.recvBytes, stats.receivedBytes);
+		publishDelta(metricTotalSentPackets, cm.sentPackets, stats.accumulated.sentPackets);
+		publishDelta(metricTotalRecvPackets, cm.recvPackets, stats.accumulated.receivedPackets);
+	}
+}

--- a/rts/Net/ServerMetrics/NetworkMetrics.h
+++ b/rts/Net/ServerMetrics/NetworkMetrics.h
@@ -1,0 +1,67 @@
+/* This file is part of the Recoil engine (GPL v2 or later), see LICENSE.html */
+
+#pragma once
+
+#include <vector>
+
+namespace prometheus
+{
+	template<typename T> class Family;
+	class Counter;
+	class Registry;
+}
+
+class CGameServer;
+
+/**
+ * @brief the recoil_network_ series: per-link traffic, loss, and queue health
+ *
+ * Owned by ServerMetrics. Covers real network conns only, no local loopback
+ * connections.
+ */
+class NetworkMetrics
+{
+public:
+	void Init(prometheus::Registry& registry);
+	void Update(const CGameServer& server);
+
+	/// a fresh connection restarts its counters at zero, so the delta baselines
+	/// must also be reset.
+	void ResetConnectionDeltas(int playerId);
+
+private:
+	struct ConnectionMetrics {
+		/// Last seen value of a monotonically increasing link counter, which
+		/// Update() then publishes as a delta to metrics.
+		///
+		/// Ideally we'd do a PrometheusCounter::SetValue(), but there's no API
+		/// for that like there is in other languages. So we are forced to instead
+		/// calculate a delta off an already monotonically-increasing stat.
+		struct DeltaCounter {
+			prometheus::Counter* player = nullptr;
+			double last = 0.0;
+		};
+		DeltaCounter sentBytes;
+		DeltaCounter recvBytes;
+		DeltaCounter sentPackets;
+		DeltaCounter recvPackets;
+	};
+
+	/// this player's metric slot, created on first use
+	ConnectionMetrics& ConnectionSlot(int playerId);
+
+	std::vector<ConnectionMetrics> connectionMetrics;
+
+	/// MetricsPerPlayer, latched in Init(). Gates all the per-player metrics below.
+	bool perPlayerEnabled = false;
+
+	// per-player metrics, null unless perPlayerEnabled
+	prometheus::Family<prometheus::Counter>* metricBytes = nullptr;
+	prometheus::Family<prometheus::Counter>* metricPackets = nullptr;
+
+	// server-wide aggregates, exported whether or not per-player metrics are on
+	prometheus::Counter* metricTotalSentBytes = nullptr;
+	prometheus::Counter* metricTotalRecvBytes = nullptr;
+	prometheus::Counter* metricTotalSentPackets = nullptr;
+	prometheus::Counter* metricTotalRecvPackets = nullptr;
+};

--- a/rts/Net/ServerMetrics/ServerHealthMetrics.cpp
+++ b/rts/Net/ServerMetrics/ServerHealthMetrics.cpp
@@ -69,6 +69,11 @@ void ServerHealthMetrics::Init(prometheus::Registry& registry, const std::string
 		"How far the player's last acked sim frame is behind the server, in sim frames");
 	metricPlayerCpu = gaugeFamily("recoil_server_per_player_cpu_usage",
 		"Client-reported cpu usage in [0,1]");
+	// The name is here rather than on every per-player series for the same
+	// reason the game id is: it keeps the series themselves stable/reduces
+	// churn.
+	metricPlayerInfo = gaugeFamily("recoil_server_per_player_info",
+		"Constant 1, labels map a player slot to their name");
 }
 
 
@@ -106,6 +111,13 @@ void ServerHealthMetrics::Update(const CGameServer& server)
 			numPlayers++;
 
 		PlayerMetrics& pm = GetPlayerSlot(p.id);
+
+		// player info metric is kept for the entire game once published, unlike
+		// the other gauges which disappear on player disconnects.
+		if (metrics::PerPlayerEnabled() && pm.info == nullptr) {
+			pm.info = &metricPlayerInfo->Add({{"playerid", std::to_string(p.id)}, {"player", p.name}});
+			pm.info->Set(1);
+		}
 
 		if (server.gameHasStarted && p.myState == GameParticipant::INGAME) {
 			const int lagFrames = std::max(0, server.serverFrameNum - p.lastFrameResponse);

--- a/rts/Net/ServerMetrics/ServerHealthMetrics.h
+++ b/rts/Net/ServerMetrics/ServerHealthMetrics.h
@@ -34,6 +34,7 @@ private:
 		prometheus::Gauge* lagSeconds = nullptr;
 		prometheus::Gauge* lagFrames = nullptr;
 		prometheus::Gauge* cpuUsage = nullptr;
+		prometheus::Gauge* info = nullptr;
 	};
 
 	/// get this player's metric slot, created on first use
@@ -58,4 +59,5 @@ private:
 	prometheus::Family<prometheus::Gauge>* metricPlayerLag = nullptr;
 	prometheus::Family<prometheus::Gauge>* metricPlayerLagFrames = nullptr;
 	prometheus::Family<prometheus::Gauge>* metricPlayerCpu = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricPlayerInfo = nullptr;
 };

--- a/rts/System/Metrics/Helpers.h
+++ b/rts/System/Metrics/Helpers.h
@@ -2,11 +2,24 @@
 
 #pragma once
 
+#include <algorithm>
+
 /// Deliberately free of prometheus, so the pure-logic parts of the metrics
 /// path stay reachable from unit tests without needing the prom dependency.
 namespace metrics {
 
 /// the netcode works in milliseconds, prometheus wants base units
 inline constexpr double msToSecs = 0.001;
+
+/**
+ * @brief advance a delta baseline and return what accrued since the last call
+ */
+template<typename T> T DeltaSince(T cur, T& last)
+{
+	const T delta = cur - std::min(cur, last);
+
+	last = cur;
+	return delta;
+}
 
 }


### PR DESCRIPTION
See https://github.com/beyond-all-reason/RecoilEngine/issues/3263
### What

Adds a `NetworkMetrics` class to the server metrics module that exports a basic set of metrics.

### Why

This scaffolds out the structure of the network-specific metrics, which we expand on extensively in the next few PRs. 

### AI disclosure

The whole stack was written with Claude Code, but very heavily iterated on and reviewed by me, a human.
