### PR TITLE
net: never block the main thread on udp sends

### DIFF
--- a/doc/pr-changelogs/3293.md
+++ b/doc/pr-changelogs/3293.md
@@ -1,0 +1,1 @@
+ * fixed freezes caused by the network connection taking too long to send packets.

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -1074,6 +1074,8 @@ void UDPConnection::SendPacket(Packet& pkt)
 		mySocket->send_to(buffer(sendBuffer), addr, flags, err);
 		// a full send buffer surfaces as try_again, give it a moment to drain
 		if (err && err.value() == asio::error::try_again) {
+			/* Balance between too many resends (lower)
+			 * and main thread stalls (higher) */ 
 			constexpr int drainWaitMs = 5;
 #ifdef _WIN32
 			WSAPOLLFD pfd = {(SOCKET)mySocket->native_handle(), POLLWRNORM, 0};

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -820,8 +820,8 @@ std::string UDPConnection::Statistics() const
 		"\t%u bytes recv'd in %u packets (%.3f bytes/packet)\n",
 		"\t{%.3fx, %.3fx} relative protocol overhead {up, down}\n",
 		"\t%u incoming chunks dropped, %u outgoing chunks resent\n",
-		"\t%u outgoing packets dropped on a full send buffer\n",
 		"\t%u incoming chunks processed\n",
+		"\t%u outgoing packets dropped on a full send buffer\n",
 	};
 
 	std::string msg = "[UDPConnection::Statistics]\n";
@@ -829,8 +829,8 @@ std::string UDPConnection::Statistics() const
 	msg += spring::format(fmts[1], dataRecv, recvPackets, spring::SafeDivide(dataRecv * 1.0f, recvPackets * 1.0f));
 	msg += spring::format(fmts[2], spring::SafeDivide(sentOverhead * 1.0f, dataSent * 1.0f), spring::SafeDivide(recvOverhead * 1.0f, dataRecv * 1.0f));
 	msg += spring::format(fmts[3], droppedChunks, resentChunks);
-	msg += spring::format(fmts[4], droppedSends);
-	msg += spring::format(fmts[5], lastInOrder + 1);
+	msg += spring::format(fmts[4], lastInOrder + 1);
+	msg += spring::format(fmts[5], droppedSends);
 	return msg;
 }
 

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -269,7 +269,7 @@ void UDPConnection::Init()
 	// make sure protocoldef is initialized
 	CBaseNetProtocol::Get();
 
-	// a blocking send_to wedges the main thread when the send buffer fills up
+	// make sure we don't block the main thread with send_to if the send buffer is full
 	if (mySocket != nullptr) {
 		asio::error_code nbErr;
 		mySocket->non_blocking(true, nbErr);

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -710,6 +710,8 @@ void UDPConnection::Flush(const bool forced)
 	if (muted)
 		return;
 
+	drainWaited = false;
+
 	const spring_time curTime = spring_gettime();
 
 	// do not create chunks more than chunksPerSec times per second
@@ -1072,8 +1074,10 @@ void UDPConnection::SendPacket(Packet& pkt)
 
 	EMULATE_LATENCY( !EMULATE_PACKET_LOSS( LOSS_COUNTER ) ) {
 		mySocket->send_to(buffer(sendBuffer), addr, flags, err);
-		// a full send buffer surfaces as try_again, give it a moment to drain
-		if (err && err.value() == asio::error::try_again) {
+		// a full send buffer surfaces as try_again, give it a moment to drain.
+		// once per flush pass: NetProtocol.cpp holds a spinlock over this
+		if (err && err.value() == asio::error::try_again && !drainWaited) {
+			drainWaited = true;
 			/* Balance between too many resends (lower)
 			 * and main thread stalls (higher) */ 
 			constexpr int drainWaitMs = 5;

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -1075,7 +1075,7 @@ void UDPConnection::SendPacket(Packet& pkt)
 	EMULATE_LATENCY( !EMULATE_PACKET_LOSS( LOSS_COUNTER ) ) {
 		mySocket->send_to(buffer(sendBuffer), addr, flags, err);
 		// a full send buffer surfaces as try_again, give it a moment to drain.
-		// once per flush pass: NetProtocol.cpp holds a spinlock over this
+		// once per flush pass, so a flush with multiple packets doesn't wait multiple times
 		if (err && err.value() == asio::error::try_again && !drainWaited) {
 			drainWaited = true;
 			/* Balance between too many resends (lower)

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -1,5 +1,9 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#ifndef _WIN32
+#include <poll.h>
+#endif
+
 #include "UDPConnection.h"
 
 #include <cinttypes>
@@ -264,6 +268,14 @@ void UDPConnection::Init()
 {
 	// make sure protocoldef is initialized
 	CBaseNetProtocol::Get();
+
+	// a blocking send_to wedges the main thread when the send buffer fills up
+	if (mySocket != nullptr) {
+		asio::error_code nbErr;
+		mySocket->non_blocking(true, nbErr);
+		if (nbErr)
+			LOG_L(L_WARNING, "[%s] could not set non-blocking mode: %s", __func__, nbErr.message().c_str());
+	}
 
 	lastNakTime = spring_gettime();
 	lastUnackResentTime = spring_gettime();
@@ -808,6 +820,7 @@ std::string UDPConnection::Statistics() const
 		"\t%u bytes recv'd in %u packets (%.3f bytes/packet)\n",
 		"\t{%.3fx, %.3fx} relative protocol overhead {up, down}\n",
 		"\t%u incoming chunks dropped, %u outgoing chunks resent\n",
+		"\t%u outgoing packets dropped on a full send buffer\n",
 		"\t%u incoming chunks processed\n",
 	};
 
@@ -816,7 +829,8 @@ std::string UDPConnection::Statistics() const
 	msg += spring::format(fmts[1], dataRecv, recvPackets, spring::SafeDivide(dataRecv * 1.0f, recvPackets * 1.0f));
 	msg += spring::format(fmts[2], spring::SafeDivide(sentOverhead * 1.0f, dataSent * 1.0f), spring::SafeDivide(recvOverhead * 1.0f, dataRecv * 1.0f));
 	msg += spring::format(fmts[3], droppedChunks, resentChunks);
-	msg += spring::format(fmts[4], lastInOrder + 1);
+	msg += spring::format(fmts[4], droppedSends);
+	msg += spring::format(fmts[5], lastInOrder + 1);
 	return msg;
 }
 
@@ -1058,10 +1072,31 @@ void UDPConnection::SendPacket(Packet& pkt)
 
 	EMULATE_LATENCY( !EMULATE_PACKET_LOSS( LOSS_COUNTER ) ) {
 		mySocket->send_to(buffer(sendBuffer), addr, flags, err);
+		// a full send buffer surfaces as try_again, give it a moment to drain
+		if (err && err.value() == asio::error::try_again) {
+			constexpr int drainWaitMs = 5;
+#ifdef _WIN32
+			WSAPOLLFD pfd = {(SOCKET)mySocket->native_handle(), POLLWRNORM, 0};
+			if (WSAPoll(&pfd, 1, drainWaitMs) > 0)
+#else
+			struct pollfd pfd = {mySocket->native_handle(), POLLOUT, 0};
+			if (poll(&pfd, 1, drainWaitMs) > 0)
+#endif
+			{
+				err.clear();
+				mySocket->send_to(buffer(sendBuffer), addr, flags, err);
+			}
+		}
 	}
 
 	if (CheckErrorCode(err))
 		return;
+
+	// a dropped packet is not a sent packet
+	if (err) {
+		droppedSends += 1;
+		return;
+	}
 
 	dataSent += sendBuffer.size();
 	sentPackets += 1;

--- a/rts/System/Net/UDPConnection.h
+++ b/rts/System/Net/UDPConnection.h
@@ -243,6 +243,7 @@ private:
 
 	unsigned int sentOverhead, recvOverhead;
 	unsigned int sentPackets, recvPackets;
+	unsigned int droppedSends = 0;
 
 	class BandwidthUsage {
 	public:

--- a/rts/System/Net/UDPConnection.h
+++ b/rts/System/Net/UDPConnection.h
@@ -244,6 +244,7 @@ private:
 	unsigned int sentOverhead, recvOverhead;
 	unsigned int sentPackets, recvPackets;
 	unsigned int droppedSends = 0;
+	bool drainWaited = false;
 
 	class BandwidthUsage {
 	public:


### PR DESCRIPTION
A synchronous send_to blocks until the send buffer drains, which freezes the whole client when the link chokes. Hit this on macOS mid game, with the VPN on

The socket is non-blocking now. A full buffer surfaces as try_again, which CheckErrorCode already treats as harmless, so the packet gets 5ms to drain and is dropped after that, same as a packet lost on the wire. Drops are counted in the connection statistics