### PR TITLE
CommandAI: stop moving when the active command is removed

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -4028,6 +4028,8 @@ int LuaSyncedCtrl::SetUnitMoveGoal(lua_State* L)
 		unit->moveType->StartMoving(pos, radius, speed);
 	}
 
+	// the goal no longer belongs to the active command (see CCommandAI::ExecuteRemove)
+	unit->commandAI->moveGoalCmdTag = 0;
 	return 0;
 }
 

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1282,6 +1282,17 @@ void CCommandAI::ExecuteRemove(const Command& c)
 				if (!facCAI && (ci == queue->begin())) {
 					if (!active) {
 						active = true;
+
+						// the active command is pulled out from under the unit (a queue
+						// edit, or DependentDied because the command's target object was
+						// deleted); FinishCommand() alone leaves the move-type heading for
+						// the goal this command set, so a mobile attacker that was still
+						// closing in on a target that just died walks on to the target's
+						// last position with an empty queue; stop unless the next command
+						// is a move command, which sets its own goal right away
+						if (queue->size() < 2 || !(queue->begin() + 1)->IsMoveCommand())
+							StopMove();
+
 						FinishCommand();
 						ci = queue->begin();
 						break;

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -76,6 +76,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(repeatOrders),
 	CR_MEMBER(lastSelectedCommandPage),
 	CR_MEMBER(inCommand),
+	CR_MEMBER(moveGoalCmdTag),
 	CR_MEMBER(commandDeathDependences),
 	CR_MEMBER(targetLostTimer),
 
@@ -1288,9 +1289,14 @@ void CCommandAI::ExecuteRemove(const Command& c)
 						// deleted); FinishCommand() alone leaves the move-type heading for
 						// the goal this command set, so a mobile attacker that was still
 						// closing in on a target that just died walks on to the target's
-						// last position with an empty queue; stop unless the next command
-						// is a move command, which sets its own goal right away
-						if (queue->size() < 2 || !(queue->begin() + 1)->IsMoveCommand())
+						// last position with an empty queue
+						//
+						// only touch the goal if this command gave it (a goal set from Lua
+						// is left alone), and as in ExecuteMove do not stop-and-restart when
+						// the next command moves the unit anyway
+						const bool nextMoves = (queue->size() >= 2 && (queue->begin() + 1)->IsMoveCommand());
+
+						if (OwnsMoveGoal(qc.GetTag()) && !nextMoves)
 							StopMove();
 
 						FinishCommand();
@@ -1310,6 +1316,13 @@ void CCommandAI::ExecuteRemove(const Command& c)
 	}
 
 	repeatOrders = prevRepeat;
+}
+
+
+bool CCommandAI::OwnsMoveGoal(unsigned int cmdTag) const
+{
+	// the move-type may since have been stopped, or given another goal from Lua
+	return (cmdTag != 0 && cmdTag == moveGoalCmdTag && owner->moveType->progressState == AMoveType::Active);
 }
 
 

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -55,6 +55,8 @@ public:
 
 	virtual void BuggerOff(const float3& pos, float radius) {}
 	virtual void StopMove() {}
+	/// true if the move-type is still executing a goal that the command with this tag gave it
+	bool OwnsMoveGoal(unsigned int cmdTag) const;
 
 	void StopAttackingTargetIf(const std::function<bool(const CUnit*)>& pred);
 	void StopAttackingAllyTeam(int ally);
@@ -132,6 +134,10 @@ public:
 	bool repeatOrders;
 	int lastSelectedCommandPage;
 	int inCommand;
+
+	/// tag of the command that gave the move-type its current goal (CMobileCAI::SetGoal),
+	/// 0 if the goal was set from Lua instead (Spring.SetUnitMoveGoal)
+	unsigned int moveGoalCmdTag = 0;
 protected:
 	bool HandleBuildOptionInsertion(int cmdId);
 	bool HandleBuildOptionRemoval(int cmdId);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -1000,22 +1000,38 @@ void CMobileCAI::SetGoal(const float3& pos, const float3& /*curPos*/, float goal
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// check if owner already has a move order to this position with the same radius
-	if (owner->moveType->IsMovingTowards(pos, goalRadius, true))
-		return;
+	if (owner->moveType->IsMovingTowards(pos, goalRadius, true)) {
+		// a goal that a previous command gave (e.g. one replaced by a queue edit) now
+		// belongs to the active command, so that removing it stops the unit (see
+		// ExecuteRemove); a goal set from Lua (tag 0) is left alone
+		if (moveGoalCmdTag != 0)
+			moveGoalCmdTag = ActiveCmdTag();
 
-	// give new move order
+		return;
+	}
+
+	// give new move order, owned by the active command
 	owner->moveType->StartMoving(pos, goalRadius);
+	moveGoalCmdTag = ActiveCmdTag();
 }
 
 void CMobileCAI::SetGoal(const float3& pos, const float3& /*curPos*/, float goalRadius, float speed)
 {
 	RECOIL_DETAILED_TRACY_ZONE;
 	// check if owner already has a move order to this position with the same radius
-	if (owner->moveType->IsMovingTowards(pos, goalRadius, true))
-		return;
+	if (owner->moveType->IsMovingTowards(pos, goalRadius, true)) {
+		// a goal that a previous command gave (e.g. one replaced by a queue edit) now
+		// belongs to the active command, so that removing it stops the unit (see
+		// ExecuteRemove); a goal set from Lua (tag 0) is left alone
+		if (moveGoalCmdTag != 0)
+			moveGoalCmdTag = ActiveCmdTag();
 
-	// give new move order
+		return;
+	}
+
+	// give new move order, owned by the active command
 	owner->moveType->StartMoving(pos, goalRadius, speed);
+	moveGoalCmdTag = ActiveCmdTag();
 }
 
 bool CMobileCAI::SetFrontMoveCommandPos(const float3& pos)

--- a/rts/Sim/Units/CommandAI/MobileCAI.h
+++ b/rts/Sim/Units/CommandAI/MobileCAI.h
@@ -27,6 +27,7 @@ public:
 	virtual void BuggerOff(const float3& pos, float radius) override;
 
 	bool SetFrontMoveCommandPos(const float3& pos);
+	unsigned int ActiveCmdTag() const { return commandQue.empty() ? 0 : commandQue.front().GetTag(); }
 
 	void StopMove() override;
 	void StopMoveAndKeepPointing(const float3& p, const float r, bool b);


### PR DESCRIPTION
Fixes #3332.

## Problem

When a unit's attack target is deleted, `CCommandAI::DependentDied` removes every command that references it through `ExecuteRemove(CMD_REMOVE, tag)`. For the active command `ExecuteRemove` only calls `FinishCommand()`, so the move type keeps heading for the goal that command had set. A mobile unit that was still closing in on the target when it died (its own shot during a close-in step, or an ally's) therefore walks on to the target's last position with an empty queue. The `targetDied` branch in `CMobileCAI::ExecuteAttack`, which does `StopMoveAndFinishCommand()`, never runs for this case: by the next SlowUpdate the command is already gone. Removing the active command from the queue with `CMD_REMOVE` has the same effect.

Replay from the issue (2026.07.04, All That Glitters): the Armada commander kills the last queued Flea at frame 2287, one close-in step after it started moving (goal = Flea position minus its radius, 3492.1,1208.6); the order is finished at frame 2289 with an empty queue and the move type still `Active` on that waypoint; the commander walks ~290 elmo and stops on the waypoint at frame 2525. The seven Fleas before it died while the commander already stood in range, so nothing was visible there.

The same path is reachable without a dying target. BAR's `command_skip_current` (key N, `cmd_commandq_manager.lua`) removes the active command with `CMD_REMOVE` and then sends an explicit `CMD_STOP` when that was the only command in the queue ("keeps performing command otherwise"), which is a game-side workaround for exactly this. With a `CMD_WAIT` queued behind a move order (Shift+Y in BAR) no stop is sent and the unit walks on to the removed order's goal; verified in-game on 2026.07.04.

## Change

`ExecuteRemove` stops the unit before finishing the removed active command, but only if that command owns the move goal and the next queued command is not a move command (which sets its own goal right away, as `ExecuteMove` assumes too).

Ownership is tracked in `CCommandAI::moveGoalCmdTag`, the tag of the command that gave the move type its current goal:

* `CMobileCAI::SetGoal` sets it to the active command after `StartMoving`. If the unit is already heading for the requested goal and a command owns that goal, the active command takes it over (e.g. an attack order replaced through a queue edit, where the original is removed while second in the queue). A goal with tag 0 is left alone.
* `Spring.SetUnitMoveGoal` resets it to 0, so a goal a gadget set while a command was active is never cancelled by that command's removal.
* `CCommandAI::OwnsMoveGoal(tag)` requires the tag to match and the move type to be `Active`, so a stopped unit needs no bookkeeping.

`StopMove()` is the existing virtual (no-op in `CCommandAI`, `moveType->StopMoving()` in `CMobileCAI`); factory queues are not affected (they take the `RemoveBuildCommand` branch).

## Validation

Headless reproducer ([bar-attack-reproducers/dead-target](https://github.com/eun-ice/bar-attack-reproducers/tree/main/dead-target): gadget, All That Glitters v2.2.3, Armada commander at the replay position, Flea 568 elmo away; before = origin/master 680e33a241):

| variant | before | after |
|---|---|---|
| attack order, target destroyed once the commander has walked 120 elmo | walks 415 elmo on with an empty queue, stops 38 elmo from the dead Flea's spot | stops after 1.4 elmo |
| same, with a move order shift-queued behind the attack (control) | goes straight to the move goal | goes straight to the move goal |
| plain move order, active command removed with `CMD_REMOVE` after 120 elmo | walks 427 elmo on to the removed goal | stops after 0.1 elmo |
| attack order, a gadget calls `Spring.SetUnitMoveGoal` to another spot in the same frame the target is destroyed | walks to the Lua goal | walks to the Lua goal (the first commit of this PR stopped it) |
| attack order replaced via `CMD_INSERT` at the front, original removed by tag, target destroyed 30 frames later | walks 378 elmo on to the dead Flea's spot | stops after 1.4 elmo |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
