### PR TITLE
Honour useMuzzle in projectile weapons' GetAimFromPos

### DIFF
--- a/doc/pr-changelogs/3317.md
+++ b/doc/pr-changelogs/3317.md
@@ -1,0 +1,1 @@
+ * `MissileLauncher`, `Cannon`, and `StarburstLauncher` type weapons now use their AimFrom piece rather than the Query piece when deciding whether they have a free line of fire (matters for calling `script.AimWeapon` and `Spring.GetUnitWeaponHaveFreeLineOfFire`).

--- a/rts/Sim/Weapons/Cannon.h
+++ b/rts/Sim/Weapons/Cannon.h
@@ -46,7 +46,7 @@ private:
 	float3 GetWantedDir(const float3& diff);
 	float3 CalcWantedDir(const float3& diff) const;
 
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
+	const float3& GetAimFromPos(bool useMuzzle = false) const override { return (useMuzzle ? weaponMuzzlePos : aimFromPos); }
 
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;

--- a/rts/Sim/Weapons/MissileLauncher.h
+++ b/rts/Sim/Weapons/MissileLauncher.h
@@ -14,7 +14,7 @@ public:
 	void UpdateWantedDir() override final;
 
 private:
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
+	const float3& GetAimFromPos(bool useMuzzle = false) const override { return (useMuzzle ? weaponMuzzlePos : aimFromPos); }
 
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;

--- a/rts/Sim/Weapons/StarburstLauncher.h
+++ b/rts/Sim/Weapons/StarburstLauncher.h
@@ -14,7 +14,7 @@ public:
 	float GetRange2D(float boost, float ydiff) const override final;
 
 private:
-	const float3& GetAimFromPos(bool useMuzzle = false) const override { return weaponMuzzlePos; }
+	const float3& GetAimFromPos(bool useMuzzle = false) const override { return (useMuzzle ? weaponMuzzlePos : aimFromPos); }
 
 	bool HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const override final;
 	void FireImpl(const bool scriptCall) override final;


### PR DESCRIPTION
## Work

`CWeapon::TryTarget` calls `GetAimFromPos(preFire)` to pick the point it tests line of fire from: the aim-from piece while deciding whether a target is worth taking, the muzzle when actually firing. `CMissileLauncher`, `CCannon` and `CStarburstLauncher` override it to return the muzzle unconditionally, so for them the pre-fire test runs from wherever the muzzle piece happens to rest. This makes the three overrides honour `useMuzzle`, which is what the base class already does.

`TestRange` measures from `aimFromPos` directly and is unchanged. The only callers of `GetAimFromPos` are `TryTarget` and Lua's `GetUnitWeaponHaveFreeLineOfFire` default source. Firing still needs a clear line from the muzzle, since `UpdateFire` tests with `preFire = true`.

## Issue

Beyond All Reason's Rocketeer rests its launcher arm hanging down, and the arm carries the muzzle piece. From that pose any ridge between the bot and a target blocks the muzzle ray, `Attack` refuses the target, and because a weapon is only aimed at a target it has accepted, nothing ever raises the arm. Game-side set targets stay passive forever, attack orders make the bot path around the obstacle, and auto-targeting never fires. One shot at the floor unjams it until the arm drops again. Reported and diagnosed on the BAR Discord; the game-side workaround is beyond-all-reason/Beyond-All-Reason#9056.

## Test

Built `spring-headless` from this branch and ran BAR's ridge scenario (Rocketeer at rest behind a 9-elmo ridge, target 360 elmos away) on stock game code with the workaround removed: ground Set Target accepted in 1 frame, unit Set Target in 1 frame, Attack order in 1 frame without moving, fire-at-will enemy in 9 frames. On 2026.07.04 none of the four is ever accepted. Line of fire measured from the aim piece and from the muzzle piece at rest agree with the new default and the old one respectively.

Behaviour note: a cannon whose barrel tip is blocked while its turret pivot is not will now accept the target and hold fire until the line clears, where before it would have refused the target and, under an attack order, moved closer. That is already how every non-projectile weapon behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8JZx1GnqtfY8VUXjLZTkx
