### PR TITLE
Destroy loader created objects on failed load

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1037,6 +1037,12 @@ void CGame::KillSimulation()
 	RECOIL_DETAILED_TRACY_ZONE;
 	LOG("[Game::%s][1]", __func__);
 
+	// a failed load leaves half-initialized objects behind, freeing them crashes
+	if (spring::exitCode == spring::EXIT_CODE_NOLOAD && gu->globalQuit) {
+		LOG_L(L_WARNING, "[Game::%s] simulation never finished loading, leaking it", __func__);
+		return;
+	}
+
 	// Kill all teams that are still alive, in
 	// case the game did not do so through Lua.
 	//

--- a/rts/Game/WaitCommandsAI.cpp
+++ b/rts/Game/WaitCommandsAI.cpp
@@ -537,7 +537,9 @@ CWaitCommandsAI::TimeWait::TimeWait(int _duration, CUnit* _unit)
 	duration = _duration;
 	factory = false;
 
-	AddDeathDependence(unit, DEPENDENCE_WAITCMD);
+	// creg
+	if (unit != nullptr)
+		AddDeathDependence(unit, DEPENDENCE_WAITCMD);
 }
 
 

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -94,7 +94,7 @@ CFeature::~CFeature()
 	UnBlock();
 	quadField.RemoveFeature(this);
 
-	if (!def->geoThermal)
+	if (def == nullptr || !def->geoThermal)
 		return;
 
 	CGeoThermSmokeProjectile::GeoThermDestroyed(this);

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -539,6 +539,10 @@ CGroundMoveType::CGroundMoveType(CUnit* owner):
 
 CGroundMoveType::~CGroundMoveType()
 {
+	// creg
+	if (owner == nullptr)
+		return;
+
 	Disconnect();
 
 	if (nextPathId != 0) {

--- a/rts/Sim/MoveTypes/ScriptMoveType.cpp
+++ b/rts/Sim/MoveTypes/ScriptMoveType.cpp
@@ -71,6 +71,10 @@ CScriptMoveType::CScriptMoveType(CUnit* unit): AMoveType(unit)
 CScriptMoveType::~CScriptMoveType()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// creg
+	if (owner == nullptr)
+		return;
+
 	// clean up if noBlocking was made true at
 	// some point during this script's lifetime
 	// and not reset

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.cpp
@@ -183,7 +183,8 @@ CWeaponProjectile::CWeaponProjectile(const ProjectileParams& params)
 CWeaponProjectile::~CWeaponProjectile()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	DynDamageArray::DecRef(damages);
+	if (damages != nullptr)
+		DynDamageArray::DecRef(damages);
 }
 
 

--- a/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
+++ b/rts/Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h
@@ -76,7 +76,7 @@ public:
 	const DynDamageArray* damages;
 
 protected:
-	CWeaponProjectile() { }
+	CWeaponProjectile(): damages(nullptr) { }
 	void UpdateInterception();
 	virtual void UpdateGroundBounce();
 

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -216,6 +216,10 @@ CBuilderCAI::CBuilderCAI(CUnit* owner):
 CBuilderCAI::~CBuilderCAI()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// creg
+	if (owner == nullptr)
+		return;
+
 	CBuilderCaches::RemoveUnitFromReclaimers(owner);
 	CBuilderCaches::RemoveUnitFromFeatureReclaimers(owner);
 	CBuilderCaches::RemoveUnitFromResurrecters(owner);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -256,7 +256,9 @@ CMobileCAI::CMobileCAI(CUnit* owner):
 
 CMobileCAI::~CMobileCAI()
 {
-	SetTransportee(nullptr);
+	// creg
+	if (owner != nullptr)
+		SetTransportee(nullptr);
 }
 
 

--- a/rts/Sim/Units/UnitTypes/ExtractorBuilding.cpp
+++ b/rts/Sim/Units/UnitTypes/ExtractorBuilding.cpp
@@ -37,7 +37,9 @@ float CExtractorBuilding::maxExtractionRange = 0.0f;
 
 CExtractorBuilding::~CExtractorBuilding()
 {
-	ResetExtraction();
+	// creg
+	if (script != nullptr)
+		ResetExtraction();
 }
 
 void CExtractorBuilding::PreInit(const UnitLoadParams& params)

--- a/rts/Sim/Weapons/PlasmaRepulser.cpp
+++ b/rts/Sim/Weapons/PlasmaRepulser.cpp
@@ -100,7 +100,8 @@ CPlasmaRepulser::~CPlasmaRepulser()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	quadField.RemoveRepulser(this);
-	sscPool.RemoveCollection(this);
+	if (weaponDef != nullptr)
+		sscPool.RemoveCollection(this);
 }
 
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -208,9 +208,10 @@ CWeapon::~CWeapon()
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	assert(weaponMemPool.mapped(this));
-	DynDamageArray::DecRef(damages);
+	if (damages != nullptr)
+		DynDamageArray::DecRef(damages);
 
-	if (weaponDef->interceptor)
+	if (weaponDef != nullptr && weaponDef->interceptor)
 		interceptHandler.RemoveInterceptorWeapon(this);
 }
 

--- a/rts/System/creg/SerializeLuaState.cpp
+++ b/rts/System/creg/SerializeLuaState.cpp
@@ -48,12 +48,11 @@ private:
 	lua_State* mainthread;
 };
 
+// the target lua_State owns these allocations
 void freeProtector(void *m) {
-	assert(false);
 }
 
 void* allocProtector(size_t size) {
-	assert(false);
 	return nullptr;
 }
 

--- a/rts/System/creg/Serializer.cpp
+++ b/rts/System/creg/Serializer.cpp
@@ -13,6 +13,7 @@
 #include "System/Log/ILog.h"
 #include "System/Platform/byteorder.h"
 #include "System/Exceptions.h"
+#include "System/StringUtil.h"
 
 #include <algorithm>
 #include <fstream>
@@ -415,11 +416,9 @@ CInputStreamSerializer::CInputStreamSerializer()
 
 CInputStreamSerializer::~CInputStreamSerializer()
 {
-	for (StoredObject& o: objects) {
-		if (o.obj) {
-			classRefs[o.classRef]->DeleteInstance(o.obj);
-		}
-	}
+	// the entries are live or half-initialized objects, deleting either crashes
+	if (!objects.empty())
+		LOG_L(L_WARNING, "[creg::%s] load failed, leaking %d partially loaded objects", __func__, int(objects.size()));
 }
 
 bool CInputStreamSerializer::IsWriting()
@@ -476,6 +475,8 @@ void CInputStreamSerializer::SerializeObjectPtr(void** ptr, creg::Class* cls)
 {
 	unsigned int id;
 	ReadVarSizeUInt(stream, &id);
+	if (id >= objects.size())
+		throw content_error("Save corrupted: object reference " + IntToString(id) + " out of range (" + IntToString(objects.size()) + " objects)");
 	if (id) {
 		StoredObject& o = objects [id];
 		if (o.obj) *ptr = o.obj;
@@ -501,7 +502,13 @@ void CInputStreamSerializer::SerializeObjectInstance(void* inst, creg::Class* cl
 	if (id == 0)
 		return; // this is old save game and it has not this object - skip it
 
+	if (id >= objects.size())
+		throw content_error("Save corrupted: instance reference " + IntToString(id) + " out of range (" + IntToString(objects.size()) + " objects)");
+
 	StoredObject& o = objects[id];
+	creg::Class* fileCls = classRefs[o.classRef];
+	if (fileCls != cls)
+		throw content_error(std::string("Save incompatible: file contains ") + fileCls->name + " where " + cls->name + " was expected (the save was made with different settings)");
 	assert(!o.obj);
 	assert(o.isEmbedded);
 
@@ -637,6 +644,8 @@ void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Cla
 
 		creg::Class* cls = classRefs[object.classRef];
 		SerializeObject(cls, object.obj);
+		if (stream->fail())
+			throw content_error(std::string("Save corrupted: stream exhausted while reading ") + cls->name);
 		LOG_SL(LOG_SECTION_CREG_SERIALIZER, L_DEBUG, "Deserialized %s size:%i", cls->name, cls->size);
 	}
 

--- a/rts/System/creg/Serializer.cpp
+++ b/rts/System/creg/Serializer.cpp
@@ -537,6 +537,23 @@ void CallPostLoad(creg::Class* c, creg::Class* oc, void* obj)
 	}
 }
 
+void CInputStreamSerializer::UnwindConstructedObjects()
+{
+	// preallocated objects must be destructed before their containers are freed
+	for (auto it = constructionOrder.rbegin(); it != constructionOrder.rend(); ++it) {
+		StoredObject& o = objects[*it];
+		Class* c = classRefs[o.classRef];
+
+		if (o.isPrealloced) {
+			c->DestructInstance(o.obj);
+		} else {
+			c->DeleteInstance(o.obj);
+		}
+	}
+	constructionOrder.clear();
+	objects.clear();
+}
+
 void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Class*& rootCls)
 {
 	PackageHeader ph;
@@ -546,6 +563,10 @@ void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Cla
 
 	if (memcmp(ph.magic, CREG_PACKAGE_FILE_ID, 4) != 0)
 		throw content_error("Incorrect object package file ID");
+
+	// the table always holds the dummy and the root object
+	if (ph.numObjects < 2)
+		throw content_error("Save corrupted: object table too small");
 
 	// Load references
 	classRefs.resize(ph.numObjClassRefs);
@@ -572,67 +593,97 @@ void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Cla
 	}
 
 	// Create all non-embedded objects
+	s->seekg(0, std::ios::end);
+	const size_t streamSize = s->tellg();
 	s->seekg(ph.objTableOffset);
 	objects.resize(ph.numObjects);
 
-	struct PreallocObj {
-		size_t size;
-		int contID;
-		size_t offset;
-	};
-	std::map<int, PreallocObj> preallocObjs;  // objID -> PreallocObj
+	try {
+		struct PreallocObj {
+			size_t size;
+			int contID;
+			size_t offset;
+		};
+		std::map<int, PreallocObj> preallocObjs;  // objID -> PreallocObj
 
-	for (int a = 0; a < ph.numObjects; a++) {
-		unsigned int classRefIndex;
-		char isEmbedded;
+		for (int a = 0; a < ph.numObjects; a++) {
+			unsigned int classRefIndex;
+			char isEmbedded;
 
-		ReadVarSizeUInt(stream, &classRefIndex);
-		stream->read((char*)&isEmbedded, sizeof(char));
-		Class* c = classRefs[classRefIndex];
+			ReadVarSizeUInt(stream, &classRefIndex);
+			stream->read((char*)&isEmbedded, sizeof(char));
+			if (stream->fail())
+				throw content_error("Save corrupted: object table truncated");
+			if (classRefIndex >= classRefs.size())
+				throw content_error("Save corrupted: invalid class reference " + IntToString(classRefIndex));
+			Class* c = classRefs[classRefIndex];
 
-		objects[a].obj = nullptr;
+			objects[a].obj = nullptr;
+			objects[a].size = 0;
+			objects[a].isPrealloced = false;
 
-		if (!isEmbedded) {
-			size_t size = c->size;
+			if (!isEmbedded) {
+				if (c->constructor == nullptr)
+					throw content_error("Save corrupted: object of abstract class " + std::string(c->name));
 
-			if (c->HasGetSize())
-				ReadVarSizeUInt(stream, &size);
+				size_t size = c->size;
 
-			if (c->HasPrealloc()) {
-				PreallocObj po;
-				po.size = size;
-				ReadVarSizeUInt(stream, &po.contID);
-				ReadVarSizeUInt(stream, &po.offset);
-				// Postpone objects with placement-new
-				preallocObjs[a] = po;
-			} else {
-				// Allocate and construct
-				objects[a].obj = c->CreateInstance(size);
+				if (c->HasGetSize()) {
+					ReadVarSizeUInt(stream, &size);
+					if (size > streamSize)
+						throw content_error("Save corrupted: oversized object of class " + std::string(c->name));
+				}
+
+				objects[a].size = size;
+
+				if (c->HasPrealloc()) {
+					PreallocObj po;
+					po.size = size;
+					ReadVarSizeUInt(stream, &po.contID);
+					ReadVarSizeUInt(stream, &po.offset);
+					if (po.contID < 0 || po.contID >= ph.numObjects)
+						throw content_error("Save corrupted: prealloc container reference out of range");
+					// Postpone objects with placement-new
+					preallocObjs[a] = po;
+				} else {
+					// Allocate and construct
+					objects[a].obj = c->CreateInstance(size);
+					constructionOrder.push_back(a);
+				}
+			}
+
+			objects[a].isEmbedded = !!isEmbedded;
+			objects[a].classRef = classRefIndex;
+		}
+
+		size_t numPreallocs = 0;  // in case of nested preallocation containers
+		while (numPreallocs != preallocObjs.size()) {
+			numPreallocs = preallocObjs.size();
+			const auto pro = preallocObjs;
+			for (const auto& kv : pro) {
+				const PreallocObj& po = kv.second;
+				void* container = objects[po.contID].obj;
+				if (container == nullptr)  // parent container wasn't created yet
+					continue;
+				StoredObject& so = objects[kv.first];
+				Class* c = classRefs[so.classRef];
+				const size_t contSize = objects[po.contID].size;
+				if (po.offset > contSize || po.size > contSize - po.offset)
+					throw content_error("Save corrupted: prealloc object outside container");
+				// Allocate with placement-new and construct
+				so.obj = c->CreateInstance(po.size, (char*)container + po.offset);
+				so.isPrealloced = true;
+				constructionOrder.push_back(kv.first);
+				preallocObjs.erase(kv.first);
 			}
 		}
-
-		objects[a].isEmbedded = !!isEmbedded;
-		objects[a].classRef = classRefIndex;
+		if (!preallocObjs.empty())
+			throw std::string("Placement-new error: Referencing non-serialized container");
+	} catch (...) {
+		// every created object is still default constructed
+		UnwindConstructedObjects();
+		throw;
 	}
-
-	size_t numPreallocs = 0;  // in case of nested preallocation containers
-	while (numPreallocs != preallocObjs.size()) {
-		numPreallocs = preallocObjs.size();
-		const auto pro = preallocObjs;
-		for (const auto& kv : pro) {
-			const PreallocObj& po = kv.second;
-			void* container = objects[po.contID].obj;
-			if (container == nullptr)  // parent container wasn't created yet
-				continue;
-			StoredObject& so = objects[kv.first];
-			Class* c = classRefs[so.classRef];
-			// Allocate with placement-new and construct
-			so.obj = c->CreateInstance(po.size, (char*)container + po.offset);
-			preallocObjs.erase(kv.first);
-		}
-	}
-	if (!preallocObjs.empty())
-		throw std::string("Placement-new error: Referencing non-serialized container");
 
 	const int endOffset = s->tellg();
 
@@ -678,6 +729,7 @@ void CInputStreamSerializer::LoadPackage(std::istream* s, void*& root, creg::Cla
 	s->seekg(endOffset);
 
 	unfixedPointers.clear();
+	constructionOrder.clear();
 	objects.clear();
 }
 

--- a/rts/System/creg/Serializer.h
+++ b/rts/System/creg/Serializer.h
@@ -146,9 +146,14 @@ namespace creg {
 		{
 			void* obj;
 			int classRef;
+			size_t size;
 			bool isEmbedded;
+			bool isPrealloced;
 		};
 		std::vector<StoredObject> objects;
+		std::vector<unsigned> constructionOrder; // ids of loader created objects
+
+		void UnwindConstructedObjects();
 
 		struct PostLoadCallback
 		{

--- a/rts/System/creg/creg.cpp
+++ b/rts/System/creg/creg.cpp
@@ -187,7 +187,8 @@ void* Class::CreateInstance(size_t size)
 {
 	void* inst;
 	if (poolAlloc != nullptr) {
-		inst = poolAlloc(size);
+		if ((inst = poolAlloc(size)) == nullptr)
+			throw std::bad_alloc();
 	} else {
 		inst = ::operator new(size, std::align_val_t{(size_t)alignment});
 		isAlignableAddress = true;
@@ -207,6 +208,12 @@ void* Class::CreateInstance(size_t size, void* addr)
 		constructor(inst);
 
 	return inst;
+}
+
+void Class::DestructInstance(void* inst)
+{
+	if (destructor != nullptr)
+		destructor(inst);
 }
 
 void Class::DeleteInstance(void* inst)

--- a/rts/System/creg/creg.h
+++ b/rts/System/creg/creg.h
@@ -100,6 +100,7 @@ namespace creg {
 		void* CreateInstance(size_t size);
 		void* CreateInstance(size_t size, void* addr);
 		void DeleteInstance(void* inst);
+		void DestructInstance(void* inst);
 
 		/// Calculate a checksum from the class metadata
 		void CalculateChecksum(unsigned int& checksum);


### PR DESCRIPTION
Follow up to #3277. While no object data was read yet, everything created is deleted in reverse order on failure, with no leak. A failure during data reading keeps the old path, those objects are not safe to delete. The object table fields read from the file are validated, broken values throw content_error

Tested on a save with 109k objects, corrupting the table in different places gives a clean error, an intact save still loads. The branch is on top of #3277.