### PR TITLE
Weapons: Fix muzzle below terrain reporting free line of fire

### DIFF
--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -7,4 +7,16 @@ title = "Running changelog"
 
 This is the bleeding-edge changelog since version 2026.07, for **pre-release 2026.08**.
 
-No changes as of yet.
+# Fixes
+* Line-of-fire and other synced ground traces (`TraceRay`, `CWeapon::HaveFreeLineOfFire`,
+`Spring.GetUnitWeaponHaveFreeLineOfFire`) no longer report a free line when the ray starts
+below the terrain. `LineGroundCol` returns a hit distance of 0 for such a ray and `TraceRay`
+discarded that as "no hit", so a weapon whose muzzle or aim-from piece was inside a cliff
+believed it could shoot through it, stopped, and never fired. Cannons had the same problem
+with their trajectory trace and now reject a source below the interpolated terrain height
+outright, the test the fire-time check already applies to the muzzle.
+* The underground test of `LineGroundCol` (also behind `Spring.TraceRayGround*`) compares the
+ray origin against the interpolated terrain height instead of the corner vertex of its
+heightmap square. Next to a steep cliff that vertex could sit far above an origin that was
+well clear of the ground, so the whole ground trace was skipped. A ray that starts exactly
+on the surface is no longer treated as underground.

--- a/doc/site/content/changelogs/_index.markdown
+++ b/doc/site/content/changelogs/_index.markdown
@@ -12,9 +12,11 @@ This is the bleeding-edge changelog since version 2026.07, for **pre-release 202
 `Spring.GetUnitWeaponHaveFreeLineOfFire`) no longer report a free line when the ray starts
 below the terrain. `LineGroundCol` returns a hit distance of 0 for such a ray and `TraceRay`
 discarded that as "no hit", so a weapon whose muzzle or aim-from piece was inside a cliff
-believed it could shoot through it, stopped, and never fired. Cannons had the same problem
-with their trajectory trace and now reject a source below the interpolated terrain height
-outright, the test the fire-time check already applies to the muzzle.
+believed it could shoot through it, stopped, and never fired. Both the base weapon and cannon
+line-of-fire checks now reject a source below the interpolated terrain height when ground
+avoidance is enabled, even if the target is within explosion range. This matches the existing
+pre-fire muzzle check; the base weapon's explosion-range exception remains for surface sources
+and ground hits farther along the shot.
 * The underground test of `LineGroundCol` (also behind `Spring.TraceRayGround*`) compares the
 ray origin against the interpolated terrain height instead of the corner vertex of its
 heightmap square. Next to a steep cliff that vertex could sit far above an origin that was

--- a/rts/Game/TraceRay.cpp
+++ b/rts/Game/TraceRay.cpp
@@ -316,7 +316,9 @@ float TraceRay(
 		// ground intersection
 		const float groundLength = CGround::LineGroundCol(pos, pos + dir * traceLength);
 
-		if (traceLength > groundLength && groundLength > 0.0f) {
+		// a return value of 0 means the ray starts underground (or on the surface pointing into
+		// it), which blocks it at the origin; only -1 signals that the ground was not hit at all
+		if (traceLength > groundLength && groundLength >= 0.0f) {
 			traceLength = groundLength;
 
 			hitUnit = nullptr;

--- a/rts/Map/Ground.cpp
+++ b/rts/Map/Ground.cpp
@@ -242,10 +242,11 @@ float CGround::LineGroundCol(float3 from, float3 to, bool synced)
 	if (synced) {
 		// TODO: do this in unsynced too?
 		// check if our start position is underground (assume ground is unpassable for cannons etc.)
-		const int sx = from.x / SQUARE_SIZE;
-		const int sz = from.z / SQUARE_SIZE;
-
-		if (from.y <= hm[sz * mapDims.mapxp1 + sx])
+		// compare against the interpolated surface rather than the corner vertex of the square:
+		// next to a steep rise that vertex can sit far above a start point that is well clear of
+		// the ground, and a start exactly on the surface is not underground (LineGroundSquareCol
+		// reports a hit at distance 0 for it if the ray points into the ground)
+		if (from.y < InterpolateCornerHeight(from.x, from.z, hm))
 			return 0.0f + skippedDist;
 	}
 

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -77,6 +77,12 @@ bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 
 	const float xzTargetDist = targetVec.LengthNormalize();
 
+	// a source below the terrain (e.g. a muzzle inside a cliff) blocks the shot at its origin;
+	// TrajectoryGroundCol reports this as distance 0 too, but against GetApproximateHeight, which
+	// on rough ground can lie above a source that is clear of the interpolated surface
+	if ((avoidFlags & Collision::NOGROUND) == 0 && srcPos.y < CGround::GetHeightReal(srcPos))
+		return false;
+
 	// linear parabolic coefficient is the ratio of vertical velocity to horizontal velocity, with slight adjustment due to acceleration being applied in discrete steps.
 	// quadratic parabolic coefficient is the ratio of gravity to (horizontal velocity)^2
 	const float projectileSpeedHorizontal = std::max(0.001f,projectileSpeed * launchDir.Length2D()); //ensure projectileSpeedHorizontal cannot be zero

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -98,9 +98,9 @@ bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		-1.0f;
 	const float angleSpread = (AccuracyExperience() + SprayAngleExperience()) * 0.6f * 0.9f;
 
-	// Unlike CWeapon's ray trace, this scan uses approximate cell-center terrain heights.
-	// A zero-distance hit can therefore report an above-ground source as blocked; keep > 0.
-	// The GetHeightReal check above rejects sources that are actually underground.
+	// This scan uses approximate cell-center terrain heights, so a zero-distance hit
+	// can report an above-ground source as blocked. Keep > 0; the GetHeightReal check
+	// above rejects sources that are actually underground.
 	if (groundDist > 0.0f)
 		return false;
 
@@ -267,4 +267,3 @@ float CCannon::GetStaticRange2D(const float2& baseConsts, const float2& projCons
 
 	return (CalcRange2D({baseConsts.y, 0.7071067f, 100.0f}, projConsts, {wdRangeBoostFact, wdHeightBoostFact}));
 }
-

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -98,6 +98,9 @@ bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		-1.0f;
 	const float angleSpread = (AccuracyExperience() + SprayAngleExperience()) * 0.6f * 0.9f;
 
+	// Unlike CWeapon's ray trace, this scan uses approximate cell-center terrain heights.
+	// A zero-distance hit can therefore report an above-ground source as blocked; keep > 0.
+	// The GetHeightReal check above rejects sources that are actually underground.
 	if (groundDist > 0.0f)
 		return false;
 

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -60,6 +60,10 @@ void CCannon::UpdateRange(const float val)
 bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// Use real terrain height: the trajectory scan's approximate height can be above a clear source.
+	if ((avoidFlags & Collision::NOGROUND) == 0 && srcPos.y < CGround::GetHeightReal(srcPos))
+		return false;
+
 	// assume we can still fire at partially submerged targets
 	if (!weaponDef->waterweapon && TargetUnderWater(tgtPos, trg))
 		return false;
@@ -76,12 +80,6 @@ bool CCannon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		return true;
 
 	const float xzTargetDist = targetVec.LengthNormalize();
-
-	// a source below the terrain (e.g. a muzzle inside a cliff) blocks the shot at its origin;
-	// TrajectoryGroundCol reports this as distance 0 too, but against GetApproximateHeight, which
-	// on rough ground can lie above a source that is clear of the interpolated surface
-	if ((avoidFlags & Collision::NOGROUND) == 0 && srcPos.y < CGround::GetHeightReal(srcPos))
-		return false;
 
 	// linear parabolic coefficient is the ratio of vertical velocity to horizontal velocity, with slight adjustment due to acceleration being applied in discrete steps.
 	// quadratic parabolic coefficient is the ratio of gravity to (horizontal velocity)^2

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1138,7 +1138,8 @@ bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		const float tgtDst = tgtPos.SqDistance(srcPos + tgtDir * gndDst);
 
 		// true iff ground does not block the ray of length <length> from <srcPos> along <tgtDir>
-		if ((gndDst > 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
+		// (a distance of 0 means <srcPos> itself is underground; -1 is not possible since length > 0)
+		if ((gndDst >= 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
 			return false;
 
 		unit = nullptr;

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1142,8 +1142,8 @@ bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		const float tgtDst = tgtPos.SqDistance(srcPos + tgtDir * gndDst);
 
 		// true iff ground does not block the ray of length <length> from <srcPos> along <tgtDir>
-		// Unlike CCannon's approximate trajectory scan, this ray trace uses the terrain surface.
-		// A surface source pointing into terrain can hit at distance 0, so keep >= 0 and the AoE exception.
+		// A surface source pointing into terrain can hit at distance 0, so keep >= 0
+		// and retain the AoE exception.
 		if ((gndDst >= 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
 			return false;
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1118,6 +1118,10 @@ bool CWeapon::TestRange(const float3& tgtPos, const SWeaponTarget& trg) const
 bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, const SWeaponTarget& trg) const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
+	// Match the pre-fire muzzle check before considering the ground-hit AoE exception.
+	if ((avoidFlags & Collision::NOGROUND) == 0 && srcPos.y < CGround::GetHeightReal(srcPos))
+		return false;
+
 	float3 tgtDir = tgtPos - srcPos;
 
 	const float length = tgtDir.LengthNormalize();
@@ -1138,7 +1142,7 @@ bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		const float tgtDst = tgtPos.SqDistance(srcPos + tgtDir * gndDst);
 
 		// true iff ground does not block the ray of length <length> from <srcPos> along <tgtDir>
-		// (a distance of 0 means <srcPos> itself is underground; -1 is not possible since length > 0)
+		// A surface source pointing into terrain can still hit at distance 0.
 		if ((gndDst >= 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
 			return false;
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1142,7 +1142,8 @@ bool CWeapon::HaveFreeLineOfFire(const float3& srcPos, const float3& tgtPos, con
 		const float tgtDst = tgtPos.SqDistance(srcPos + tgtDir * gndDst);
 
 		// true iff ground does not block the ray of length <length> from <srcPos> along <tgtDir>
-		// A surface source pointing into terrain can still hit at distance 0.
+		// Unlike CCannon's approximate trajectory scan, this ray trace uses the terrain surface.
+		// A surface source pointing into terrain can hit at distance 0, so keep >= 0 and the AoE exception.
 		if ((gndDst >= 0.0f) && (tgtDst > Square(damages->damageAreaOfEffect)))
 			return false;
 


### PR DESCRIPTION
Units whose muzzle is clipping inside terrain stop moving and try to shoot, because `CWeapon::HaveFreeLineOfFire` and `CCannon::HaveFreeLineOfFire` return the shot as unobstructed if it starts below terrain.


Partly addresses #3242. 
Likely addresses #3301 (see below).

## Problem


`CGround::LineGroundCol` returns a hit distance of **0** when the ray origin is below the terrain. `TraceRay` only accepted ground hits with `groundLength > 0.0f`, and `CWeapon::HaveFreeLineOfFire` applied the same `> 0` filter to the returned distance. A ray that starts underground was therefore reported as *unobstructed*. `CCannon::HaveFreeLineOfFire` had the identical pattern with `CGround::TrajectoryGroundCol`, which also reports 0 for that case.

Consequences:

* A Sheldon standing against a cliff with its muzzle 65 elmo inside the rock passes the pre-aim line-of-fire test, stops, and can never fire because the fire-time test rejects the underground muzzle (#3242, the "stops and does not even start to walk" case).
* `Spring.GetUnitWeaponHaveFreeLineOfFire` tells game code the same thing.

Additionally the underground test in `LineGroundCol` compared the origin against the **corner vertex** of its heightmap square rather than the interpolated surface. Next to a steep cliff that vertex can sit far above an origin that is well clear of the ground, and then the whole ground trace was skipped. That is the shape of #3301: a mech at the foot of a cliff reports a free line of fire to a unit on top of it as soon as it moves close to the cliff face. `Spring.TraceRayGroundBetweenPositions`, which @FLOZi swapped in, treats 0 as a hit and so looked correct in the same situation.

## Change

* `TraceRay`: accept a ground distance of 0 as a hit (the ray is blocked at its origin). Only -1 means "no ground hit".
* `CWeapon::HaveFreeLineOfFire`: same for the returned distance. `CMissileLauncher` already handled it.
* `CCannon::HaveFreeLineOfFire`: reject a source below `GetHeightReal` explicitly, the test the fire-time check already applies to the muzzle, and keep ignoring the 0 from `TrajectoryGroundCol`. That scan uses `GetApproximateHeight`, which on rough ground lies above sources a couple of elmo clear of the interpolated surface; accepting its 0 blocked 48 above-ground probe points that are free today.
* `CGround::LineGroundCol`: the underground test compares against the interpolated height (`InterpolateCornerHeight`) and treats an origin exactly on the surface as above ground. `LineGroundSquareCol` still returns a hit at distance 0 when such a ray points into the ground, so the "unit position on the surface" case keeps working for rays pointing up and is blocked for rays pointing down.

Callers that scan ground with `TraceRay` are `HaveFreeLineOfFire`, `BeamLaser`, `LightningCannon`, `Rifle` and the AI callbacks. The weapons already refuse to fire when the real muzzle is below `GetHeightReal` (`TryTarget`, `preFire`), so with the interpolated underground test they never reach the new "blocked at origin" branch at fire time.

#3241 is stacked on this PR. Its explicit below-ground check for the predicted muzzle stays: it also covers weapons that skip ground checks (`avoidGround = false`) and mirrors the fire-time test.

## Validation

Headless probe in the #3242 rock scenario (five Sheldons behind the rock on All That Glitters, one with its muzzle inside the cliff; gadget `dbg_lof_underground_probe.lua` in my workspace), same BAR checkout, before = engine without this commit:

The probe creates a Flea (BeamLaser, `CWeapon::HaveFreeLineOfFire`) and a Pawn (Cannon, `CCannon::HaveFreeLineOfFire`) and calls `Spring.GetUnitWeaponHaveFreeLineOfFire` with explicit source positions towards the Fatboy.

| test | before | after |
|---|---|---|
| Sheldon with its muzzle 65 elmo inside the cliff: 3-arg and 6-arg (from muzzle) call | free / free | blocked / blocked |
| the other four Sheldons (muzzle 11 below to 26 above ground) | blocked | blocked (unchanged) |
| source 40 elmo **below** each Sheldon's position, laser and cannon (10 calls) | all free | all blocked |
| source 40 elmo above each Sheldon's position, laser and cannon | all blocked (rock in the way) | all blocked (unchanged) |
| `Spring.TraceRayGroundBetweenPositions` from the same underground sources | hit at 0 | hit at 0 (unchanged) |
| **laser**, 289 sources 2 elmo above the ground on a 128x128 grid around the cliff Sheldon | 8 free: exactly the 8 points whose heightmap corner vertex lies above the source, i.e. where the old underground test skipped the trace | 0 free: those 8 rays hit the rock face within 2.3 elmo |
| **cannon**, same grid | 48 free | 48 free, identical set (the trajectory scan is unchanged) |

Full rock reproducer (hold position and maneuver) on master + this commit: the cliff Sheldon's pre-aim test now fails (`tryTarget=false lofAim=false lofMuzzle=false`), so it no longer stops believing it has a shot. Getting it to walk out of the corner is what #3241 does; without it master's CommandAI still leaves it there.
