### PR TITLE
Replace deprecated std::aligned_storage

### DIFF
--- a/rts/System/MemPoolTypes.h
+++ b/rts/System/MemPoolTypes.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstring> // memset
 #include <cmath>
+#include <algorithm>
 #include <array>
 #include <deque>
 #include <vector>
@@ -62,14 +63,16 @@ private:
 };
 
 // Helper to infer the memory alignment and size from a set of types.
-template <class ...T>
-#if 0 // doesn't compile on MSVC 19.37
-struct TypesMem {
-    alignas(alignof(T)...) uint8_t data[std::max({sizeof(T)...})];
-};
-#else
-using TypesMem = std::aligned_storage_t< std::max({ sizeof(T)... }), std::max({ alignof(T)... }) >;
-#endif
+template<class... T>
+inline constexpr size_t TypesMemAlignment = std::max({alignof(T)...});
+
+template<class... T>
+inline constexpr size_t TypesMemSize = [] {
+	constexpr size_t alignment = TypesMemAlignment<T...>;
+	constexpr size_t size = std::max({sizeof(T)...});
+
+	return ((size + alignment - 1) / alignment) * alignment;
+}();
 
 template<size_t S, size_t Alignment> struct DynMemPool {
 public:
@@ -163,8 +166,8 @@ private:
 };
 
 // Helper to infer the DynMemPool pool parameters from a types.
-template<class ...T>
-using DynMemPoolT = DynMemPool<sizeof(TypesMem<T...>), alignof(TypesMem<T...>)>;
+template<class... T>
+using DynMemPoolT = DynMemPool<TypesMemSize<T...>, TypesMemAlignment<T...>>;
 
 // fixed-size dynamic version
 // page size per chunk, number of chunks, number of pages per chunk
@@ -286,8 +289,8 @@ private:
 };
 
 // Helper to infer the FixedDynMemPool pool parameters from a types.
-template<size_t N, size_t K, class ...T>
-using FixedDynMemPoolT = FixedDynMemPool<sizeof(TypesMem<T...>), N, K, alignof(TypesMem<T...>)>;
+template<size_t N, size_t K, class... T>
+using FixedDynMemPoolT = FixedDynMemPool<TypesMemSize<T...>, N, K, TypesMemAlignment<T...>>;
 
 // fixed-size version.
 template<size_t N, size_t S, size_t Alignment> struct StaticMemPool {
@@ -372,8 +375,8 @@ private:
 };
 
 // Helper to infer the StaticMemPool pool parameters from a types.
-template<size_t N, class ...T>
-using StaticMemPoolT = StaticMemPool<N, sizeof(TypesMem<T...>), alignof(TypesMem<T...>)>;
+template<size_t N, class... T>
+using StaticMemPoolT = StaticMemPool<N, TypesMemSize<T...>, TypesMemAlignment<T...>>;
 
 
 // dynamic memory allocator operating with stable index positions


### PR DESCRIPTION
This resurrects #3053 authored by devgit283 to reduce the number of compiler warnings.
The PR was approved but never merged because devgit283 deleted their GitHub account.  

This is the original PR description:
> std::aligned_storage was deprecated in c++23, https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead
> 
> There was already a unused replacement but this code still doesn't compile with MSVC.
> 
> https://github.com/beyond-all-reason/RecoilEngine/blob/83642b066f755ac182ef97ea540569c07e59d2ff/rts/System/MemPoolTypes.h#L66-L70
> 
> ### AI Disclosure
> 
> No LLM was used.