### PR TITLE
Fix flickering build preview caused by OOB access

### DIFF
--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -1636,6 +1636,14 @@ bool CUnitDrawerGLSL::ShowUnitBuildSquare(const BuildInfo& buildInfo, const std:
 
 	uint64_t hashKey = spring::LiteHash(pos);
 	hashKey = spring::hash_combine(spring::LiteHash(buildInfo.buildFacing), hashKey);
+	// TestUnitBuildSquare statuses also depend on the definition and queued
+	// commands. Both the world and minimap passes share this cache.
+	hashKey = spring::hash_combine(spring::LiteHash(buildInfo.def->id), hashKey);
+	for (const Command& command: commands) {
+		hashKey = spring::hash_combine(spring::LiteHash(command.GetID()), hashKey);
+		for (unsigned int i = 0; i < command.GetNumParams(); ++i)
+			hashKey = spring::hash_combine(spring::LiteHash(command.GetParam(i)), hashKey);
+	}
 
 	static constexpr int CACHE_VALIDITY_PERIOD = GAME_SPEED / 5;
 	std::erase_if(buildCache, [](const BuildCache& bc) {
@@ -2361,4 +2369,3 @@ void CUnitDrawerGL4::DrawUnitModelBeingBuiltOpaque(const CUnit* unit, bool noLua
 
 	glPopAttrib();
 }
-

--- a/rts/Rendering/Units/UnitDrawer.cpp
+++ b/rts/Rendering/Units/UnitDrawer.cpp
@@ -1625,6 +1625,7 @@ bool CUnitDrawerGLSL::ShowUnitBuildSquare(const BuildInfo& buildInfo, const std:
 
 	struct BuildCache {
 		uint64_t key;
+		int unitDefID;
 		int createFrame;
 		bool canBuild;
 		std::vector<uint8_t> statuses;
@@ -1658,8 +1659,14 @@ bool CUnitDrawerGLSL::ShowUnitBuildSquare(const BuildInfo& buildInfo, const std:
 
 	bool canBuild;
 
-	const auto it = std::find_if(buildCache.begin(), buildCache.end(), [hashKey](const BuildCache& bc) {
-		return bc.key == hashKey;
+	// A hash collision may reuse incorrect statuses. Verify the UnitDef separately
+	// to prevent an OOB read from a mismatched footprint; collisions within the
+	// same UnitDef may still render incorrect status data.
+	const auto it = std::find_if(buildCache.begin(), buildCache.end(), [hashKey, &buildInfo](const BuildCache& bc) {
+		return (
+			bc.key == hashKey &&
+			bc.unitDefID == buildInfo.def->id
+		);
 	});
 	if (it != buildCache.end()) {
 		statuses = it->statuses;
@@ -1678,6 +1685,7 @@ bool CUnitDrawerGLSL::ShowUnitBuildSquare(const BuildInfo& buildInfo, const std:
 		auto& buildCacheItem = buildCache.back();
 
 		buildCacheItem.key = hashKey;
+		buildCacheItem.unitDefID = buildInfo.def->id;
 		buildCacheItem.canBuild = canBuild;
 		buildCacheItem.createFrame = gs->frameNum;
 		buildCacheItem.statuses = statuses;


### PR DESCRIPTION
## What

Closes #3295.

The issue shows a flickering or outdated build preview.

This is reproducible on master when the game is paused, the mouse is not moved and

- the previewed building changes, e.g. switching from wind to botlab using a grid key
- the build queue changes, e.g. by pressing N

Videos in #3295 


## Cause

The build status is cached for 6 simulation frames, with only the position and facing being the cache keys.

This can result in reuse of a wrong build status for 6 simulation frames (e.g. while game is paused).

The cached status contains a "statuses" array that might be for a smaller building (e.g. 2x2) but if reused for a larger building it will be accessed OOB, causing random status data to be displayed, causing the flickering.

Even if the cached status is for a same size or larger building, the status displayed might be incorrect.

## Fix

- include the selected UnitDef in the build-square preview cache identity hash
- include queued build-command IDs and parameters consumed by `TestUnitBuildSquare` hash
- validate the UnitDef directly when looking up a cache entry to avoid OOB on hash collisions.


## AI disclosure

OpenAI Codex was used interactively to isolate the existing change onto current master, build it, and draft the issue and PR text. I reviewed the resulting change.