### PR TITLE
Annotate parameter table for SetSunLighting

### DIFF
--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4206,6 +4206,25 @@ int LuaUnsyncedCtrl::SetSunDirection(lua_State* L)
 	return 0;
 }
 
+/***
+ * @class SunLightingParams
+ *
+ * The parameter table for sun lighting
+ * @see Spring.SetSunLighting
+ *
+ * @field specularExponent number?
+ * @field groundShadowDensity number?
+ * @field modelShadowDensity number?
+ * @field groundAmbientColor rgba?
+ * @field groundDiffuseColor rgba?
+ * @field groundSpecularColor rgba?
+ * @field unitAmbientColor rgba?
+ * @field modelAmbientColor rgba?
+ * @field unitDiffuseColor rgba?
+ * @field modelDiffuseColor rgba?
+ * @field unitSpecularColor rgba?
+ * @field modelSpecularColor rgba?
+ */
 
 /***
  * Modify sun lighting parameters.
@@ -4215,7 +4234,7 @@ int LuaUnsyncedCtrl::SetSunDirection(lua_State* L)
  * ```
  *
  * @function Spring.SetSunLighting
- * @param params { groundAmbientColor: rgb, groundDiffuseColor: rgb }
+ * @param params SunLightingParams
  */
 int LuaUnsyncedCtrl::SetSunLighting(lua_State* L)
 {


### PR DESCRIPTION
`Spring.SetSunLighting` was partially/incorrectly documented as only accepting two mandatory keys in the parameter table. I looked into [`LuaUnsyncedCtrl::SetSunLighting`](https://github.com/beyond-all-reason/RecoilEngine/blob/f403d8878af48d63f15fa23f2580cd326efca1fb/rts/Lua/LuaUnsyncedCtrl.cpp#L4220-L4254) and [`CSunLighting::SetValue`](https://github.com/beyond-all-reason/RecoilEngine/blob/f403d8878af48d63f15fa23f2580cd326efca1fb/rts/Rendering/Env/SunLighting.cpp#L101-L142) to determine the actual shape of the params table, with many keys, some number and some float4 values, all optional.