### PR TITLE
Ensure consistent timestamp reading in ITaskGroup::GetDeltaTime

### DIFF
--- a/rts/System/Threading/ThreadPool.h
+++ b/rts/System/Threading/ThreadPool.h
@@ -224,7 +224,10 @@ public:
 	}
 
 	uint32_t GetId() const { return id; }
-	uint64_t GetDeltaTime(const spring_time t) const { return (std::max(ts.load(), uint64_t(t.toNanoSecsi())) - ts); }
+	uint64_t GetDeltaTime(const spring_time t0) const {
+		const uint64_t t1 = ts.load();
+		return (std::max(t1, uint64_t(t0.toNanoSecsi())) - t1);
+	}
 
 	void UpdateId() { id = lastId.fetch_add(1); }
 	void SetTimeStamp(const spring_time t) { ts = t.toNanoSecsi(); }


### PR DESCRIPTION
The timestamp `std::atomic<uint64_t> ts` can be modified concurrently between its two reads
in the original implementation. This caused effectively useless values getting returned by the function.
