### PR TITLE
fix: missing explicit death type when deleting a finished unit

### DIFF
--- a/doc/pr-changelogs/3310.md
+++ b/doc/pr-changelogs/3310.md
@@ -1,0 +1,2 @@
+ * added `Game.envDamageTypes.ForceDeleted`, used for the "force delete and recycle ID" mode to `Spring.DestroyUnit`, if recycling a unit that never died "normally".
+ * fixed `Spring.DestroyUnit` passing weaponDefID 0 (which is one of the valid weapon defs defined by the game, and not an "environmental" one) when force deleting live units.

--- a/rts/Lua/LuaConstGame.cpp
+++ b/rts/Lua/LuaConstGame.cpp
@@ -292,6 +292,7 @@ bool LuaConstGame::PushEntries(lua_State* L)
 			LuaPushNamedNumber(L, "SetNegativeHealth", -CSolidObject::DAMAGE_NEGATIVE_HEALTH    );
 			LuaPushNamedNumber(L, "OutOfBounds"      , -CSolidObject::DAMAGE_KILLED_OOB         );
 			LuaPushNamedNumber(L, "KilledByCheat"    , -CSolidObject::DAMAGE_KILLED_CHEAT       );
+			LuaPushNamedNumber(L, "ForceDeleted"     , -CSolidObject::DAMAGE_FORCE_DELETED      );
 			LuaPushNamedNumber(L, "KilledByLua"      , -CSolidObject::DAMAGE_KILLED_LUA         );
 		lua_rawset(L, -3);
 	}

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -113,6 +113,7 @@ public:
 		DAMAGE_KAMIKAZE_ACTIVATED  = 18,
 		DAMAGE_CONSTRUCTION_DECAY  = 19,
 		DAMAGE_TURNED_INTO_FEATURE = 20,
+		DAMAGE_FORCE_DELETED       = 21,
 
 		// Keep killed by Lua as last index here. This will be exposed as
 		// lowest index for games. As we keep killed by Lua as lowest index,
@@ -121,7 +122,7 @@ public:
 		//      envTypes.CullingStrike      = envTypes.KilledByLua - 1
 		//      envTypes.SummonTimerExpired = envTypes.KilledByLua - 2
 		//
-		DAMAGE_KILLED_LUA = 21
+		DAMAGE_KILLED_LUA = 22
 	};
 
 	CSolidObject();

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -234,8 +234,8 @@ public:
 
 public:
 	void KilledScriptFinished(int wreckLevel) { deathScriptFinished = true; delayedWreckLevel = wreckLevel; }
-	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID = 0);
-	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID = 0);
+	void ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
+	virtual void KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, int weaponDefID);
 	virtual void IncomingMissile(CMissileProjectile* missile);
 	CFeature* CreateWreck(int wreckLevel, int smokeTime);
 

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -268,7 +268,7 @@ bool CUnitHandler::QueueDeleteUnit(CUnit* unit)
 	// there are many ways to fiddle with "deathScriptFinished", so a unit may
 	// arrive here not having been properly killed while isDead is still false
 	// make sure we always call Killed; no-op if isDead was already set to true
-	unit->ForcedKillUnit(nullptr, false, true);
+	unit->ForcedKillUnit(nullptr, false, true, -CSolidObject::DAMAGE_UNIT_SCRIPT);
 	unitsToBeRemoved.push_back(unit);
 	return true;
 }

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -268,7 +268,7 @@ bool CUnitHandler::QueueDeleteUnit(CUnit* unit)
 	// there are many ways to fiddle with "deathScriptFinished", so a unit may
 	// arrive here not having been properly killed while isDead is still false
 	// make sure we always call Killed; no-op if isDead was already set to true
-	unit->ForcedKillUnit(nullptr, false, true, -CSolidObject::DAMAGE_UNIT_SCRIPT);
+	unit->ForcedKillUnit(nullptr, false, true, -CSolidObject::DAMAGE_FORCE_DELETED);
 	unitsToBeRemoved.push_back(unit);
 	return true;
 }


### PR DESCRIPTION
weaponDefID 0 is a real weapondef and not an envDamageType, but is used in CUnitHandler::QueueDeleteUnit as a fallback/default. Reaching deletion through deathScriptFinished probably should use the script kill weapon instead.

This does change what UnitDestroyed reports for some code paths, and drops the default argument on KillUnit and ForcedKillUnit, probably correct to do but needs to be careful.