### PR TITLE
Warn when a replacement mouse cursor has no frames

### DIFF
--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -1168,6 +1168,12 @@ bool CMouseHandler::ReplaceMouseCursor(
 
 	CMouseCursor newCursor = CMouseCursor(newName, hotSpot);
 
+	// a replacement that loaded no frames draws nothing, so this silently turns
+	// a working cursor invisible. Whether the engine should refuse it is a
+	// behaviour question, since content may rely on it to hide the cursor.
+	if (!newCursor.IsValid())
+		LOG_L(L_WARNING, "[MouseHandler::%s] replacement \"%s\" for \"%s\" has no frames, the cursor will draw nothing", __func__, newName.c_str(), oldName.c_str());
+
 	// replace here so SetCursor() operates with new CMouseCursor() object
 	// hold on the destruction of old CMouseCursor() in this place. Otherwise bad things will happen.
 	std::swap(loadedCursors.at(fileIt->second), newCursor);


### PR DESCRIPTION
Spring.ReplaceMouseCursor with a name whose files load no frames silently turns a working cursor invisible. That reads as a rendering bug, and on macOS (#3271) it cost a debugging session before the cause surfaced.

It warns rather than refuses because content may rely on a frameless replacement to hide the cursor deliberately.