### PR TITLE
Expose weapon shot and burst lifecycle call-ins to synced Lua

### DIFF
--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -84,6 +84,7 @@ CALLIN_LIST = {
 
 	-- weapon callins
 	"StockpileChanged",
+	"UnitWeaponBurstStart",
 	"UnitWeaponBurstEnd",
 
 	-- feature callins

--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -84,6 +84,7 @@ CALLIN_LIST = {
 
 	-- weapon callins
 	"StockpileChanged",
+	"UnitWeaponBurstEnd",
 
 	-- feature callins
 	"FeatureCreated",

--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -86,6 +86,7 @@ CALLIN_LIST = {
 	"StockpileChanged",
 	"UnitWeaponBurstStart",
 	"UnitWeaponBurstEnd",
+	"UnitWeaponFired",
 
 	-- feature callins
 	"FeatureCreated",

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1685,6 +1685,14 @@ function gadgetHandler:StockpileChanged(unitID, unitDefID, unitTeam,
   end
 end
 
+function gadgetHandler:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam,
+                                          weaponNum, weaponDefID, commandID, commandTag)
+  for _,g in r_ipairs(self.UnitWeaponBurstEndList) do
+    g:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam,
+                         weaponNum, weaponDefID, commandID, commandTag)
+  end
+end
+
 function gadgetHandler:UnitHarvestStorageFull(unitID, unitDefID, unitTeam)
   for _,g in r_ipairs(self.UnitHarvestStorageFullList) do
     g:UnitHarvestStorageFull(unitID, unitDefID, unitTeam)

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1685,11 +1685,9 @@ function gadgetHandler:StockpileChanged(unitID, unitDefID, unitTeam,
   end
 end
 
-function gadgetHandler:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam,
-                                          weaponNum, weaponDefID, commandID, commandTag)
+function gadgetHandler:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)
   for _,g in r_ipairs(self.UnitWeaponBurstEndList) do
-    g:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam,
-                         weaponNum, weaponDefID, commandID, commandTag)
+    g:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)
   end
 end
 

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1685,6 +1685,12 @@ function gadgetHandler:StockpileChanged(unitID, unitDefID, unitTeam,
   end
 end
 
+function gadgetHandler:UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)
+  for _,g in r_ipairs(self.UnitWeaponBurstStartList) do
+    g:UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)
+  end
+end
+
 function gadgetHandler:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)
   for _,g in r_ipairs(self.UnitWeaponBurstEndList) do
     g:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1697,6 +1697,12 @@ function gadgetHandler:UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum
   end
 end
 
+function gadgetHandler:UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
+  for _,g in r_ipairs(self.UnitWeaponFiredList) do
+    g:UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
+  end
+end
+
 function gadgetHandler:UnitHarvestStorageFull(unitID, unitDefID, unitTeam)
   for _,g in r_ipairs(self.UnitHarvestStorageFullList) do
     g:UnitHarvestStorageFull(unitID, unitDefID, unitTeam)

--- a/doc/pr-changelogs/3286.md
+++ b/doc/pr-changelogs/3286.md
@@ -1,2 +1,3 @@
 ### Features
  * added the synced `UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)` and `UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)` call-ins, gated by `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst`
+ * `UnitWeaponBurstStart` marks initialization of burst state, possibly before weapon windup completes, and does not guarantee a matching end event if the unit is destroyed or Lua modifies weapon state

--- a/doc/pr-changelogs/3286.md
+++ b/doc/pr-changelogs/3286.md
@@ -1,2 +1,2 @@
 ### Features
- * added the synced, watch-gated `UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)` call-in and `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst`
+ * added the synced `UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)` and `UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)` call-ins, gated by `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst`

--- a/doc/pr-changelogs/3286.md
+++ b/doc/pr-changelogs/3286.md
@@ -1,0 +1,2 @@
+### Features
+ * added the synced, watch-gated `UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)` call-in and `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst`

--- a/doc/pr-changelogs/3286.md
+++ b/doc/pr-changelogs/3286.md
@@ -1,3 +1,4 @@
 ### Features
  * added the synced `UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)` and `UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)` call-ins, gated by `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst`
  * `UnitWeaponBurstStart` marks initialization of burst state, possibly before weapon windup completes, and does not guarantee a matching end event if the unit is destroyed or Lua modifies weapon state
+ * added synced `UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)`, gated independently by `Script.GetWatchWeaponFired` / `Script.SetWatchWeaponFired`, once per fired burst shot rather than per projectile; skipped shots and direct unit-script `EmitSfx` firing outside the burst path do not trigger it

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,9 +7,4 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-## Lua API
-
-- Add the synced, watch-gated `UnitWeaponBurstEnd` call-in. It is delivered at
-  the end of the simulation frame with the unit and weapon identifiers plus a
-  snapshot of the active command ID and tag from when the burst ended. Add
-  `Script.GetWatchWeaponBurst` and `Script.SetWatchWeaponBurst` to control it.
+No changes as of yet.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,4 +7,9 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-No changes as of yet.
+## Lua API
+
+- Add the synced, watch-gated `UnitWeaponBurstEnd` call-in. It is delivered at
+  the end of the simulation frame with the unit and weapon identifiers plus a
+  snapshot of the active command ID and tag from when the burst ended. Add
+  `Script.GetWatchWeaponBurst` and `Script.SetWatchWeaponBurst` to control it.

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2358,6 +2358,43 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
 }
 
 
+/*** Called immediately when a weapon burst starts.
+ *
+ * @function Callins:UnitWeaponBurstStart
+ *
+ * @param unitID integer
+ * @param unitDefID integer
+ * @param unitTeam integer
+ * @param weaponNum integer
+ *
+ * @see Script.SetWatchWeaponBurst
+ */
+void CLuaHandle::UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	const int weaponDefID = weapon->weaponDef->id;
+
+	if (weaponDefID < 0 || static_cast<size_t>(weaponDefID) >= watchWeaponBurstDefs.size())
+		return;
+	if (!watchWeaponBurstDefs[weaponDefID])
+		return;
+
+	LUA_CALL_IN_CHECK(L);
+	luaL_checkstack(L, 6, __func__);
+
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return;
+
+	lua_pushnumber(L, unit->id);
+	lua_pushnumber(L, unit->unitDef->id);
+	lua_pushnumber(L, unit->team);
+	lua_pushnumber(L, weapon->weaponNum + LUA_WEAPON_BASE_INDEX);
+
+	RunCallIn(L, cmdStr, 4, 0);
+}
+
+
 /*** Called immediately when a weapon burst ends.
  *
  * @function Callins:UnitWeaponBurstEnd

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2360,6 +2360,11 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
 
 /*** Called immediately when a weapon burst starts.
  *
+ * This marks initialization of the engine burst state and can run before the first shot
+ * when the weapon has a windup. It does not guarantee a matching
+ * `UnitWeaponBurstEnd`: for example, the unit can be destroyed or Lua can modify the
+ * weapon state before the burst completes.
+ *
  * @function Callins:UnitWeaponBurstStart
  *
  * @param unitID integer

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2358,6 +2358,65 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
 }
 
 
+/*** Called after a weapon burst ends and the rest of the simulation frame has completed.
+ *
+ * The command ID and tag are snapshots taken when the burst ended, before the
+ * command AI processed the final shot. They are `nil` if the unit had no command.
+ * The referenced unit or command may no longer exist when this deferred call-in runs.
+ *
+ * @function Callins:UnitWeaponBurstEnd
+ *
+ * @param unitID integer
+ * @param unitDefID integer
+ * @param unitTeam integer
+ * @param weaponNum integer
+ * @param weaponDefID integer
+ * @param commandID integer?
+ * @param commandTag integer?
+ *
+ * @see Script.SetWatchWeaponBurst
+ */
+void CLuaHandle::UnitWeaponBurstEnd(
+	int unitID,
+	int unitDefID,
+	int unitTeam,
+	int weaponNum,
+	int weaponDefID,
+	bool hasCommand,
+	int commandID,
+	unsigned int commandTag)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	if (weaponDefID < 0 || static_cast<size_t>(weaponDefID) >= watchWeaponBurstDefs.size())
+		return;
+	if (!watchWeaponBurstDefs[weaponDefID])
+		return;
+
+	LUA_CALL_IN_CHECK(L);
+	luaL_checkstack(L, 9, __func__);
+
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return;
+
+	lua_pushnumber(L, unitID);
+	lua_pushnumber(L, unitDefID);
+	lua_pushnumber(L, unitTeam);
+	lua_pushnumber(L, weaponNum + LUA_WEAPON_BASE_INDEX);
+	lua_pushnumber(L, weaponDefID);
+
+	if (hasCommand) {
+		lua_pushnumber(L, commandID);
+		lua_pushnumber(L, commandTag);
+	} else {
+		lua_pushnil(L);
+		lua_pushnil(L);
+	}
+
+	RunCallIn(L, cmdStr, 7, 0);
+}
+
+
 
 /*** Receives messages from unsynced sent via `Spring.SendLuaRulesMsg` or `Spring.SendLuaUIMsg`.
  *

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2358,11 +2358,7 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
 }
 
 
-/*** Called after a weapon burst ends and the rest of the simulation frame has completed.
- *
- * The command ID and tag are snapshots taken when the burst ended, before the
- * command AI processed the final shot. They are `nil` if the unit had no command.
- * The referenced unit or command may no longer exist when this deferred call-in runs.
+/*** Called immediately when a weapon burst ends.
  *
  * @function Callins:UnitWeaponBurstEnd
  *
@@ -2370,50 +2366,32 @@ void CLuaHandle::StockpileChanged(const CUnit* unit,
  * @param unitDefID integer
  * @param unitTeam integer
  * @param weaponNum integer
- * @param weaponDefID integer
- * @param commandID integer?
- * @param commandTag integer?
  *
  * @see Script.SetWatchWeaponBurst
  */
-void CLuaHandle::UnitWeaponBurstEnd(
-	int unitID,
-	int unitDefID,
-	int unitTeam,
-	int weaponNum,
-	int weaponDefID,
-	bool hasCommand,
-	int commandID,
-	unsigned int commandTag)
+void CLuaHandle::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	const int weaponDefID = weapon->weaponDef->id;
+
 	if (weaponDefID < 0 || static_cast<size_t>(weaponDefID) >= watchWeaponBurstDefs.size())
 		return;
 	if (!watchWeaponBurstDefs[weaponDefID])
 		return;
 
 	LUA_CALL_IN_CHECK(L);
-	luaL_checkstack(L, 9, __func__);
+	luaL_checkstack(L, 6, __func__);
 
 	static const LuaHashString cmdStr(__func__);
 	if (!cmdStr.GetGlobalFunc(L))
 		return;
 
-	lua_pushnumber(L, unitID);
-	lua_pushnumber(L, unitDefID);
-	lua_pushnumber(L, unitTeam);
-	lua_pushnumber(L, weaponNum + LUA_WEAPON_BASE_INDEX);
-	lua_pushnumber(L, weaponDefID);
+	lua_pushnumber(L, unit->id);
+	lua_pushnumber(L, unit->unitDef->id);
+	lua_pushnumber(L, unit->team);
+	lua_pushnumber(L, weapon->weaponNum + LUA_WEAPON_BASE_INDEX);
 
-	if (hasCommand) {
-		lua_pushnumber(L, commandID);
-		lua_pushnumber(L, commandTag);
-	} else {
-		lua_pushnil(L);
-		lua_pushnil(L);
-	}
-
-	RunCallIn(L, cmdStr, 7, 0);
+	RunCallIn(L, cmdStr, 4, 0);
 }
 
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -2437,6 +2437,52 @@ void CLuaHandle::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon)
 }
 
 
+/*** Called immediately after a weapon fires one shot of its burst.
+ *
+ * Runs once after all projectiles for that shot have been fired, before command-AI
+ * notification and `UnitWeaponBurstEnd`. A skipped shot does not trigger this event.
+ * Unlike `ProjectileCreated`, this reports a firing step, not individual projectiles
+ * or hits. Continuous beam weapons can fire one such step per simulation frame.
+ * Direct unit-script `EmitSfx` firing outside the burst path is not reported.
+ *
+ * This is an immediate notification, independent of cloak state. Games should defer
+ * command-queue mutations until a later game-frame call-in.
+ *
+ * @function Callins:UnitWeaponFired
+ *
+ * @param unitID integer
+ * @param unitDefID integer
+ * @param unitTeam integer
+ * @param weaponNum integer
+ *
+ * @see Script.SetWatchWeaponFired
+ */
+void CLuaHandle::UnitWeaponFired(const CUnit* unit, const CWeapon* weapon)
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	const int weaponDefID = weapon->weaponDef->id;
+
+	if (weaponDefID < 0 || static_cast<size_t>(weaponDefID) >= watchWeaponFiredDefs.size())
+		return;
+	if (!watchWeaponFiredDefs[weaponDefID])
+		return;
+
+	LUA_CALL_IN_CHECK(L);
+	luaL_checkstack(L, 6, __func__);
+
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return;
+
+	lua_pushnumber(L, unit->id);
+	lua_pushnumber(L, unit->unitDef->id);
+	lua_pushnumber(L, unit->team);
+	lua_pushnumber(L, weapon->weaponNum + LUA_WEAPON_BASE_INDEX);
+
+	RunCallIn(L, cmdStr, 4, 0);
+}
+
+
 
 /*** Receives messages from unsynced sent via `Spring.SendLuaRulesMsg` or `Spring.SendLuaUIMsg`.
  *

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef LUA_HANDLE_H
-#define LUA_HANDLE_H
+#pragma once
 #include <cinttypes>
 
 #include "System/EventClient.h"
@@ -197,6 +196,7 @@ class CLuaHandle : public CEventClient
 		                      const CWeapon* weapon, int oldCount) override;
 		void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon) override;
 		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) override;
+		void UnitWeaponFired(const CUnit* unit, const CWeapon* weapon) override;
 
 		void Save(zipFile archive) override;
 
@@ -377,6 +377,7 @@ class CLuaHandle : public CEventClient
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision
 		std::vector<bool> watchProjectileDefs;  // callin masks for Projectile*
 		std::vector<bool> watchWeaponBurstDefs; // callin masks for UnitWeaponBurstStart, UnitWeaponBurstEnd
+		std::vector<bool> watchWeaponFiredDefs; // callin mask for UnitWeaponFired
 		std::vector<bool> watchExplosionDefs;   // callin masks for Explosion
 		std::vector<bool> watchAllowTargetDefs; // callin masks for AllowWeapon*Target*
 
@@ -443,6 +444,3 @@ inline bool CLuaHandle::RunCallInLUS(lua_State* L, std::string* ts, int inArgs, 
 
 /******************************************************************************/
 /******************************************************************************/
-
-
-#endif /* LUA_HANDLE_H */

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -195,6 +195,15 @@ class CLuaHandle : public CEventClient
 
 		void StockpileChanged(const CUnit* owner,
 		                      const CWeapon* weapon, int oldCount) override;
+		void UnitWeaponBurstEnd(
+			int unitID,
+			int unitDefID,
+			int unitTeam,
+			int weaponNum,
+			int weaponDefID,
+			bool hasCommand,
+			int commandID,
+			unsigned int commandTag) override;
 
 		void Save(zipFile archive) override;
 
@@ -374,6 +383,7 @@ class CLuaHandle : public CEventClient
 		std::vector<bool> watchUnitDefs;        // callin masks for Unit*Collision, UnitMoveFailed
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision
 		std::vector<bool> watchProjectileDefs;  // callin masks for Projectile*
+		std::vector<bool> watchWeaponBurstDefs; // callin masks for UnitWeaponBurstEnd
 		std::vector<bool> watchExplosionDefs;   // callin masks for Explosion
 		std::vector<bool> watchAllowTargetDefs; // callin masks for AllowWeapon*Target*
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -195,6 +195,7 @@ class CLuaHandle : public CEventClient
 
 		void StockpileChanged(const CUnit* owner,
 		                      const CWeapon* weapon, int oldCount) override;
+		void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon) override;
 		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) override;
 
 		void Save(zipFile archive) override;
@@ -375,7 +376,7 @@ class CLuaHandle : public CEventClient
 		std::vector<bool> watchUnitDefs;        // callin masks for Unit*Collision, UnitMoveFailed
 		std::vector<bool> watchFeatureDefs;     // callin masks for UnitFeatureCollision
 		std::vector<bool> watchProjectileDefs;  // callin masks for Projectile*
-		std::vector<bool> watchWeaponBurstDefs; // callin masks for UnitWeaponBurstEnd
+		std::vector<bool> watchWeaponBurstDefs; // callin masks for UnitWeaponBurstStart, UnitWeaponBurstEnd
 		std::vector<bool> watchExplosionDefs;   // callin masks for Explosion
 		std::vector<bool> watchAllowTargetDefs; // callin masks for AllowWeapon*Target*
 

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -195,15 +195,7 @@ class CLuaHandle : public CEventClient
 
 		void StockpileChanged(const CUnit* owner,
 		                      const CWeapon* weapon, int oldCount) override;
-		void UnitWeaponBurstEnd(
-			int unitID,
-			int unitDefID,
-			int unitTeam,
-			int weaponNum,
-			int weaponDefID,
-			bool hasCommand,
-			int commandID,
-			unsigned int commandTag) override;
+		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) override;
 
 		void Save(zipFile archive) override;
 

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -2180,16 +2180,6 @@ int CSyncedLuaHandle::GetWatchWeaponDef(lua_State* L) {
 		watched |= luaL_checkboolean(L, -1);
 		lua_pop(L, 1);
 	}
-	{
-		GetWatchWeaponBurstDef(L);
-		watched |= luaL_checkboolean(L, -1);
-		lua_pop(L, 1);
-	}
-	{
-		GetWatchWeaponFiredDef(L);
-		watched |= luaL_checkboolean(L, -1);
-		lua_pop(L, 1);
-	}
 
 	lua_pushboolean(L, watched);
 	return 1;
@@ -2237,11 +2227,7 @@ GetWatchDef(Synced, Feature)
  *
  * Same as calling:
  * ```lua
- * Script.GetWatchExplosion(weaponDefID)
- * or Script.GetWatchProjectile(weaponDefID)
- * or Script.GetWatchAllowTarget(weaponDefID)
- * or Script.GetWatchWeaponBurst(weaponDefID)
- * or Script.GetWatchWeaponFired(weaponDefID)
+ * Script.GetWatchExplosion(weaponDefID) or Script.GetWatchProjectile(weaponDefID) or Script.GetWatchAllowTarget(weaponDefID)
  * ```
  *
  * @param weaponDefID WeaponDefID
@@ -2356,8 +2342,6 @@ SetWatchDef(Synced, Feature)
  * Script.SetWatchExplosion(weaponDefID)
  * Script.SetWatchProjectile(weaponDefID)
  * Script.SetWatchAllowTarget(weaponDefID)
- * Script.SetWatchWeaponBurst(weaponDefID)
- * Script.SetWatchWeaponFired(weaponDefID)
  * ```
  *
  * Generally it's better to use those methods to avoid registering uneeded callins.
@@ -2369,8 +2353,6 @@ SetWatchDef(Synced, Feature)
  * @see Script.SetWatchExplosion
  * @see Script.SetWatchProjectile
  * @see Script.SetWatchAllowTarget
- * @see Script.SetWatchWeaponBurst
- * @see Script.SetWatchWeaponFired
  */
 
 /*** Register or deregister weaponDefID for explosion callins.

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -2268,12 +2268,12 @@ GetWatchDef(Unsynced, Explosion)
 GetWatchDef(Synced, Projectile)
 
 
-/*** Query whether burst-end callins are registered for a weaponDefID.
+/*** Query whether burst callins are registered for a weaponDefID.
  *
  * @function Script.GetWatchWeaponBurst
  *
  * @param weaponDefID integer
- * @return boolean watched `true` if burst-end callins are registered, otherwise `false`.
+ * @return boolean watched `true` if burst callins are registered, otherwise `false`.
  *
  * @see Script.SetWatchWeaponBurst
  */
@@ -2379,7 +2379,7 @@ SetWatchDef(Unsynced, Explosion)
 SetWatchDef(Synced, Projectile)
 
 
-/*** Register or deregister weaponDefID for `UnitWeaponBurstEnd`.
+/*** Register or deregister weaponDefID for `UnitWeaponBurstStart` and `UnitWeaponBurstEnd`.
  *
  * @function Script.SetWatchWeaponBurst
  *
@@ -2387,6 +2387,7 @@ SetWatchDef(Synced, Projectile)
  * @param watch boolean Whether to register or deregister.
  *
  * @see Script.GetWatchWeaponBurst
+ * @see Callins:UnitWeaponBurstStart
  * @see Callins:UnitWeaponBurstEnd
  */
 

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -435,6 +435,7 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 	watchProjectileDefs.resize(weaponDefHandler->NumWeaponDefs() + 1, false); // last bit controls piece-projectiles
 	watchAllowTargetDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
 	watchWeaponBurstDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
+	watchWeaponFiredDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
 
 	// load the standard libraries
 	LuaLibs::OpenSynced(L, true);
@@ -488,6 +489,8 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 		LuaPushNamedCFunc(L, "SetWatchAllowTarget",  SetWatchAllowTargetDef);
 		LuaPushNamedCFunc(L, "GetWatchWeaponBurst",  GetWatchWeaponBurstDef);
 		LuaPushNamedCFunc(L, "SetWatchWeaponBurst",  SetWatchWeaponBurstDef);
+		LuaPushNamedCFunc(L, "GetWatchWeaponFired",  GetWatchWeaponFiredDef);
+		LuaPushNamedCFunc(L, "SetWatchWeaponFired",  SetWatchWeaponFiredDef);
 		LuaPushNamedCFunc(L, "GetWatchWeapon",       GetWatchWeaponDef);
 		LuaPushNamedCFunc(L, "SetWatchWeapon",       SetWatchWeaponDef);
 	lua_pop(L, 1);
@@ -2182,6 +2185,11 @@ int CSyncedLuaHandle::GetWatchWeaponDef(lua_State* L) {
 		watched |= luaL_checkboolean(L, -1);
 		lua_pop(L, 1);
 	}
+	{
+		GetWatchWeaponFiredDef(L);
+		watched |= luaL_checkboolean(L, -1);
+		lua_pop(L, 1);
+	}
 
 	lua_pushboolean(L, watched);
 	return 1;
@@ -2233,6 +2241,7 @@ GetWatchDef(Synced, Feature)
  * or Script.GetWatchProjectile(weaponDefID)
  * or Script.GetWatchAllowTarget(weaponDefID)
  * or Script.GetWatchWeaponBurst(weaponDefID)
+ * or Script.GetWatchWeaponFired(weaponDefID)
  * ```
  *
  * @param weaponDefID WeaponDefID
@@ -2279,6 +2288,19 @@ GetWatchDef(Synced, Projectile)
  */
 
 GetWatchDef(Synced, WeaponBurst)
+
+
+/*** Query whether shot callins are registered for a weaponDefID.
+ *
+ * @function Script.GetWatchWeaponFired
+ *
+ * @param weaponDefID integer
+ * @return boolean watched `true` if shot callins are registered, otherwise `false`.
+ *
+ * @see Script.SetWatchWeaponFired
+ */
+
+GetWatchDef(Synced, WeaponFired)
 
 
 /*** Query whether weapon targeting callins are registered for a weaponDefID.
@@ -2335,6 +2357,7 @@ SetWatchDef(Synced, Feature)
  * Script.SetWatchProjectile(weaponDefID)
  * Script.SetWatchAllowTarget(weaponDefID)
  * Script.SetWatchWeaponBurst(weaponDefID)
+ * Script.SetWatchWeaponFired(weaponDefID)
  * ```
  *
  * Generally it's better to use those methods to avoid registering uneeded callins.
@@ -2347,6 +2370,7 @@ SetWatchDef(Synced, Feature)
  * @see Script.SetWatchProjectile
  * @see Script.SetWatchAllowTarget
  * @see Script.SetWatchWeaponBurst
+ * @see Script.SetWatchWeaponFired
  */
 
 /*** Register or deregister weaponDefID for explosion callins.
@@ -2392,6 +2416,20 @@ SetWatchDef(Synced, Projectile)
  */
 
 SetWatchDef(Synced, WeaponBurst)
+
+
+/*** Register or deregister weaponDefID for `UnitWeaponFired`.
+ *
+ * @function Script.SetWatchWeaponFired
+ *
+ * @param weaponDefID integer
+ * @param watch boolean Whether to register or deregister.
+ *
+ * @see Script.GetWatchWeaponFired
+ * @see Callins:UnitWeaponFired
+ */
+
+SetWatchDef(Synced, WeaponFired)
 
 
 /*** Register or deregister weaponDefID for weapon targeting callins.

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -434,6 +434,7 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 	watchExplosionDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
 	watchProjectileDefs.resize(weaponDefHandler->NumWeaponDefs() + 1, false); // last bit controls piece-projectiles
 	watchAllowTargetDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
+	watchWeaponBurstDefs.resize(weaponDefHandler->NumWeaponDefs(), false);
 
 	// load the standard libraries
 	LuaLibs::OpenSynced(L, true);
@@ -485,6 +486,8 @@ bool CSyncedLuaHandle::Init(std::string code, const std::string& file)
 		LuaPushNamedCFunc(L, "SetWatchProjectile",   SetWatchProjectileDef);
 		LuaPushNamedCFunc(L, "GetWatchAllowTarget",  GetWatchAllowTargetDef);
 		LuaPushNamedCFunc(L, "SetWatchAllowTarget",  SetWatchAllowTargetDef);
+		LuaPushNamedCFunc(L, "GetWatchWeaponBurst",  GetWatchWeaponBurstDef);
+		LuaPushNamedCFunc(L, "SetWatchWeaponBurst",  SetWatchWeaponBurstDef);
 		LuaPushNamedCFunc(L, "GetWatchWeapon",       GetWatchWeaponDef);
 		LuaPushNamedCFunc(L, "SetWatchWeapon",       SetWatchWeaponDef);
 	lua_pop(L, 1);
@@ -2174,6 +2177,11 @@ int CSyncedLuaHandle::GetWatchWeaponDef(lua_State* L) {
 		watched |= luaL_checkboolean(L, -1);
 		lua_pop(L, 1);
 	}
+	{
+		GetWatchWeaponBurstDef(L);
+		watched |= luaL_checkboolean(L, -1);
+		lua_pop(L, 1);
+	}
 
 	lua_pushboolean(L, watched);
 	return 1;
@@ -2221,7 +2229,10 @@ GetWatchDef(Synced, Feature)
  *
  * Same as calling:
  * ```lua
- * Script.GetWatchExplosion(weaponDefID) or Script.GetWatchProjectile(weaponDefID) or Script.GetWatchAllowTarget(weaponDefID)
+ * Script.GetWatchExplosion(weaponDefID)
+ * or Script.GetWatchProjectile(weaponDefID)
+ * or Script.GetWatchAllowTarget(weaponDefID)
+ * or Script.GetWatchWeaponBurst(weaponDefID)
  * ```
  *
  * @param weaponDefID WeaponDefID
@@ -2255,6 +2266,19 @@ GetWatchDef(Unsynced, Explosion)
  */
 
 GetWatchDef(Synced, Projectile)
+
+
+/*** Query whether burst-end callins are registered for a weaponDefID.
+ *
+ * @function Script.GetWatchWeaponBurst
+ *
+ * @param weaponDefID integer
+ * @return boolean watched `true` if burst-end callins are registered, otherwise `false`.
+ *
+ * @see Script.SetWatchWeaponBurst
+ */
+
+GetWatchDef(Synced, WeaponBurst)
 
 
 /*** Query whether weapon targeting callins are registered for a weaponDefID.
@@ -2310,6 +2334,7 @@ SetWatchDef(Synced, Feature)
  * Script.SetWatchExplosion(weaponDefID)
  * Script.SetWatchProjectile(weaponDefID)
  * Script.SetWatchAllowTarget(weaponDefID)
+ * Script.SetWatchWeaponBurst(weaponDefID)
  * ```
  *
  * Generally it's better to use those methods to avoid registering uneeded callins.
@@ -2321,6 +2346,7 @@ SetWatchDef(Synced, Feature)
  * @see Script.SetWatchExplosion
  * @see Script.SetWatchProjectile
  * @see Script.SetWatchAllowTarget
+ * @see Script.SetWatchWeaponBurst
  */
 
 /*** Register or deregister weaponDefID for explosion callins.
@@ -2351,6 +2377,20 @@ SetWatchDef(Unsynced, Explosion)
  */
 
 SetWatchDef(Synced, Projectile)
+
+
+/*** Register or deregister weaponDefID for `UnitWeaponBurstEnd`.
+ *
+ * @function Script.SetWatchWeaponBurst
+ *
+ * @param weaponDefID integer
+ * @param watch boolean Whether to register or deregister.
+ *
+ * @see Script.GetWatchWeaponBurst
+ * @see Callins:UnitWeaponBurstEnd
+ */
+
+SetWatchDef(Synced, WeaponBurst)
 
 
 /*** Register or deregister weaponDefID for weapon targeting callins.

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -167,12 +167,15 @@ class CSyncedLuaHandle : public CLuaHandle
 		static int SetWatchProjectileDef(lua_State* L);
 		static int GetWatchAllowTargetDef(lua_State* L);
 		static int SetWatchAllowTargetDef(lua_State* L);
+		static int GetWatchWeaponBurstDef(lua_State* L);
+		static int SetWatchWeaponBurstDef(lua_State* L);
 
 		static int GetWatchWeaponDef(lua_State* L);
 		static int SetWatchWeaponDef(lua_State* L) {
 			SetWatchExplosionDef(L);
 			SetWatchProjectileDef(L);
 			SetWatchAllowTargetDef(L);
+			SetWatchWeaponBurstDef(L);
 			return 0;
 		}
 };

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef LUA_HANDLE_SYNCED
-#define LUA_HANDLE_SYNCED
+#pragma once
 
 #include <string>
 
@@ -169,6 +168,8 @@ class CSyncedLuaHandle : public CLuaHandle
 		static int SetWatchAllowTargetDef(lua_State* L);
 		static int GetWatchWeaponBurstDef(lua_State* L);
 		static int SetWatchWeaponBurstDef(lua_State* L);
+		static int GetWatchWeaponFiredDef(lua_State* L);
+		static int SetWatchWeaponFiredDef(lua_State* L);
 
 		static int GetWatchWeaponDef(lua_State* L);
 		static int SetWatchWeaponDef(lua_State* L) {
@@ -176,6 +177,7 @@ class CSyncedLuaHandle : public CLuaHandle
 			SetWatchProjectileDef(L);
 			SetWatchAllowTargetDef(L);
 			SetWatchWeaponBurstDef(L);
+			SetWatchWeaponFiredDef(L);
 			return 0;
 		}
 };
@@ -285,6 +287,3 @@ class CSplitLuaHandle
 		friend class CGameStateCollector;
 		static LuaRulesParams::Params gameParams;
 };
-
-
-#endif /* LUA_HANDLE_SYNCED */

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -176,8 +176,6 @@ class CSyncedLuaHandle : public CLuaHandle
 			SetWatchExplosionDef(L);
 			SetWatchProjectileDef(L);
 			SetWatchAllowTargetDef(L);
-			SetWatchWeaponBurstDef(L);
-			SetWatchWeaponFiredDef(L);
 			return 0;
 		}
 };

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -717,6 +717,13 @@ void CUnit::UpdateWeapons()
 }
 
 
+void CUnit::StartBurst(const CWeapon* weapon)
+{
+	script->FireWeapon(weapon->weaponNum);
+	eventHandler.UnitWeaponBurstStart(this, weapon);
+}
+
+
 void CUnit::EndBurst(const CWeapon* weapon)
 {
 	script->EndBurst(weapon->weaponNum);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -731,6 +731,15 @@ void CUnit::EndBurst(const CWeapon* weapon)
 }
 
 
+void CUnit::WeaponFired(CWeapon* weapon)
+{
+	eventHandler.UnitWeaponFired(this, weapon);
+
+	const bool searchForNewTarget = (weapon->salvoLeft == 0) && (weapon->GetCurrentTarget() == curTarget);
+	commandAI->WeaponFired(weapon, searchForNewTarget);
+}
+
+
 void CUnit::UpdateTransportees()
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -716,6 +716,14 @@ void CUnit::UpdateWeapons()
 	}
 }
 
+
+void CUnit::EndBurst(const CWeapon* weapon)
+{
+	script->EndBurst(weapon->weaponNum);
+	eventHandler.UnitWeaponBurstEnd(this, weapon);
+}
+
+
 void CUnit::UpdateTransportees()
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -184,6 +184,7 @@ public:
 
 	void UpdateWeapons();
 	void UpdateWeaponVectors();
+	void StartBurst(const CWeapon* weapon);
 	void EndBurst(const CWeapon* weapon);
 
 	void SlowUpdateWeapons();

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -186,6 +186,7 @@ public:
 	void UpdateWeaponVectors();
 	void StartBurst(const CWeapon* weapon);
 	void EndBurst(const CWeapon* weapon);
+	void WeaponFired(CWeapon* weapon);
 
 	void SlowUpdateWeapons();
 	void SlowUpdateKamikaze(bool scanForTargets);

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -184,6 +184,7 @@ public:
 
 	void UpdateWeapons();
 	void UpdateWeaponVectors();
+	void EndBurst(const CWeapon* weapon);
 
 	void SlowUpdateWeapons();
 	void SlowUpdateKamikaze(bool scanForTargets);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -566,6 +566,7 @@ void CWeapon::UpdateSalvo()
 
 				// Special case needed here if the last shot of the salvo has been cancelled.
 				if (salvoLeft == 0) {
+					eventHandler.UnitWeaponBurstEnd(owner, this);
 					owner->script->EndBurst(weaponNum);
 
 					const bool searchForNewTarget = (currentTarget == owner->curTarget);
@@ -601,6 +602,9 @@ void CWeapon::UpdateSalvo()
 		owner->script->WorldRockUnit((-wantedDir).SafeNormalize2D());
 
 	const bool searchForNewTarget = (salvoLeft == 0) && (currentTarget == owner->curTarget);
+	if (salvoLeft == 0)
+		eventHandler.UnitWeaponBurstEnd(owner, this);
+
 	owner->commandAI->WeaponFired(this, searchForNewTarget);
 
 	if (salvoLeft == 0)

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -566,8 +566,7 @@ void CWeapon::UpdateSalvo()
 
 				// Special case needed here if the last shot of the salvo has been cancelled.
 				if (salvoLeft == 0) {
-					owner->script->EndBurst(weaponNum);
-					eventHandler.UnitWeaponBurstEnd(owner, this);
+					owner->EndBurst(this);
 
 					const bool searchForNewTarget = (currentTarget == owner->curTarget);
 					owner->commandAI->WeaponFired(this, searchForNewTarget, false);
@@ -605,8 +604,7 @@ void CWeapon::UpdateSalvo()
 	owner->commandAI->WeaponFired(this, searchForNewTarget);
 
 	if (salvoLeft == 0) {
-		owner->script->EndBurst(weaponNum);
-		eventHandler.UnitWeaponBurstEnd(owner, this);
+		owner->EndBurst(this);
 	}
 }
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -566,8 +566,8 @@ void CWeapon::UpdateSalvo()
 
 				// Special case needed here if the last shot of the salvo has been cancelled.
 				if (salvoLeft == 0) {
-					eventHandler.UnitWeaponBurstEnd(owner, this);
 					owner->script->EndBurst(weaponNum);
+					eventHandler.UnitWeaponBurstEnd(owner, this);
 
 					const bool searchForNewTarget = (currentTarget == owner->curTarget);
 					owner->commandAI->WeaponFired(this, searchForNewTarget, false);
@@ -602,13 +602,12 @@ void CWeapon::UpdateSalvo()
 		owner->script->WorldRockUnit((-wantedDir).SafeNormalize2D());
 
 	const bool searchForNewTarget = (salvoLeft == 0) && (currentTarget == owner->curTarget);
-	if (salvoLeft == 0)
-		eventHandler.UnitWeaponBurstEnd(owner, this);
-
 	owner->commandAI->WeaponFired(this, searchForNewTarget);
 
-	if (salvoLeft == 0)
+	if (salvoLeft == 0) {
 		owner->script->EndBurst(weaponNum);
+		eventHandler.UnitWeaponBurstEnd(owner, this);
+	}
 }
 
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -508,7 +508,7 @@ void CWeapon::UpdateFire()
 
 	owner->lastMuzzleFlameSize = muzzleFlareSize;
 	owner->lastMuzzleFlameDir = wantedDir;
-	owner->script->FireWeapon(weaponNum);
+	owner->StartBurst(this);
 }
 
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -596,15 +596,11 @@ void CWeapon::UpdateSalvo()
 		Fire(false);
 	}
 
-	if (projectilesPerShot > 0)
-		eventHandler.UnitWeaponFired(owner, this);
-
 	// Rock the unit in the direction of fire
 	if (owner->script->HasRockUnit())
 		owner->script->WorldRockUnit((-wantedDir).SafeNormalize2D());
 
-	const bool searchForNewTarget = (salvoLeft == 0) && (currentTarget == owner->curTarget);
-	owner->commandAI->WeaponFired(this, searchForNewTarget);
+	owner->WeaponFired(this);
 
 	if (salvoLeft == 0) {
 		owner->EndBurst(this);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -596,6 +596,9 @@ void CWeapon::UpdateSalvo()
 		Fire(false);
 	}
 
+	if (projectilesPerShot > 0)
+		eventHandler.UnitWeaponFired(owner, this);
+
 	// Rock the unit in the direction of fire
 	if (owner->script->HasRockUnit())
 		owner->script->WorldRockUnit((-wantedDir).SafeNormalize2D());

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -205,15 +205,7 @@ class CEventClient
 
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}
-		virtual void UnitWeaponBurstEnd(
-			int unitID,
-			int unitDefID,
-			int unitTeam,
-			int weaponNum,
-			int weaponDefID,
-			bool hasCommand,
-			int commandID,
-			unsigned int commandTag) {}
+		virtual void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) {}
 
 		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) { return false; }
 

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -205,6 +205,7 @@ class CEventClient
 
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}
+		virtual void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon) {}
 		virtual void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) {}
 
 		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) { return false; }

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -205,6 +205,15 @@ class CEventClient
 
 		virtual void StockpileChanged(const CUnit* unit,
 		                              const CWeapon* weapon, int oldCount) {}
+		virtual void UnitWeaponBurstEnd(
+			int unitID,
+			int unitDefID,
+			int unitTeam,
+			int weaponNum,
+			int weaponDefID,
+			bool hasCommand,
+			int commandID,
+			unsigned int commandTag) {}
 
 		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) { return false; }
 

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef EVENT_CLIENT_H
-#define EVENT_CLIENT_H
+#pragma once
 
 #include <algorithm>
 #include <map>
@@ -207,6 +206,7 @@ class CEventClient
 		                              const CWeapon* weapon, int oldCount) {}
 		virtual void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon) {}
 		virtual void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon) {}
+		virtual void UnitWeaponFired(const CUnit* unit, const CWeapon* weapon) {}
 
 		virtual bool Explosion(int weaponID, const WeaponDef* weaponDef, const CExplosionParams& params) { return false; }
 
@@ -392,6 +392,3 @@ class CEventClient
 		virtual void MetalMapChanged(const int x, const int z) {}
 		/// @}
 };
-
-
-#endif /* EVENT_CLIENT_H */

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -5,6 +5,10 @@
 #include "Game/GameHelper.h"
 #include "Lua/LuaCallInCheck.h"
 #include "Lua/LuaOpenGL.h"  // FIXME -- should be moved
+#include "Sim/Units/CommandAI/CommandAI.h"
+#include "Sim/Units/UnitDef.h"
+#include "Sim/Weapons/Weapon.h"
+#include "Sim/Weapons/WeaponDef.h"
 
 #include "System/Config/ConfigHandler.h"
 #include "System/Platform/Threading.h"
@@ -40,6 +44,7 @@ void CEventHandler::ResetState()
 	eventMap.reserve(64);
 	handles.clear();
 	handles.reserve(16);
+	unitWeaponBurstEndEvents.clear();
 
 	SetupEvents();
 }
@@ -559,7 +564,56 @@ void CEventHandler::GameFrame(int gameFrame)
 void CEventHandler::GameFramePost(int gameFrame)
 {
 	ZoneScoped;
+	DispatchUnitWeaponBurstEndEvents();
 	ITERATE_EVENTCLIENTLIST(GameFramePost, gameFrame);
+}
+
+void CEventHandler::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon)
+{
+	if (listUnitWeaponBurstEnd.empty())
+		return;
+
+	const CCommandQueue& commandQueue = unit->commandAI->commandQue;
+	const bool hasCommand = !commandQueue.empty();
+	const Command* command = hasCommand ? &commandQueue.front() : nullptr;
+
+	unitWeaponBurstEndEvents.push_back({
+		.unitID = unit->id,
+		.unitDefID = unit->unitDef->id,
+		.unitTeam = unit->team,
+		.weaponNum = weapon->weaponNum,
+		.weaponDefID = weapon->weaponDef->id,
+		.hasCommand = hasCommand,
+		.commandID = hasCommand ? command->GetID() : 0,
+		.commandTag = hasCommand ? command->GetTag() : 0,
+	});
+}
+
+void CEventHandler::DispatchUnitWeaponBurstEndEvents()
+{
+	const size_t eventCount = unitWeaponBurstEndEvents.size();
+
+	for (size_t eventIndex = 0; eventIndex < eventCount; ++eventIndex) {
+		// Copy before invoking clients: a callback can indirectly queue another event.
+		const UnitWeaponBurstEndEvent event = unitWeaponBurstEndEvents[eventIndex];
+		IterateEventClientList(
+			listUnitWeaponBurstEnd,
+			&CEventClient::UnitWeaponBurstEnd,
+			event.unitID,
+			event.unitDefID,
+			event.unitTeam,
+			event.weaponNum,
+			event.weaponDefID,
+			event.hasCommand,
+			event.commandID,
+			event.commandTag
+		);
+	}
+
+	unitWeaponBurstEndEvents.erase(
+		unitWeaponBurstEndEvents.begin(),
+		unitWeaponBurstEndEvents.begin() + eventCount
+	);
 }
 
 void CEventHandler::GameProgress(int gameFrame)

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -5,10 +5,6 @@
 #include "Game/GameHelper.h"
 #include "Lua/LuaCallInCheck.h"
 #include "Lua/LuaOpenGL.h"  // FIXME -- should be moved
-#include "Sim/Units/CommandAI/CommandAI.h"
-#include "Sim/Units/UnitDef.h"
-#include "Sim/Weapons/Weapon.h"
-#include "Sim/Weapons/WeaponDef.h"
 
 #include "System/Config/ConfigHandler.h"
 #include "System/Platform/Threading.h"
@@ -44,7 +40,6 @@ void CEventHandler::ResetState()
 	eventMap.reserve(64);
 	handles.clear();
 	handles.reserve(16);
-	unitWeaponBurstEndEvents.clear();
 
 	SetupEvents();
 }
@@ -564,56 +559,7 @@ void CEventHandler::GameFrame(int gameFrame)
 void CEventHandler::GameFramePost(int gameFrame)
 {
 	ZoneScoped;
-	DispatchUnitWeaponBurstEndEvents();
 	ITERATE_EVENTCLIENTLIST(GameFramePost, gameFrame);
-}
-
-void CEventHandler::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon)
-{
-	if (listUnitWeaponBurstEnd.empty())
-		return;
-
-	const CCommandQueue& commandQueue = unit->commandAI->commandQue;
-	const bool hasCommand = !commandQueue.empty();
-	const Command* command = hasCommand ? &commandQueue.front() : nullptr;
-
-	unitWeaponBurstEndEvents.push_back({
-		.unitID = unit->id,
-		.unitDefID = unit->unitDef->id,
-		.unitTeam = unit->team,
-		.weaponNum = weapon->weaponNum,
-		.weaponDefID = weapon->weaponDef->id,
-		.hasCommand = hasCommand,
-		.commandID = hasCommand ? command->GetID() : 0,
-		.commandTag = hasCommand ? command->GetTag() : 0,
-	});
-}
-
-void CEventHandler::DispatchUnitWeaponBurstEndEvents()
-{
-	const size_t eventCount = unitWeaponBurstEndEvents.size();
-
-	for (size_t eventIndex = 0; eventIndex < eventCount; ++eventIndex) {
-		// Copy before invoking clients: a callback can indirectly queue another event.
-		const UnitWeaponBurstEndEvent event = unitWeaponBurstEndEvents[eventIndex];
-		IterateEventClientList(
-			listUnitWeaponBurstEnd,
-			&CEventClient::UnitWeaponBurstEnd,
-			event.unitID,
-			event.unitDefID,
-			event.unitTeam,
-			event.weaponNum,
-			event.weaponDefID,
-			event.hasCommand,
-			event.commandID,
-			event.commandTag
-		);
-	}
-
-	unitWeaponBurstEndEvents.erase(
-		unitWeaponBurstEndEvents.begin(),
-		unitWeaponBurstEndEvents.begin() + eventCount
-	);
 }
 
 void CEventHandler::GameProgress(int gameFrame)

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -1,7 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
-#ifndef EVENT_HANDLER_H
-#define EVENT_HANDLER_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -145,6 +144,7 @@ class CEventHandler
 		                      const CWeapon* weapon, int oldCount);
 		void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon);
 		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon);
+		void UnitWeaponFired(const CUnit* unit, const CWeapon* weapon);
 
 		bool CommandFallback(const CUnit* unit, const Command& cmd);
 		bool AllowCommand(const CUnit* unit, const Command& cmd, int playerNum, bool fromSynced, bool fromLua);
@@ -755,6 +755,12 @@ inline void CEventHandler::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* 
 }
 
 
+inline void CEventHandler::UnitWeaponFired(const CUnit* unit, const CWeapon* weapon)
+{
+	ITERATE_UNIT_ALLYTEAM_EVENTCLIENTLIST(UnitWeaponFired, unit, weapon)
+}
+
+
 inline void CEventHandler::DefaultCommand(const CUnit* unit, const CFeature* feature, int& cmd)
 {
 	const size_t count = listDefaultCommand.size();
@@ -809,5 +815,3 @@ inline void CEventHandler::RenderProjectileDestroyed(const CProjectile* proj)
 #undef UNIT_CALLIN_NO_PARAM
 #undef UNIT_CALLIN_INT_PARAMS
 #undef UNIT_CALLIN_LOS_PARAM
-
-#endif /* EVENT_HANDLER_H */

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -143,6 +143,7 @@ class CEventHandler
 
 		void StockpileChanged(const CUnit* unit,
 		                      const CWeapon* weapon, int oldCount);
+		void UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon);
 		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon);
 
 		bool CommandFallback(const CUnit* unit, const Command& cmd);
@@ -739,6 +740,12 @@ inline void CEventHandler::StockpileChanged(const CUnit* unit,
                                                 int oldCount)
 {
 	ITERATE_UNIT_ALLYTEAM_EVENTCLIENTLIST(StockpileChanged, unit, weapon, oldCount)
+}
+
+
+inline void CEventHandler::UnitWeaponBurstStart(const CUnit* unit, const CWeapon* weapon)
+{
+	ITERATE_UNIT_ALLYTEAM_EVENTCLIENTLIST(UnitWeaponBurstStart, unit, weapon)
 }
 
 

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -361,19 +361,6 @@ class CEventHandler
 		                EventClientList* list, int props);
 		void ListInsert(EventClientList& ciList, CEventClient* ec);
 		void ListRemove(EventClientList& ciList, CEventClient* ec);
-		void DispatchUnitWeaponBurstEndEvents();
-
-		struct UnitWeaponBurstEndEvent {
-			int unitID;
-			int unitDefID;
-			int unitTeam;
-			int weaponNum;
-			int weaponDefID;
-			bool hasCommand;
-			int commandID;
-			unsigned int commandTag;
-		};
-
 	private:
 		CEventClient* mouseOwner;
 
@@ -381,7 +368,6 @@ class CEventHandler
 		EventMap eventMap;
 
 		EventClientList handles;
-		std::vector<UnitWeaponBurstEndEvent> unitWeaponBurstEndEvents;
 
 	#define SETUP_EVENT(name, props) EventClientList list ## name;
 	#define SETUP_UNMANAGED_EVENT(name, props)
@@ -753,6 +739,12 @@ inline void CEventHandler::StockpileChanged(const CUnit* unit,
                                                 int oldCount)
 {
 	ITERATE_UNIT_ALLYTEAM_EVENTCLIENTLIST(StockpileChanged, unit, weapon, oldCount)
+}
+
+
+inline void CEventHandler::UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon)
+{
+	ITERATE_UNIT_ALLYTEAM_EVENTCLIENTLIST(UnitWeaponBurstEnd, unit, weapon)
 }
 
 

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -143,6 +143,7 @@ class CEventHandler
 
 		void StockpileChanged(const CUnit* unit,
 		                      const CWeapon* weapon, int oldCount);
+		void UnitWeaponBurstEnd(const CUnit* unit, const CWeapon* weapon);
 
 		bool CommandFallback(const CUnit* unit, const Command& cmd);
 		bool AllowCommand(const CUnit* unit, const Command& cmd, int playerNum, bool fromSynced, bool fromLua);
@@ -360,6 +361,18 @@ class CEventHandler
 		                EventClientList* list, int props);
 		void ListInsert(EventClientList& ciList, CEventClient* ec);
 		void ListRemove(EventClientList& ciList, CEventClient* ec);
+		void DispatchUnitWeaponBurstEndEvents();
+
+		struct UnitWeaponBurstEndEvent {
+			int unitID;
+			int unitDefID;
+			int unitTeam;
+			int weaponNum;
+			int weaponDefID;
+			bool hasCommand;
+			int commandID;
+			unsigned int commandTag;
+		};
 
 	private:
 		CEventClient* mouseOwner;
@@ -368,6 +381,7 @@ class CEventHandler
 		EventMap eventMap;
 
 		EventClientList handles;
+		std::vector<UnitWeaponBurstEndEvent> unitWeaponBurstEndEvents;
 
 	#define SETUP_EVENT(name, props) EventClientList list ## name;
 	#define SETUP_UNMANAGED_EVENT(name, props)

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -93,6 +93,7 @@
 	SETUP_EVENT(Explosion, MANAGED_BIT | CONTROL_BIT)
 
 	SETUP_EVENT(StockpileChanged, MANAGED_BIT)
+	SETUP_EVENT(UnitWeaponBurstStart, MANAGED_BIT)
 	SETUP_EVENT(UnitWeaponBurstEnd, MANAGED_BIT)
 
 	// unsynced call-ins

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -93,6 +93,7 @@
 	SETUP_EVENT(Explosion, MANAGED_BIT | CONTROL_BIT)
 
 	SETUP_EVENT(StockpileChanged, MANAGED_BIT)
+	SETUP_EVENT(UnitWeaponBurstEnd, MANAGED_BIT)
 
 	// unsynced call-ins
 	SETUP_EVENT(Save,           MANAGED_BIT | UNSYNCED_BIT)

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -95,6 +95,7 @@
 	SETUP_EVENT(StockpileChanged, MANAGED_BIT)
 	SETUP_EVENT(UnitWeaponBurstStart, MANAGED_BIT)
 	SETUP_EVENT(UnitWeaponBurstEnd, MANAGED_BIT)
+	SETUP_EVENT(UnitWeaponFired, MANAGED_BIT)
 
 	// unsynced call-ins
 	SETUP_EVENT(Save,           MANAGED_BIT | UNSYNCED_BIT)

--- a/test/validation/weapon_events/README.md
+++ b/test/validation/weapon_events/README.md
@@ -1,0 +1,31 @@
+# Weapon event validation
+
+Build `engine-headless` and `basecontent`, then run:
+
+```sh
+python3 test/validation/weapon_events/run.py \
+  build-amd64-linux/spring-headless /path/to/quicksilver_remake_1.24.sd7
+```
+
+For another map, pass its archive and `--map-name 'Map Name'`. The runner creates
+an isolated temporary data directory and prints its location, retaining logs for
+inspection. It uses the base content beside the supplied engine and a small test
+game; it does not need BAR or change an installed game. An engine without the new
+API must fail with `missing shot watch API`.
+
+The synced gadget exercises the real weapon update and base gadget-handler paths:
+
+- Three burst shots with four projectiles each: three fired events, twelve
+  projectile events, one start and one end; the firing weapon is in slot 2.
+- One-shot firing with cloak intent disabled, and firing from cloak.
+- A dropped target before the last burst shot: two fired events and one end.
+- A script-blocked initial shot: no start, fired, or end event.
+- Independent shot/burst watch flags, defaults, and aggregate watch accessors.
+- A continuous beam: one fired event per engine firing step.
+- Callback identity and ordering: projectiles precede the fired event, which
+  precedes burst end.
+
+For manual verification, run the same fixture with a newly built graphical
+`spring` executable and inspect the `WEAPON_EVENTS` lines in `infolog.txt`.
+`WEAPON_EVENTS PASS` and a successful runner exit are required. This is automated
+simulation coverage; it does not claim a human gameplay check or a BAR cloak fix.

--- a/test/validation/weapon_events/README.md
+++ b/test/validation/weapon_events/README.md
@@ -20,7 +20,8 @@ The synced gadget exercises the real weapon update and base gadget-handler paths
 - One-shot firing with cloak intent disabled, and firing from cloak.
 - A dropped target before the last burst shot: two fired events and one end.
 - A script-blocked initial shot: no start, fired, or end event.
-- Independent shot/burst watch flags, defaults, and aggregate watch accessors.
+- Independent shot/burst watch flags, defaults, and unchanged legacy watch accessors.
+- A zero-projectile shot: one fired event and no projectile or script Shot calls.
 - A continuous beam: one fired event per engine firing step.
 - Callback identity and ordering: projectiles precede the fired event, which
   precedes burst end.

--- a/test/validation/weapon_events/game/LuaRules/Gadgets/weapon_events.lua
+++ b/test/validation/weapon_events/game/LuaRules/Gadgets/weapon_events.lua
@@ -1,0 +1,172 @@
+-- SPDX-License-Identifier: GPL-2.0-or-later
+function gadget:GetInfo()
+	return { name = "Weapon event validation", layer = 0, enabled = true }
+end
+if not gadgetHandler:IsSyncedCode() then
+	return false
+end
+
+local cases, failure = {}, false
+local names = { "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam" }
+local function check(ok, message)
+	if not ok then
+		failure = true
+		Spring.Echo("WEAPON_EVENTS FAIL: " .. message)
+	end
+end
+
+function gadget:Initialize()
+	check(type(Script.SetWatchWeaponFired) == "function", "missing shot watch API")
+	if failure then
+		return
+	end
+	for _, name in ipairs(names) do
+		local wd = WeaponDefNames[name].id
+		check(not Script.GetWatchWeaponFired(wd), "shot watch defaults off")
+		Script.SetWatchWeaponFired(wd, true)
+		check(Script.GetWatchWeapon(wd), "aggregate getter includes shot watch")
+		check(not Script.GetWatchWeaponBurst(wd), "shot watch leaves burst watch off")
+		Script.SetWatchWeapon(wd, false)
+		check(not Script.GetWatchWeaponFired(wd), "aggregate setter disables shot watch")
+		Script.SetWatchWeapon(wd, true)
+		check(Script.GetWatchWeaponFired(wd), "aggregate setter enables shot watch")
+		Script.SetWatchWeapon(wd, false)
+		Script.SetWatchWeaponFired(wd, name ~= "silent")
+		Script.SetWatchWeaponBurst(wd, name ~= "onlyfired")
+		Script.SetWatchProjectile(wd, true)
+	end
+end
+
+function gadget:GameFrame(frame)
+	if failure then
+		SendToUnsynced("weapon_events_done")
+		return
+	end
+	if frame == 1 then
+		for i, name in ipairs(names) do
+			local x, z = Game.mapSizeX / 2, Game.mapSizeZ / 2 + i * 64
+			local u = Spring.CreateUnit(name, x, Spring.GetGroundHeight(x, z), z, 0, 0)
+			check(u ~= nil, "create " .. name)
+			if u then
+				cases[u] = { name = name, starts = 0, fired = 0, ends = 0, projectiles = 0, scriptShots = 0 }
+				Spring.UnitScript.CreateScript(u, {
+					QueryWeapon = function()
+						return 1
+					end,
+					AimFromWeapon = function()
+						return 1
+					end,
+					AimWeapon = function(w)
+						Spring.SetUnitWeaponState(u, w, "aimReady", 1)
+					end,
+					BlockShot = function(w)
+						return name == "blocked" or (name == "multi" and w == 1)
+					end,
+					Shot = function()
+						cases[u].scriptShots = cases[u].scriptShots + 1
+					end,
+				})
+				-- The single-shot case keeps cloak intent off, reproducing the missing
+				-- notification context from BAR #6618. The multi case starts cloaked.
+				Spring.SetUnitCloak(u, name == "multi" and 1 or 0)
+				local y = math.max(0, Spring.GetGroundHeight(x, z), Spring.GetGroundHeight(x + 300, z)) + 100
+				Spring.MoveCtrl.Enable(u)
+				Spring.MoveCtrl.SetPosition(u, x, y, z)
+				cases[u].target = { x + 300, y, z }
+			end
+		end
+	end
+	for u, case in pairs(cases) do
+		if frame == 32 then
+			check(Spring.GetUnitIsCloaked(u) == (case.name == "multi"), case.name .. " initial cloak state")
+			Spring.GiveOrderToUnit(u, CMD.ATTACK, case.target, 0)
+		end
+
+		if case.name == "cancel" and case.fired == 2 and not case.dropped then
+			-- Drop the target between the second and third shots, outside callbacks.
+			Spring.GiveOrderToUnit(u, CMD.STOP, {}, 0)
+			Spring.SetUnitTarget(u, nil)
+			case.dropped = true
+		end
+	end
+end
+
+local function eventCase(u, ud, team, weapon)
+	local case = cases[u]
+	if not case then
+		return
+	end
+	check(ud == UnitDefNames[case.name].id and team == 0, "unit identity")
+	check(weapon == (case.name == "multi" and 2 or 1), "one-based weapon slot")
+	return case
+end
+
+function gadget:UnitWeaponBurstStart(u, ud, team, weapon)
+	local case = eventCase(u, ud, team, weapon)
+	if case then
+		case.starts = case.starts + 1
+		check(case.fired == 0 and case.projectiles == 0, "start precedes firing")
+	end
+end
+
+function gadget:ProjectileCreated(_, owner)
+	local case = cases[owner]
+	if case then
+		case.projectiles = case.projectiles + 1
+	end
+end
+
+function gadget:UnitWeaponFired(u, ud, team, weapon)
+	local case = eventCase(u, ud, team, weapon)
+	if not case then
+		return
+	end
+	case.fired = case.fired + 1
+	check(case.ends == 0, "shot precedes burst end")
+	local perShot = case.name == "multi" and 4 or 1
+	check(case.scriptShots == case.fired * perShot, "shot event follows all script Shot calls")
+	if case.name ~= "beam" then
+		check(case.projectiles == case.fired * perShot, "shot event follows all projectiles")
+	end
+end
+
+function gadget:UnitWeaponBurstEnd(u, ud, team, weapon)
+	local case = eventCase(u, ud, team, weapon)
+	if case then
+		case.ends = case.ends + 1
+	end
+end
+
+function gadget:GameFramePost(frame)
+	if frame ~= 120 then
+		return
+	end
+	for _, case in pairs(cases) do
+		local shots = case.name == "multi" and 3
+			or case.name == "cancel" and 2
+			or case.name == "beam" and 3
+			or case.name == "blocked" and 0
+			or 1
+		local bursts = case.name == "blocked" or case.name == "onlyfired"
+		check(case.starts == (bursts and 0 or 1), case.name .. " start count")
+		check(case.ends == (bursts and 0 or 1), case.name .. " end count")
+		check(case.fired == (case.name == "silent" and 0 or shots), case.name .. " fired count")
+		if case.name ~= "beam" then
+			check(case.projectiles == shots * (case.name == "multi" and 4 or 1), case.name .. " projectile count")
+		end
+		Spring.Echo(
+			string.format(
+				"WEAPON_EVENTS %s: start=%d fired=%d end=%d projectiles=%d",
+				case.name,
+				case.starts,
+				case.fired,
+				case.ends,
+				case.projectiles
+			)
+		)
+	end
+	if not failure then
+		Spring.Echo("WEAPON_EVENTS PASS")
+	end
+	SendToUnsynced("weapon_events_done")
+end

--- a/test/validation/weapon_events/game/LuaRules/Gadgets/weapon_events.lua
+++ b/test/validation/weapon_events/game/LuaRules/Gadgets/weapon_events.lua
@@ -7,7 +7,7 @@ if not gadgetHandler:IsSyncedCode() then
 end
 
 local cases, failure = {}, false
-local names = { "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam" }
+local names = { "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam", "zero" }
 local function check(ok, message)
 	if not ok then
 		failure = true
@@ -23,14 +23,23 @@ function gadget:Initialize()
 	for _, name in ipairs(names) do
 		local wd = WeaponDefNames[name].id
 		check(not Script.GetWatchWeaponFired(wd), "shot watch defaults off")
-		Script.SetWatchWeaponFired(wd, true)
-		check(Script.GetWatchWeapon(wd), "aggregate getter includes shot watch")
-		check(not Script.GetWatchWeaponBurst(wd), "shot watch leaves burst watch off")
-		Script.SetWatchWeapon(wd, false)
-		check(not Script.GetWatchWeaponFired(wd), "aggregate setter disables shot watch")
+		check(not Script.GetWatchWeaponBurst(wd), "burst watch defaults off")
 		Script.SetWatchWeapon(wd, true)
-		check(Script.GetWatchWeaponFired(wd), "aggregate setter enables shot watch")
+		check(Script.GetWatchWeapon(wd), "legacy setter enables legacy watches")
+		check(not Script.GetWatchWeaponFired(wd), "legacy setter leaves shot watch off")
+		check(not Script.GetWatchWeaponBurst(wd), "legacy setter leaves burst watch off")
 		Script.SetWatchWeapon(wd, false)
+		Script.SetWatchWeaponFired(wd, true)
+		check(not Script.GetWatchWeapon(wd), "legacy getter excludes shot watch")
+		check(not Script.GetWatchWeaponBurst(wd), "shot watch leaves burst watch off")
+		Script.SetWatchWeaponFired(wd, false)
+		Script.SetWatchWeaponBurst(wd, true)
+		check(not Script.GetWatchWeapon(wd), "legacy getter excludes burst watch")
+		check(not Script.GetWatchWeaponFired(wd), "burst watch leaves shot watch off")
+		Script.SetWatchWeaponFired(wd, true)
+		Script.SetWatchWeapon(wd, false)
+		check(Script.GetWatchWeaponFired(wd), "legacy setter leaves shot watch on")
+		check(Script.GetWatchWeaponBurst(wd), "legacy setter leaves burst watch on")
 		Script.SetWatchWeaponFired(wd, name ~= "silent")
 		Script.SetWatchWeaponBurst(wd, name ~= "onlyfired")
 		Script.SetWatchProjectile(wd, true)
@@ -123,7 +132,7 @@ function gadget:UnitWeaponFired(u, ud, team, weapon)
 	end
 	case.fired = case.fired + 1
 	check(case.ends == 0, "shot precedes burst end")
-	local perShot = case.name == "multi" and 4 or 1
+	local perShot = case.name == "zero" and 0 or case.name == "multi" and 4 or 1
 	check(case.scriptShots == case.fired * perShot, "shot event follows all script Shot calls")
 	if case.name ~= "beam" then
 		check(case.projectiles == case.fired * perShot, "shot event follows all projectiles")
@@ -152,7 +161,10 @@ function gadget:GameFramePost(frame)
 		check(case.ends == (bursts and 0 or 1), case.name .. " end count")
 		check(case.fired == (case.name == "silent" and 0 or shots), case.name .. " fired count")
 		if case.name ~= "beam" then
-			check(case.projectiles == shots * (case.name == "multi" and 4 or 1), case.name .. " projectile count")
+			check(
+				case.projectiles == shots * (case.name == "zero" and 0 or case.name == "multi" and 4 or 1),
+				case.name .. " projectile count"
+			)
 		end
 		Spring.Echo(
 			string.format(

--- a/test/validation/weapon_events/game/LuaRules/draw.lua
+++ b/test/validation/weapon_events/game/LuaRules/draw.lua
@@ -1,0 +1,11 @@
+-- SPDX-License-Identifier: GPL-2.0-or-later
+function Update()
+	if Spring.GetGameFrame() < 0 then
+		Spring.SendCommands("forcestart")
+	end
+end
+function RecvFromSynced(message)
+	if message == "weapon_events_done" then
+		Spring.SendCommands("quitforce")
+	end
+end

--- a/test/validation/weapon_events/game/LuaRules/main.lua
+++ b/test/validation/weapon_events/game/LuaRules/main.lua
@@ -1,0 +1,2 @@
+-- SPDX-License-Identifier: GPL-2.0-or-later
+VFS.Include("LuaGadgets/gadgets.lua", nil, VFS.ZIP_ONLY)

--- a/test/validation/weapon_events/game/gamedata/defs.lua
+++ b/test/validation/weapon_events/game/gamedata/defs.lua
@@ -1,0 +1,43 @@
+-- SPDX-License-Identifier: GPL-2.0-or-later
+local units, weapons = {}, {}
+for _, name in ipairs({ "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam" }) do
+	weapons[name] = {
+		name = name,
+		weaponType = name == "beam" and "BeamLaser" or "Cannon",
+		turret = true,
+		firetolerance = 32768,
+		range = 1000,
+		reloadtime = 60,
+		weaponVelocity = 600,
+		burst = (name == "multi" or name == "cancel") and 3 or 1,
+		burstrate = 0.2,
+		projectiles = name == "multi" and 4 or 1,
+		beamtime = 0.1,
+		weaponTimer = 5,
+		avoidFriendly = false,
+		avoidFeature = false,
+		avoidGround = false,
+		collideFriendly = false,
+		fireSubmersed = true,
+		damage = { default = 1 },
+	}
+	local slot = { name = name, burstControlWhenOutOfArc = 1, fastQueryPointUpdate = true }
+	units[name] = {
+		name = name,
+		objectName = "fir_tree_small.s3o",
+		script = "weapon_events.lua", -- attached by the validation gadget
+		maxDamage = 10000,
+		explodeAs = name,
+		selfDestructAs = name,
+		footprintX = 1,
+		footprintZ = 1,
+		maxWaterDepth = 10000,
+		canAttack = true,
+		canCloak = true,
+		decloakOnFire = true,
+		cloakCost = 0,
+		sightDistance = 1000,
+		weapons = name == "multi" and { slot, slot } or { slot },
+	}
+end
+return { unitdefs = units, weapondefs = weapons, featuredefs = {}, armordefs = {}, movedefs = {} }

--- a/test/validation/weapon_events/game/gamedata/defs.lua
+++ b/test/validation/weapon_events/game/gamedata/defs.lua
@@ -1,6 +1,6 @@
 -- SPDX-License-Identifier: GPL-2.0-or-later
 local units, weapons = {}, {}
-for _, name in ipairs({ "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam" }) do
+for _, name in ipairs({ "single", "multi", "cancel", "blocked", "silent", "onlyfired", "beam", "zero" }) do
 	weapons[name] = {
 		name = name,
 		weaponType = name == "beam" and "BeamLaser" or "Cannon",
@@ -11,7 +11,7 @@ for _, name in ipairs({ "single", "multi", "cancel", "blocked", "silent", "onlyf
 		weaponVelocity = 600,
 		burst = (name == "multi" or name == "cancel") and 3 or 1,
 		burstrate = 0.2,
-		projectiles = name == "multi" and 4 or 1,
+		projectiles = name == "zero" and 0 or name == "multi" and 4 or 1,
 		beamtime = 0.1,
 		weaponTimer = 5,
 		avoidFriendly = false,

--- a/test/validation/weapon_events/game/modinfo.lua
+++ b/test/validation/weapon_events/game/modinfo.lua
@@ -1,0 +1,2 @@
+-- SPDX-License-Identifier: GPL-2.0-or-later
+return { name = "Weapon event validation", version = "1", modtype = 1, depend = { "Spring content v1" } }

--- a/test/validation/weapon_events/run.py
+++ b/test/validation/weapon_events/run.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+"""Run weapon event coverage in a fresh isolated data directory."""
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import zipfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("engine", type=Path, help="Built spring-headless executable")
+parser.add_argument("map_archive", type=Path)
+parser.add_argument("--map-name", default="Quicksilver Remake 1.24")
+args = parser.parse_args()
+engine = args.engine.resolve(strict=True)
+map_archive = args.map_archive.resolve(strict=True)
+if any(c in args.map_name for c in ";{}\r\n"):
+    parser.error("invalid map name")
+data = Path(tempfile.mkdtemp(prefix="recoil-weapon-events-"))
+(data / "games").mkdir()
+(data / "maps").mkdir()
+(data / "maps" / map_archive.name).symlink_to(map_archive)
+game = Path(__file__).parent / "game"
+with zipfile.ZipFile(data / "games" / "weapon-events.sdz", "w") as archive:
+    for source in sorted(game.rglob("*")):
+        if source.is_file():
+            archive.write(source, source.relative_to(game))
+(data / "springsettings.cfg").write_text("LuaUI = 0\nLuaMenu = 0\nWindowState = 0\n")
+script = data / "startscript.txt"
+script.write_text(f"""[GAME]
+{{
+    MapName={args.map_name};
+    GameType=Weapon event validation 1;
+    GameStartDelay=0;
+    StartPosType=0;
+    RecordDemo=0;
+    MyPlayerName=TestRunner;
+    IsHost=1;
+    HostPort=0;
+    FixedRNGSeed=1;
+    [MODOPTIONS] {{ LuaGaia=0; }}
+    [ALLYTEAM0] {{ NumAllies=0; }}
+    [TEAM0] {{ AllyTeam=0; TeamLeader=0; }}
+    [PLAYER0] {{ Name=TestRunner; Team=0; }}
+}}
+""")
+print(f"Test data and logs: {data}", flush=True)
+# Prevent an inherited Spring data override from adding a production installation.
+env = {k: v for k, v in os.environ.items() if k not in ("SPRING_DATADIR", "SPRING_WRITEDIR")}
+with (data / "console.log").open("w") as log:
+    result = subprocess.run(
+        [str(engine), "--isolation", "--write-dir", str(data), str(script)],
+        cwd=data, env=env, stdout=log, stderr=subprocess.STDOUT, timeout=120,
+    )
+output = (data / "console.log").read_text(errors="replace")
+for line in output.splitlines():
+    if "WEAPON_EVENTS" in line:
+        print(line)
+if (result.returncode or "WEAPON_EVENTS PASS" not in output
+        or "WEAPON_EVENTS FAIL" in output or "RunCallInTraceback" in output):
+    raise SystemExit(f"Weapon event validation failed (engine exit {result.returncode}); see {data / 'console.log'}")


### PR DESCRIPTION
## Why

Synced Lua cannot directly observe weapon burst boundaries or individual firing steps. Counting projectiles cannot reliably recover them: one shot can create multiple projectiles, and the final shot of a burst can be skipped.

This PR exposes the engine's events directly.

Closes #3285.

This would help improve
- https://github.com/beyond-all-reason/Beyond-All-Reason/pull/9164
- https://github.com/beyond-all-reason/Beyond-All-Reason/pull/8773

## API

Add three immediate synced managed call-ins, forwarded through the base gadget handler:

```lua
UnitWeaponBurstStart(unitID, unitDefID, unitTeam, weaponNum)
UnitWeaponFired(unitID, unitDefID, unitTeam, weaponNum)
UnitWeaponBurstEnd(unitID, unitDefID, unitTeam, weaponNum)
```

`weaponNum` is the one-based weapon slot.

- **BurstStart** marks burst-state initialization, possibly before windup completes. Unit destruction or Lua weapon-state changes can prevent a matching end.
- **Fired** runs once per fired burst shot, after its projectile loop and before command-AI notification and burst end. Skipped shots produce no fired event. Continuous beams can produce one firing step per simulation frame. Direct unit-script `EmitSfx` firing outside the burst path is not reported.
- **BurstEnd** marks burst completion, including when the final shot was skipped.

Burst boundaries route their existing unit-script callback and Lua event through `CUnit`. They share the per-WeaponDef `Script.GetWatchWeaponBurst` / `Script.SetWatchWeaponBurst` filter. Individual firing events use a separate `Script.GetWatchWeaponFired` / `Script.SetWatchWeaponFired` filter. Aggregate weapon watch accessors include both filters.

All events are immediate notifications. Consumers that mutate command queues should record the event and defer those mutations to a game-frame call-in.

## Validation

- Built `engine-headless` and `basecontent` with the supported Linux container build.
- `test_EventClient`: 2 assertions passed.
- New isolated simulation fixture in `test/validation/weapon_events`: seven cases passed through the real weapon update and base gadget-handler paths. Covers three shots/twelve projectiles, weapon slot 2, a skipped final shot, script-blocked firing, independent watch filters, aggregate watch accessors, continuous beams, and callback ordering.
- The unmodified local engine fails the fixture on the missing shot API as expected.
- Lua 5.1 syntax, fixture StyLua formatting, Python syntax, and `git diff --check` passed.

The current revision has automated simulation coverage. Refreshed human gameplay verification remains outstanding.

## AI / LLM usage statement

OpenAI Codex assisted with investigation, implementation, automated validation, and this PR description. @eun-ice reviewed and edited the related issue and manually verified an earlier prototype; the current revision requires human review and gameplay verification.
