### PR TITLE
Allow non-aircraft to use area attack

### DIFF
--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -785,6 +785,8 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_BOOL("canSelfRepair",         ud.canSelfRepair);
 	ADD_BOOL("canReclaim",            ud.canReclaim);
 	ADD_BOOL("canAttack",             ud.canAttack);
+	ADD_BOOL("canAreaAttack",         ud.canAreaAttack);
+	ADD_INT( "groundAttackSalvoSize", ud.groundAttackSalvoSize);
 	ADD_BOOL("canPatrol",             ud.canPatrol);
 	ADD_BOOL("canFight",              ud.canFight);
 	ADD_BOOL("canGuard",              ud.canGuard);

--- a/rts/Rendering/CommandDrawer.cpp
+++ b/rts/Rendering/CommandDrawer.cpp
@@ -34,6 +34,32 @@ static const CUnit* GetTrackableUnit(const CUnit* caiOwner, const CUnit* cmdUnit
 	return cmdUnit;
 }
 
+void CommandDrawer::DrawAreaAttackCommand(const CCommandAI* cai, const Command& cmd) const
+{
+	const CUnit* owner = cai->owner;
+
+	if (
+		cai->inCommand == CMD_ATTACK &&
+		!cai->commandQue.empty() &&
+		&cmd == &cai->commandQue.front() &&
+		owner->curTarget.type == Target_Pos
+	) {
+		glSurfaceCircle(
+			owner->curTarget.groundPos,
+			13.0f,
+			{ cmdColors.attack },
+			64
+		);
+	}
+
+	const float3& endPos = cmd.GetPos(0);
+
+	lineDrawer.DrawLineAndIcon(CMD_AREA_ATTACK, endPos, cmdColors.attack);
+	lineDrawer.Break(endPos, cmdColors.attack);
+	glSurfaceCircle(endPos, cmd.GetParam(3), { cmdColors.attack }, cmdCircleResolution);
+	lineDrawer.RestartWithColor(cmdColors.attack);
+}
+
 CommandDrawer* CommandDrawer::GetInstance() {
 	// luaQueuedUnitSet gets cleared each frame, so this is fine wrt. reloading
 	static CommandDrawer drawer;
@@ -130,6 +156,9 @@ void CommandDrawer::DrawCommands(const CCommandAI* cai, int queueDrawDepth) cons
 					lineDrawer.DrawLineAndIcon(cmdID, float3(x, y, z), cmdColors.attack);
 				}
 			} break;
+			case CMD_AREA_ATTACK: {
+				DrawAreaAttackCommand(cai, *ci);
+			} break;
 
 			case CMD_WAIT: {
 				DrawWaitIcon(*ci);
@@ -198,14 +227,7 @@ void CommandDrawer::DrawAirCAICommands(const CAirCAI* cai, int queueDrawDepth) c
 			} break;
 
 			case CMD_AREA_ATTACK: {
-				const float3& endPos = ci->GetPos(0);
-
-				lineDrawer.DrawLineAndIcon(cmdID, endPos, cmdColors.attack);
-				lineDrawer.Break(endPos, cmdColors.attack);
-
-				glSurfaceCircle(endPos, ci->GetParam(3), { cmdColors.attack }, cmdCircleResolution);
-
-				lineDrawer.RestartWithColor(cmdColors.attack);
+				DrawAreaAttackCommand(cai, *ci);
 			} break;
 
 			case CMD_GUARD: {
@@ -453,6 +475,9 @@ void CommandDrawer::DrawFactoryCAICommands(const CFactoryCAI* cai, int queueDraw
 					lineDrawer.DrawLineAndIcon(cmdID, float3(x, y, z), cmdColors.attack);
 				}
 			} break;
+			case CMD_AREA_ATTACK: {
+				DrawAreaAttackCommand(cai, *ci);
+			} break;
 
 			case CMD_GUARD: {
 				const CUnit* unit = GetTrackableUnit(owner, unitHandler.GetUnit(ci->GetParam(0)));
@@ -543,6 +568,9 @@ void CommandDrawer::DrawMobileCAICommands(const CMobileCAI* cai, int queueDrawDe
 
 					lineDrawer.DrawLineAndIcon(cmdID, float3(x, y, z), cmdColors.attack);
 				}
+			} break;
+			case CMD_AREA_ATTACK: {
+				DrawAreaAttackCommand(cai, *ci);
 			} break;
 
 			case CMD_GUARD: {
@@ -797,4 +825,3 @@ void CommandDrawer::DrawQuedBuildingSquares(const CBuilderCAI* cai) const
 		glDisableClientState(GL_VERTEX_ARRAY);
 	}
 }
-

--- a/rts/Rendering/CommandDrawer.h
+++ b/rts/Rendering/CommandDrawer.h
@@ -33,6 +33,7 @@ private:
 	void DrawFactoryCAICommands(const CFactoryCAI*, int queueDrawDepth) const;
 	void DrawMobileCAICommands(const CMobileCAI*, int queueDrawDepth) const;
 
+	void DrawAreaAttackCommand(const CCommandAI*, const Command&) const;
 	void DrawWaitIcon(const Command&) const;
 	void DrawDefaultCommand(const Command&, const CUnit*) const;
 

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -69,19 +69,6 @@ CAirCAI::CAirCAI(CUnit* owner)
 {
 	cancelDistance = 16000;
 
-	if (owner->unitDef->canAttack) {
-		SCommandDescription c;
-
-		c.id   = CMD_AREA_ATTACK;
-		c.type = CMDTYPE_ICON_AREA;
-
-		c.action    = "areaattack";
-		c.name      = "Area attack";
-		c.tooltip   = c.name + ": Sets the aircraft to attack enemy units within a circle";
-		c.mouseicon = c.name;
-		possibleCommands.push_back(commandDescriptionCache.GetPtr(std::move(c)));
-	}
-
 	basePos = owner->pos;
 }
 
@@ -153,13 +140,6 @@ void CAirCAI::GiveCommandReal(const Command& c, bool fromSynced)
 	if (!(c.GetOpts() & SHIFT_KEY) && nonQueingCommands.find(c.GetID()) == nonQueingCommands.end()) {
 		activeCommand = 0;
 		tempOrder = false;
-	}
-
-	if (c.GetID() == CMD_AREA_ATTACK && c.GetNumParams() < 4) {
-		Command c2(CMD_ATTACK, c.GetOpts());
-		c2.CopyParams(c);
-		CCommandAI::GiveAllowedCommand(c2);
-		return;
 	}
 
 	CCommandAI::GiveAllowedCommand(c);
@@ -596,4 +576,3 @@ bool CAirCAI::SelectNewAreaAttackTargetOrPos(const Command& ac)
 
 	return true;
 }
-

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -142,6 +142,13 @@ void CAirCAI::GiveCommandReal(const Command& c, bool fromSynced)
 		tempOrder = false;
 	}
 
+	if (c.GetID() == CMD_AREA_ATTACK && c.GetNumParams() < 4) {
+		Command attackCmd(CMD_ATTACK, c.GetOpts());
+		attackCmd.CopyParams(c);
+		CCommandAI::GiveAllowedCommand(attackCmd);
+		return;
+	}
+
 	CCommandAI::GiveAllowedCommand(c);
 }
 

--- a/rts/Sim/Units/CommandAI/AirCAI.cpp
+++ b/rts/Sim/Units/CommandAI/AirCAI.cpp
@@ -449,13 +449,13 @@ void CAirCAI::ExecuteAreaAttack(Command& c)
 		if (orderTarget && orderTarget->pos.SqDistance2D(pos) > Square(radius)) {
 			// target wandered out of the attack-area
 			SetOrderTarget(nullptr);
-			SelectNewAreaAttackTargetOrPos(c);
+			SelectNewAreaAttackPos(c);
 		}
 	} else {
 		if (myPlane->aircraftState != AAirMoveType::AIRCRAFT_LANDED) {
 			inCommand = CMD_ATTACK;
 
-			SelectNewAreaAttackTargetOrPos(c);
+			SelectNewAreaAttackPos(c);
 		}
 	}
 }
@@ -544,7 +544,7 @@ void CAirCAI::BuggerOff(const float3& pos, float radius)
 }
 
 
-bool CAirCAI::SelectNewAreaAttackTargetOrPos(const Command& ac)
+bool CAirCAI::SelectNewAreaAttackPos(const Command& ac)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(ac.GetID() == CMD_AREA_ATTACK);

--- a/rts/Sim/Units/CommandAI/AirCAI.h
+++ b/rts/Sim/Units/CommandAI/AirCAI.h
@@ -27,7 +27,7 @@ public:
 //	void StopMove();
 
 	void ExecuteGuard(Command& c) override;
-	void ExecuteAreaAttack(Command& c);
+	void ExecuteAreaAttack(Command& c) override;
 	void ExecuteAttack(Command& c) override;
 	void ExecuteFight(Command& c) override;
 	void ExecuteMove(Command& c) override;

--- a/rts/Sim/Units/CommandAI/AirCAI.h
+++ b/rts/Sim/Units/CommandAI/AirCAI.h
@@ -36,7 +36,7 @@ public:
 
 private:
 	bool AirAutoGenerateTarget(AAirMoveType*);
-	bool SelectNewAreaAttackTargetOrPos(const Command& ac) override;
+	bool SelectNewAreaAttackPos(const Command& ac) override;
 	void PushOrUpdateReturnFight() {
 		CCommandAI::PushOrUpdateReturnFight(commandPos1, commandPos2);
 	}

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -979,13 +979,6 @@ void CCommandAI::ClearTargetLock(const Command &c) {
 void CCommandAI::GiveAllowedCommand(const Command& c, bool fromSynced)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (c.GetID() == CMD_AREA_ATTACK && c.GetNumParams() < 4) {
-		Command attackCmd(CMD_ATTACK, c.GetOpts());
-		attackCmd.CopyParams(c);
-		GiveAllowedCommand(attackCmd, fromSynced);
-		return;
-	}
-
 	if (ExecuteStateCommand(c))
 		return;
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1568,11 +1568,11 @@ void CCommandAI::ExecuteAreaAttack(Command& c)
 
 	groundAttackSalvosFired = 0;
 	inCommand = CMD_ATTACK;
-	SelectNewAreaAttackTargetOrPos(c);
+	SelectNewAreaAttackPos(c);
 }
 
 
-bool CCommandAI::SelectNewAreaAttackTargetOrPos(const Command& ac)
+bool CCommandAI::SelectNewAreaAttackPos(const Command& ac)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(ac.GetID() == CMD_AREA_ATTACK);
@@ -1852,7 +1852,7 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, boo
 		// positions in its circle; Repeat rotates completed queued circles.
 		// The return value says whether a new target was chosen.
 		if (haveAreaAttackCmd && groundAttackSalvoComplete && !orderFinished) {
-			orderFinished = !SelectNewAreaAttackTargetOrPos(c);
+			orderFinished = !SelectNewAreaAttackPos(c);
 		}
 	}
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -76,6 +76,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(repeatOrders),
 	CR_MEMBER(lastSelectedCommandPage),
 	CR_MEMBER(inCommand),
+	CR_MEMBER(groundAttackSalvosFired),
 	CR_MEMBER(commandDeathDependences),
 	CR_MEMBER(targetLostTimer),
 
@@ -93,6 +94,7 @@ CCommandAI::CCommandAI():
 	inCommand(CMD_STOP),
 	repeatOrders(false),
 	lastSelectedCommandPage(0),
+	groundAttackSalvosFired(0),
 	targetLostTimer(TARGET_LOST_TIMER)
 {}
 
@@ -107,6 +109,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 	inCommand(CMD_STOP),
 	repeatOrders(false),
 	lastSelectedCommandPage(0),
+	groundAttackSalvosFired(0),
 	targetLostTimer(TARGET_LOST_TIMER)
 {
 	{
@@ -131,6 +134,19 @@ CCommandAI::CCommandAI(CUnit* owner):
 		c.action    = "attack";
 		c.name      = "Attack";
 		c.tooltip   = c.name + ": Attacks a unit or a position on the ground";
+		c.mouseicon = c.name;
+		possibleCommands.push_back(commandDescriptionCache.GetPtr(std::move(c)));
+	}
+
+	if (owner->unitDef->canAreaAttack && IsAttackCapable()) {
+		SCommandDescription c;
+
+		c.id   = CMD_AREA_ATTACK;
+		c.type = CMDTYPE_ICON_AREA;
+
+		c.action    = "areaattack";
+		c.name      = "Area attack";
+		c.tooltip   = c.name + ": Attacks positions within a circle";
 		c.mouseicon = c.name;
 		possibleCommands.push_back(commandDescriptionCache.GetPtr(std::move(c)));
 	}
@@ -686,6 +702,11 @@ bool CCommandAI::AllowedCommand(const Command& c, bool fromSynced)
 	const bool aiOrder = !teamAIs.empty(); // assume no sharing with AI
 
 	switch (cmdID) {
+		case CMD_AREA_ATTACK: {
+			if (!ud->canAreaAttack || !IsAttackCapable())
+				return false;
+		} break;
+
 		case CMD_MANUALFIRE: {
 			if (!ud->canManualFire)
 				return false;
@@ -958,6 +979,13 @@ void CCommandAI::ClearTargetLock(const Command &c) {
 void CCommandAI::GiveAllowedCommand(const Command& c, bool fromSynced)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	if (c.GetID() == CMD_AREA_ATTACK && c.GetNumParams() < 4) {
+		Command attackCmd(CMD_ATTACK, c.GetOpts());
+		attackCmd.CopyParams(c);
+		GiveAllowedCommand(attackCmd, fromSynced);
+		return;
+	}
+
 	if (ExecuteStateCommand(c))
 		return;
 
@@ -1501,6 +1529,8 @@ void CCommandAI::ExecuteAttack(Command& c)
 			return;
 		}
 	} else {
+		groundAttackSalvosFired = 0;
+
 		if (c.GetNumParams() == 1) {
 			CUnit* targetUnit = unitHandler.GetUnit(c.GetParam(0));
 
@@ -1525,6 +1555,39 @@ void CCommandAI::ExecuteAttack(Command& c)
 			inCommand = CMD_ATTACK;
 		}
 	}
+}
+
+
+void CCommandAI::ExecuteAreaAttack(Command& c)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(owner->unitDef->canAreaAttack);
+
+	if (inCommand == CMD_ATTACK)
+		return;
+
+	groundAttackSalvosFired = 0;
+	inCommand = CMD_ATTACK;
+	SelectNewAreaAttackTargetOrPos(c);
+}
+
+
+bool CCommandAI::SelectNewAreaAttackTargetOrPos(const Command& ac)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(ac.GetID() == CMD_AREA_ATTACK);
+
+	if (ac.GetID() != CMD_AREA_ATTACK || ac.GetNumParams() < 4)
+		return false;
+
+	const float3& pos = ac.GetPos(0);
+	const float radius = ac.GetParam(3);
+
+	float3 attackPos = pos + (gsRNG.NextVector() * radius);
+	attackPos.y = CGround::GetHeightAboveWater(attackPos.x, attackPos.z);
+
+	owner->AttackGround(attackPos, !ac.IsInternalOrder(), false);
+	return true;
 }
 
 
@@ -1571,6 +1634,10 @@ void CCommandAI::SlowUpdate()
 		}
 		case CMD_ATTACK: {
 			ExecuteAttack(c);
+			return;
+		}
+		case CMD_AREA_ATTACK: {
+			ExecuteAreaAttack(c);
 			return;
 		}
 		case CMD_MANUALFIRE: {
@@ -1674,6 +1741,7 @@ void CCommandAI::FinishCommand()
 
 	inCommand = CMD_STOP;
 	targetDied = false;
+	groundAttackSalvosFired = 0;
 
 	SetOrderTarget(nullptr);
 	eoh->CommandFinished(*owner, cmd);
@@ -1754,27 +1822,36 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget, boo
 	bool orderFinished = false;
 
 	if (searchForNewTarget) {
+		bool groundAttackSalvoComplete = false;
+
+		if (haveGroundAttackCmd || haveAreaAttackCmd) {
+			groundAttackSalvosFired += 1;
+			groundAttackSalvoComplete = (groundAttackSalvosFired >= owner->unitDef->groundAttackSalvoSize);
+
+			if (groundAttackSalvoComplete)
+				groundAttackSalvosFired = 0;
+		}
+
 		// manual fire or attack commands with meta will only fire a single salvo
-		// noAutoTarget weapons finish an attack commands after a
-		// salvo if they have more orders queued
+		// Ground-attack commands finish after a salvo if they have more
+		// movement orders queued. The last ground attack remains active.
 		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY))
 			orderFinished = true;
 
-		if (weapon->noAutoTarget && !(c.GetOpts() & META_KEY) && haveGroundAttackCmd && HasMoreMoveCommands())
+		const bool advanceQueuedGroundAttack =
+			!(c.GetOpts() & META_KEY) &&
+			(haveGroundAttackCmd || haveAreaAttackCmd) &&
+			groundAttackSalvoComplete &&
+			HasMoreMoveCommands();
+
+		if (advanceQueuedGroundAttack)
 			orderFinished = true;
 
-		// if we have an area-attack command and this was the
-		// last salvo of our main weapon, assume we completed an attack
-		// (run) on one position and move to the next
-		//
-		// if we have >= 2 consecutive CMD_ATTACK's, then
-		//   SelectNAATP --> FinishCommand (inCommand=false) -->
-		//   SlowUpdate --> ExecuteAttack (inCommand=true) -->
-		//   queue has advanced
-		//
-		// @SelectNewAreaAttackTargetOrPos
-		// return argument says if a new area attack target was chosen, else finish current command
-		if (haveAreaAttackCmd) {
+		// A queued area attack advances after one configured salvo at its
+		// current random position. The final area attack keeps choosing new
+		// positions in its circle; Repeat rotates completed queued circles.
+		// The return value says whether a new target was chosen.
+		if (haveAreaAttackCmd && groundAttackSalvoComplete && !orderFinished) {
 			orderFinished = !SelectNewAreaAttackTargetOrPos(c);
 		}
 	}
@@ -1861,4 +1938,3 @@ void CCommandAI::StopAttackingAllyTeam(int ally)
 	RECOIL_DETAILED_TRACY_ZONE;
 	StopAttackingTargetIf([&](const CUnit* t) { return (t != nullptr && t->allyteam == ally); });
 }
-

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -88,6 +88,7 @@ public:
 	 * @brief Causes this CommandAI to execute the attack order c
 	 */
 	virtual void ExecuteAttack(Command& c);
+	virtual void ExecuteAreaAttack(Command& c);
 
 	/**
 	 * @brief executes the stop command c
@@ -132,11 +133,11 @@ public:
 	bool repeatOrders;
 	int lastSelectedCommandPage;
 	int inCommand;
+	int groundAttackSalvosFired;
 protected:
 	bool HandleBuildOptionInsertion(int cmdId);
 	bool HandleBuildOptionRemoval(int cmdId);
-	// return true by default so non-AirCAI's trigger FinishCommand
-	virtual bool SelectNewAreaAttackTargetOrPos(const Command& ac) { return true; }
+	virtual bool SelectNewAreaAttackTargetOrPos(const Command& ac);
 
 	bool IsAttackCapable() const;
 	bool SkipParalyzeTarget(const CUnit* target) const;

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -137,7 +137,7 @@ public:
 protected:
 	bool HandleBuildOptionInsertion(int cmdId);
 	bool HandleBuildOptionRemoval(int cmdId);
-	virtual bool SelectNewAreaAttackTargetOrPos(const Command& ac);
+	virtual bool SelectNewAreaAttackPos(const Command& ac);
 
 	bool IsAttackCapable() const;
 	bool SkipParalyzeTarget(const CUnit* target) const;

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -366,11 +366,12 @@ void CMobileCAI::Execute()
 	Command& c = commandQue.front();
 
 	switch (c.GetID()) {
-		case CMD_MOVE:      { ExecuteMove(c);     return; }
-		case CMD_PATROL:    { ExecutePatrol(c);   return; }
-		case CMD_FIGHT:     { ExecuteFight(c);    return; }
-		case CMD_GUARD:     { ExecuteGuard(c);    return; }
-		case CMD_LOAD_ONTO: { ExecuteLoadOnto(c); return; }
+		case CMD_MOVE:        { ExecuteMove(c);       return; }
+		case CMD_PATROL:      { ExecutePatrol(c);     return; }
+		case CMD_FIGHT:       { ExecuteFight(c);      return; }
+		case CMD_GUARD:       { ExecuteGuard(c);      return; }
+		case CMD_AREA_ATTACK: { ExecuteAreaAttack(c); return; }
+		case CMD_LOAD_ONTO:   { ExecuteLoadOnto(c);   return; }
 	}
 
 	if (owner->unitDef->IsTransportUnit()) {
@@ -966,6 +967,30 @@ void CMobileCAI::ExecuteAttack(Command& c)
 		ExecuteGroundAttack(c);
 		return;
 	}
+}
+
+
+void CMobileCAI::ExecuteAreaAttack(Command& c)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert(owner->unitDef->canAreaAttack);
+
+	const float3& pos = c.GetPos(0);
+	const float radius = c.GetParam(3);
+	const float goalRadius = std::max(owner->maxRange - radius, static_cast<float>(SQUARE_SIZE));
+
+	if (owner->pos.SqDistance2D(pos) > Square(goalRadius)) {
+		if (inCommand == CMD_ATTACK) {
+			owner->DropCurrentAttackTarget();
+			inCommand = CMD_STOP;
+		}
+
+		SetGoal(pos, owner->pos, goalRadius);
+		return;
+	}
+
+	StopMove();
+	CCommandAI::ExecuteAreaAttack(c);
 }
 
 

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -44,6 +44,7 @@ public:
 	void StopSlowGuard();
 	void StartSlowGuard(float speed);
 	void ExecuteAttack(Command& c) override;
+	void ExecuteAreaAttack(Command& c) override;
 	void ExecuteStop(Command& c) override;
 
 	virtual void Execute();

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -166,6 +166,8 @@ UnitDef::UnitDef()
 
 	, canmove(false)
 	, canAttack(false)
+	, canAreaAttack(false)
+	, groundAttackSalvoSize(1)
 	, canFight(false)
 	, canPatrol(false)
 	, canGuard(false)
@@ -383,6 +385,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	canPatrol    = udTable.GetBool("canPatrol",       true);
 	canGuard     = udTable.GetBool("canGuard",        true);
 	canRepeat    = udTable.GetBool("canRepeat",       true);
+	groundAttackSalvoSize = std::max(udTable.GetInt("groundAttackSalvoSize", 1), 1);
 	canCloak     = udTable.GetBool("canCloak",        (udTable.GetFloat("cloakCost", 0.0f) != 0.0f));
 	canSelfD     = udTable.GetBool("canSelfDestruct", true);
 	canKamikaze  = udTable.GetBool("kamikaze",        false);
@@ -633,6 +636,10 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 			}
 		}
 	}
+
+	// Preserve the historical default for strafing aircraft while allowing
+	// games to opt other unit types into the native area-attack command.
+	canAreaAttack = udTable.GetBool("canAreaAttack", IsStrafingAirUnit());
 
 	if (IsAirUnit()) {
 		if (IsFighterAirUnit() || IsBomberAirUnit()) {
@@ -908,4 +915,3 @@ bool UnitDef::HasBomberWeapon(unsigned int idx) const {
 	assert(HasWeapon(idx));
 	return (weapons[idx].def->IsAircraftWeapon());
 }
-

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -637,8 +637,6 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 		}
 	}
 
-	// Preserve the historical default for strafing aircraft while allowing
-	// games to opt other unit types into the native area-attack command.
 	canAreaAttack = udTable.GetBool("canAreaAttack", IsStrafingAirUnit());
 
 	if (IsAirUnit()) {

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -279,6 +279,8 @@ public:
 	// order-capabilities for CommandAI
 	bool canmove;
 	bool canAttack;
+	bool canAreaAttack;
+	int groundAttackSalvoSize;
 	bool canFight;
 	bool canPatrol;
 	bool canGuard;


### PR DESCRIPTION
Closes #1032.

## Summary

- Add `canAreaAttack` as an opt-in UnitDef property for non-aircraft while preserving the historical default for strafing aircraft.
- Move area-attack execution into the shared command AI so static and mobile ground units can select random ground targets inside the commanded circle.
- Add `groundAttackSalvoSize` to control how many ground shots are fired before advancing to the next queued area attack.
- Support queue progression, Repeat, movement into range, and native command rendering for ground area attacks.

Regular `CMD_ATTACK` input and execution are not converted into area attack. Games must explicitly set `canAreaAttack` for non-aircraft, so existing unit behavior remains unchanged by default. The BAR UnitDef opt-ins and removal of its Lua workaround are intentionally separate in companion PR [Beyond-All-Reason #8890](https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8890).

## Videos

Queuing and Repeat now work as expected with ground attacks:

https://github.com/user-attachments/assets/5f39c6df-0e6d-46ef-8eb7-c04f4c995b18

Fixes [Beyond-All-Reason #8774](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8774).

Area Attack now works engine-side:

https://github.com/user-attachments/assets/ab61ef2e-3d89-4dc1-b2d3-0ce795abe7d3

Fixes [Beyond-All-Reason #8772](https://github.com/beyond-all-reason/Beyond-All-Reason/issues/8772).

## Testing

- Built `engine-legacy` successfully with the supported Linux container build.
- Manually tested in BAR
- Verified regular point/unit attack behavior remains available.
- Verified explicit area attack selects changing ground targets within the circle.
- Verified Shift-queued circles advance after the configured salvo and Repeat cycles the queue.
- Verified the final non-repeating area command remains active and command circles/current ground targets render.
- Verified existing aircraft area attack remains available.
- Ran `git diff --check`.

## AI disclosure

OpenAI Codex assisted with implementation, review, build/test orchestration, and drafting this PR. I reviewed the changes and manually verified the behavior in-game before submission.
