### PR TITLE
Override map gravity mod rule

### DIFF
--- a/doc/pr-changelogs/3283.md
+++ b/doc/pr-changelogs/3283.md
@@ -1,0 +1,1 @@
+ * add `system.forcedMapGravityStrength` modrule. If set, it overrides the map's `gravity` (same units, elmo/s^2) everywhere the engine uses it, including `Game.gravity`. Unset (nil) keeps the map value.

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -4,6 +4,7 @@
 #include "MapInfo.h"
 
 #include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/ModInfo.h"
 #include "Rendering/GlobalRendering.h"
 
 #include "Lua/LuaParser.h"
@@ -97,7 +98,7 @@ void CMapInfo::ReadGlobal()
 	map.hardness      = topTable.GetFloat("maphardness", 100.0f);
 	map.notDeformable = topTable.GetBool("notDeformable", false);
 
-	map.gravity = topTable.GetFloat("gravity", 130.0f);
+	map.gravity = (modInfo.overrideMapGravity) ? modInfo.forcedMapGravityStrength : topTable.GetFloat("gravity", CModInfo::DEFAULT_MAP_GRAVITY);
 	map.gravity = std::max(0.001f, map.gravity);
 	map.gravity = -map.gravity / (GAME_SPEED * GAME_SPEED);
 

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -98,7 +98,7 @@ void CMapInfo::ReadGlobal()
 	map.hardness      = topTable.GetFloat("maphardness", 100.0f);
 	map.notDeformable = topTable.GetBool("notDeformable", false);
 
-	map.gravity = (modInfo.overrideMapGravity) ? modInfo.forcedMapGravityStrength : topTable.GetFloat("gravity", CModInfo::DEFAULT_MAP_GRAVITY);
+	map.gravity = modInfo.forcedMapGravityStrength.value_or(topTable.GetFloat("gravity", 130.0f));
 	map.gravity = std::max(0.001f, map.gravity);
 	map.gravity = -map.gravity / (GAME_SPEED * GAME_SPEED);
 

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -138,6 +138,8 @@ void CModInfo::ResetState()
 		qtMaxNodesSearchedRelativeToMapOpenNodes = 0.25;
 
 		enableSmoothMesh = true;
+		overrideMapGravity = false;
+		forcedMapGravityStrength = CModInfo::DEFAULT_MAP_GRAVITY;
 		smoothMeshResDivider = 2;
 		smoothMeshSmoothRadius = 40;
 		quadFieldQuadSizeInElmos = 128;
@@ -199,6 +201,8 @@ void CModInfo::Init(const std::string& modFileName)
 		qtMaxNodesSearchedRelativeToMapOpenNodes = system.GetFloat("qtMaxNodesSearchedRelativeToMapOpenNodes", qtMaxNodesSearchedRelativeToMapOpenNodes);
 
 		enableSmoothMesh = system.GetBool("enableSmoothMesh", enableSmoothMesh);
+		overrideMapGravity = system.GetBool("overrideMapGravity", overrideMapGravity);
+		forcedMapGravityStrength = system.GetFloat("forcedMapGravityStrength", forcedMapGravityStrength);
 		smoothMeshResDivider = system.GetInt("smoothMeshResDivider", smoothMeshResDivider);
 		smoothMeshSmoothRadius = system.GetInt("smoothMeshSmoothRadius", smoothMeshSmoothRadius);
 

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -138,8 +138,7 @@ void CModInfo::ResetState()
 		qtMaxNodesSearchedRelativeToMapOpenNodes = 0.25;
 
 		enableSmoothMesh = true;
-		overrideMapGravity = false;
-		forcedMapGravityStrength = CModInfo::DEFAULT_MAP_GRAVITY;
+		forcedMapGravityStrength.reset();
 		smoothMeshResDivider = 2;
 		smoothMeshSmoothRadius = 40;
 		quadFieldQuadSizeInElmos = 128;
@@ -201,8 +200,8 @@ void CModInfo::Init(const std::string& modFileName)
 		qtMaxNodesSearchedRelativeToMapOpenNodes = system.GetFloat("qtMaxNodesSearchedRelativeToMapOpenNodes", qtMaxNodesSearchedRelativeToMapOpenNodes);
 
 		enableSmoothMesh = system.GetBool("enableSmoothMesh", enableSmoothMesh);
-		overrideMapGravity = system.GetBool("overrideMapGravity", overrideMapGravity);
-		forcedMapGravityStrength = system.GetFloat("forcedMapGravityStrength", forcedMapGravityStrength);
+		if (system.GetType("forcedMapGravityStrength") == LuaTable::NUMBER)
+			forcedMapGravityStrength = system.GetFloat("forcedMapGravityStrength", 0.0f);
 		smoothMeshResDivider = system.GetInt("smoothMeshResDivider", smoothMeshResDivider);
 		smoothMeshSmoothRadius = system.GetInt("smoothMeshSmoothRadius", smoothMeshSmoothRadius);
 

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -234,6 +234,9 @@ public:
 
 	bool enableSmoothMesh;
 
+	bool overrideMapGravity; // Enable to override the map gravity, with the value in forcedMapGravityStrength.
+	float forcedMapGravityStrength; // If overrideMapGravity is true, then use this value for the gravity strength. Otherwise, use the map's gravity. Default's to 130.0f, which is the default map gravity.
+
 	/// Reduce the resolution of the smooth mesh by the divider value. Increasing the value reduces
 	/// the accuracy of the smooth mesh, but improves performance. Minimum 1, default 2.
 	int smoothMeshResDivider;
@@ -254,6 +257,8 @@ public:
 
 	// If true, players can select their start position by clicking the map
 	bool useStartPositionSelecter;
+
+	static constexpr float DEFAULT_MAP_GRAVITY = 130.0f;
 };
 
 extern CModInfo modInfo;

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -3,6 +3,7 @@
 #ifndef MOD_INFO_H
 #define MOD_INFO_H
 
+#include <optional>
 #include <string>
 #include "Sim/Misc/Resource.h"
 #include "Sim/Path/PFSTypes.h"
@@ -234,8 +235,8 @@ public:
 
 	bool enableSmoothMesh;
 
-	bool overrideMapGravity; // Enable to override the map gravity, with the value in forcedMapGravityStrength.
-	float forcedMapGravityStrength; // If overrideMapGravity is true, then use this value for the gravity strength. Otherwise, use the map's gravity. Default's to 130.0f, which is the default map gravity.
+	/// If set, overrides the map's gravity (in elmo/s^2, same units as mapinfo `gravity`).
+	std::optional<float> forcedMapGravityStrength;
 
 	/// Reduce the resolution of the smooth mesh by the divider value. Increasing the value reduces
 	/// the accuracy of the smooth mesh, but improves performance. Minimum 1, default 2.
@@ -257,8 +258,6 @@ public:
 
 	// If true, players can select their start position by clicking the map
 	bool useStartPositionSelecter;
-
-	static constexpr float DEFAULT_MAP_GRAVITY = 130.0f;
 };
 
 extern CModInfo modInfo;


### PR DESCRIPTION
A clean way to override map gravity. There's aspects of how gravity is used that the game cannot reach itself. Rather than case down all the corner cases and have override code in Lua, a simple mod rule override could be used to set the gravity without any ambiguity.