### PR TITLE
feat: Add SetUnitDead, RemoveUnit and split their responsibilities

### DIFF
--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -7,6 +7,7 @@
 #include "System/Platform/Misc.h"
 #include "Rendering/Fonts/glFont.h"
 #include "Sim/Misc/CustomColorPalette.h"
+#include "Sim/Units/Unit.h"
 
 /******************************************************************************
  * Engine constants
@@ -29,6 +30,7 @@
  * @field groupAddDoesntSelect boolean Whether 'group add' also selects the group (does both if false)
  * @field deadTeamsKeepUnitLimit boolean Whether engine redistributes dead team unitlimit to allies (false) or keeps it as-is (true)
  * @field reliableLuaMapShaders boolean Whether forward-only Lua map shaders activate without a deferred draw and Spring.SetMapShader program swaps refresh cached uniform locations
+ * @field canReviveUnits boolean Whether the engine can bring a dead unit back, i.e. whether Spring.SetUnitDead accepts `false`
  */
 
 /***
@@ -70,7 +72,7 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 	 *
 	 * will be compatible even on engines that don't yet know about the entry at all. */
 	lua_pushliteral(L, "FeatureSupport");
-	lua_createtable(L, 0, 11);
+	lua_createtable(L, 0, 15);
 		LuaPushNamedBool(L, "NegativeGetUnitCurrentCommand", true);
 		LuaPushNamedBool(L, "hasExitOnlyYardmaps", true);
 		LuaPushNamedNumber(L, "rmlUiApiVersion", 1);
@@ -85,6 +87,7 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 		LuaPushNamedBool(L, "groupAddDoesntSelect", true);
 		LuaPushNamedBool(L, "deadTeamsKeepUnitLimit", false);
 		LuaPushNamedBool(L, "reliableLuaMapShaders", true);
+		LuaPushNamedBool(L, "canReviveUnits", CAN_REVIVE_UNITS);
 	lua_rawset(L, -3);
 
 	lua_pushliteral(L, "textColorCodes");

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -176,6 +176,8 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(CreateUnit);
 	REGISTER_LUA_CFUNC(DestroyUnit);
+	REGISTER_LUA_CFUNC(SetUnitDead);
+	REGISTER_LUA_CFUNC(RemoveUnit);
 	REGISTER_LUA_CFUNC(TransferUnit);
 	REGISTER_LUA_CFUNC(TransferTeamMaxUnits);
 
@@ -1991,6 +1993,118 @@ int LuaSyncedCtrl::DestroyUnit(lua_State* L)
 	inDestroyUnit--;
 
 	return 0;
+}
+
+
+/***
+ * Set whether a unit is dead, and why.
+ *
+ * This flips the unit's dead state and intentionally does as little else as possible.
+ *
+ * It reports the death event to the relevant callins, then runs the unit death script.
+ * Attackers are not awarded any XP and are not credited with any kills.
+ * Death explosions are not fired and the physical unit is not deleted.
+ * Use `Spring.RemoveUnit` to control how the unit model/body is disposed.
+ * Simulate side effects yourself, e.g. adding attacker xp, spawning explosions/wrecks.
+ *
+ * @function Spring.SetUnitDead
+ * @see Spring.RemoveUnit
+ * @see Spring.GetUnitIsDead
+ * @param unitID UnitID
+ * @param dead boolean Must be `true`. Reviving a dead unit is not supported yet; check `Engine.FeatureSupport.canReviveUnits` before passing `false`.
+ * @param weaponDefID integer? (Default: `Game.envDamageTypes.KilledByLua`) the death type reported to `UnitDestroyed`. See `Game.envDamageTypes`.
+ * @param attackerID UnitID? named as the killer in `UnitDestroyed`. No experience or kill count is awarded.
+ * @return boolean changed `false` if the unit was already dead.
+ */
+int LuaSyncedCtrl::SetUnitDead(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	luaL_checktype(L, 2, LUA_TBOOLEAN);
+
+	if (!lua_toboolean(L, 2)) {
+		static_assert(!CAN_REVIVE_UNITS, "Spring.SetUnitDead has no revive path");
+
+		luaL_error(L, "[%s] reviving a unit is not supported, see Engine.FeatureSupport.canReviveUnits", __func__);
+	}
+
+	if (unit->HasStartedDying()) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	const int weaponDefID = luaL_optint(L, 3, -CSolidObject::DAMAGE_KILLED_LUA);
+
+	if (weaponDefID >= int(weaponDefHandler->NumWeaponDefs()))
+		luaL_error(L, "[%s] invalid weaponDefID %d", __func__, weaponDefID);
+
+	CUnit* attacker = nullptr;
+
+	if (!lua_isnoneornil(L, 4))
+		attacker = ParseUnit(L, __func__, 4);
+
+	if (inDestroyUnit >= MAX_CMD_RECURSION_DEPTH)
+		luaL_error(L, "[%s] recursion is not permitted, max depth: %d", __func__, MAX_CMD_RECURSION_DEPTH);
+
+	inDestroyUnit++;
+
+	ASSERT_SYNCED(unit->id);
+	unit->ForcedKillUnit(attacker, false, false, weaponDefID, true);
+
+	inDestroyUnit--;
+
+	lua_pushboolean(L, unit->HasStartedDying());
+	return 1;
+}
+
+
+/***
+ * Dispose of a dead unit's physical body and remove it from the simulation.
+ *
+ * Has no effect on units that are not dead. See `Spring.SetUnitDead`.
+ * Death explosions and extra wreckage are not handled here, either,
+ * but if the unit's death script chose a wreck level, it can be ignored.
+ *
+ * @function Spring.RemoveUnit
+ * @see Spring.SetUnitDead
+ * @param unitID UnitID
+ * @param noWreck boolean? (Default: `true`) when the unit's death script already chose a wreck level, suppress the wreckage.
+ * @param cleanupImmediately boolean? (Default: `false`) removes the unit unconditionally and makes its ID available for immediate reuse (otherwise it takes a few frames). Refused from inside some callins; check the return value.
+ * @return boolean removed `false` if the unit was still alive.
+ * @return boolean recycled whether the ID was freed for immediate reuse.
+ */
+int LuaSyncedCtrl::RemoveUnit(lua_State* L)
+{
+	CUnit* unit = ParseUnit(L, __func__, 1);
+
+	if (unit == nullptr)
+		return 0;
+
+	if (!unit->HasStartedDying()) {
+		lua_pushboolean(L, false);
+		lua_pushboolean(L, false);
+		return 2;
+	}
+
+	const bool noWreck = luaL_optboolean(L, 2, true);
+	const bool cleanupImmediately = luaL_optboolean(L, 3, false);
+
+	ASSERT_SYNCED(unit->id);
+
+	unit->blockWreck = noWreck;
+
+	if (!unit->deathScriptFinished)
+		unit->KilledScriptFinished(-1); // declare the script done
+
+	// refused while the UnitHandler is updating
+	const bool recycled = (cleanupImmediately && unitHandler.GarbageCollectUnit(unit->id));
+
+	lua_pushboolean(L, true);
+	lua_pushboolean(L, recycled);
+	return 2;
 }
 
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -75,6 +75,8 @@ class LuaSyncedCtrl
 
 		static int CreateUnit(lua_State* L);
 		static int DestroyUnit(lua_State* L);
+		static int SetUnitDead(lua_State* L);
+		static int RemoveUnit(lua_State* L);
 		static int TransferUnit(lua_State* L);
 		static int TransferTeamMaxUnits(lua_State* L);
 

--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -1092,7 +1092,7 @@ void CGame::ClientReadNet()
 						if (unit->team != srcTeamID)
 							continue;
 
-						if (unit->isDead)
+						if (!unit->CanChangeTeam())
 							continue;
 						if (unit->IsCrashing())
 							continue;

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -170,7 +170,7 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 	// do not check if the unit is inside a transporter here
 	// non-firebase transporters stun their cargo, so are already handled below
 	// firebase transporters should not deprive sensor coverage from their cargo
-	if (unit->isDead || unit->beingBuilt)
+	if (!unit->IsSimulating() || unit->beingBuilt)
 		return;
 
 	// NOTE:

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -468,7 +468,7 @@ bool CStrafeAirMoveType::Update()
 			const CCommandQueue& cmdQue = owner->commandAI->commandQue;
 
 			const bool isAttacking = (!cmdQue.empty() && (cmdQue.front()).GetID() == CMD_ATTACK);
-			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->isDead) || owner->curTarget.type == Target_Pos);
+			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->HasStartedDying()) || owner->curTarget.type == Target_Pos);
 
 			/*
 			const float brakeDistSq = Square(0.5f * lastSpd.SqLength2D() / decRate);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -111,7 +111,7 @@ CUnit::~CUnit()
 	//   we nevertheless want the sim-frame latency between CUnitKilledCB()
 	//   and the CreateWreckage() call to be as low as possible to prevent
 	//   position discontinuities
-	if (delayedWreckLevel >= 0)
+	if (delayedWreckLevel >= 0 && !blockWreck)
 		CreateWreck(delayedWreckLevel - 1, 1);
 
 	if (deathExpDamages != nullptr)
@@ -472,7 +472,7 @@ void CUnit::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int wea
 	ForcedKillUnit(attacker, selfDestruct, reclaimed, weaponDefID);
 }
 
-void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID)
+void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID, bool noDeathExplosion)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (isDead)
@@ -499,9 +499,9 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 	const WeaponDef* wd = selfDestruct? unitDef->selfdExpWeaponDef: unitDef->deathExpWeaponDef;
 	const DynDamageArray* da = selfDestruct? selfdExpDamages: deathExpDamages;
 
-	if (wd != nullptr) {
+	if (wd != nullptr && !noDeathExplosion) {
 		assert(da != nullptr);
-		const CExplosionParams params = {
+		const CExplosionParams expParams = {
 			.pos                  = pos,
 			.dir                  = ZeroVector,
 			.damages              = *da,
@@ -520,7 +520,7 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, i
 			.projectileID         = static_cast<uint32_t>(-1u)
 		};
 
-		helper->Explosion(params);
+		helper->Explosion(expParams);
 	}
 
 	recentDamage += (maxHealth * 2.0f * selfDestruct);
@@ -2962,6 +2962,7 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(allowUseWeapons),
 
 	CR_MEMBER(deathScriptFinished),
+	CR_MEMBER(blockWreck),
 	CR_MEMBER(delayedWreckLevel),
 
 	CR_MEMBER(restTime),

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -423,7 +423,7 @@ void CUnit::FinishedBuilding(bool postInit)
 		soloBuilder = nullptr;
 	}
 
-	if (isDead) // Lua can kill a freshy spawned unit in UnitCreated
+	if (HasStartedDying()) // Lua can kill a freshy spawned unit in UnitCreated
 		return;
 
 	ChangeLos(realLosRadius, realAirLosRadius);
@@ -673,7 +673,7 @@ void CUnit::Update()
 
 	if (beingBuilt)
 		return;
-	if (isDead)
+	if (!IsSimulating())
 		return;
 
 	recentDamage *= 0.9f;
@@ -766,7 +766,7 @@ void CUnit::ReleaseTransportees(CUnit* attacker, bool selfDestruct, bool reclaim
 		CUnit* transportee = tu.unit;
 		assert(transportee != this);
 
-		if (transportee->isDead)
+		if (transportee->HasStartedDying())
 			continue;
 
 		transportee->SetTransporter(nullptr);
@@ -1314,9 +1314,7 @@ void CUnit::DoDamage(
 	int weaponDefID,
 	int projectileID
 ) {
-	if (isDead)
-		return;
-	if (IsCrashing() || IsInVoid())
+	if (!CanTakeDamage())
 		return;
 
 	float baseDamage = damages.Get(armorType);
@@ -1351,7 +1349,7 @@ void CUnit::DoDamage(
 		// unit might have been killed via Lua from within UnitDamaged (e.g.
 		// through a recursive DoDamage call from AddUnitDamage or directly
 		// via DestroyUnit); can skip the rest
-		if (isDead)
+		if (HasStartedDying())
 			return;
 
 		eoh->UnitDamaged(*this, attacker, baseDamage, weaponDefID, projectileID, isParalyzer);
@@ -1373,7 +1371,7 @@ void CUnit::DoDamage(
 
 	KillUnit(attacker, false, false, weaponDefID);
 
-	if (!isDead)
+	if (!HasStartedDying())
 		return;
 	if (beingBuilt)
 		return;
@@ -1519,7 +1517,7 @@ void CUnit::ChangeLos(int losRad, int airRad)
 bool CUnit::ChangeTeam(int newteam, ChangeType type)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead)
+	if (!CanChangeTeam())
 		return false;
 
 	// do not allow unit count violations due to team swapping
@@ -1988,7 +1986,7 @@ void CUnit::TurnIntoNanoframe()
 bool CUnit::AddBuildPower(CUnit* builder, float amount)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead || IsCrashing())
+	if (!CanAcceptBuildPower())
 		return false;
 
 	// stop decaying on building AND reclaim

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -243,8 +243,8 @@ public:
 
 public:
 	void KilledScriptFinished(int wreckLevel) { deathScriptFinished = true; delayedWreckLevel = wreckLevel; }
-	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID = 0);
-	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID = 0);
+	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
+	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
 	virtual void IncomingMissile(CMissileProjectile* missile);
 	CFeature* CreateWreck(int wreckLevel, int smokeTime);
 

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -62,6 +62,9 @@ static constexpr uint8_t LOS_ALL_MASK_BITS = \
 	(LOS_INLOS_MASK | LOS_INRADAR_MASK | LOS_PREVLOS_MASK | LOS_CONTRADAR_MASK);
 
 
+// whether a unit can leave the dead state; see Engine.FeatureSupport.canReviveUnits
+static constexpr bool CAN_REVIVE_UNITS = false;
+
 class CUnit : public CSolidObject
 {
 public:
@@ -243,7 +246,7 @@ public:
 
 public:
 	void KilledScriptFinished(int wreckLevel) { deathScriptFinished = true; delayedWreckLevel = wreckLevel; }
-	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
+	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID, bool noDeathExplosion = false);
 	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
 	virtual void IncomingMissile(CMissileProjectile* missile);
 	CFeature* CreateWreck(int wreckLevel, int smokeTime);
@@ -522,6 +525,8 @@ public:
 
 	// signals if script has finished executing Killed and the unit can be deleted
 	bool deathScriptFinished = false;
+	// set by Spring.RemoveUnit; the wreck is only created later, in ~CUnit
+	bool blockWreck = false;
 
 	// if true, unit will not be automatically fired upon unless attacker's fireState is set to > FIREATWILL
 	bool neutral = false;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Sim/Objects/SolidObject.h"
+#include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/Resource.h"
 #include "Sim/Weapons/WeaponTarget.h"
 #include "System/Matrix44f.h"
@@ -168,6 +169,14 @@ public:
 	bool CanUpdateWeapons() const {
 		return (forceUseWeapons || (allowUseWeapons && !onTempHoldFire && !isDead && !beingBuilt && !IsStunned()));
 	}
+
+	bool HasStartedDying() const { return isDead; }
+	bool IsSimulating() const { return !isDead; }
+	// Individual callers still test LOS, category, allegiance, etc. separately.
+	bool IsTargetable() const { return (!isDead || modInfo.fireAtKilled); }
+	bool CanTakeDamage() const { return (!isDead && !IsCrashing() && !IsInVoid()); }
+	bool CanChangeTeam() const { return !isDead; }
+	bool CanAcceptBuildPower() const { return (!isDead && !IsCrashing()); }
 
 	void SetNeutral(bool b);
 	void SetStunned(bool stun);

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -268,7 +268,7 @@ bool CUnitHandler::QueueDeleteUnit(CUnit* unit)
 	// there are many ways to fiddle with "deathScriptFinished", so a unit may
 	// arrive here not having been properly killed while isDead is still false
 	// make sure we always call Killed; no-op if isDead was already set to true
-	unit->ForcedKillUnit(nullptr, false, true);
+	unit->ForcedKillUnit(nullptr, false, true, -CSolidObject::DAMAGE_UNIT_SCRIPT);
 	unitsToBeRemoved.push_back(unit);
 	return true;
 }

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -376,7 +376,7 @@ void CUnitHandler::SlowUpdateUnits()
 			unit->SlowUpdateWeapons();
 			unit->SanityCheck();
 
-			if (!unit->isDead && unit->localModel.GetBoundariesNeedsRecalc())
+			if (unit->IsSimulating() && unit->localModel.GetBoundariesNeedsRecalc())
 				updateBoundingVolumeList.emplace_back(unit);
 		}
 	}

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -238,13 +238,17 @@ bool CUnitHandler::GarbageCollectUnit(unsigned int id)
 	if (inUpdateCall)
 		return false;
 
-	assert(unitsToBeRemoved.empty());
+	CUnit* unit = units[id];
 
-	if (!QueueDeleteUnit(units[id]))
+	if (unit == nullptr)
+		return false;
+	if (!QueueDeleteUnit(unit))
 		return false;
 
-	// only processes units[id]
-	DeleteUnits();
+	// the queue holds units killed on a previous frame plus what we've enqueued
+	spring::VectorEraseAll(unitsToBeRemoved, unit);
+
+	DeleteUnit(unit);
 
 	return (idPool.RecycleID(id));
 }

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -172,7 +172,7 @@ void CFactory::Update()
 
 void CFactory::StartBuild(const UnitDef* buildeeDef) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead)
+	if (!IsSimulating())
 		return;
 
 	const float3& buildPos = CalcBuildPos(script->QueryBuildInfo());

--- a/rts/Sim/Units/UnitTypes/Factory.h
+++ b/rts/Sim/Units/UnitTypes/Factory.h
@@ -35,7 +35,8 @@ public:
 	/// supply the build piece to speed up
 	float3 CalcBuildPos(int buildPiece = -1);
 
-	void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
+	using CUnit::KillUnit;
+	void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID) override;
 	void PreInit(const UnitLoadParams& params);
 	bool ChangeTeam(int newTeam, ChangeType type);
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -321,10 +321,10 @@ void CWeapon::Update()
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()
-									&& currentTarget.unit != nullptr && currentTarget.unit->isDead;
+									&& currentTarget.unit != nullptr && currentTarget.unit->HasStartedDying();
 	if (fastAutoRetargetRequired) {
 		// switch to unit's target if it has one - see next bit below
-		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->isDead)
+		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->HasStartedDying())
 								|| (owner->curTarget.type != Target_Unit && owner->curTarget.type != Target_None);
 		if (ownerTargetIsValid)
 			DropCurrentTarget();
@@ -1032,7 +1032,7 @@ bool CWeapon::TestTarget(const float3& tgtPos, const SWeaponTarget& trg) const
 				return false;
 			if ((trg.unit->category & onlyTargetCategory) == 0)
 				return false;
-			if (trg.unit->isDead && !modInfo.fireAtKilled)
+			if (!trg.unit->IsTargetable())
 				return false;
 			if (trg.unit->IsCrashing() && !modInfo.fireAtCrashing)
 				return false;


### PR DESCRIPTION
Resolves https://github.com/beyond-all-reason/RecoilEngine/issues/3287

Has its prework commits split into three PRs:
- https://github.com/beyond-all-reason/RecoilEngine/pull/3309
- https://github.com/beyond-all-reason/RecoilEngine/pull/3310
- https://github.com/beyond-all-reason/RecoilEngine/pull/3311

And should rebase onto those before merging. The last commit contains the feature change.

### Work done

Adds `Spring.SetUnitDead` and `Spring.RemoveUnit` for killing and disposing units from lua with accurate death reports back to game callins.

Side effects like death explosions, wrecks, and attacker credit are up to the game to decide and up to them, in some cases, to get right.

### Considerations

This comes with some new gotchas; avoiding these is easier via some examples rather than listing everywhere in engine code that may be unintuitive through the API.

```lua
-- a death that game code can recognize
Spring.SetUnitDead(unitID, true, myEnvDamageType)

-- ...credited to a killer
Spring.SetUnitDead(unitID, true, myEnvDamageType, attackerID)

-- ...with a bang, since nothing explodes on its own
Spring.SetUnitDead(unitID, true, myEnvDamageType)
Spring.SpawnExplosion(x, y, z, { weaponDef = someWeaponDefID })

-- atomized: no explosion, no animation, no corpse
Spring.SetUnitDead(unitID, true, Game.envDamageTypes.Reclaimed)
Spring.RemoveUnit(unitID, true)

-- upgraded, evolved: gone now, ID reusable this frame, model -> model
Spring.SetUnitDead(unitID, true, myEvolutionType)
local _, recycled = Spring.RemoveUnit(unitID, true, true)
if recycled then
    Spring.CreateUnit(evolvedDefID, x, y, z, facing, teamID, false, false, unitID)
end

-- gone immediately, but leaves the corpse its death script picked
Spring.SetUnitDead(unitID, true, myEnvDamageType)
Spring.RemoveUnit(unitID, false, true)

-- you control the corpse instead of the script (maybe transfer unit velocity too):
Spring.SetUnitDead(unitID, true, myEnvDamageType)
Spring.RemoveUnit(unitID, true)
Spring.CreateUnitWreck(unitDefID, x, y, z, ...)
```

But there are also timing and lifecycle bugs. The UnitHandler refuses to do some work during its own updates; we might want to defer these in-engine rather than require that games do so, but this also makes the API dishonest. Unsure.