### PR TITLE
Draw rectangle outlines as line primitives

### DIFF
--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -610,7 +610,6 @@ void CSelectedUnitsHandler::Draw()
 	glDisable(GL_DEPTH_TEST);
 	glEnable(GL_BLEND); // for line smoothing
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 	glLineWidth(cmdColors.UnitBoxLineWidth());
 
 	SColor color1(cmdColors.unitBox);
@@ -717,7 +716,6 @@ void CSelectedUnitsHandler::Draw()
 	}
 
 	glLineWidth(1.0f);
-	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 	glDisable(GL_BLEND);
 	glEnable(GL_DEPTH_TEST);
 	glDepthMask(true);

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3402,10 +3402,13 @@ void CGuiHandler::DrawOptionLEDs(const IconInfo& icon)
 
 		glRectf(startx, starty, startx + xs, starty + ys);
 
-		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 		glColor4f(1.0f, 1.0f, 1.0f, 0.5f);
-		glRectf(startx, starty, startx + xs, starty + ys);
-		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+		glBegin(GL_LINE_LOOP);
+			glVertex2f(startx     , starty     );
+			glVertex2f(startx     , starty + ys);
+			glVertex2f(startx + xs, starty + ys);
+			glVertex2f(startx + xs, starty     );
+		glEnd();
 	}
 }
 

--- a/rts/Game/UI/StartPosSelecter.cpp
+++ b/rts/Game/UI/StartPosSelecter.cpp
@@ -139,23 +139,31 @@ void CStartPosSelecter::Draw()
 	const float mx =                               float(mouse->lastx)  * globalRendering->pixelX;
 	const float my = (globalRendering->viewSizeY - float(mouse->lasty)) * globalRendering->pixelY;
 
-	{
-		gleDrawQuadC(readyBox, InBox(mx, my, readyBox)? SColor{0.7f, 0.2f, 0.2f, guiAlpha}: SColor{0.7f, 0.7f, 0.2f, guiAlpha}, rb);
-
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-	}
+	const SColor boxColor = InBox(mx, my, readyBox)? SColor{0.7f, 0.2f, 0.2f, guiAlpha}: SColor{0.7f, 0.7f, 0.2f, guiAlpha};
 
 	{
-		gleDrawQuadC(readyBox, InBox(mx, my, readyBox)? SColor{0.7f, 0.2f, 0.2f, guiAlpha}: SColor{0.7f, 0.7f, 0.2f, guiAlpha}, rb);
+		// filled box
+		gleDrawQuadC(readyBox, boxColor, rb);
 
-		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-	}
-	{
 		shader.Enable();
 		rb.DrawElements(GL_TRIANGLES);
 		shader.Disable();
+	}
+
+	{
+		// outline on top of it, brightening the edges
+		rb.AddQuadLines(
+			{ {readyBox.x1, readyBox.y1, 0.0f}, boxColor },
+			{ {readyBox.x2, readyBox.y1, 0.0f}, boxColor },
+			{ {readyBox.x2, readyBox.y2, 0.0f}, boxColor },
+			{ {readyBox.x1, readyBox.y2, 0.0f}, boxColor }
+		);
+
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+		shader.Enable();
+		rb.DrawElements(GL_LINES);
+		shader.Disable();
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	}
 
 	{

--- a/rts/Rendering/CommandDrawer.cpp
+++ b/rts/Rendering/CommandDrawer.cpp
@@ -675,9 +675,10 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		uwaterCommands += (bi.pos.y < CGround::GetWaterLevel(bi.pos.x, bi.pos.z));
 	}
 
-	// worst case - 2 squares per building (when underwater) - 8 vertices * 3 floats
-	std::vector<GLfloat>   quadVerts(buildCommands * 12);
-	std::vector<GLfloat> uwquadVerts(buildCommands * 12); // underwater
+	// worst case - 2 squares per building (when underwater), each square being
+	// 4 line segments - 8 vertices * 3 floats
+	std::vector<GLfloat>   quadVerts(buildCommands * 24);
+	std::vector<GLfloat> uwquadVerts(buildCommands * 24); // underwater
 	// 4 vertical lines
 	std::vector<GLfloat> lineVerts(uwaterCommands * 24);
 	// colors for lines
@@ -686,6 +687,28 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 	unsigned int   quadcounter = 0;
 	unsigned int uwquadcounter = 0;
 	unsigned int   linecounter = 0;
+
+	// the squares are outlines, and glPolygonMode(GL_LINE) is not honored by
+	// every driver, so emit them as line segments
+	const auto AddSquareLines = [](std::vector<GLfloat>& verts, unsigned int& counter, float x1, float x2, float z1, float z2, float y) {
+		constexpr int cornerX[4] = { 0, 0, 1, 1 };
+		constexpr int cornerZ[4] = { 0, 1, 1, 0 };
+
+		const float xs[2] = { x1, x2 };
+		const float zs[2] = { z1, z2 };
+
+		for (int i = 0; i < 4; ++i) {
+			const int j = (i + 1) % 4;
+
+			verts[counter++] = xs[cornerX[i]];
+			verts[counter++] = y;
+			verts[counter++] = zs[cornerZ[i]];
+
+			verts[counter++] = xs[cornerX[j]];
+			verts[counter++] = y;
+			verts[counter++] = zs[cornerZ[j]];
+		}
+	};
 
 	for (const Command& c: commandQue) {
 		if (buildOptions.find(c.GetID()) == buildOptions.end())
@@ -707,18 +730,7 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		const float x2 = bi.pos.x + xsize;
 		const float z2 = bi.pos.z + zsize;
 
-		quadVerts[quadcounter++] = x1;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z1;
-		quadVerts[quadcounter++] = x1;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z2;
-		quadVerts[quadcounter++] = x2;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z2;
-		quadVerts[quadcounter++] = x2;
-		quadVerts[quadcounter++] = h + 1;
-		quadVerts[quadcounter++] = z1;
+		AddSquareLines(quadVerts, quadcounter, x1, x2, z1, z2, h + 1);
 
 		if (bi.pos.y >= 0.0f)
 			continue;
@@ -728,18 +740,7 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 			0.0f, 0.5f, 1.0f, 1.0f, // end color
 		};
 
-		uwquadVerts[uwquadcounter++] = x1;
-		uwquadVerts[uwquadcounter++] = 0.0f;
-		uwquadVerts[uwquadcounter++] = z1;
-		uwquadVerts[uwquadcounter++] = x1;
-		uwquadVerts[uwquadcounter++] = 0.0f;
-		uwquadVerts[uwquadcounter++] = z2;
-		uwquadVerts[uwquadcounter++] = x2;
-		uwquadVerts[uwquadcounter++] = 0.0f;
-		uwquadVerts[uwquadcounter++] = z2;
-		uwquadVerts[uwquadcounter++] = x2;
-		uwquadVerts[uwquadcounter++] = 0.0f;
-		uwquadVerts[uwquadcounter++] = z1;
+		AddSquareLines(uwquadVerts, uwquadcounter, x1, x2, z1, z2, 0.0f);
 
 		for (int i = 0; i < 4; ++i) {
 			std::copy(col, col + 8, lineColors.begin() + linecounter * 2 + i * 8);
@@ -776,15 +777,14 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 
 	if (quadcounter > 0) {
 		glEnableClientState(GL_VERTEX_ARRAY);
-		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 		glVertexPointer(3, GL_FLOAT, 0, &quadVerts[0]);
-		glDrawArrays(GL_QUADS, 0, quadcounter / 3);
+		glDrawArrays(GL_LINES, 0, quadcounter / 3);
 
 		if (linecounter > 0) {
 			glPushAttrib(GL_CURRENT_BIT);
 			glColor4f(0.0f, 0.5f, 1.0f, 1.0f); // same as end color of lines
 			glVertexPointer(3, GL_FLOAT, 0, &uwquadVerts[0]);
-			glDrawArrays(GL_QUADS, 0, uwquadcounter / 3);
+			glDrawArrays(GL_LINES, 0, uwquadcounter / 3);
 			glPopAttrib();
 
 			glEnableClientState(GL_COLOR_ARRAY);


### PR DESCRIPTION
Four UI sites drew a filled rectangle in GL_LINE polygon mode to get an outline. That only works where the driver has a wireframe fill mode, and a GL layered over a Vulkan driver without fillModeNonSolid (Zink over KosmicKrisp on macOS, #3271) draws nothing there instead. Emitting the four edges as line primitives is what these sites meant and works everywhere.

StartPosSelecter's ready box also drew a second filled quad over the first on every platform, so its outline now appears too.

SelectedUnitsHandler's polygon mode toggle only affected the build squares drawn inside CommandDrawer, which now emit lines themselves, so it goes as well.