### PR TITLE
feat(metrics): export packet loss on both directions of a connection

### DIFF
--- a/rts/Net/ServerMetrics/NetworkMetrics.cpp
+++ b/rts/Net/ServerMetrics/NetworkMetrics.cpp
@@ -29,6 +29,7 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 	const auto gaugeFamily = [&](const char* name, const char* help) {
 		return &prometheus::BuildGauge().Name(name).Help(help).Register(registry);
 	};
+	const auto counter = [&](const char* name, const char* help) { return &counterFamily(name, help)->Add({}); };
 	const auto gauge = [&](const char* name, const char* help) { return &gaugeFamily(name, help)->Add({}); };
 
 	// direction is a label rather than part of the name, to make querying
@@ -43,6 +44,16 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 	metricTotalSentPackets = &packets.Add({{"direction", "outgoing"}});
 	metricTotalRecvPackets = &packets.Add({{"direction", "incoming"}});
 
+	metricTotalResentOutgoingChunks = counter("recoil_network_resent_outgoing_chunks_total",
+		"Chunks retransmitted to clients after they looked lost, i.e. a resend driven by a nak or an ack timeout. Each retransmission counts, so one chunk resent repeatedly adds repeatedly. Proactive duplication from redundancy mode is counted separately in recoil_network_redundant_outgoing_chunks_total, not here");
+	metricTotalRedundantOutgoingChunks = counter("recoil_network_redundant_outgoing_chunks_total",
+		"Chunks retransmitted purely because the link duplicates by policy aka the bandwidth cost of redundancy mode, not a loss symptom");
+	metricTotalDuplicateIncomingChunks = counter("recoil_network_duplicate_incoming_chunks_total",
+		"Chunks discarded on arrival because the same chunk had already been received");
+	metricTotalMissingIncomingChunks = counter("recoil_network_missing_incoming_chunks_total",
+		"Chunks from clients observed missing at a send pass. Reordering that outlives a pass counts here as well as real loss");
+	metricRedundancyLinks = gauge("recoil_network_redundancy_mode_connections",
+		"Live connections with a non-zero loss factor, i.e. running in proactive-retransmit mode");
 	metricTotalOutgoingBw = gauge("recoil_network_outgoing_bandwidth_bytes_per_second",
 		"Rolling average of the send rate over all client connections");
 	metricTotalUnackedOutgoingChunks = gauge("recoil_network_unacked_outgoing_chunks",
@@ -65,6 +76,16 @@ void NetworkMetrics::Init(prometheus::Registry& registry)
 		"Bytes over this client connection, by direction. No series exists for local loopback connections");
 	metricPackets = counterFamily("recoil_network_per_connection_packets_total",
 		"UDP packets over this client connection, by direction");
+	metricResentOutgoingChunks = counterFamily("recoil_network_per_connection_resent_outgoing_chunks_total",
+		"Chunks retransmitted to this client because they looked lost, excluding redundancy-mode duplication. see the aggregate recoil_network_resent_outgoing_chunks_total");
+	metricRedundantOutgoingChunks = counterFamily("recoil_network_per_connection_redundant_outgoing_chunks_total",
+		"Chunks retransmitted to this client purely because the link duplicates by policy");
+	metricDuplicateIncomingChunks = counterFamily("recoil_network_per_connection_duplicate_incoming_chunks_total",
+		"Chunks from this client discarded on arrival because the same chunk had already been received");
+	metricMissingIncomingChunks = counterFamily("recoil_network_per_connection_missing_incoming_chunks_total",
+		"Chunks from this client observed missing at a send pass. Reordering that outlives a pass counts here as well as real loss");
+	metricLossFactor = gaugeFamily("recoil_network_per_connection_loss_factor",
+		"Client-declared network loss factor for this link (0 = normal). Above zero the link duplicates chunks by policy");
 	metricOutgoingBw = gaugeFamily("recoil_network_per_connection_outgoing_bandwidth_bytes_per_second",
 		"Rolling average of the send rate to this client, as used by outgoing bandwidth limiting");
 	metricUnackedOutgoingChunks = gaugeFamily("recoil_network_per_connection_unacked_outgoing_chunks",
@@ -88,6 +109,7 @@ void NetworkMetrics::ReleaseConnectionGauges(ConnectionMetrics& cm)
 		child = nullptr;
 	};
 
+	release(metricLossFactor, cm.lossFactor);
 	release(metricOutgoingBw, cm.outgoingBw);
 	release(metricUnackedOutgoingChunks, cm.unackedOutgoingChunks);
 	release(metricOutgoingResendQueueDepth, cm.outgoingResendQueueDepth);
@@ -113,6 +135,7 @@ void NetworkMetrics::ResetConnectionDeltas(int playerId)
 
 void NetworkMetrics::Update(const CGameServer& server)
 {
+	int numRedundancyLinks = 0;
 	float totalOutgoingBw = 0.0f;
 	unsigned int totalUnackedOutgoingChunks = 0;
 	unsigned int totalOutgoingResendQueueDepth = 0;
@@ -157,6 +180,11 @@ void NetworkMetrics::Update(const CGameServer& server)
 			cm.recvBytes.player   = &metricBytes->Add({{"playerid", playerId}, {"direction", "incoming"}});
 			cm.sentPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "outgoing"}});
 			cm.recvPackets.player = &metricPackets->Add({{"playerid", playerId}, {"direction", "incoming"}});
+			cm.resentOutgoingChunks.player   = &metricResentOutgoingChunks->Add(labels);
+			cm.redundantOutgoingChunks.player = &metricRedundantOutgoingChunks->Add(labels);
+			cm.duplicateIncomingChunks.player  = &metricDuplicateIncomingChunks->Add(labels);
+			cm.missingIncomingChunks.player = &metricMissingIncomingChunks->Add(labels);
+			cm.lossFactor         = &metricLossFactor->Add(labels);
 			cm.outgoingBw         = &metricOutgoingBw->Add(labels);
 			cm.unackedOutgoingChunks      = &metricUnackedOutgoingChunks->Add(labels);
 			cm.outgoingResendQueueDepth   = &metricOutgoingResendQueueDepth->Add(labels);
@@ -168,6 +196,10 @@ void NetworkMetrics::Update(const CGameServer& server)
 		publishDelta(metricTotalRecvBytes, cm.recvBytes, stats.receivedBytes);
 		publishDelta(metricTotalSentPackets, cm.sentPackets, stats.accumulated.sentPackets);
 		publishDelta(metricTotalRecvPackets, cm.recvPackets, stats.accumulated.receivedPackets);
+		publishDelta(metricTotalResentOutgoingChunks, cm.resentOutgoingChunks, stats.accumulated.resentOutgoingChunks);
+		publishDelta(metricTotalRedundantOutgoingChunks, cm.redundantOutgoingChunks, stats.accumulated.redundantOutgoingChunks);
+		publishDelta(metricTotalDuplicateIncomingChunks, cm.duplicateIncomingChunks, stats.accumulated.duplicateIncomingChunks);
+		publishDelta(metricTotalMissingIncomingChunks, cm.missingIncomingChunks, stats.accumulated.missingIncomingChunks);
 
 		totalOutgoingBw += stats.live.outgoingBandwidthBytesPerSec;
 		totalUnackedOutgoingChunks += stats.live.unackedOutgoingChunks;
@@ -175,7 +207,10 @@ void NetworkMetrics::Update(const CGameServer& server)
 		totalIncomingReorderQueueDepth += stats.live.incomingReorderQueueDepth;
 		totalOutgoingQueueBytes += stats.live.outgoingQueueBytes;
 
+		numRedundancyLinks += (stats.live.lossFactor > 0);
+
 		if (perPlayerEnabled) {
+			cm.lossFactor->Set(stats.live.lossFactor);
 			cm.outgoingBw->Set(stats.live.outgoingBandwidthBytesPerSec);
 			cm.unackedOutgoingChunks->Set(stats.live.unackedOutgoingChunks);
 			cm.outgoingResendQueueDepth->Set(stats.live.outgoingResendQueueDepth);
@@ -184,6 +219,7 @@ void NetworkMetrics::Update(const CGameServer& server)
 		}
 	}
 
+	metricRedundancyLinks->Set(numRedundancyLinks);
 	metricTotalOutgoingBw->Set(totalOutgoingBw);
 	metricTotalUnackedOutgoingChunks->Set(totalUnackedOutgoingChunks);
 	metricTotalOutgoingResendQueueDepth->Set(totalOutgoingResendQueueDepth);

--- a/rts/Net/ServerMetrics/NetworkMetrics.h
+++ b/rts/Net/ServerMetrics/NetworkMetrics.h
@@ -46,7 +46,12 @@ private:
 		DeltaCounter recvBytes;
 		DeltaCounter sentPackets;
 		DeltaCounter recvPackets;
+		DeltaCounter resentOutgoingChunks;
+		DeltaCounter redundantOutgoingChunks;
+		DeltaCounter duplicateIncomingChunks;
+		DeltaCounter missingIncomingChunks;
 
+		prometheus::Gauge* lossFactor = nullptr;
 		prometheus::Gauge* outgoingBw = nullptr;
 		prometheus::Gauge* unackedOutgoingChunks = nullptr;
 		prometheus::Gauge* outgoingResendQueueDepth = nullptr;
@@ -69,6 +74,11 @@ private:
 	// per-player metrics, null unless perPlayerEnabled
 	prometheus::Family<prometheus::Counter>* metricBytes = nullptr;
 	prometheus::Family<prometheus::Counter>* metricPackets = nullptr;
+	prometheus::Family<prometheus::Counter>* metricResentOutgoingChunks = nullptr;
+	prometheus::Family<prometheus::Counter>* metricRedundantOutgoingChunks = nullptr;
+	prometheus::Family<prometheus::Counter>* metricDuplicateIncomingChunks = nullptr;
+	prometheus::Family<prometheus::Counter>* metricMissingIncomingChunks = nullptr;
+	prometheus::Family<prometheus::Gauge>* metricLossFactor = nullptr;
 	prometheus::Family<prometheus::Gauge>* metricOutgoingBw = nullptr;
 	prometheus::Family<prometheus::Gauge>* metricUnackedOutgoingChunks = nullptr;
 	prometheus::Family<prometheus::Gauge>* metricOutgoingResendQueueDepth = nullptr;
@@ -80,6 +90,11 @@ private:
 	prometheus::Counter* metricTotalRecvBytes = nullptr;
 	prometheus::Counter* metricTotalSentPackets = nullptr;
 	prometheus::Counter* metricTotalRecvPackets = nullptr;
+	prometheus::Counter* metricTotalResentOutgoingChunks = nullptr;
+	prometheus::Counter* metricTotalRedundantOutgoingChunks = nullptr;
+	prometheus::Counter* metricTotalDuplicateIncomingChunks = nullptr;
+	prometheus::Counter* metricTotalMissingIncomingChunks = nullptr;
+	prometheus::Gauge* metricRedundancyLinks = nullptr;
 	prometheus::Gauge* metricTotalOutgoingBw = nullptr;
 	prometheus::Gauge* metricTotalUnackedOutgoingChunks = nullptr;
 	prometheus::Gauge* metricTotalOutgoingResendQueueDepth = nullptr;

--- a/rts/System/Net/ConnectionStats.h
+++ b/rts/System/Net/ConnectionStats.h
@@ -39,8 +39,13 @@ struct UdpStats {
 		unsigned int receivedPackets = 0;
 		/// chunks put back on the wire after having been sent once
 		unsigned int resentOutgoingChunks = 0;
+		/// retransmitted purely because the link duplicates by policy
+		unsigned int redundantOutgoingChunks = 0;
 		/// chunks discarded on arrival because the same chunk had already been received
 		unsigned int duplicateIncomingChunks = 0;
+		/// chunks seen missing at a send pass, i.e. a gap in the received sequence
+		/// NOTE: long-lived reordering is indistinguishable from loss
+		unsigned int missingIncomingChunks = 0;
 		/// cumulative protocol header bytes
 		unsigned int sentOverheadBytes = 0;
 		unsigned int receivedOverheadBytes = 0;
@@ -59,6 +64,8 @@ struct UdpStats {
 		float outgoingBandwidthBytesPerSec = 0.0f;
 		unsigned int unackedOutgoingChunks = 0;
 		unsigned int outgoingResendQueueDepth = 0;
+		/// loss factor the UDP link is running with. See UDPConnection::SetLossFactor()
+		unsigned int lossFactor = 0;
 	} live;
 };
 

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -301,6 +301,7 @@ void UDPConnection::Init()
 
 	lastNak = -1;
 	accumulatedStats = {};
+	highestCountedMissingChunk = -1;
 	mtu = globalConfig.mtu;
 	reconnectTime = globalConfig.reconnectTimeout;
 
@@ -556,7 +557,7 @@ void UDPConnection::ProcessRawPacket(Packet& incoming)
 
 					if (unAckPos >= 0 && unAckPos < unackedOutgoingChunks.size()) {
 						assert(unackedOutgoingChunks[unAckPos]->chunkNumber == nextCont + i);
-						RequestResend(unackedOutgoingChunks[unAckPos], true);
+						RequestResend(unackedOutgoingChunks[unAckPos], true, true);
 					}
 				}
 			} else if (incoming.nakType > 0) {
@@ -576,7 +577,7 @@ void UDPConnection::ProcessRawPacket(Packet& incoming)
 
 					if (unAckPos < unackedOutgoingChunks.size()) {
 						assert(unackedOutgoingChunks[unAckPos]->chunkNumber == (nextCont + incoming.naks[i]));
-						RequestResend(unackedOutgoingChunks[unAckPos], true);
+						RequestResend(unackedOutgoingChunks[unAckPos], true, true);
 					}
 
 					++unAckPos;
@@ -820,6 +821,7 @@ ConnectionStats UDPConnection::GetStats() const
 	stats.live.outgoingResendQueueDepth = resendRequested.size();
 	stats.live.incomingReorderQueueDepth = waitingPackets.size();
 	stats.live.outgoingQueueBytes = OutgoingQueuedBytes();
+	stats.live.lossFactor = netLossFactor;
 	return stats;
 }
 
@@ -874,6 +876,17 @@ void UDPConnection::SendIfNecessary(bool flushed)
 			droppedPackets.pop_back();
 		}
 
+		// droppedPackets still lists a gap on every pass until the gap is filled.
+		// Chunk numbers only ascend, so we can dedupe by only counting above the
+		// highest chunk we've seen so far.
+		if (StatsSampling()) {
+			for (const int missingChunkNum: droppedPackets) {
+				if (missingChunkNum <= highestCountedMissingChunk)
+					continue;
+				highestCountedMissingChunk = missingChunkNum;
+				accumulatedStats.missingIncomingChunks += 1;
+			}
+		}
 
 		unsigned int numContinuous = 0;
 
@@ -900,7 +913,7 @@ void UDPConnection::SendIfNecessary(bool flushed)
 		// resend last packet if we didn't get an ack within reasonable time
 		// and don't plan sending out a new chunk either
 		if (newChunks.empty())
-			RequestResend(*unackedOutgoingChunks.rbegin(), false);
+			RequestResend(*unackedOutgoingChunks.rbegin(), false, true);
 
 		lastUnackResentTime = curTime;
 	}
@@ -984,6 +997,9 @@ void UDPConnection::SendIfNecessary(bool flushed)
 			resend = !resend;
 
 			if (resend && canResend) {
+				// the branches below push at most one chunk
+				const size_t numChunksBefore = buf.chunks.size();
+
 				if (UseMinLossFactor()) {
 					if (erasedResendChunks.find(resFwdIter->first) == erasedResendChunks.end())
 						buf.chunks.push_back(resFwdIter->second);
@@ -1014,7 +1030,13 @@ void UDPConnection::SendIfNecessary(bool flushed)
 					rev = (rev + 1) % 4;
 				}
 
-				accumulatedStats.resentOutgoingChunks += 1;
+				// separate "loss" as specifically a link-quality signal, excluding our explicit duplication policy
+				if (buf.chunks.size() > numChunksBefore) {
+					if (buf.chunks.back()->lossSuspected)
+						accumulatedStats.resentOutgoingChunks += 1;
+					else
+						accumulatedStats.redundantOutgoingChunks += 1;
+				}
 				maxResend -= 1;
 
 				sent = true;
@@ -1043,7 +1065,7 @@ void UDPConnection::SendIfNecessary(bool flushed)
 
 	// on a lossy connection chunks can be sent multiple times, see switch above
 	for (int i = unackPrevSize; i < unackedOutgoingChunks.size(); ++i) {
-		RequestResend(unackedOutgoingChunks[i], true);
+		RequestResend(unackedOutgoingChunks[i], true, false);
 	}
 
 	UpdateResendRequests();
@@ -1085,8 +1107,10 @@ void UDPConnection::AckChunks(int lastAck)
 	}
 }
 
-void UDPConnection::RequestResend(ChunkPtr ptr, bool noSort)
+void UDPConnection::RequestResend(const ChunkPtr& ptr, bool noSort, bool lossSuspected)
 {
+	ptr->lossSuspected |= lossSuspected;
+
 	resendRequested.emplace_back(ptr->chunkNumber, ptr);
 
 	if (noSort)

--- a/rts/System/Net/UDPConnection.h
+++ b/rts/System/Net/UDPConnection.h
@@ -36,6 +36,10 @@ public:
 	std::int32_t chunkNumber;
 	std::uint8_t chunkSize;
 	std::vector<std::uint8_t> data;
+
+	/// retransmission was requested because the chunk looks lost (nak or ack
+	/// timeout), but explicitly *not* because of the link duplication policy
+	bool lossSuspected = false;
 };
 typedef std::shared_ptr<Chunk> ChunkPtr;
 
@@ -149,7 +153,7 @@ private:
 	void SendIfNecessary(bool flushed);
 	void AckChunks(int lastAck);
 
-	void RequestResend(ChunkPtr ptr, bool noSort);
+	void RequestResend(const ChunkPtr& ptr, bool noSort, bool lossSuspected);
 	void SendPacket(Packet& pkt);
 
 	/// application bytes queued for this link but not yet transmitted
@@ -241,6 +245,8 @@ private:
 	unsigned int currentPacketChunkNum;
 
 	UdpStats::Accumulated accumulatedStats;
+
+	int highestCountedMissingChunk;
 
 	class BandwidthUsage {
 	public:


### PR DESCRIPTION
See https://github.com/beyond-all-reason/RecoilEngine/issues/3263

### What

Exports packet-loss signals on both directions of each UDP connection. For outgoing packets, this includes outgoing chunks resent because they looked lost, and outgoing chunks duplicated purely by the redundancy policy.

For incoming packets, this is duplicate inbound chunks, and inbound chunks observed missing.

The existing `resentOutgoingChunks` counter combined real re-transmissions with redundancy-mode duplication, making it useless as a link-quality signal. We split the two apart so a lossy client link is distinguishable from one just running with a redundancy mode loss factor.

### Why

In tandem with the last PR, this should now give us a good connection-health picture. Queue depths show backpressure (the last PR), but loss is sort of the first level "why" behind that.

### AI disclosure

The whole stack was written with Claude Code, but very heavily iterated on and reviewed by me, a human.
