### PR TITLE
Refactor asio API usage to no longer use deprecated interfaces

### DIFF
--- a/doc/pr-changelogs/3313.md
+++ b/doc/pr-changelogs/3313.md
@@ -1,0 +1,2 @@
+### Internals relevant to engine devs
+ * made it possible to migrate to `asio` v1.38.2 by no longer using deprecated API

--- a/rts/Net/AutohostInterface.cpp
+++ b/rts/Net/AutohostInterface.cpp
@@ -162,7 +162,7 @@ enum EVENT
 using namespace asio;
 
 AutohostInterface::AutohostInterface(const std::string& remoteIP, int remotePort, const std::string& localIP, int localPort)
-		: autohost(netcode::netservice)
+		: autohost(netcode::netcontext)
 		, initialized(false)
 {
 	std::string errorMsg = AutohostInterface::TryBindSocket(autohost, remoteIP, remotePort, localIP, localPort);
@@ -399,7 +399,7 @@ std::string AutohostInterface::GetChatMessage()
 	return "";
 }
 
-void AutohostInterface::Send(asio::mutable_buffers_1 buffer)
+void AutohostInterface::Send(asio::mutable_buffer buffer)
 {
 	if (autohost.is_open()) {
 		try {

--- a/rts/Net/AutohostInterface.h
+++ b/rts/Net/AutohostInterface.h
@@ -57,7 +57,7 @@ public:
 	std::string GetChatMessage();
 
 private:
-	void Send(asio::mutable_buffers_1 sendBuffer);
+	void Send(asio::mutable_buffer sendBuffer);
 
 	/**
 	 * Tries to bind a socket for communication with a UDP server.

--- a/rts/System/Net/Socket.cpp
+++ b/rts/System/Net/Socket.cpp
@@ -11,7 +11,7 @@
 namespace netcode
 {
 
-asio::io_service netservice;
+asio::io_context netcontext;
 
 bool CheckErrorCode(asio::error_code& err)
 {
@@ -36,13 +36,11 @@ asio::ip::udp::endpoint ResolveAddr(const std::string& host, int port, asio::err
 		return ip::udp::endpoint(tempAddr, port);
 
 	auto errBuf = *err; // WrapResolve() might clear err
-	asio::io_service io_service;
-	ip::udp::resolver resolver(io_service);
-	ip::udp::resolver::query query(host, IntToString(port));
-	auto iter = WrapResolve(resolver, query, err);
-	ip::udp::resolver::iterator end;
-	if (!*err && iter != end) {
-		return *iter;
+	asio::io_context io_context;
+	ip::udp::resolver resolver(io_context);
+	auto results = WrapResolve(resolver, host, IntToString(port), err);
+	if (!*err && !results.empty()) {
+		return *results.begin();
 	}
 
 	if (!*err) *err = errBuf;
@@ -56,29 +54,30 @@ asio::ip::address WrapIP(const std::string& ip,
 	asio::ip::address addr;
 
 	if (err == NULL) {
-		addr = asio::ip::address::from_string(ip);
+		addr = asio::ip::make_address(ip);
 	} else {
-		addr = asio::ip::address::from_string(ip, *err);
+		addr = asio::ip::make_address(ip, *err);
 	}
 
 	// (date of note: 08/05/10)
-	// something in from_string() is invalidating the FPU flags
+	// something in make_address() is invalidating the FPU flags
 	// tested on win2k and linux (not happening there)
 	streflop::streflop_init<streflop::Simple>();
 	return addr;
 }
 
-asio::ip::udp::resolver::iterator WrapResolve(
+asio::ip::udp::resolver::results_type WrapResolve(
 		asio::ip::udp::resolver& resolver,
-		asio::ip::udp::resolver::query& query,
-		asio::error_code* err)
+		std::string_view host,
+		std::string_view service,
+		asio::error_code* err) 
 {
-	asio::ip::udp::resolver::iterator resolveIt;
+	asio::ip::udp::resolver::results_type resolveIt;
 
-	if (err == NULL) {
-		resolveIt = resolver.resolve(query);
+	if (err == nullptr) {
+		resolveIt = resolver.resolve(host, service);
 	} else {
-		resolveIt = resolver.resolve(query, *err);
+		resolveIt = resolver.resolve(host, service, *err);
 	}
 
 	// (date of note: 08/22/10)

--- a/rts/System/Net/Socket.h
+++ b/rts/System/Net/Socket.h
@@ -3,7 +3,7 @@
 #ifndef SOCKET_H
 #define SOCKET_H
 
-#include <asio/io_service.hpp>
+#include <asio/io_context.hpp>
 #include <asio/ip/udp.hpp>
 #include <asio/ip/tcp.hpp>
 
@@ -11,7 +11,7 @@
 namespace netcode
 {
 
-extern asio::io_service netservice;
+extern asio::io_context netcontext;
 
 /**
  * Check if a network error occurred and eventually log it.
@@ -37,10 +37,12 @@ asio::ip::address WrapIP(const std::string& ip,
  * Encapsulates the ip::udp::resolver::resolve(query) function,
  * for sync relevant reasons.
  */
-asio::ip::udp::resolver::iterator WrapResolve(
-		asio::ip::udp::resolver& resolver,
-		asio::ip::udp::resolver::query& query,
-		asio::error_code* err = NULL);
+
+asio::ip::udp::resolver::results_type WrapResolve(
+        asio::ip::udp::resolver& resolver,
+        std::string_view host,
+        std::string_view service,
+        asio::error_code* err = nullptr);
 
 
 asio::ip::address GetAnyAddress(const bool IPv6);

--- a/rts/System/Net/UDPConnection.cpp
+++ b/rts/System/Net/UDPConnection.cpp
@@ -247,7 +247,7 @@ UDPConnection::UDPConnection(int sourcePort, const std::string& address, const u
 
 	ip::address sourceAddr = GetAnyAddress(addr.address().is_v6());
 	std::shared_ptr<ip::udp::socket> tempSocket(new ip::udp::socket(
-			netcode::netservice, ip::udp::endpoint(sourceAddr, sourcePort)));
+			netcode::netcontext, ip::udp::endpoint(sourceAddr, sourcePort)));
 	mySocket = tempSocket;
 
 	Init();
@@ -439,7 +439,7 @@ void UDPConnection::Update()
 
 	if (!sharedSocket && !closed) {
 		// duplicated code with UDPListener
-		netservice.poll();
+		netcontext.poll();
 
 		size_t bytesAvailable = 0;
 

--- a/rts/System/Net/UDPListener.cpp
+++ b/rts/System/Net/UDPListener.cpp
@@ -54,7 +54,7 @@ std::string UDPListener::TryBindSocket(int port, std::shared_ptr<asio::ip::udp::
 		if ((port < 0) || (port > 65535))
 			throw std::range_error("Port is out of range [0, 65535]: " + std::to_string(port));
 
-		sock.reset(new ip::udp::socket(netservice));
+		sock.reset(new ip::udp::socket(netcontext));
 		sock->open(ip::udp::v6(), err); // test IP v6 support
 
 		const bool supportsIPv6 = !err;
@@ -107,7 +107,7 @@ std::string UDPListener::TryBindSocket(int port, std::shared_ptr<asio::ip::udp::
 
 void UDPListener::Update(int loopSleepTime) {
 	if (loopSleepTime == 0)
-		netservice.poll();
+		netcontext.poll();
 	else {
 		fd_set rset;
 		FD_ZERO(&rset);


### PR DESCRIPTION
Migrate from `asio::io_service` to `asio::io_context`, adapt new `resolver`
method signatures and return types, and use `asio::mutable_buffer` instead of `asio::mutable_buffers_1`.

This makes the Recoil engine code compatible with the new Networking TS compatible API https://think-async.com/Asio/asio-1.38.2/doc/asio/net_ts.html. With these changes in-place it would be possible to update the asio library to version 1.38.2 from 1.30.2 without further changes to engine code  
