### PR TITLE
Make Spring.GetCEGID return nil for undefined CEGs

### DIFF
--- a/doc/pr-changelogs/3284.md
+++ b/doc/pr-changelogs/3284.md
@@ -1,0 +1,5 @@
+### Caveats
+ * `Spring.GetCEGID` no longer returns an ID for lazy-loaded CEGs before they are actually loaded (these are the ones not referenced by any defs and only spawnable via Lua).
+
+### Fixes
+ * fixed a potential desync caused by calls to `Spring.GetCEGID` from unsynced changing what is returned in synced (it used to assign new IDs for every invalid request).

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -6080,13 +6080,20 @@ int LuaSyncedRead::GetUnitDefDimensions(lua_State* L)
 
 
 /***
- *
+ * Returns the ID of a custom explosion generator by its name.
  * @function Spring.GetCEGID
- * @return integer cegID
+ * @param cegName string
+ * @return integer? cegID
  */
 int LuaSyncedRead::GetCEGID(lua_State* L)
 {
-	lua_pushnumber(L, explGenHandler.LoadCustomGeneratorID(luaL_checkstring(L, 1)));
+
+	const char* cegName = luaL_checkstring(L, 1);
+	if (explGenHandler.IsCustomGeneratorDefined(cegName)) {
+		lua_pushnumber(L, explGenHandler.LoadCustomGeneratorID(cegName));
+	} else {
+		lua_pushnil(L);
+	}
 	return 1;
 }
 

--- a/rts/Sim/Projectiles/ExplosionGenerator.cpp
+++ b/rts/Sim/Projectiles/ExplosionGenerator.cpp
@@ -281,7 +281,14 @@ void CExplosionGeneratorHandler::ReloadGenerators(const std::string& tag) {
 	}
 }
 
+// tag is bare name without CEG_PREFIX_STRING
+bool CExplosionGeneratorHandler::IsCustomGeneratorDefined(const char* tag) const {
+	RECOIL_DETAILED_TRACY_ZONE;
+	const LuaTable* root = GetExplosionTableRoot();
+	const LuaTable& expTable = (root != nullptr) ? root->SubTable(tag) : LuaTable();
 
+	return expTable.IsValid();
+}
 
 unsigned int CExplosionGeneratorHandler::LoadGeneratorID(const char* tag, const char* pre)
 {

--- a/rts/Sim/Projectiles/ExplosionGenerator.h
+++ b/rts/Sim/Projectiles/ExplosionGenerator.h
@@ -57,6 +57,8 @@ public:
 	void ParseExplosionTables();
 	void ReloadGenerators(const std::string&);
 
+	bool IsCustomGeneratorDefined(const char* tag) const;
+
 	unsigned int LoadCustomGeneratorID(const char* tag) { return (LoadGeneratorID(tag, CEG_PREFIX_STRING)); }
 	unsigned int LoadGeneratorID(const char* tag, const char* pre = "");
 


### PR DESCRIPTION
Fixes #1779

`Spring.GetCEGID` used `LoadCustomGeneratorID`, which allocates a new (dead) generator for any unknown name, so there was no way to tell from Lua whether a CEG exists.

- Add `CExplosionGeneratorHandler::IsCustomGeneratorDefined`: non-allocating check against the parsed `explosions.lua` table (same check `CCustomExplosionGenerator::Load` does).
- `Spring.GetCEGID` returns `nil` for undefined names; defined ones behave as before (incl. lazy load). Doc comment updated.

Guard is in `GetCEGID` only; changing `LoadGenerator` itself would affect weapon defs / `EmitSfx` / `UnitDrawer` and should be its own ticket.

### Testing
Manual, Linux, BAR `test-31090`. A widget calls `Spring.GetCEGID` in `Initialize` on:
- a real CEG that is already loaded at game start (`genericshellexplosion-small-bomb`)
- a garbage name, twice, and a second garbage name
- defined CEGs that nothing has loaded at game start (`blood_spray_small`, `fogdirty`, `burnblackbig-anim`), with another garbage name in between
- a defined CEG that was already loaded (`geobubbles`)

Master: garbage names get IDs 318/319 and push the lazily loaded CEGs to 320-322.
Fix: garbage names return `nil` and consume nothing; the lazily loaded CEGs get 318-320; already loaded CEGs are unaffected.

<details>
<summary>Test widget</summary>

```lua
function widget:GetInfo()
  return { name = "CEG ID test", layer = 0, enabled = true }
end

local function echoCEGID(name)
  Spring.Echo("[cegtest]", name, Spring.GetCEGID(name))
end

function widget:Initialize()
  echoCEGID("genericshellexplosion-small-bomb") -- loaded at game start
  echoCEGID("undefined-garbage-name")
  echoCEGID("undefined-garbage-name")
  echoCEGID("another-undefined-garbage-name")
  -- defined in BAR effects/ but not loaded at game start
  echoCEGID("blood_spray_small")
  echoCEGID("fogdirty")
  echoCEGID("geobubbles") -- already loaded
  echoCEGID("undefined-garbage-name")
  echoCEGID("burnblackbig-anim")
end
```
</details>

Before (master 9b4be36):
```
[cegtest], genericshellexplosion-small-bomb, 28
[cegtest], undefined-garbage-name, 318
[cegtest], undefined-garbage-name, 318
[cegtest], another-undefined-garbage-name, 319
[cegtest], blood_spray_small, 320
[cegtest], fogdirty, 321
[cegtest], geobubbles, 299
[cegtest], undefined-garbage-name, 318
[cegtest], burnblackbig-anim, 322
```
After:
```
[cegtest], genericshellexplosion-small-bomb, 28
[cegtest], undefined-garbage-name, nil
[cegtest], undefined-garbage-name, nil
[cegtest], another-undefined-garbage-name, nil
[cegtest], blood_spray_small, 318
[cegtest], fogdirty, 319
[cegtest], geobubbles, 299
[cegtest], undefined-garbage-name, nil
[cegtest], burnblackbig-anim, 320
```
The `[CCEG::Load] table for CEG "..." invalid` warnings for the garbage names are also gone from infolog.

AI disclosure: Claude Code was used to explore the code and review diff. Code written & tested by me.

