### PR TITLE
refactor: use named predicates for conditions on isDead

### DIFF
--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -1092,7 +1092,7 @@ void CGame::ClientReadNet()
 						if (unit->team != srcTeamID)
 							continue;
 
-						if (unit->isDead)
+						if (!unit->CanChangeTeam())
 							continue;
 						if (unit->IsCrashing())
 							continue;

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -170,7 +170,7 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 	// do not check if the unit is inside a transporter here
 	// non-firebase transporters stun their cargo, so are already handled below
 	// firebase transporters should not deprive sensor coverage from their cargo
-	if (unit->isDead || unit->beingBuilt)
+	if (!unit->IsSimulating() || unit->beingBuilt)
 		return;
 
 	// NOTE:

--- a/rts/Sim/Misc/LosHandler.cpp
+++ b/rts/Sim/Misc/LosHandler.cpp
@@ -170,7 +170,7 @@ inline void ILosType::UpdateUnit(CUnit* unit, bool ignore)
 	// do not check if the unit is inside a transporter here
 	// non-firebase transporters stun their cargo, so are already handled below
 	// firebase transporters should not deprive sensor coverage from their cargo
-	if (!unit->IsSimulating() || unit->beingBuilt)
+	if (unit->IsDead() || unit->beingBuilt)
 		return;
 
 	// NOTE:

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -468,7 +468,7 @@ bool CStrafeAirMoveType::Update()
 			const CCommandQueue& cmdQue = owner->commandAI->commandQue;
 
 			const bool isAttacking = (!cmdQue.empty() && (cmdQue.front()).GetID() == CMD_ATTACK);
-			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->isDead) || owner->curTarget.type == Target_Pos);
+			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->HasStartedDying()) || owner->curTarget.type == Target_Pos);
 
 			/*
 			const float brakeDistSq = Square(0.5f * lastSpd.SqLength2D() / decRate);

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -468,7 +468,7 @@ bool CStrafeAirMoveType::Update()
 			const CCommandQueue& cmdQue = owner->commandAI->commandQue;
 
 			const bool isAttacking = (!cmdQue.empty() && (cmdQue.front()).GetID() == CMD_ATTACK);
-			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->HasStartedDying()) || owner->curTarget.type == Target_Pos);
+			const bool keepAttacking = ((owner->curTarget.type == Target_Unit && !owner->curTarget.unit->IsDead()) || owner->curTarget.type == Target_Pos);
 
 			/*
 			const float brakeDistSq = Square(0.5f * lastSpd.SqLength2D() / decRate);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -423,7 +423,7 @@ void CUnit::FinishedBuilding(bool postInit)
 		soloBuilder = nullptr;
 	}
 
-	if (isDead) // Lua can kill a freshy spawned unit in UnitCreated
+	if (HasStartedDying()) // Lua can kill a freshy spawned unit in UnitCreated
 		return;
 
 	ChangeLos(realLosRadius, realAirLosRadius);
@@ -673,7 +673,7 @@ void CUnit::Update()
 
 	if (beingBuilt)
 		return;
-	if (isDead)
+	if (!IsSimulating())
 		return;
 
 	recentDamage *= 0.9f;
@@ -766,7 +766,7 @@ void CUnit::ReleaseTransportees(CUnit* attacker, bool selfDestruct, bool reclaim
 		CUnit* transportee = tu.unit;
 		assert(transportee != this);
 
-		if (transportee->isDead)
+		if (transportee->HasStartedDying())
 			continue;
 
 		transportee->SetTransporter(nullptr);
@@ -1314,9 +1314,7 @@ void CUnit::DoDamage(
 	int weaponDefID,
 	int projectileID
 ) {
-	if (isDead)
-		return;
-	if (IsCrashing() || IsInVoid())
+	if (!CanTakeDamage())
 		return;
 
 	float baseDamage = damages.Get(armorType);
@@ -1351,7 +1349,7 @@ void CUnit::DoDamage(
 		// unit might have been killed via Lua from within UnitDamaged (e.g.
 		// through a recursive DoDamage call from AddUnitDamage or directly
 		// via DestroyUnit); can skip the rest
-		if (isDead)
+		if (HasStartedDying())
 			return;
 
 		eoh->UnitDamaged(*this, attacker, baseDamage, weaponDefID, projectileID, isParalyzer);
@@ -1373,7 +1371,7 @@ void CUnit::DoDamage(
 
 	KillUnit(attacker, false, false, weaponDefID);
 
-	if (!isDead)
+	if (!HasStartedDying())
 		return;
 	if (beingBuilt)
 		return;
@@ -1519,7 +1517,7 @@ void CUnit::ChangeLos(int losRad, int airRad)
 bool CUnit::ChangeTeam(int newteam, ChangeType type)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead)
+	if (!CanChangeTeam())
 		return false;
 
 	// do not allow unit count violations due to team swapping
@@ -1988,7 +1986,7 @@ void CUnit::TurnIntoNanoframe()
 bool CUnit::AddBuildPower(CUnit* builder, float amount)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead || IsCrashing())
+	if (!CanAcceptBuildPower())
 		return false;
 
 	// stop decaying on building AND reclaim

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -423,7 +423,7 @@ void CUnit::FinishedBuilding(bool postInit)
 		soloBuilder = nullptr;
 	}
 
-	if (HasStartedDying()) // Lua can kill a freshy spawned unit in UnitCreated
+	if (IsDead()) // Lua can kill a freshy spawned unit in UnitCreated
 		return;
 
 	ChangeLos(realLosRadius, realAirLosRadius);
@@ -766,7 +766,7 @@ void CUnit::ReleaseTransportees(CUnit* attacker, bool selfDestruct, bool reclaim
 		CUnit* transportee = tu.unit;
 		assert(transportee != this);
 
-		if (transportee->HasStartedDying())
+		if (transportee->IsDead())
 			continue;
 
 		transportee->SetTransporter(nullptr);
@@ -1349,7 +1349,7 @@ void CUnit::DoDamage(
 		// unit might have been killed via Lua from within UnitDamaged (e.g.
 		// through a recursive DoDamage call from AddUnitDamage or directly
 		// via DestroyUnit); can skip the rest
-		if (HasStartedDying())
+		if (IsDead())
 			return;
 
 		eoh->UnitDamaged(*this, attacker, baseDamage, weaponDefID, projectileID, isParalyzer);
@@ -1371,7 +1371,7 @@ void CUnit::DoDamage(
 
 	KillUnit(attacker, false, false, weaponDefID);
 
-	if (!HasStartedDying())
+	if (!IsDead())
 		return;
 	if (beingBuilt)
 		return;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -673,7 +673,7 @@ void CUnit::Update()
 
 	if (beingBuilt)
 		return;
-	if (!IsSimulating())
+	if (IsDead())
 		return;
 
 	recentDamage *= 0.9f;

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Sim/Objects/SolidObject.h"
+#include "Sim/Misc/ModInfo.h"
 #include "Sim/Misc/Resource.h"
 #include "Sim/Weapons/WeaponTarget.h"
 #include "System/Matrix44f.h"
@@ -168,6 +169,14 @@ public:
 	bool CanUpdateWeapons() const {
 		return (forceUseWeapons || (allowUseWeapons && !onTempHoldFire && !isDead && !beingBuilt && !IsStunned()));
 	}
+
+	bool HasStartedDying() const { return isDead; }
+	bool IsSimulating() const { return !isDead; }
+	// Individual callers still test LOS, category, allegiance, etc. separately.
+	bool IsTargetable() const { return (!isDead || modInfo.fireAtKilled); }
+	bool CanTakeDamage() const { return (!isDead && !IsCrashing() && !IsInVoid()); }
+	bool CanChangeTeam() const { return !isDead; }
+	bool CanAcceptBuildPower() const { return (!isDead && !IsCrashing()); }
 
 	void SetNeutral(bool b);
 	void SetStunned(bool stun);

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -170,7 +170,7 @@ public:
 		return (forceUseWeapons || (allowUseWeapons && !onTempHoldFire && !isDead && !beingBuilt && !IsStunned()));
 	}
 
-	bool HasStartedDying() const { return isDead; }
+	bool IsDead() const { return isDead; }
 	bool IsSimulating() const { return !isDead; }
 	// Individual callers still test LOS, category, allegiance, etc. separately.
 	bool IsTargetable() const { return (!isDead || modInfo.fireAtKilled); }

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -171,7 +171,6 @@ public:
 	}
 
 	bool IsDead() const { return isDead; }
-	bool IsSimulating() const { return !isDead; }
 	// Individual callers still test LOS, category, allegiance, etc. separately.
 	bool IsTargetable() const { return (!isDead || modInfo.fireAtKilled); }
 	bool CanTakeDamage() const { return (!isDead && !IsCrashing() && !IsInVoid()); }

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -376,7 +376,7 @@ void CUnitHandler::SlowUpdateUnits()
 			unit->SlowUpdateWeapons();
 			unit->SanityCheck();
 
-			if (!unit->isDead && unit->localModel.GetBoundariesNeedsRecalc())
+			if (unit->IsSimulating() && unit->localModel.GetBoundariesNeedsRecalc())
 				updateBoundingVolumeList.emplace_back(unit);
 		}
 	}

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -376,7 +376,7 @@ void CUnitHandler::SlowUpdateUnits()
 			unit->SlowUpdateWeapons();
 			unit->SanityCheck();
 
-			if (unit->IsSimulating() && unit->localModel.GetBoundariesNeedsRecalc())
+			if (!unit->IsDead() && unit->localModel.GetBoundariesNeedsRecalc())
 				updateBoundingVolumeList.emplace_back(unit);
 		}
 	}

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -172,7 +172,7 @@ void CFactory::Update()
 
 void CFactory::StartBuild(const UnitDef* buildeeDef) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (isDead)
+	if (!IsSimulating())
 		return;
 
 	const float3& buildPos = CalcBuildPos(script->QueryBuildInfo());

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -172,7 +172,7 @@ void CFactory::Update()
 
 void CFactory::StartBuild(const UnitDef* buildeeDef) {
 	RECOIL_DETAILED_TRACY_ZONE;
-	if (!IsSimulating())
+	if (IsDead())
 		return;
 
 	const float3& buildPos = CalcBuildPos(script->QueryBuildInfo());

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -321,10 +321,10 @@ void CWeapon::Update()
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()
-									&& currentTarget.unit != nullptr && currentTarget.unit->isDead;
+									&& currentTarget.unit != nullptr && currentTarget.unit->HasStartedDying();
 	if (fastAutoRetargetRequired) {
 		// switch to unit's target if it has one - see next bit below
-		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->isDead)
+		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->HasStartedDying())
 								|| (owner->curTarget.type != Target_Unit && owner->curTarget.type != Target_None);
 		if (ownerTargetIsValid)
 			DropCurrentTarget();
@@ -1038,7 +1038,7 @@ bool CWeapon::TestTarget(const float3& tgtPos, const SWeaponTarget& trg) const
 				return false;
 			if ((trg.unit->category & onlyTargetCategory) == 0)
 				return false;
-			if (trg.unit->isDead && !modInfo.fireAtKilled)
+			if (!trg.unit->IsTargetable())
 				return false;
 			if (trg.unit->IsCrashing() && !modInfo.fireAtCrashing)
 				return false;

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -321,10 +321,10 @@ void CWeapon::Update()
 
 	// Fast auto targeting needs to trigger an immediate retarget once the target is dead.
 	bool fastAutoRetargetRequired = fastAutoRetargeting && HaveTarget()
-									&& currentTarget.unit != nullptr && currentTarget.unit->HasStartedDying();
+									&& currentTarget.unit != nullptr && currentTarget.unit->IsDead();
 	if (fastAutoRetargetRequired) {
 		// switch to unit's target if it has one - see next bit below
-		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->HasStartedDying())
+		bool ownerTargetIsValid = (owner->curTarget.type == Target_Unit && currentTarget.unit != nullptr && !currentTarget.unit->IsDead())
 								|| (owner->curTarget.type != Target_Unit && owner->curTarget.type != Target_None);
 		if (ownerTargetIsValid)
 			DropCurrentTarget();


### PR DESCRIPTION
Any direct read of isDead is left alone, including the sync dump.

Units remain valid throughout a whole death sequence, with modrules and game behaviors that change interactions during that time. Naming these predicates might help to make them (i) searchable later via this change and (ii) reversible.

Renamed conditions were checking for several ideas: can this unit fire, can it be targeted, can it take damage, can its ownership change, can build steps apply to it, is it still simulating(?). These are easy to check when death is a one-way trip but may be more difficult later. A couple of these are just isDead checks, renamed to be clear that units remain in "isDead" potentially a long period; not exciting.

All current code evaluates to the same results outside of debug builds. There are also a couple nails that stick out, also kept the same:

- modInfo.fireAtKilled is used in CWeapon::TestTarget and not in the fast-auto-retarget check in CWeapon::Update.
- CUnit::ChangeTeam checks isDead and the net path that calls it also checks IsCrashing.