### PR TITLE
Fail broken savegame loads with an error

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1037,6 +1037,12 @@ void CGame::KillSimulation()
 	RECOIL_DETAILED_TRACY_ZONE;
 	LOG("[Game::%s][1]", __func__);
 
+	// a failed load leaves half-initialized objects behind, freeing them crashes
+	if (spring::exitCode == spring::EXIT_CODE_NOLOAD && gu->globalQuit) {
+		LOG_L(L_WARNING, "[Game::%s] simulation never finished loading, leaking it", __func__);
+		return;
+	}
+
 	// Kill all teams that are still alive, in
 	// case the game did not do so through Lua.
 	//

--- a/rts/System/creg/Serializer.cpp
+++ b/rts/System/creg/Serializer.cpp
@@ -13,6 +13,7 @@
 #include "System/Log/ILog.h"
 #include "System/Platform/byteorder.h"
 #include "System/Exceptions.h"
+#include "System/StringUtil.h"
 
 #include <algorithm>
 #include <fstream>
@@ -415,11 +416,9 @@ CInputStreamSerializer::CInputStreamSerializer()
 
 CInputStreamSerializer::~CInputStreamSerializer()
 {
-	for (StoredObject& o: objects) {
-		if (o.obj) {
-			classRefs[o.classRef]->DeleteInstance(o.obj);
-		}
-	}
+	// the entries are live or half-initialized objects, deleting either crashes
+	if (!objects.empty())
+		LOG_L(L_WARNING, "[creg::%s] load failed, leaking %d partially loaded objects", __func__, int(objects.size()));
 }
 
 bool CInputStreamSerializer::IsWriting()
@@ -476,6 +475,8 @@ void CInputStreamSerializer::SerializeObjectPtr(void** ptr, creg::Class* cls)
 {
 	unsigned int id;
 	ReadVarSizeUInt(stream, &id);
+	if (id >= objects.size())
+		throw content_error("Save corrupted: object reference " + IntToString(id) + " out of range (" + IntToString(objects.size()) + " objects)");
 	if (id) {
 		StoredObject& o = objects [id];
 		if (o.obj) *ptr = o.obj;
@@ -501,7 +502,13 @@ void CInputStreamSerializer::SerializeObjectInstance(void* inst, creg::Class* cl
 	if (id == 0)
 		return; // this is old save game and it has not this object - skip it
 
+	if (id >= objects.size())
+		throw content_error("Save corrupted: instance reference " + IntToString(id) + " out of range (" + IntToString(objects.size()) + " objects)");
+
 	StoredObject& o = objects[id];
+	creg::Class* fileCls = classRefs[o.classRef];
+	if (fileCls != cls)
+		throw content_error(std::string("Save incompatible: file contains ") + fileCls->name + " where " + cls->name + " was expected (the save was made with different settings)");
 	assert(!o.obj);
 	assert(o.isEmbedded);
 
@@ -637,6 +644,8 @@ void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Cla
 
 		creg::Class* cls = classRefs[object.classRef];
 		SerializeObject(cls, object.obj);
+		if (stream->fail())
+			throw content_error(std::string("Save corrupted: stream exhausted while reading ") + cls->name);
 		LOG_SL(LOG_SECTION_CREG_SERIALIZER, L_DEBUG, "Deserialized %s size:%i", cls->name, cls->size);
 	}
 


### PR DESCRIPTION
Loading a corrupted or settings incompatible save currently either crashes or hangs forever. I hit both on my own saves while debugging #3270.

Object references from the stream now get bounds checked against the object table, the stored class is compared with the expected one, and the stream state is checked after each object, so a broken save stops loading and reports a content_error. On my save the error was "instance reference 1121925726 out of range (436885 objects)"

The serializer dtor used to delete every table entry during unwinding and that crashed on live engine objects, now it deletes nothing and just warns how many objects leaked, a failed load stays a dead end, but with an error. Possibly the case in #611, the save there hangs on load waiting for an exception that this PR would throw, I couldn't test that save, the link is dead.

Same on the way out,KillSimulation now skips a sim that never finished loading, so the whole thing ends with the error dialog and a normal exit