### PR TITLE
feat(metrics): export network queue depths and send rate

### DIFF
--- a/rts/Net/ServerMetrics/NetworkMetrics.cpp
+++ b/rts/Net/ServerMetrics/NetworkMetrics.cpp
@@ -2,15 +2,18 @@
 
 #include "NetworkMetrics.h"
 
+#include <algorithm>
 #include <map>
 #include <string>
 #include <variant>
 
 #include <prometheus/counter.h>
+#include <prometheus/gauge.h>
 #include <prometheus/registry.h>
 
 #include "Net/GameParticipant.h"
 #include "Net/GameServer.h"
+#include "System/GlobalConfig.h"
 #include "System/Metrics/Helpers.h"
 #include "System/Metrics/Metrics.h"
 #include "System/Net/ConnectionStats.h"
@@ -23,6 +26,10 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 	const auto counterFamily = [&](const char* name, const char* help) {
 		return &prometheus::BuildCounter().Name(name).Help(help).Register(registry);
 	};
+	const auto gaugeFamily = [&](const char* name, const char* help) {
+		return &prometheus::BuildGauge().Name(name).Help(help).Register(registry);
+	};
+	const auto gauge = [&](const char* name, const char* help) { return &gaugeFamily(name, help)->Add({}); };
 
 	// direction is a label rather than part of the name, to make querying
 	// more intuitive
@@ -36,6 +43,20 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 	metricTotalSentPackets = &packets.Add({{"direction", "outgoing"}});
 	metricTotalRecvPackets = &packets.Add({{"direction", "incoming"}});
 
+	metricTotalOutgoingBw = gauge("recoil_network_outgoing_bandwidth_bytes_per_second",
+		"Rolling average of the send rate over all client connections");
+	metricTotalUnackedOutgoingChunks = gauge("recoil_network_unacked_outgoing_chunks",
+		"Chunks sent to clients and not yet acked, summed over all connections");
+	metricTotalOutgoingResendQueueDepth = gauge("recoil_network_outgoing_resend_queue_depth",
+		"Chunks queued for retransmission, summed over all connections. A sustained non-zero depth means chunks are being flagged for resend faster than they clear, e.g. under packet loss or a stalled link");
+	metricTotalIncomingReorderQueueDepth = gauge("recoil_network_incoming_reorder_queue_depth",
+		"Chunks from clients held in the reorder buffer behind a missing chunk, summed over all connections. Fills on benign reordering as well as on real loss");
+	metricTotalOutgoingQueueBytes = gauge("recoil_network_outgoing_queue_bytes",
+		"Application bytes queued for clients and not yet transmitted, summed over all connections");
+
+	gauge("recoil_network_outgoing_bandwidth_limit_bytes_per_second",
+		"Configured per-connection outgoing bandwidth cap in bytes/sec (0 = unlimited). A static config value (LinkOutgoingBandwidth), not a live measurement")->Set(globalConfig.linkOutgoingBandwidth);
+
 	perPlayerEnabled = metrics::PerPlayerEnabled();
 	if (!perPlayerEnabled)
 		return;
@@ -44,6 +65,34 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 		"Bytes over this client connection, by direction. No series exists for local loopback connections");
 	metricPackets = counterFamily("recoil_network_per_connection_packets_total",
 		"UDP packets over this client connection, by direction");
+	metricOutgoingBw = gaugeFamily("recoil_network_per_connection_outgoing_bandwidth_bytes_per_second",
+		"Rolling average of the send rate to this client, as used by outgoing bandwidth limiting");
+	metricUnackedOutgoingChunks = gaugeFamily("recoil_network_per_connection_unacked_outgoing_chunks",
+		"Chunks sent to this client and not yet acked");
+	metricOutgoingResendQueueDepth = gaugeFamily("recoil_network_per_connection_outgoing_resend_queue_depth",
+		"Chunks queued for retransmission to this client");
+	metricIncomingReorderQueueDepth = gaugeFamily("recoil_network_per_connection_incoming_reorder_queue_depth",
+		"Chunks from this client held in the reorder buffer behind a missing chunk");
+	metricOutgoingQueueBytes = gaugeFamily("recoil_network_per_connection_outgoing_queue_bytes",
+		"Application bytes queued for this client and not yet transmitted");
+}
+
+
+void NetworkMetrics::ReleaseConnectionGauges(ConnectionMetrics& cm)
+{
+	const auto release = [](prometheus::Family<prometheus::Gauge>* family, prometheus::Gauge*& child) {
+		if (child == nullptr)
+			return;
+
+		family->Remove(child);
+		child = nullptr;
+	};
+
+	release(metricOutgoingBw, cm.outgoingBw);
+	release(metricUnackedOutgoingChunks, cm.unackedOutgoingChunks);
+	release(metricOutgoingResendQueueDepth, cm.outgoingResendQueueDepth);
+	release(metricIncomingReorderQueueDepth, cm.incomingReorderQueueDepth);
+	release(metricOutgoingQueueBytes, cm.outgoingQueueBytes);
 }
 
 
@@ -64,6 +113,12 @@ void NetworkMetrics::ResetConnectionDeltas(int playerId)
 
 void NetworkMetrics::Update(const CGameServer& server)
 {
+	float totalOutgoingBw = 0.0f;
+	unsigned int totalUnackedOutgoingChunks = 0;
+	unsigned int totalOutgoingResendQueueDepth = 0;
+	unsigned int totalIncomingReorderQueueDepth = 0;
+	unsigned int totalOutgoingQueueBytes = 0;
+
 	const auto publishDelta = [this](
 		prometheus::Counter* total, ConnectionMetrics::DeltaCounter& dc, double cur, double scale = 1.0
 	) {
@@ -79,6 +134,8 @@ void NetworkMetrics::Update(const CGameServer& server)
 		ConnectionMetrics& cm = ConnectionSlot(p.id);
 
 		if (p.clientLink == nullptr) {
+			// don't let the metrics for a disconnected player get scraped
+			ReleaseConnectionGauges(cm);
 			cm = ConnectionMetrics{};
 			continue;
 		}
@@ -95,15 +152,41 @@ void NetworkMetrics::Update(const CGameServer& server)
 		// Label by player slot id. See recoil_server_per_player_info to resolve to names.
 		if (perPlayerEnabled && cm.sentBytes.player == nullptr) {
 			const std::string playerId = std::to_string(p.id);
+			const std::map<std::string, std::string> labels = {{"playerid", playerId}};
 			cm.sentBytes.player   = &metricBytes->Add({{"playerid", playerId}, {"direction", "outgoing"}});
 			cm.recvBytes.player   = &metricBytes->Add({{"playerid", playerId}, {"direction", "incoming"}});
 			cm.sentPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "outgoing"}});
 			cm.recvPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "incoming"}});
+			cm.outgoingBw         = &metricOutgoingBw->Add(labels);
+			cm.unackedOutgoingChunks      = &metricUnackedOutgoingChunks->Add(labels);
+			cm.outgoingResendQueueDepth   = &metricOutgoingResendQueueDepth->Add(labels);
+			cm.incomingReorderQueueDepth  = &metricIncomingReorderQueueDepth->Add(labels);
+			cm.outgoingQueueBytes     = &metricOutgoingQueueBytes->Add(labels);
 		}
 
 		publishDelta(metricTotalSentBytes, cm.sentBytes, stats.sentBytes);
 		publishDelta(metricTotalRecvBytes, cm.recvBytes, stats.receivedBytes);
 		publishDelta(metricTotalSentPackets, cm.sentPackets, stats.accumulated.sentPackets);
 		publishDelta(metricTotalRecvPackets, cm.recvPackets, stats.accumulated.receivedPackets);
+
+		totalOutgoingBw += stats.live.outgoingBandwidthBytesPerSec;
+		totalUnackedOutgoingChunks += stats.live.unackedOutgoingChunks;
+		totalOutgoingResendQueueDepth += stats.live.outgoingResendQueueDepth;
+		totalIncomingReorderQueueDepth += stats.live.incomingReorderQueueDepth;
+		totalOutgoingQueueBytes += stats.live.outgoingQueueBytes;
+
+		if (perPlayerEnabled) {
+			cm.outgoingBw->Set(stats.live.outgoingBandwidthBytesPerSec);
+			cm.unackedOutgoingChunks->Set(stats.live.unackedOutgoingChunks);
+			cm.outgoingResendQueueDepth->Set(stats.live.outgoingResendQueueDepth);
+			cm.incomingReorderQueueDepth->Set(stats.live.incomingReorderQueueDepth);
+			cm.outgoingQueueBytes->Set(stats.live.outgoingQueueBytes);
+		}
 	}
+
+	metricTotalOutgoingBw->Set(totalOutgoingBw);
+	metricTotalUnackedOutgoingChunks->Set(totalUnackedOutgoingChunks);
+	metricTotalOutgoingResendQueueDepth->Set(totalOutgoingResendQueueDepth);
+	metricTotalIncomingReorderQueueDepth->Set(totalIncomingReorderQueueDepth);
+	metricTotalOutgoingQueueBytes->Set(totalOutgoingQueueBytes);
 }

--- a/rts/Net/ServerMetrics/NetworkMetrics.h
+++ b/rts/Net/ServerMetrics/NetworkMetrics.h
@@ -8,6 +8,7 @@ namespace prometheus
 {
 	template<typename T> class Family;
 	class Counter;
+	class Gauge;
 	class Registry;
 }
 
@@ -45,10 +46,20 @@ private:
 		DeltaCounter recvBytes;
 		DeltaCounter sentPackets;
 		DeltaCounter recvPackets;
+
+		prometheus::Gauge* outgoingBw = nullptr;
+		prometheus::Gauge* unackedOutgoingChunks = nullptr;
+		prometheus::Gauge* outgoingResendQueueDepth = nullptr;
+		prometheus::Gauge* incomingReorderQueueDepth = nullptr;
+		prometheus::Gauge* outgoingQueueBytes = nullptr;
 	};
 
 	/// this player's metric slot, created on first use
 	ConnectionMetrics& ConnectionSlot(int playerId);
+
+	/// drop a connection's gauges from the registry rather than leave them
+	/// reporting a connection that is gone. Counters are cumulative and stay.
+	void ReleaseConnectionGauges(ConnectionMetrics& cm);
 
 	std::vector<ConnectionMetrics> connectionMetrics;
 
@@ -58,10 +69,20 @@ private:
 	// per-player metrics, null unless perPlayerEnabled
 	prometheus::Family<prometheus::Counter>* metricBytes = nullptr;
 	prometheus::Family<prometheus::Counter>* metricPackets = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricOutgoingBw = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricUnackedOutgoingChunks = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricOutgoingResendQueueDepth = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricIncomingReorderQueueDepth = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricOutgoingQueueBytes = nullptr;
 
 	// server-wide aggregates, exported whether or not per-player metrics are on
 	prometheus::Counter* metricTotalSentBytes = nullptr;
 	prometheus::Counter* metricTotalRecvBytes = nullptr;
 	prometheus::Counter* metricTotalSentPackets = nullptr;
 	prometheus::Counter* metricTotalRecvPackets = nullptr;
+	prometheus::Gauge* metricTotalOutgoingBw = nullptr;
+	prometheus::Gauge* metricTotalUnackedOutgoingChunks = nullptr;
+	prometheus::Gauge* metricTotalOutgoingResendQueueDepth = nullptr;
+	prometheus::Gauge* metricTotalIncomingReorderQueueDepth = nullptr;
+	prometheus::Gauge* metricTotalOutgoingQueueBytes = nullptr;
 };

--- a/rts/System/Net/ConnectionStats.h
+++ b/rts/System/Net/ConnectionStats.h
@@ -52,6 +52,13 @@ struct UdpStats {
 	struct Live {
 		/// inbound chunks delivered in order so far
 		unsigned int processedIncomingChunks = 0;
+		/// received but undeliverable until an earlier chunk arrives
+		unsigned int incomingReorderQueueDepth = 0;
+		/// handed to the link and not yet on the wire
+		unsigned int outgoingQueueBytes = 0;
+		float outgoingBandwidthBytesPerSec = 0.0f;
+		unsigned int unackedOutgoingChunks = 0;
+		unsigned int outgoingResendQueueDepth = 0;
 	} live;
 };
 

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -795,6 +795,19 @@ bool UDPConnection::CanReconnect() const {
 	return (globalConfig.reconnectTimeout > 0);
 }
 
+unsigned int UDPConnection::OutgoingQueuedBytes() const
+{
+	unsigned int bytes = 0;
+
+	for (const std::shared_ptr<const RawPacket>& pkt: outgoingData)
+		bytes += pkt->length;
+
+	for (const ChunkPtr& chunk: newChunks)
+		bytes += chunk->data.size();
+
+	return bytes;
+}
+
 ConnectionStats UDPConnection::GetStats() const
 {
 	UdpStats stats;
@@ -802,6 +815,11 @@ ConnectionStats UDPConnection::GetStats() const
 	stats.receivedBytes = dataRecv;
 	stats.accumulated = accumulatedStats;
 	stats.live.processedIncomingChunks = lastInOrder + 1;
+	stats.live.outgoingBandwidthBytesPerSec = outgoing.GetAverage();
+	stats.live.unackedOutgoingChunks = unackedOutgoingChunks.size();
+	stats.live.outgoingResendQueueDepth = resendRequested.size();
+	stats.live.incomingReorderQueueDepth = waitingPackets.size();
+	stats.live.outgoingQueueBytes = OutgoingQueuedBytes();
 	return stats;
 }
 

--- a/rts/System/Net/UDPConnection.h
+++ b/rts/System/Net/UDPConnection.h
@@ -152,6 +152,9 @@ private:
 	void RequestResend(ChunkPtr ptr, bool noSort);
 	void SendPacket(Packet& pkt);
 
+	/// application bytes queued for this link but not yet transmitted
+	unsigned int OutgoingQueuedBytes() const;
+
 	void UpdateWaitingPackets();
 	void UpdateResendRequests();
 


### PR DESCRIPTION
See https://github.com/beyond-all-reason/RecoilEngine/issues/3263
### What

Here is where the net metrics start to get interesting/meaningful.

Exports live queue-health and send-rate metrics for each UDP connection: outgoing send-rate average, unacked outgoing chunks, outgoing resend-queue depth, incoming reorder-queue depth, and application bytes still queued for send... Both in aggregate and per-player/per-connection.

### Why

This set of metrics should help identify if/when a connection is backing up. These will help identify the 'why' behind lag or disconnects, namely surfacing send-side pressure (a symptom of a saturated connection), but we expand it to export everything. 

It won't show explicit throttling but it will show if bandwidth is exceeding the bandwidth limit bytes, which is presumed broken right now. A later PR will add an explicit "throttle duration" metric so this will be more clear, but that requires some larger changes.

### AI disclosure

The whole stack was written with Claude Code, but very heavily iterated on and reviewed by me, a human.
