### PR TITLE
docs: type gl.ReadPixels pixel formats and return values

### DIFF
--- a/rts/Lua/LuaConstGL.cpp
+++ b/rts/Lua/LuaConstGL.cpp
@@ -741,6 +741,47 @@ bool LuaConstGL::PushEntries(lua_State* L)
 	/*** @field GL.FRAMEBUFFER integer */
 	PUSH_GL(FRAMEBUFFER);
 
+	/******************************************************************************
+	 * Pixel Formats
+	 *
+	 * Accepted by `gl.ReadPixels` as its pixel format, and by the `format` field
+	 * of the `gl.CreateTexture` and `gl.CreateRBO` options tables.
+	 *
+	 * @section pixelformats
+	******************************************************************************/
+
+	/*** @field GL.COLOR_INDEX integer */
+	PUSH_GL(COLOR_INDEX);
+	/*** @field GL.STENCIL_INDEX integer */
+	PUSH_GL(STENCIL_INDEX);
+	/*** @field GL.DEPTH_COMPONENT integer */
+	PUSH_GL(DEPTH_COMPONENT);
+
+	/*** @field GL.RED integer */
+	PUSH_GL(RED);
+	/*** @field GL.GREEN integer */
+	PUSH_GL(GREEN);
+	/*** @field GL.BLUE integer */
+	PUSH_GL(BLUE);
+	/*** @field GL.ALPHA integer */
+	PUSH_GL(ALPHA);
+
+	/*** @field GL.RGB integer */
+	PUSH_GL(RGB);
+	/*** @field GL.RGBA integer */
+	PUSH_GL(RGBA);
+	/*** @field GL.BGR integer */
+	PUSH_GL(BGR);
+	/*** @field GL.BGRA integer */
+	PUSH_GL(BGRA);
+
+	/*** Only accepted in the compatibility profile, i.e. with `ForceCoreContext` unset.
+	 * @field GL.LUMINANCE integer */
+	PUSH_GL(LUMINANCE);
+	/*** Only accepted in the compatibility profile, i.e. with `ForceCoreContext` unset.
+	 * @field GL.LUMINANCE_ALPHA integer */
+	PUSH_GL(LUMINANCE_ALPHA);
+
 	return true;
 
 #undef PUSH_GL
@@ -757,21 +798,6 @@ bool LuaConstGL::PushEntries(lua_State* L)
 /// @field GL_RGBA16F_ARB 0x881A
 
 /// @field GL_RGBA32F_ARB 0x8814
-
-/// @field GL_DEPTH_COMPONENT 0x1902
-
-/******************************************************************************
- * Not included, but useful RBO Formats
- * @section rboformats
-******************************************************************************/
-
-/// @field GL_RGB 0x1907
-
-/// @field GL_RGBA 0x1908
-
-/// @field GL_DEPTH_COMPONENT 0x1902
-
-/// @field GL_STENCIL_INDEX 0x1901
 
 /******************************************************************************
  * Not included, but useful FBO Targets

--- a/rts/Lua/LuaOpenGL.cpp
+++ b/rts/Lua/LuaOpenGL.cpp
@@ -6419,44 +6419,118 @@ static void PushPixelData(lua_State* L, int fSize, const float*& data)
 
 
 /***
+ * Pixel format with a single color component.
+ *
+ * Pass the matching `GL` table constant, e.g. `GL.RED`.
+ *
+ * `GL.COLOR_INDEX`, `GL.ALPHA` and `GL.LUMINANCE` were removed in the core
+ * profile, and are only accepted while running in the compatibility profile,
+ * i.e. with the `ForceCoreContext` config unset. `GL.COLOR_INDEX` additionally
+ * requires a color-index color buffer, which Recoil never creates.
+ *
+ * `GL.STENCIL_INDEX` and `GL.DEPTH_COMPONENT` require the read buffer to
+ * actually have the matching attachment.
+ *
+ * @alias GLPixelFormat1
+ * | 6400 # `GL.COLOR_INDEX` (`0x1900`)
+ * | 6401 # `GL.STENCIL_INDEX` (`0x1901`)
+ * | 6402 # `GL.DEPTH_COMPONENT` (`0x1902`)
+ * | 6403 # `GL.RED` (`0x1903`)
+ * | 6404 # `GL.GREEN` (`0x1904`)
+ * | 6405 # `GL.BLUE` (`0x1905`)
+ * | 6406 # `GL.ALPHA` (`0x1906`)
+ * | 6409 # `GL.LUMINANCE` (`0x1909`)
+ */
+/***
+ * Pixel format with two color components.
+ *
+ * `GL.LUMINANCE_ALPHA` was removed in the core profile, and is only accepted
+ * while running in the compatibility profile, i.e. with the `ForceCoreContext`
+ * config unset.
+ *
+ * @alias GLPixelFormat2
+ * | 6410 # `GL.LUMINANCE_ALPHA` (`0x190A`)
+ */
+/***
+ * Pixel format with three color components.
+ *
+ * @alias GLPixelFormat3
+ * | 6407 # `GL.RGB` (`0x1907`)
+ * | 32992 # `GL.BGR` (`0x80E0`)
+ */
+/***
+ * Pixel format with four color components.
+ *
+ * @alias GLPixelFormat4
+ * | 6408 # `GL.RGBA` (`0x1908`)
+ * | 32993 # `GL.BGRA` (`0x80E1`)
+ */
+/***
  * Get single pixel.
+ *
+ * One value is returned per component of `format`, in the order the format
+ * names them, so `GL.BGRA` returns blue, green, red and alpha.
+ *
  * @function gl.ReadPixels
  * @param x integer
  * @param y integer
  * @param w 1
  * @param h 1
- * @param format GL? (Default: `GL.RGBA`)
- * @return number ... Color value (color size based on format).
+ * @param format GLPixelFormat4? (Default: `GL.RGBA`, i.e. `6408`)
+ * @return number red
+ * @return number green
+ * @return number blue
+ * @return number alpha
+ * @overload fun(x: integer, y: integer, w: 1, h: 1, format: GLPixelFormat3): number, number, number
+ * @overload fun(x: integer, y: integer, w: 1, h: 1, format: GLPixelFormat2): number, number
+ * @overload fun(x: integer, y: integer, w: 1, h: 1, format: GLPixelFormat1): number
  */
 /***
  * Get column of pixels.
+ *
  * @function gl.ReadPixels
  * @param x integer
  * @param y integer
  * @param w 1
  * @param h integer
- * @param format GL? (Default: `GL.RGBA`)
- * @return number[][] colors Column of color values (color size based on format).
+ * @param format GLPixelFormat4? (Default: `GL.RGBA`, i.e. `6408`)
+ * @return [number,number,number,number][] colors Color values indexed by row.
+ * @overload fun(x: integer, y: integer, w: 1, h: integer, format: GLPixelFormat3): [number,number,number][]
+ * @overload fun(x: integer, y: integer, w: 1, h: integer, format: GLPixelFormat2): [number,number][]
+ * @overload fun(x: integer, y: integer, w: 1, h: integer, format: GLPixelFormat1): number[]
  */
 /***
  * Get row of pixels.
+ *
  * @function gl.ReadPixels
  * @param x integer
  * @param y integer
  * @param w integer
  * @param h 1
- * @param format GL? (Default: `GL.RGBA`)
- * @return number[][] colors Row of color values (color size based on format).
+ * @param format GLPixelFormat4? (Default: `GL.RGBA`, i.e. `6408`)
+ * @return [number,number,number,number][] colors Color values indexed by column.
+ * @overload fun(x: integer, y: integer, w: integer, h: 1, format: GLPixelFormat3): [number,number,number][]
+ * @overload fun(x: integer, y: integer, w: integer, h: 1, format: GLPixelFormat2): [number,number][]
+ * @overload fun(x: integer, y: integer, w: integer, h: 1, format: GLPixelFormat1): number[]
  */
 /***
- * Get columns of pixels.
+ * Get a rectangle of pixels.
+ *
+ * `glReadPixels` fills the region row by row, and those values are then handed
+ * out as `w` tables of `h` values each. For a square region that works out to
+ * `colors[row][column]`, which is how callers index it; for a non-square one
+ * the nesting does not line up with the pixel grid at all.
+ *
  * @function gl.ReadPixels
  * @param x integer
  * @param y integer
  * @param w integer
  * @param h integer
- * @param format GL? (Default: `GL.RGBA`)
- * @return number[][][] colors Array of columns of color values (color size based on format).
+ * @param format GLPixelFormat4? (Default: `GL.RGBA`, i.e. `6408`)
+ * @return [number,number,number,number][][] colors Pixels of the region, nested as described above.
+ * @overload fun(x: integer, y: integer, w: integer, h: integer, format: GLPixelFormat3): [number,number,number][][]
+ * @overload fun(x: integer, y: integer, w: integer, h: integer, format: GLPixelFormat2): [number,number][][]
+ * @overload fun(x: integer, y: integer, w: integer, h: integer, format: GLPixelFormat1): number[][]
  */
 int LuaOpenGL::ReadPixels(lua_State* L)
 {


### PR DESCRIPTION
`gl.ReadPixels` takes a pixel format and returns one or more color values in that format. It was annotated generically and incorrectly.

**The base pixel formats were not in the `GL` table.** `LuaConstGL.cpp` only pushed sized internal formats (`RGBA8`, `RGBA32F`, …), and listed `GL_RGBA`, `GL_RGB`, `GL_DEPTH_COMPONENT` and `GL_STENCIL_INDEX` under *"Not included, but useful"*. So `GL` was the wrong type, and the documented default `GL.RGBA` named a constant that did not exist. This PR adds them: the thirteen base formats `PixelFormatSize` accepts are pushed, and the four aliases reference them by name.

**Single-component formats do not return tables.** `PushPixelData` pushes a bare number per pixel when `fSize == 1`, so `number[][]` was wrong for `GL.RED`, `GL.LUMINANCE`, etc.

**The 2D block no longer claims an index order.** `glReadPixels` fills the region row by row, but the `w > 1 && h > 1` branch walks `x` outer and `y` inner, so the result is that buffer reshaped into `w` groups of `h`. That equals `colors[row][column]` only when `w == h`. Every caller I looked at in Beyond-All-Reason indexes `result[row][column]`, so the annotation now describes the reshape and says where it lines up.

### Behaviour change — please review this part specifically

Publishing `GL.RGBA` and `GL.ALPHA` is not just an annotation change. Both are already referenced by Beyond-All-Reason, where they currently evaluate to `nil`. A `nil` value never lands in a `gl.CreateTexture` options table, so the `lua_next` walk never visits the key and the C++ default `GL_RGBA8` stands. Once the constants are defined those call sites start passing a real value:

| constant | BAR call sites | today | after this PR |
| --- | --- | --- | --- |
| `GL.RGBA` | 31, all `format = GL.RGBA` in `gl.CreateTexture` | `GL_RGBA8` | unsized `GL_RGBA`, driver picks the size |
| `GL.ALPHA` | 8, same pattern | `GL_RGBA8` | single-channel `GL_ALPHA` |
| `GL.RGB` | 1, `gl.ReadPixels` in `cmd_get_player_data.lua` | reads 4 components | reads 3 — **fixes** that call site |

`GetDataFormatFromInternalFormat` and `GetDataTypeFromInternalFormat` both fall through their `default:` branch for `GL_RGBA`, so the calls stay valid, but the meaning genuinely changes.

### Testing

Doc comments plus thirteen `PUSH_GL` lines. No behavioural C++ is touched beyond what publishing those constants implies in other codebases.

Extracted the library with `lua-doc-extractor` and type-checked a consumer against it with `lua-language-server` 3.19.1:

| call | resolves to |
| --- | --- |
| `ReadPixels(0, 0, 1, 1)` | 4 × `number` |
| `ReadPixels(0, 0, 1, 1, GL.LUMINANCE)` | 1 × `number` |
| `ReadPixels(0, 0, 1, 16)` → `col[1][4]` | `number` |
| `ReadPixels(0, 0, 1, 16, GL.LUMINANCE)` → `colL[1]` | `number` (flat array) |
| `ReadPixels(0, 0, 8, 8, GL.RGB)` → `grid[1][1][3]` | `number` |
| `ReadPixels(0, 0, 1, 1, 0x8058)` (`GL_RGBA8`) | rejected, not a pixel format |

No false positives: valid calls are silent, a format held in a `local` still narrows to its literal, and indexing past a tuple's length is not flagged.

> ### Left for later

**Non-square regions are transposed.** Per the above, the 2d nesting doesn't correspond to any actual shape for non-square regions. Nothing shipped with the engine calls `gl.ReadPixels`, but two Beyond-All-Reason callers read non-square regions and then index the result as `[row][column]`. I will be investigating this for a possible future fix.

### AI disclosure

Written with Claude Code (Opus 5). The analysis of which formats the binding accepts, the annotation design, the decision to publish the constants, and the `lua-language-server` / `emmylua_check` verification above were AI-assisted. I reviewed the result and confirmed the tool runs. I understand the changes being made here.

I will un-draft this PR once I have tested with Beyond All Reason to ensure that publishing the previously-nonexistent GL enum constants won't break anything there.
