### PR TITLE
docs: ID alias followup

### DIFF
--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -2534,9 +2534,9 @@ string CSplitLuaHandle::LoadFile(const std::string& filename, const std::string&
 /***
  * @class CallAsTeamOptions
  * @x_helper
- * @field ctrl integer Ctrl team ID.
- * @field read integer Read team ID.
- * @field select integer Select team ID.
+ * @field ctrl TeamID
+ * @field read TeamID
+ * @field select TeamID
  */
 
 /*** Calls a function from given team's PoV. In particular this makes callouts obey that team's visibility rules.

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -5774,7 +5774,7 @@ int LuaSyncedCtrl::SetProjectileIsIntercepted(lua_State* L)
 
 /***
  * @function Spring.SetProjectileDamages
- * @param unitID integer
+ * @param projectileID ProjectileID
  * @param weaponNum integer
  * @param key string
  * @param value number

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -3345,7 +3345,7 @@ int LuaSyncedRead::GetUnitNearestAlly(lua_State* L)
  * @param useLOS boolean? (Default: `true`) requires LOS/radar visibility of allied team.
  * @param sphereDistTest boolean? (Default: `false`) determines if using spherical(3D, includes target radius) or cylindrical(2D) search.
  * @param checkSightDist boolean? (Default: `false`) determine if during filter process, if candidate distance to be within candidate LOS radius.
- * @return integer? unitID
+ * @return UnitID? unitID
  */
 int LuaSyncedRead::GetUnitNearestEnemy(lua_State* L)
 {
@@ -4618,7 +4618,7 @@ int LuaSyncedRead::GetUnitBuildFacing(lua_State* L)
  * Works for both mobile builders and factories.
  *
  * @param unitID UnitID
- * @return integer buildeeUnitID or nil
+ * @return UnitID? buildeeUnitID
  */
 int LuaSyncedRead::GetUnitIsBuilding(lua_State* L)
 {
@@ -4738,7 +4738,7 @@ int LuaSyncedRead::GetUnitWorkerTask(lua_State* L)
  * @function Spring.GetUnitEffectiveBuildRange
  * Useful for setting move goals manually.
  * @param unitID UnitID
- * @param buildeeDefID integer or nil
+ * @param buildeeDefID UnitDefID?
  * @return number effectiveBuildRange counted to the center of prospective buildee; buildRange if buildee nil
  */
 int LuaSyncedRead::GetUnitEffectiveBuildRange(lua_State* L)
@@ -5882,7 +5882,7 @@ int LuaSyncedRead::GetUnitEstimatedPath(lua_State* L)
  *
  * @function Spring.GetUnitLastAttacker
  * @param unitID UnitID
- * @return integer? attackerUnitID `nil` if the unit has no last attacker or the attacker is not visible.
+ * @return UnitID? attackerUnitID `nil` if the unit has no last attacker or the attacker is not visible.
  */
 int LuaSyncedRead::GetUnitLastAttacker(lua_State* L)
 {
@@ -6778,7 +6778,7 @@ static int PackBuildQueue(lua_State* L, bool canBuild, const char* caller)
  *
  * @function Spring.GetFullBuildQueue
  * @param unitID UnitID
- * @return table<number,number>? buildqueue indexed by unitDefID with count values
+ * @return table<UnitDefID,integer>? buildqueue indexed by unitDefID with count values
  */
 int LuaSyncedRead::GetFullBuildQueue(lua_State* L)
 {
@@ -6790,7 +6790,7 @@ int LuaSyncedRead::GetFullBuildQueue(lua_State* L)
  *
  * @function Spring.GetRealBuildQueue
  * @param unitID UnitID
- * @return table<number,number>? buildqueue indexed by unitDefID with count values
+ * @return table<UnitDefID,integer>? buildqueue indexed by unitDefID with count values
  */
 int LuaSyncedRead::GetRealBuildQueue(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -2403,7 +2403,7 @@ namespace {
  * @function Spring.GetRenderUnits
  * @param drawMask DrawMask (Default: `0`) Filter objects by their draw flags.
  * @param sendMask true Whether to send objects draw flags as second return
- * @return integer[] featureIDs
+ * @return UnitID[] unitIDs
  * @return DrawFlag[] drawFlags
  */
 
@@ -2412,7 +2412,7 @@ namespace {
  * @function Spring.GetRenderUnits
  * @param drawMask DrawMask (Default: `0`) Filter objects by their draw flags.
  * @param sendMask false? Whether to send objects draw flags as second return
- * @return integer[] featureIDs
+ * @return UnitID[] unitIDs
  */
 int LuaUnsyncedRead::GetRenderUnits(lua_State* L)
 {

--- a/rts/Sim/Units/Scripts/LuaUnitScript.cpp
+++ b/rts/Sim/Units/Scripts/LuaUnitScript.cpp
@@ -1154,7 +1154,7 @@ static inline int ParseAxis(lua_State* L, const char* caller, int index)
 /*** Create a Lua unit script for the given unit, replacing any existing script.
  *
  * @function UnitScriptTable.CreateScript
- * @param unitID integer
+ * @param unitID UnitID
  * @param callIns table<string, function>
  * @return nil
  */
@@ -1189,7 +1189,7 @@ int CLuaUnitScript::CreateScript(lua_State* L)
 /*** Update or remove a callIn on a unit script.
  *
  * @function UnitScriptTable.UpdateCallIn
- * @param unitID integer
+ * @param unitID UnitID
  * @param callin string
  * @param func function?
  * @return nil
@@ -1221,7 +1221,7 @@ int CLuaUnitScript::UpdateCallIn(lua_State* L)
 /*** Execute a function in the context of a unit's script environment.
  *
  * @function UnitScriptTable.CallAsUnit
- * @param unitID integer
+ * @param unitID UnitID
  * @param func function
  * @param ... any arguments passed to func
  * @return any ... values returned by func
@@ -1297,7 +1297,7 @@ int CLuaUnitScript::GetUnitValue(lua_State* L, CUnitScript* script, int arg)
 /*** Get a COB/script value for a unit (synced gadget API).
  *
  * @function UnitScriptTable.GetUnitCOBValue
- * @param unitID integer
+ * @param unitID UnitID
  * @param val integer COB value ID (use COB constants)
  * @param ... number optional extra args for certain COB values
  * @return integer value
@@ -1354,7 +1354,7 @@ int CLuaUnitScript::SetUnitValue(lua_State* L, CUnitScript* script, int arg)
 /*** Set a COB/script value for a unit (synced gadget API).
  *
  * @function UnitScriptTable.SetUnitCOBValue
- * @param unitID integer
+ * @param unitID UnitID
  * @param val integer COB value ID (use COB constants)
  * @param param integer|boolean value to set
  * @return nil
@@ -1439,7 +1439,7 @@ int CLuaUnitScript::EmitSfx(lua_State* L)
  *
  * @function UnitScriptTable.AttachUnit
  * @param piece integer 1-indexed piece number
- * @param transporteeID integer
+ * @param transporteeID UnitID
  * @return nil
  */
 int CLuaUnitScript::AttachUnit(lua_State* L)
@@ -1462,7 +1462,7 @@ int CLuaUnitScript::AttachUnit(lua_State* L)
 /*** Drop a transported unit.
  *
  * @function UnitScriptTable.DropUnit
- * @param transporteeID integer
+ * @param transporteeID UnitID
  * @return nil
  */
 int CLuaUnitScript::DropUnit(lua_State* L)
@@ -1980,7 +1980,7 @@ int CLuaUnitScript::GetPiecePosDir(lua_State* L)
 /*** Get the unit ID of the currently executing unit script.
  *
  * @function UnitScriptTable.GetActiveUnitID
- * @return integer? unitID
+ * @return UnitID? unitID
  */
 int CLuaUnitScript::GetActiveUnitID(lua_State* L)
 {


### PR DESCRIPTION
Twenty annotations that name an identifier but type it as a plain number, in the places
#3231 missed. Pure documentation; no generated signature changes except one rename.

## Testing

- `mise run lua_library` produces no extractor errors, and the generated delta is exactly
  the twenty annotations plus the one `SetProjectileDamages` signature line.
- `mise run lua_check` passes on the regenerated library.

## AI usage disclosure

Claude Opus 5 authored 95% of code, 50% of PR description, 100% of commit message. I have reviewed these changes, understand them, and endorse them.