### PR TITLE
Stop saving the ground decal drawer

### DIFF
--- a/rts/System/LoadSave/CregLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/CregLoadSaveHandler.cpp
@@ -19,7 +19,6 @@
 #include "Net/GameServer.h"
 #include "Rendering/Textures/ColorMap.h"
 #include "Rendering/Units/UnitDrawer.h"
-#include "Rendering/Env/Decals/GroundDecalHandler.h"
 #include "Sim/Ecs/Helper.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Units/UnitHandler.h"
@@ -112,7 +111,6 @@ void CGameStateCollector::Serialize(creg::ISerializer* s)
 	mapType->Serialize(s, &CSplitLuaHandle::gameParams);
 
 	s->SerializeObjectInstance(CUnitDrawer::modelDrawerData->GetSavedData(), CUnitDrawer::modelDrawerData->GetSavedData()->GetClass());
-	s->SerializeObjectInstance(groundDecals, groundDecals->GetClass());
 }
 
 


### PR DESCRIPTION
Follow up from #3277, the decal patch. Old saves with decal data will not load, with #3277 that shows up as a clean "Save incompatible" error, without it they desync

Maybe losing scars over a save is unacceptable, I can offer an alternative: a read side switch on the class stored in the file, or an always alive decal data object plus render only drawers
