### PR TITLE
Fix targeting facilities applying radar error to the capturer.

### DIFF
--- a/doc/pr-changelogs/3262.md
+++ b/doc/pr-changelogs/3262.md
@@ -1,0 +1,1 @@
+* fixed that transferring a `targfac` would keep applying the bonus to the previous owner forever, while the new owner would see no change initially and receive a penalty when disabled.

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1560,6 +1560,9 @@ bool CUnit::ChangeTeam(int newteam, ChangeType type)
 		teamHandler.Team(newteam)->resStorage += storage;
 	}
 
+	// Deactivate pinpointers before team change to remove any bonuses applied to current team.
+	if (activated && unitDef->targfac && !teamHandler.AlliedTeams(oldteam, newteam))
+		Deactivate();
 
 	team = newteam;
 	if (paletteIndex == static_cast<uint16_t>(oldteam))

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1560,7 +1560,6 @@ bool CUnit::ChangeTeam(int newteam, ChangeType type)
 		teamHandler.Team(newteam)->resStorage += storage;
 	}
 
-	// Move targeting-upgrade radar error between allyteams before allyteam is reassigned.
 	if (!beingBuilt && activated && unitDef->targfac) {
 		losHandler->IncreaseAllyTeamRadarErrorSize(allyteam);
 		losHandler->DecreaseAllyTeamRadarErrorSize(teamHandler.AllyTeam(newteam));

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1560,9 +1560,11 @@ bool CUnit::ChangeTeam(int newteam, ChangeType type)
 		teamHandler.Team(newteam)->resStorage += storage;
 	}
 
-	// Deactivate pinpointers before team change to remove any bonuses applied to current team.
-	if (activated && unitDef->targfac && !teamHandler.AlliedTeams(oldteam, newteam))
-		Deactivate();
+	// Move targeting-upgrade radar error between allyteams before allyteam is reassigned.
+	if (!beingBuilt && activated && unitDef->targfac) {
+		losHandler->IncreaseAllyTeamRadarErrorSize(allyteam);
+		losHandler->DecreaseAllyTeamRadarErrorSize(teamHandler.AllyTeam(newteam));
+	}
 
 	team = newteam;
 	if (paletteIndex == static_cast<uint16_t>(oldteam))


### PR DESCRIPTION
ChangeTeamReset turns units off after allyteam already changed, so an active pinpointer's deactivate penalty hit the new owner and left the old team's bonus in place.


Repro:
Make 4 pinpointers. Leave them on. Have enemy capture your 4 pinpointers. 

Despite the fact that you now have 0 pinpointers, you still have 100% accurate radar
<img width="315" height="402" alt="image" src="https://github.com/user-attachments/assets/b10328c4-d3f4-458b-8972-5c32db46ac97" />

Alternative repro: 
have enemy make 5 pinpointers. capture them while they are on. Turn (or leave them off). 

The radar dots now have so much inaccuracy they now jump off the map. The inaccuracy scales with number of pinpointers you capture. If too many, it doesn't show up because it's too far off the map.

<img width="2110" height="1419" alt="image" src="https://github.com/user-attachments/assets/66022e98-8dd8-4b40-801f-8a285362a95f" />

Explanation:
Radar error starts at 96. Each on pinpointer on an ally team divides that team’s number by 2. Each off multiplies it by 2. Off is not “do nothing”; it is “undo a bonus,” and the undo always hits whoever currently owns it.

Capture of an enemy pinpointer that was on:
1. Enemy team already got the divide (their 96 became 48).
2. Recoil then switches the building to your ally team.
3. Recoil then turns it off (capture always issues on/off 0 for non-allies). This happens in `ResetTeamState()`
4. Off multiplies your number by 2 (96 → 192).

Tested:
Confirmed radar is (as expected) inaccurate after enemy captures all your pinpointers. 
<img width="201" height="148" alt="image" src="https://github.com/user-attachments/assets/fe41fbfb-a95c-400b-a600-b5416159343a" />


and radar is not wildly inaccurate after you capture enemy pinpointers.  ( the screenshot looks the same as above lol)
Turning on the pinpointers makes them accurate again (as expected). 



AI (Cursor) used for finding change, manual review / testing. 