### PR TITLE
fix: cleanupImmediately on one unit deletes others

### DIFF
--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -238,13 +238,17 @@ bool CUnitHandler::GarbageCollectUnit(unsigned int id)
 	if (inUpdateCall)
 		return false;
 
-	assert(unitsToBeRemoved.empty());
+	CUnit* unit = units[id];
 
-	if (!QueueDeleteUnit(units[id]))
+	if (unit == nullptr)
+		return false;
+	if (!QueueDeleteUnit(unit))
 		return false;
 
-	// only processes units[id]
-	DeleteUnits();
+	// the queue holds units killed on a previous frame plus what we've enqueued
+	spring::VectorEraseAll(unitsToBeRemoved, unit);
+
+	DeleteUnit(unit);
 
 	return (idPool.RecycleID(id));
 }


### PR DESCRIPTION
GarbageCollectUnit will drain unitsToBeRemoved to get one unit. The queue is filled at the end of one update and drained at the start of the next, but GameFrame runs before unitHandler.Update, so the queue is non-empty when deleting here with cleanupImmediately. Real Q: Do any current games have this bug?

That tripped the assert in debug builds. In release, it would delete every other queued unit a frame early. A very mysterious-seeming bug from the receiving end probably.

ParseUnit does not reject dead units, so maybe this would queue a unit a second time and DeleteUnit on the same pointer twice. Null checks are added against dereferencing in case.