### PR TITLE
assimp: include <cmath> in the inline headers

### DIFF
--- a/rts/lib/assimp/include/assimp/matrix3x3.inl
+++ b/rts/lib/assimp/include/assimp/matrix3x3.inl
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_MATRIX3X3_INL_INC
 
 #ifdef __cplusplus
+#include <cmath>
 #include "matrix3x3.h"
 
 #include "matrix4x4.h"

--- a/rts/lib/assimp/include/assimp/matrix4x4.inl
+++ b/rts/lib/assimp/include/assimp/matrix4x4.inl
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __cplusplus
 
+#include <cmath>
 #include "matrix4x4.h"
 #include "matrix3x3.h"
 #include "quaternion.h"

--- a/rts/lib/assimp/include/assimp/quaternion.inl
+++ b/rts/lib/assimp/include/assimp/quaternion.inl
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_QUATERNION_INL_INC
 
 #ifdef __cplusplus
+#include <cmath>
 #include "quaternion.h"
 
 #include "lib/streflop/streflop_cond.h"

--- a/rts/lib/assimp/include/assimp/vector2.inl
+++ b/rts/lib/assimp/include/assimp/vector2.inl
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_VECTOR2D_INL_INC
 
 #ifdef __cplusplus
+#include <cmath>
 #include "vector2.h"
 
 #include "lib/streflop/streflop_cond.h"

--- a/rts/lib/assimp/include/assimp/vector3.inl
+++ b/rts/lib/assimp/include/assimp/vector3.inl
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_VECTOR3D_INL_INC
 
 #ifdef __cplusplus
+#include <cmath>
 #include "vector3.h"
 
 #include "lib/streflop/streflop_cond.h"


### PR DESCRIPTION
These call sqrt, cos, acos and friends unqualified. libstdc++ pulls the declarations in transitively, libc++ does not, so the build fails there. Nothing in CI catches it, the workflows build on Linux and Windows only