### PR TITLE
Load BC4/BC5/BC7 DDS textures (DX10 header) in nv_dds

### DIFF
--- a/rts/Rendering/Textures/nv_dds.cpp
+++ b/rts/Rendering/Textures/nv_dds.cpp
@@ -9,7 +9,8 @@
 // Description:
 //
 // Loads DDS images (DXTC1, DXTC3, DXTC5, RGB (888, 888X), and RGBA (8888) are
-// supported) for use in OpenGL. Image is flipped when its loaded as DX images
+// supported) for use in OpenGL. Files with a DX10 extended header are
+// accepted, texture arrays are not. Image is flipped when its loaded as DX images
 // are stored with different coordinate system. If file has mipmaps and/or
 // cubemaps then these are loaded as well. Volume textures can be loaded as
 // well but they must be uncompressed.
@@ -349,6 +350,24 @@ bool CDDSImage::load(string filename, bool flipImage)
 	file.Read(&ddsh.dwCaps2, tmp);
 	file.Read(&ddsh.dwReserved2, tmp*3);
 
+    const bool hasDX10Header = ((swabDWord(ddsh.ddspf.dwFlags) & DDSF_FOURCC) && swabDWord(ddsh.ddspf.dwFourCC) == FOURCC_DX10);
+    DDS_HEADER_DXT10 ddsh10 = {0, 0, 0, 1, 0};
+    if (hasDX10Header)
+	{
+        if (file.Read(&ddsh10.dxgiFormat, tmp) != tmp ||
+            file.Read(&ddsh10.resourceDimension, tmp) != tmp ||
+            file.Read(&ddsh10.miscFlag, tmp) != tmp ||
+            file.Read(&ddsh10.arraySize, tmp) != tmp ||
+            file.Read(&ddsh10.miscFlags2, tmp) != tmp)
+            return false;
+
+		ddsh10.dxgiFormat = swabDWord(ddsh10.dxgiFormat);
+		ddsh10.resourceDimension = swabDWord(ddsh10.resourceDimension);
+		ddsh10.miscFlag = swabDWord(ddsh10.miscFlag);
+		ddsh10.arraySize = swabDWord(ddsh10.arraySize);
+		ddsh10.miscFlags2 = swabDWord(ddsh10.miscFlags2);
+	}
+
 	// if in VFS, read post-header data directly from buffer
 	if (file.IsBuffered()) {
 		fileBuf = std::move(file.GetBuffer());
@@ -374,16 +393,29 @@ bool CDDSImage::load(string filename, bool flipImage)
 	ddsh.dwCaps1 = swabDWord(ddsh.dwCaps1);
 	ddsh.dwCaps2 = swabDWord(ddsh.dwCaps2);
 
+    if (hasDX10Header &&
+        (ddsh10.arraySize != 1 ||
+         (ddsh10.resourceDimension != DX10_DIMENSION_TEXTURE2D && ddsh10.resourceDimension != DX10_DIMENSION_TEXTURE3D) ||
+         ((ddsh10.miscFlag & DX10_MISC_TEXTURECUBE) && ddsh10.resourceDimension != DX10_DIMENSION_TEXTURE2D)))
+		return false;
+
 	// default to flat texture type (1D, 2D, or rectangle)
 	m_type = TextureFlat;
 
-	// check if image is a cubemap
-	if (ddsh.dwCaps2 & DDSF_CUBEMAP)
-		m_type = TextureCubemap;
+	if (hasDX10Header) {
+		if (ddsh10.miscFlag & DX10_MISC_TEXTURECUBE)
+			m_type = TextureCubemap;
+		else if (ddsh10.resourceDimension == DX10_DIMENSION_TEXTURE3D)
+			m_type = Texture3D;
+	} else {
+		// check if image is a cubemap
+		if (ddsh.dwCaps2 & DDSF_CUBEMAP)
+			m_type = TextureCubemap;
 
-	// check if image is a volume texture
-	if ((ddsh.dwCaps2 & DDSF_VOLUME) && (ddsh.dwDepth > 0))
-		m_type = Texture3D;
+		// check if image is a volume texture
+		if ((ddsh.dwCaps2 & DDSF_VOLUME) && (ddsh.dwDepth > 0))
+			m_type = Texture3D;
+	}
 
 	// figure out what the image format is
 	if (ddsh.ddspf.dwFlags & DDSF_FOURCC)
@@ -401,6 +433,25 @@ bool CDDSImage::load(string filename, bool flipImage)
 			case FOURCC_DXT5:
 				m_format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
 				m_components = 4;
+				break;
+			case FOURCC_DX10:
+				switch (ddsh10.dxgiFormat)
+				{
+					case DXGI_FORMAT_BC1_UNORM:
+						m_format = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
+						m_components = 3;
+						break;
+					case DXGI_FORMAT_BC2_UNORM:
+						m_format = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
+						m_components = 4;
+						break;
+					case DXGI_FORMAT_BC3_UNORM:
+						m_format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+						m_components = 4;
+						break;
+					default:
+						return false;
+				}
 				break;
 			default:
 				//fclose(fp);

--- a/rts/Rendering/Textures/nv_dds.cpp
+++ b/rts/Rendering/Textures/nv_dds.cpp
@@ -8,12 +8,9 @@
 //
 // Description:
 //
-// Loads DDS images (DXTC1, DXTC3, DXTC5, RGB (888, 888X), and RGBA (8888) are
-// supported) for use in OpenGL. Files with a DX10 extended header are
-// accepted, texture arrays are not. Image is flipped when its loaded as DX images
-// are stored with different coordinate system. If file has mipmaps and/or
-// cubemaps then these are loaded as well. Volume textures can be loaded as
-// well but they must be uncompressed.
+// Loads DDS images for use in OpenGL. DXT1, DXT3, DXT5, BC4, BC5, BC7,
+// RGB (888, 888X), and RGBA (8888) are supported. Images are flipped to match
+// OpenGL coordinates, except BC7. Volume textures must be uncompressed.
 //
 // When multiple textures are loaded (i.e a volume or cubemap texture),
 // additional faces can be accessed using the array operator.
@@ -434,6 +431,16 @@ bool CDDSImage::load(string filename, bool flipImage)
 				m_format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
 				m_components = 4;
 				break;
+			case FOURCC_ATI1:
+			case FOURCC_BC4U:
+				m_format = GL_COMPRESSED_RED_RGTC1;
+				m_components = 1;
+				break;
+			case FOURCC_ATI2:
+			case FOURCC_BC5U:
+				m_format = GL_COMPRESSED_RG_RGTC2;
+				m_components = 2;
+				break;
 			case FOURCC_DX10:
 				switch (ddsh10.dxgiFormat)
 				{
@@ -447,6 +454,22 @@ bool CDDSImage::load(string filename, bool flipImage)
 						break;
 					case DXGI_FORMAT_BC3_UNORM:
 						m_format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+						m_components = 4;
+						break;
+					case DXGI_FORMAT_BC4_UNORM:
+						m_format = GL_COMPRESSED_RED_RGTC1;
+						m_components = 1;
+						break;
+					case DXGI_FORMAT_BC5_UNORM:
+						m_format = GL_COMPRESSED_RG_RGTC2;
+						m_components = 2;
+						break;
+					case DXGI_FORMAT_BC7_UNORM:
+						m_format = GL_COMPRESSED_RGBA_BPTC_UNORM;
+						m_components = 4;
+						break;
+					case DXGI_FORMAT_BC7_UNORM_SRGB:
+						m_format = GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM;
 						m_components = 4;
 						break;
 					default:
@@ -484,6 +507,11 @@ bool CDDSImage::load(string filename, bool flipImage)
 		fclose(fp);
 		#endif
 		return false;
+	}
+
+	if (flipImage && (m_format == GL_COMPRESSED_RGBA_BPTC_UNORM || m_format == GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM)) {
+		LOG_L(L_WARNING, "[nv_dds] cannot vertically flip BC7 image \"%s\", author it pre-flipped", filename.c_str());
+		flipImage = false;
 	}
 
 	// store primary surface width/height/depth
@@ -628,6 +656,12 @@ bool CDDSImage::save(std::string filename, bool flipImage) const
 	RECOIL_DETAILED_TRACY_ZONE;
     assert(m_valid);
     assert(m_type != TextureNone);
+
+    if (is_compressed() &&
+        m_format != GL_COMPRESSED_RGBA_S3TC_DXT1_EXT &&
+        m_format != GL_COMPRESSED_RGBA_S3TC_DXT3_EXT &&
+        m_format != GL_COMPRESSED_RGBA_S3TC_DXT5_EXT)
+        return false;
 
     DDS_HEADER ddsh;
     unsigned int headerSize = sizeof(DDS_HEADER);
@@ -778,7 +812,11 @@ bool CDDSImage::is_compressed() const
 	RECOIL_DETAILED_TRACY_ZONE;
 	return ((m_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT) ||
 		   (m_format == GL_COMPRESSED_RGBA_S3TC_DXT3_EXT) ||
-		   (m_format == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT));
+		   (m_format == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT) ||
+		   (m_format == GL_COMPRESSED_RED_RGTC1) ||
+		   (m_format == GL_COMPRESSED_RG_RGTC2) ||
+		   (m_format == GL_COMPRESSED_RGBA_BPTC_UNORM) ||
+		   (m_format == GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM));
 }
 
 #ifndef HEADLESS
@@ -1020,7 +1058,7 @@ inline unsigned int CDDSImage::size_dxtc(unsigned int width, unsigned int height
 {
 	RECOIL_DETAILED_TRACY_ZONE;
     return ((width+3)/4)*((height+3)/4)*
-        (m_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT ? 8 : 16);
+        ((m_format == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT || m_format == GL_COMPRESSED_RED_RGTC1) ? 8 : 16);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1080,6 +1118,14 @@ void CDDSImage::flip(CSurface &surface) const
             case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
                 blocksize = 16;
                 flipblocks = &CDDSImage::flip_blocks_dxtc5;
+                break;
+            case GL_COMPRESSED_RED_RGTC1:
+                blocksize = 8;
+                flipblocks = &CDDSImage::flip_blocks_bc4;
+                break;
+            case GL_COMPRESSED_RG_RGTC2:
+                blocksize = 16;
+                flipblocks = &CDDSImage::flip_blocks_bc5;
                 break;
             default:
                 return;
@@ -1265,6 +1311,40 @@ void CDDSImage::flip_blocks_dxtc5(DXTColBlock *line, unsigned int numBlocks) con
 
         swap(&curblock->row[0], &curblock->row[3], sizeof(unsigned char));
         swap(&curblock->row[1], &curblock->row[2], sizeof(unsigned char));
+
+        curblock++;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// flip a line of BC4 blocks
+void CDDSImage::flip_blocks_bc4(DXTColBlock *line, unsigned int numBlocks) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+    DXT5AlphaBlock *curblock = reinterpret_cast<DXT5AlphaBlock*>(line);
+
+    for (unsigned int i = 0; i < numBlocks; i++)
+    {
+        flip_dxt5_alpha(curblock);
+
+        curblock++;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// flip a line of BC5 blocks
+void CDDSImage::flip_blocks_bc5(DXTColBlock *line, unsigned int numBlocks) const
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+    DXT5AlphaBlock *curblock = reinterpret_cast<DXT5AlphaBlock*>(line);
+
+    for (unsigned int i = 0; i < numBlocks; i++)
+    {
+        flip_dxt5_alpha(curblock);
+
+        curblock++;
+
+        flip_dxt5_alpha(curblock);
 
         curblock++;
     }

--- a/rts/Rendering/Textures/nv_dds.h
+++ b/rts/Rendering/Textures/nv_dds.h
@@ -51,6 +51,17 @@ namespace nv_dds
     const unsigned int FOURCC_DXT1 = 0x31545844; //(MAKEFOURCC('D','X','T','1'))
     const unsigned int FOURCC_DXT3 = 0x33545844; //(MAKEFOURCC('D','X','T','3'))
     const unsigned int FOURCC_DXT5 = 0x35545844; //(MAKEFOURCC('D','X','T','5'))
+    const unsigned int FOURCC_DX10 = 0x30315844; //(MAKEFOURCC('D','X','1','0'))
+
+    // Supported DXGI formats
+    const unsigned int DXGI_FORMAT_BC1_UNORM = 71;
+    const unsigned int DXGI_FORMAT_BC2_UNORM = 74;
+    const unsigned int DXGI_FORMAT_BC3_UNORM = 77;
+
+    // DDS_HEADER_DXT10 values
+    const unsigned int DX10_DIMENSION_TEXTURE2D = 3;
+    const unsigned int DX10_DIMENSION_TEXTURE3D = 4;
+    const unsigned int DX10_MISC_TEXTURECUBE = 0x00000004;
 
     struct DXTColBlock
     {
@@ -83,6 +94,15 @@ namespace nv_dds
         unsigned int dwGBitMask;
         unsigned int dwBBitMask;
         unsigned int dwABitMask;
+    };
+
+    struct DDS_HEADER_DXT10
+    {
+        unsigned int dxgiFormat;
+        unsigned int resourceDimension;
+        unsigned int miscFlag;
+        unsigned int arraySize;
+        unsigned int miscFlags2;
     };
 
     struct DDS_HEADER

--- a/rts/Rendering/Textures/nv_dds.h
+++ b/rts/Rendering/Textures/nv_dds.h
@@ -51,12 +51,20 @@ namespace nv_dds
     const unsigned int FOURCC_DXT1 = 0x31545844; //(MAKEFOURCC('D','X','T','1'))
     const unsigned int FOURCC_DXT3 = 0x33545844; //(MAKEFOURCC('D','X','T','3'))
     const unsigned int FOURCC_DXT5 = 0x35545844; //(MAKEFOURCC('D','X','T','5'))
+    const unsigned int FOURCC_ATI1 = 0x31495441; //(MAKEFOURCC('A','T','I','1')), BC4
+    const unsigned int FOURCC_BC4U = 0x55344342; //(MAKEFOURCC('B','C','4','U'))
+    const unsigned int FOURCC_ATI2 = 0x32495441; //(MAKEFOURCC('A','T','I','2')), BC5
+    const unsigned int FOURCC_BC5U = 0x55354342; //(MAKEFOURCC('B','C','5','U'))
     const unsigned int FOURCC_DX10 = 0x30315844; //(MAKEFOURCC('D','X','1','0'))
 
     // Supported DXGI formats
     const unsigned int DXGI_FORMAT_BC1_UNORM = 71;
     const unsigned int DXGI_FORMAT_BC2_UNORM = 74;
     const unsigned int DXGI_FORMAT_BC3_UNORM = 77;
+    const unsigned int DXGI_FORMAT_BC4_UNORM = 80;
+    const unsigned int DXGI_FORMAT_BC5_UNORM = 83;
+    const unsigned int DXGI_FORMAT_BC7_UNORM = 98;
+    const unsigned int DXGI_FORMAT_BC7_UNORM_SRGB = 99;
 
     // DDS_HEADER_DXT10 values
     const unsigned int DX10_DIMENSION_TEXTURE2D = 3;
@@ -353,6 +361,8 @@ namespace nv_dds
             void flip_blocks_dxtc1(DXTColBlock *line, unsigned int numBlocks) const;
             void flip_blocks_dxtc3(DXTColBlock *line, unsigned int numBlocks) const;
             void flip_blocks_dxtc5(DXTColBlock *line, unsigned int numBlocks) const;
+            void flip_blocks_bc4(DXTColBlock *line, unsigned int numBlocks) const;
+            void flip_blocks_bc5(DXTColBlock *line, unsigned int numBlocks) const;
             void flip_dxt5_alpha(DXT5AlphaBlock *block) const;
 
             bool write_texture(const CTexture &texture, FILE *fp) const;


### PR DESCRIPTION
DDS textures today are limited to DXT1/3/5 because `nv_dds.cpp` rejects the DX10 extended header and the BC4/BC5/BC7 FourCCs. Two things this blocks for terrain/unit shaders that sample many normal + roughness/AO maps per pixel:

1. Normal maps. DXT5 with the payload in alpha + green ("DXT5nm") works but wastes the red/blue block and gives 4-bit-quality green. BC5 (two 8-bit-quality channels) is the standard normal-map format at the same 8 bpp.
2. Combined carriers. A normal-xy + AO + roughness texture in one file needs four good channels; DXT5 gives one good channel (A) and three 5/6-bit ones. BC7 holds all four at 8 bpp.

This PR:

* parses the DX10 extended header (`DXGI_FORMAT` + `resourceDimension`/`miscFlag`), so files written by `texconv`, `nvcompress` and Compressonator load; DX10-header BC1/BC2/BC3 files map onto the already-supported S3TC formats
* maps `BC4_UNORM` (and legacy FourCCs `ATI1`/`BC4U`) onto `GL_COMPRESSED_RED_RGTC1`
* maps `BC5_UNORM` (and `ATI2`/`BC5U`) onto `GL_COMPRESSED_RG_RGTC2`
* maps `BC7_UNORM`/`BC7_UNORM_SRGB` onto `GL_COMPRESSED_(SRGB_ALPHA_)BPTC_UNORM`

Every GL 3.0+/4.x GPU supports RGTC; BPTC is core since GL 4.2, which matches the hardware BAR-class games already require for their shaders.

Notes on behaviour:

* Mip chains and the existing V-flip behaviour are unchanged. BC4/BC5 blocks reuse the DXT5 alpha block bit layout, so the existing flip code covers them.
* BC7 blocks cannot be vertically flipped without a full decode (partition/mode bit juggling), so BC7 files load unflipped with a one-time warning; they should be authored pre-flipped. This mirrors what other engines do.
* `arraySize > 1` (texture arrays) is rejected explicitly rather than misparsed. Loading arrays as `GL_TEXTURE_2D_ARRAY` would be a natural follow-up but needs new surface plumbing, so it is out of scope here.
* Saving DDS remains restricted to the classic DXT1/3/5 FourCC formats; `save()` now refuses the new formats instead of writing a broken header.

Tested on an NVIDIA RTX 5080 with OpenGL 4.6 using generated samples for legacy ATI1/ATI2, DX10 BC3/BC4/BC5/BC7, complete BC4/BC5 mip chains down to 1x1, and a classic DXT1 control. In-game rendering verified BC4/BC5 orientation and every mip level. Array, truncated-header, zero-array-size, invalid-dimension, and cube-plus-3D inputs were rejected. The decoded patterns were also cross-checked with Pillow.

Written with AI assistance (Claude and GitHub Copilot), reviewed and tested by me.