### PR TITLE
Fix AircraftBomb ground attack completion after target loss

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -819,6 +819,12 @@ void CWeapon::HoldIfTargetInvalid()
 		return;
 
 	if (!TryTarget(currentTarget)) {
+		// BombDroppers must retain ground targets until their active salvo ends.
+		// Dropping one after the aircraft passes the target prevents the CAI from
+		// associating the completed salvo with its current attack command.
+		if (noAutoTarget && HavePosTarget() && salvoLeft > 0)
+			return;
+
 		DropCurrentTarget();
 		return;
 	}


### PR DESCRIPTION
Fixes #1173.

AircraftBomb weapons can reject and clear their positional target after passing it while a multi-shot salvo is still active. The remaining bombs continue to fire, but the completed salvo no longer matches the unit's current command target. CommandAI is therefore not notified that the salvo completed, leaving the queued ground-attack command active.

Keep positional targets on `noAutoTarget` weapons while their active salvo still has shots remaining. This preserves the existing `currentTarget == owner->curTarget` completion guard, so completion of an old salvo cannot finish a replacement attack command.

Reproducer Script

[issue-3609-reproducer.zip](https://github.com/user-attachments/files/31479160/issue-3609-reproducer.zip)

Without this PR:

https://github.com/user-attachments/assets/3ff4d247-10e4-408f-ba37-ca7a31c2c488

Notice: One bomber does not advance to the next command, instead returns and fires again.

With this PR:

https://github.com/user-attachments/assets/31d6346b-67e9-49c0-9490-d20c09a6c540

All bombers advance to the next command.

Testing:
- Forge v2.3 with BAR 79192dc90acedd3199f239823d5b5ff83c5ade80
- Deterministic 50-armthund headless reproducer: before the fix, 8/50 repeated the first attack and one made three runs
- Identical headless run after the revised fix: 0/50 repeated and every bomber made exactly one run at the first target
- Replacement-command regression: start attack A, replace it with attack B during A's salvo, then queue a move. The initial broad fix skipped B (0 runs); the revised fix executes B exactly once
- Fullscreen graphical run with 10 selected armthund, camera centered on the target before ground attack, then Shift-move before any bomb release: 0/10 repeated and all continued to the move target
- Graphical behavior was manually verified by eun-ice

AI disclosure: OpenAI Codex was used extensively to create the reproducer, instrument and diagnose the engine behavior, implement and revise the change, run the headless and graphical tests, and draft this pull request. The reported graphical behavior was manually verified by eun-ice. No AI-generated media is attached.
