### PR TITLE
Snap the early build block check to the real build position

### DIFF
--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -611,6 +611,9 @@ void CBuilderCAI::ExecuteBuildCmd(Command& c)
 
 		// <build> is never parsed (except in PostLoad) so just copy it
 		build = bi;
+		// snap to the position the build will actually use, so the early check
+		// below tests the same footprint the rest of this function does
+		build.pos = CGameHelper::Pos2BuildPos(build, true);
 		inCommand = c.GetID();
 
 		// One-time early check: if repeating the order (or first run), skip immediately if now blocked


### PR DESCRIPTION
The early block check added in #2557 runs on a position snapped to 8 elmos, while the build itself uses `Pos2BuildPos`, which snaps to 16 and adds half a square for odd footprints. For an odd footprint the check therefore evaluates a footprint 8 elmos away from the one that would be placed, and can drop a build order the build itself would accept.

Snapping before the check makes the two agree. `Pos2BuildPos` is idempotent, so the later call at `MoveInBuildRange` is left alone rather than moved, keeping the diff to the check itself.

Found via a game that reserves metal spots with building masks sized exactly to a 5x5 footprint. The offset footprint overlaps one row of unmasked ground, so the order is dropped before `AllowUnitCreation` and no Lua callin can see or report it. The builder does not move and nothing is printed, which makes it hard to diagnose from the game side.

I have not been able to build and run this, so it is unverified beyond reading. The reproduction in the issue is straightforward if someone wants to confirm it.

Fixes #3267
