### PR TITLE
Threading.cpp add missing <ranges> include

### DIFF
--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <numeric>
 #include <cinttypes>
+#include <ranges>
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	#include <windows.h>


### PR DESCRIPTION
The include is needed for `std::ranges::find_if`
https://github.com/0x12A01DC/RecoilEngine/blob/d193afdea7cf79d9f02fcfe278e8e5deecfdb842/rts/System/Platform/Threading.cpp#L200-L201