### PR TITLE
System: add a views::enumerate fallback for libc++

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include "System/RangesCompat.h"
 #include "LuaHandleSynced.h"
 
 #include "LuaInclude.h"
@@ -1220,7 +1221,7 @@ bool CSyncedLuaHandle::ResourceExcess(const std::map <int, SResourcePack>& exces
 
 	for (const auto &[teamID, excess] : excesses) {
 		lua_createtable(L, excess.MAX_RESOURCES, 0);
-		for (const auto &[resourceID, resource] : std::views::enumerate(excess)) {
+		for (const auto &[resourceID, resource] : spring::views::enumerate(excess)) {
 			lua_pushnumber(L, resource);
 			lua_rawseti(L, -2, resourceID + 1);
 		}

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include "System/RangesCompat.h"
 #include "UnitDef.h"
 #include "Unit.h"
 #include "UnitHandler.h"
@@ -965,7 +966,7 @@ static auto SplitResourcePackIntoPositiveNegative (const SResourcePack &pack)
 {
 	SResourcePack positive {0.0f}, negative {0.0f};
 
-	for (auto [resourceID, value] : std::views::enumerate (pack)) {
+	for (auto [resourceID, value] : spring::views::enumerate (pack)) {
 		if (value < 0.0f)
 			negative[resourceID] = -value;
 		else

--- a/rts/System/RangesCompat.h
+++ b/rts/System/RangesCompat.h
@@ -1,0 +1,48 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef RANGES_COMPAT_H
+#define RANGES_COMPAT_H
+
+#include <version>
+#include <iterator>
+#include <ranges>
+#include <utility>
+
+namespace spring::views {
+
+#ifdef __cpp_lib_ranges_enumerate
+
+using std::views::enumerate;
+
+#else
+
+template<typename Rng> auto enumerate(Rng& rng)
+{
+	struct Iterator {
+		decltype(std::begin(rng)) it;
+		std::ptrdiff_t idx;
+
+		// the element half stays a reference, copying it would turn a
+		// mutating loop into a no-op
+		auto operator * () const { return std::pair<std::ptrdiff_t, decltype(*it)>(idx, *it); }
+		Iterator& operator ++ () { ++it; ++idx; return *this; }
+		bool operator != (const Iterator& o) const { return it != o.it; }
+	};
+
+	struct View {
+		Rng& rng;
+		Iterator begin() const { return {std::begin(rng), 0}; }
+		Iterator end  () const { return {std::end  (rng), 0}; }
+	};
+
+	return View{rng};
+}
+
+// the view holds a reference, so a temporary would dangle
+template<typename Rng> void enumerate(Rng&&) = delete;
+
+#endif
+
+}
+
+#endif // RANGES_COMPAT_H

--- a/rts/System/Sync/DumpState.cpp
+++ b/rts/System/Sync/DumpState.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include "System/RangesCompat.h"
 #include <string>
 #include <fstream>
 #include <vector>
@@ -687,15 +688,15 @@ void DumpState(int newMinFrameNum, int newMaxFrameNum, int newFramePeriod, std::
 		const CTeam* t = teamHandler.Team(a);
 
 		file << "\t\tteamID: " << t->teamNum << " (controller: " << t->GetControllerName() << ")\n";
-		for (const auto &[resourceID, value] : std::views::enumerate(t->res))
+		for (const auto &[resourceID, value] : spring::views::enumerate(t->res))
 			file << "\t\t\tstored[" << resourceID << "]: " << TapFloats(value);
-		for (const auto &[resourceID, value] : std::views::enumerate(t->resStorage))
+		for (const auto &[resourceID, value] : spring::views::enumerate(t->resStorage))
 			file << "\t\t\tmaxStorage[" << resourceID << "]: " << TapFloats(value);
-		for (const auto &[resourceID, value] : std::views::enumerate(t->resPull))
+		for (const auto &[resourceID, value] : spring::views::enumerate(t->resPull))
 			file << "\t\t\tpull[" << resourceID << "]: " << TapFloats(value);
-		for (const auto &[resourceID, value] : std::views::enumerate(t->resIncome))
+		for (const auto &[resourceID, value] : spring::views::enumerate(t->resIncome))
 			file << "\t\t\tincome[" << resourceID << "]: " << TapFloats(value);
-		for (const auto &[resourceID, value] : std::views::enumerate(t->resExpense))
+		for (const auto &[resourceID, value] : spring::views::enumerate(t->resExpense))
 			file << "\t\t\texpense[" << resourceID << "]: " << TapFloats(value);
 	}
 	#endif


### PR DESCRIPTION
std::views::enumerate is C++23. libstdc++ and the MinGW toolchain have it, libc++ does not yet, so the seven call sites fail to build there. Guarded on the feature-test macro, so on every current CI toolchain this file is just a using-declaration

The alternative is rewriting those loops with a manual counter, which makes
them worse to read. This way the file deletes itself the day libc++ ships
enumerate