### PR TITLE
Fix stack overflow when loading a savegame

### DIFF
--- a/rts/System/LoadSave/CregLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/CregLoadSaveHandler.cpp
@@ -219,6 +219,8 @@ static void PrintSize(const char* txt, int size)
 static void ReadString(std::istream& s, std::string& str)
 {
 	std::getline(s, str, '\0');
+	if (str.length() > MAX_STRING_SIZE)
+		throw content_error("[creg::ReadString] string too long");
 }
 
 

--- a/rts/System/LoadSave/CregLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/CregLoadSaveHandler.cpp
@@ -218,10 +218,7 @@ static void PrintSize(const char* txt, int size)
 
 static void ReadString(std::istream& s, std::string& str)
 {
-	char cstr[MAX_STRING_SIZE + 1];
-	s.getline(cstr, sizeof(cstr) - 1, 0);
-	str.clear();
-	str.append(cstr);
+	std::getline(s, str, '\0');
 }
 
 


### PR DESCRIPTION
Loading a savegame on macOS crashes with a stack overflow, and the crash handler then live-locks, so the game just looks frozen

Root cause: `ReadString` in CregLoadSaveHandler.cpp keeps a `char cstr[MAX_STRING_SIZE + 1]` buffer on the stack, 512 kB. The savefile header is read on the `std::async` thread from `CPreGame::AsyncExecute`, which gets the platform's default stack: 8 MB on Linux, 1-2 MB on Windows, 512 kB on macOS. There the buffer alone eats the whole stack

The fix reads the string with `std::getline(s, str, '\0')` instead, no buffer and no cap. The cap was a footgun of its own: c9377ac3d5 already grew it from 64 kB to 512 kB because Zero-K start scripts were getting silently truncated, and a string of exactly MAX_STRING_SIZE still gets truncated today (the writer allows it, the reader stores one char less and fails the stream). The source stringstream already holds the whole decompressed save, so the read can't grow past the file

Tested on macOS. A save that used to hard-freeze the engine on load now loads