### PR TITLE
Guard CQuadField ray queries against invalid lengths

### DIFF
--- a/doc/pr-changelogs/3266.md
+++ b/doc/pr-changelogs/3266.md
@@ -1,0 +1,1 @@
+ * fixed a beamlaser related crash, likely it has just been downgraded into incorrect behaviour though. The effort is ongoing, there are logs for when this happens.

--- a/rts/Sim/Misc/QuadField.cpp
+++ b/rts/Sim/Misc/QuadField.cpp
@@ -1,6 +1,7 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include <algorithm>
+#include <cmath>
 
 #include "QuadField.h"
 #include "Map/ReadMap.h"
@@ -9,6 +10,7 @@
 #include "Sim/Misc/GlobalConstants.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "System/ContainerUtil.h"
+#include "System/Log/ILog.h"
 #include "System/Threading/ThreadPool.h"
 
 #ifndef UNIT_TEST
@@ -201,6 +203,16 @@ void CQuadField::GetQuadsOnRay(QuadFieldQuery& qfq, const float3& start, const f
 	dir.AssertNaNs();
 	start.AssertNaNs();
 
+	// callers may pass invalid lengths (see https://github.com/beyond-all-reason/RecoilEngine/issues/3018),
+	// which violates the preconditions of std::clamp(t0, 0.0f, length) below and aborts on
+	// hardened builds (_GLIBCXX_ASSERTIONS). Clamp to 0 instead, which routes execution
+	// into the "special case" below and turns this into a zero-length ray query.
+	if (!std::isfinite(length) || length < 0.0f) {
+		LOG_L(L_ERROR, "[CQuadField::%s] invalid ray length %f (start=(%g,%g,%g) dir=(%g,%g,%g)), clamping to 0"
+			, __func__, length, start.x, start.y, start.z, dir.x, dir.y, dir.z);
+		length = 0.0f;
+	}
+
 	auto& queryQuads = *(qfq.quads = tempQuads[qfq.threadOwner].ReserveVector());
 
 	const float3 to = start + (dir * length);
@@ -288,6 +300,13 @@ void CQuadField::GetQuadsOnWideRay(QuadFieldQuery& qfq, const float3& start, con
 	RECOIL_DETAILED_TRACY_ZONE;
 	dir.AssertNaNs();
 	start.AssertNaNs();
+
+	// same rationale as GetQuadsOnRay above (see https://github.com/beyond-all-reason/RecoilEngine/issues/3018)
+	if (!std::isfinite(length) || length < 0.0f) {
+		LOG_L(L_ERROR, "[CQuadField::%s] invalid ray length %f (start=(%g,%g,%g) dir=(%g,%g,%g)), clamping to 0"
+			, __func__, length, start.x, start.y, start.z, dir.x, dir.y, dir.z);
+		length = 0.0f;
+	}
 
 	const float3 baseTo = start + (dir * length);
 


### PR DESCRIPTION
### Problem

On distributions that build with `_GLIBCXX_ASSERTIONS` (Arch, CachyOS,
Fedora ...), the engine periodically aborts mid-game with:

    stl_algo.h:3616: std::clamp<float>: Assertion '!(__hi < __lo)' failed.

Backtrace: `CQuadField::GetQuadsOnRay` <- `TraceRay::TraceRayShields` <-
`CBeamLaser::FireInternal` (#3018).

Root cause of the *abort* is that `std::clamp(t0, 0.0f, length)` has
undefined behavior when `hi < lo`, which happens as soon as any caller
passes a negative or non-finite ray length. The underlying *bug* is
upstream of this: in the reported case `CBeamLaser::FireInternal`
computed a negative `beamLength` (`hitColQuery.t0 = 83.66` vs
`beamLength = -82.40`; the delta matches the weapon's muzzle offset,
suggesting an inverted subtraction somewhere around
rts/Sim/Weapons/BeamLaser.cpp:360).
I have **not** attempted to fix that calculation - I don't understand the aiming code well enough - and didn't want to just throw it at an LLM after an LLM pointed me to it. But getting this guard in and double checking it locally is on the edge of what I feel just barely comfortable with.

What I can confirm from live logs is that this is not a once-a-month
event; within a single game the guard below caught:

    [CQuadField::GetQuadsOnRay] invalid ray length -1.350877 ...
    [CQuadField::GetQuadsOnRay] invalid ray length -5.354377 ...
    [CQuadField::GetQuadsOnRay] invalid ray length -19.158573 ...
    [CQuadField::GetQuadsOnRay] invalid ray length -134.201813 ...
    (etc., including bursts of 3 hits in one second)

### What this PR does

Clamps non-finite/negative `length` to `0` at the entry of both
`CQuadField::GetQuadsOnRay` and `CQuadField::GetQuadsOnWideRay` (they
share the same unguarded clamp pattern) and logs the offending values:

```cpp
if (!std::isfinite(length) || length < 0.0f) {
    LOG_L(L_ERROR, "[CQuadField::%s] invalid ray length %f (start=(%g,%g,%g) dir=(%g,%g,%g)), clamping to 0"
        , __func__, length, start.x, start.y, start.z, dir.x, dir.y, dir.z);
    length = 0.0f;
}
```

With `length = 0` the computed `to == start`, which routes into the
existing `noXdir && noZdir` early-out, so all downstream clamps become
trivially valid.
One branch per call against functions that do whole
quad enumeration - no measurable cost.

| build | before | after |
|---|---|---|
| hardened | SIGABRT mid-game | warning line, execution continues |
| non-hardened | silently degenerate quad set | identical result + log line |

The log line doubles as a breadcrumb: anyone debugging weapons code
gets exact geometry + frequency data for free, which should make the
actual sign-inversion bug trivially findable once somebody picks it up.

Closes #3018 (the reported aborts)


## Heavily LLM assisted
I rebuild it locally with ASan and a normal production build and verified that it works as intend.
No more crashes, illegal values get clamped and cause a yell in the logs.