### PR TITLE
fixed 'CREG: Test3 (Missing Class Members)' after adding paletteIndex

### DIFF
--- a/rts/Sim/Objects/SolidObject.cpp
+++ b/rts/Sim/Objects/SolidObject.cpp
@@ -51,6 +51,8 @@ CR_REG_METADATA(CSolidObject,
 	CR_MEMBER(team),
 	CR_MEMBER(allyteam),
 
+	CR_MEMBER_UN(paletteIndex),
+
 	CR_MEMBER(creationFrame),
 
 	CR_MEMBER(pieceHitFrames),


### PR DESCRIPTION
Fixes the third of the three failing tests from #3179