### PR TITLE
Fix compiler warning in StringHash.h

### DIFF
--- a/rts/System/StringHash.h
+++ b/rts/System/StringHash.h
@@ -17,7 +17,7 @@
 
 [[nodiscard]] constexpr uint32_t hashString(const std::string& str, uint32_t hash = 5381u) noexcept { return hashString(str.c_str(), str.length(), hash); }
 
-[[nodiscard]] constexpr uint32_t operator"" _hs(const char* str, std::size_t) noexcept {
+[[nodiscard]] constexpr uint32_t operator""_hs(const char* str, std::size_t) noexcept {
 	return hashString(str);
 }
 


### PR DESCRIPTION
Fixes `warning: space between quotes and suffix is deprecated in C++23` in `StringHash.h`.