### PR TITLE
pathinfo texture performance optimizations

### DIFF
--- a/doc/pr-changelogs/3334.md
+++ b/doc/pr-changelogs/3334.md
@@ -1,0 +1,1 @@
+ * Fix: `/showpathtype <movedef|id|unitdef>` now actually shows the requested view

--- a/rts/Rendering/Map/InfoTexture/Modern/Path.cpp
+++ b/rts/Rendering/Map/InfoTexture/Modern/Path.cpp
@@ -6,6 +6,7 @@
 #include "Game/SelectedUnitsHandler.h"
 #include "Game/UI/GuiHandler.h"
 #include "Sim/Misc/GlobalConstants.h"
+#include "Sim/Misc/GroundBlockingObjectMap.h"
 #include "Sim/Misc/LosHandler.h"
 #include "Sim/MoveTypes/MoveMath/MoveMath.h"
 #include "Sim/MoveTypes/MoveDefHandler.h"
@@ -21,19 +22,43 @@
 
 #include "System/Misc/TracyDefs.h"
 
+#include <bit>
+#include <cstring>
+
+
+// what the texture holds while nothing is selected
+static constexpr SColor CLEAR_COLOR = SColor(1.0f, 0.0f, 0.0f, 1.0f);
+
+// texels (re)computed per update; the MoveDef view is cheap enough per
+// texel to sweep the texture (and thus refresh) faster than the build view
+static constexpr int MOVEDEF_TEXELS_PER_UPDATE = 256 * 256;
+// bigger bands for the first sweep after a view change, so the old picture goes away quickly
+static constexpr int FIRST_SWEEP_TEXELS_PER_UPDATE = 512 * 512;
+static constexpr int   BUILD_TEXELS_PER_UPDATE = 128 * 128;
+
+// updates over which a changed row of the MoveDef view fades into the visible
+// texture; also the number of rest updates between two sweeps
+static constexpr int FADE_STEPS = 4;
 
 
 CPathTexture::CPathTexture()
 : CModernInfoTexture("path")
-, isCleared(false)
+, isCleared(true)
 //, updateFrame(0)
 , updateProcess(0)
+, restUpdates(0)
+, fadeAllRows(true)
 , lastSelectedPathType(0)
 , forcedPathType(-1)
 , forcedUnitDef(-1)
 , lastUsage(spring_gettime())
 {
 	texSize = int2(mapDims.hmapx, mapDims.hmapy);
+
+	shownTexels.assign(texSize.x * texSize.y, CLEAR_COLOR);
+	sweepTexels.assign(texSize.x * texSize.y, CLEAR_COLOR);
+	rowFadeSteps.assign(texSize.y, 0);
+	rowTouched.assign(texSize.y, 0);
 
 	GL::TextureCreationParams tcp{
 		.reqNumLevels = 1,
@@ -49,6 +74,12 @@ CPathTexture::CPathTexture()
 	if (!fbo.IsValid()) {
 		throw opengl_error("");
 	}
+
+	// start out cleared, matching the CPU mirror initialized above
+	fbo.Bind();
+	glClearColor(CLEAR_COLOR.r / 255.0f, CLEAR_COLOR.g / 255.0f, CLEAR_COLOR.b / 255.0f, CLEAR_COLOR.a / 255.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	FBO::Unbind();
 }
 
 
@@ -135,7 +166,8 @@ bool CPathTexture::ShowMoveDef(const int pathType)
 	RECOIL_DETAILED_TRACY_ZONE;
 	forcedUnitDef  = -1;
 	forcedPathType = pathType;
-	updateProcess = 0;
+	RestartSweep();
+	lastUsage = spring_gettime(); // otherwise IsUpdateNeeded() drops the forced view before its first draw
 	return true; // TODO: unused
 }
 
@@ -145,7 +177,8 @@ bool CPathTexture::ShowUnitDef(const int udefid)
 	RECOIL_DETAILED_TRACY_ZONE;
 	forcedUnitDef  = udefid;
 	forcedPathType = -1;
-	updateProcess = 0;
+	RestartSweep();
+	lastUsage = spring_gettime(); // otherwise IsUpdateNeeded() drops the forced view before its first draw
 	return true; // TODO: unused
 }
 
@@ -156,6 +189,7 @@ bool CPathTexture::IsUpdateNeeded()
 	// don't update when not rendered/used
 	if ((spring_gettime() - lastUsage).toSecsi() > 2) {
 		forcedUnitDef = forcedPathType = -1;
+		RestartSweep();
 		return false;
 	}
 
@@ -167,7 +201,7 @@ bool CPathTexture::IsUpdateNeeded()
 
 		if (buildDefID != lastSelectedPathType) {
 			lastSelectedPathType = buildDefID;
-			updateProcess = 0;
+			RestartSweep();
 			return true;
 		}
 	} else {
@@ -179,7 +213,7 @@ bool CPathTexture::IsUpdateNeeded()
 
 			if (pathType != lastSelectedPathType) {
 				lastSelectedPathType = pathType;
-				updateProcess = 0;
+				RestartSweep();
 				return true;
 			}
 		}
@@ -190,95 +224,466 @@ bool CPathTexture::IsUpdateNeeded()
 }
 
 
-void CPathTexture::Update()
+// advances the sweep by one band of texel rows, returns the end row
+int CPathTexture::AdvanceSweep(int texelsPerUpdate)
 {
-	RECOIL_DETAILED_TRACY_ZONE;
-	const MoveDef* md = GetSelectedMoveDef();
-	const UnitDef* ud = GetCurrentBuildCmdUnitDef();
-
-	// just clear
-	if (ud == nullptr && md == nullptr) {
-		isCleared = true;
-		updateProcess = 0;
-		fbo.Bind();
-		glViewport(0, 0, texSize.x, texSize.y);
-		glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
-		glClear(GL_COLOR_BUFFER_BIT);
-		FBO::Unbind();
-		globalRendering->LoadViewport();
-		return;
-	}
-
-	static std::vector<SColor> infoTexMem;
-	infoTexMem.resize(texSize.x * texSize.y, SColor(1.0f, 0.0f, 0.0f, 1.0f));
-
-	// spread update across time
-	constexpr int TEX_SIZE_TO_UPDATE_EACH_FRAME = 128*128;
+	// the build view wraps around here, the MoveDef view restarts via BeginSweep
 	if (updateProcess >= texSize.y)
 		updateProcess = 0;
 
-	int start = updateProcess;
-	const int updateLines = std::max(TEX_SIZE_TO_UPDATE_EACH_FRAME / texSize.x, ThreadPool::GetNumThreads());
-	updateProcess += updateLines;
-	updateProcess = std::min(updateProcess, texSize.y);
-	assert(updateProcess - start >= 0);
+	const int updateLines = std::max(texelsPerUpdate / texSize.x, ThreadPool::GetNumThreads());
 
-	const size_t elemOfft = start * texSize.x;
+	updateProcess = std::min(updateProcess + updateLines, texSize.y);
+	return updateProcess;
+}
 
-	//FIXME make global func
-	const bool losFullView = ((gu->spectating && gu->spectatingFullView) || losHandler->GetGlobalLOS(gu->myAllyTeam));
+
+/*
+ * <shownTexels> always mirrors the GL texture. The build view is computed
+ * straight into it, one band of rows per update, and uploaded band by band
+ * (as it always was).
+ *
+ * The MoveDef view instead computes its frame into <sweepTexels>, one band
+ * per update, and marks the rows whose texels changed. FadeRows() then blends
+ * each marked row over FADE_STEPS updates into <shownTexels> and uploads only
+ * those rows: a band fades in as soon as it is computed, so there is neither
+ * a visible sweep front nor a pop when the map changes, and on a quiet map a
+ * refresh costs just the sweep. After a view change every row is marked
+ * (fadeAllRows) and the sweep uses bigger bands to get rid of the old picture
+ * quickly. Clearing fades to CLEAR_COLOR through the same path.
+ *
+ * One refresh cycle is the sweep plus FADE_STEPS rest updates, so the last
+ * band has settled before the next sweep starts.
+ */
+void CPathTexture::Update()
+{
+	ZoneScopedN("CPathTexture::Update");
+	const MoveDef* md = GetSelectedMoveDef();
+	const UnitDef* ud = GetCurrentBuildCmdUnitDef();
+
+	// nothing selected: fade the last view out to the clear color
+	if (ud == nullptr && md == nullptr) {
+		if (!isCleared) {
+			isCleared = true;
+			RestartSweep();
+			std::fill(sweepTexels.begin(), sweepTexels.end(), CLEAR_COLOR);
+			std::fill(rowFadeSteps.begin(), rowFadeSteps.end(), FADE_STEPS);
+		}
+
+		FadeRows();
+		return;
+	}
 
 	if (ud != nullptr) {
-		for_mt(start, updateProcess, [&](const int y) {
-			int currentThread = ThreadPool::GetThreadNum();
-			for (int x = 0; x < texSize.x; ++x) {
-				const float3 pos = float3(x << 1, 0.0f, y << 1) * SQUARE_SIZE;
-				const int idx = y * texSize.x + x;
+		// build view: spread across updates, written straight into the visible texture
+		const int start = updateProcess;
+		const int end = AdvanceSweep(BUILD_TEXELS_PER_UPDATE);
 
-				BuildSquareStatus status = FREE;
-				BuildInfo bi(ud, pos, guihandler->buildFacing);
-				bi.pos = CGameHelper::Pos2BuildPos(bi, false);
+		UpdateBuildView(ud, start, end);
 
-				CFeature* f = nullptr;
+		auto binding = texture.ScopedBind();
+		texture.UploadSubImage(&shownTexels[start * texSize.x], 0, start, texSize.x, end - start);
 
-				if (CGameHelper::TestUnitBuildSquare(
-						bi, f, gu->myAllyTeam, false, nullptr, nullptr, currentThread
-					)) {
-					if (f != nullptr) {
-						status = OBJECTBLOCKED;
+		isCleared = false;
+		return;
+	}
+
+	// MoveDef view, see above
+	if (updateProcess < texSize.y) {
+		const int start = updateProcess;
+		const int end = AdvanceSweep(fadeAllRows ? FIRST_SWEEP_TEXELS_PER_UPDATE : MOVEDEF_TEXELS_PER_UPDATE);
+
+		UpdateMoveDefView(*md, start, end);
+	} else {
+		restUpdates += 1;
+	}
+
+	const bool rowsPending = FadeRows();
+
+	// the next sweep starts once every row has settled and the cycle has had
+	// its FADE_STEPS rest updates, which keeps the refresh rate (and cost) of
+	// a quiet map the same as that of a changing one
+	if (updateProcess >= texSize.y && !rowsPending && restUpdates >= FADE_STEPS)
+		BeginSweep(false);
+
+	isCleared = false;
+}
+
+
+// blends every pending row one step closer to <sweepTexels> and uploads it;
+// returns whether any row still has steps left afterwards
+bool CPathTexture::FadeRows()
+{
+	ZoneScopedN("CPathTexture::FadeRows");
+
+	bool anyPending = false;
+
+	for (int y = 0; y < texSize.y && !anyPending; ++y) {
+		anyPending = (rowFadeSteps[y] != 0);
+	}
+
+	if (!anyPending)
+		return false;
+
+	const size_t rowBytes = texSize.x * sizeof(SColor);
+
+	for_mt(0, texSize.y, [&](const int y) {
+		const int stepsLeft = rowFadeSteps[y];
+
+		rowTouched[y] = (stepsLeft != 0);
+
+		if (stepsLeft == 0)
+			return;
+
+		      uint8_t* shown = reinterpret_cast<      uint8_t*>(&shownTexels[y * texSize.x]);
+		const uint8_t* sweep = reinterpret_cast<const uint8_t*>(&sweepTexels[y * texSize.x]);
+
+		if (stepsLeft == 1) {
+			// the last step is an exact copy, so a settled texture equals the
+			// sweep buffer bit for bit regardless of the rounding of the blends
+			std::memcpy(shown, sweep, rowBytes);
+		} else {
+			// linear fade: cover a stepsLeft-th of the remaining distance
+			// (fixed-point 1/stepsLeft, vectorizes unlike a division)
+			const int weight = 256 / stepsLeft;
+
+			for (size_t i = 0; i < rowBytes; ++i) {
+				shown[i] += (((int(sweep[i]) - int(shown[i])) * weight) >> 8);
+			}
+		}
+
+		rowFadeSteps[y] = stepsLeft - 1;
+	});
+
+	// upload the runs of rows touched this step
+	bool stillPending = false;
+	int runStart = -1;
+
+	{
+		auto binding = texture.ScopedBind();
+
+		for (int y = 0; y <= texSize.y; ++y) {
+			const bool touched = (y < texSize.y) && (rowTouched[y] != 0);
+
+			if (touched) {
+				stillPending |= (rowFadeSteps[y] != 0);
+
+				if (runStart < 0)
+					runStart = y;
+
+				continue;
+			}
+
+			if (runStart >= 0) {
+				texture.UploadSubImage(&shownTexels[runStart * texSize.x], 0, runStart, texSize.x, y - runStart);
+				runStart = -1;
+			}
+		}
+	}
+
+	return stillPending;
+}
+
+
+void CPathTexture::UpdateBuildView(const UnitDef* ud, int texStart, int texEnd)
+{
+	ZoneScopedN("CPathTexture::UpdateBuildView");
+
+	for_mt(texStart, texEnd, [&](const int y) {
+		const int currentThread = ThreadPool::GetThreadNum();
+
+		SColor* texels = &shownTexels[y * texSize.x];
+
+		for (int x = 0; x < texSize.x; ++x) {
+			const float3 pos = float3(x << 1, 0.0f, y << 1) * SQUARE_SIZE;
+
+			BuildSquareStatus status = FREE;
+			BuildInfo bi(ud, pos, guihandler->buildFacing);
+			bi.pos = CGameHelper::Pos2BuildPos(bi, false);
+
+			CFeature* f = nullptr;
+
+			if (CGameHelper::TestUnitBuildSquare(
+					bi, f, gu->myAllyTeam, false, nullptr, nullptr, currentThread
+				)) {
+				if (f != nullptr) {
+					status = OBJECTBLOCKED;
+				}
+			} else {
+				status = TERRAINBLOCKED;
+			}
+
+			texels[x] = GetBuildColor(status);
+		}
+	});
+}
+
+
+/*
+ * Each texel covers a 2x2 block of map squares. Its color is the terrain
+ * speed-modifier of the top-left square, darkened by a quarter for every
+ * square of the block that CMoveMath::IsBlocked reports as BLOCK_STRUCTURE
+ * (zero speed-modifier, or a structure inside the MoveDef footprint centered
+ * on the square). Structures only count inside the local player's LOS.
+ *
+ * IsBlocked visits O(footprint area) blocking-map cells per square, and
+ * neighbouring squares revisit the same cells. Instead the band of map rows
+ * updated this frame, plus a footprint-sized margin, is scanned once for
+ * squares holding a structure that blocks this MoveDef (skipping the empty
+ * cells via the blocking-map bitmap). That mask is then dilated by the
+ * footprint, horizontally then vertically, sampling every other square
+ * exactly like RangeIsBlocked does, so both passes are plain byte-ORs over
+ * rows and the result matches IsBlocked square for square.
+ *
+ * The only part of ObjectBlockType that depends on the querying square is
+ * the in-water exemption of IsNonBlocking, which looks at the ground height
+ * there. Structures standing in water therefore go into a second mask, and
+ * the (few) squares whose footprint reaches one of them fall back to the
+ * per-square test.
+ */
+void CPathTexture::UpdateMoveDefView(const MoveDef& md, int texStart, int texEnd)
+{
+	ZoneScopedN("CPathTexture::UpdateMoveDefView");
+
+	const int mapx = mapDims.mapx;
+	const int mapy = mapDims.mapy;
+
+	// map-square rows covered by the texel rows [texStart, texEnd)
+	const int sqStart = texStart * 2;
+	const int sqEnd   = std::min(texEnd * 2, mapy);
+
+	const int xsh = md.xsizeh;
+	const int zsh = md.zsizeh;
+
+	// rows whose structures reach into the band through the footprint
+	const int padStart = std::max(sqStart - zsh, 0);
+	const int padEnd   = std::min(sqEnd   + zsh, mapy);
+	const int numPadRows = padEnd - padStart;
+
+	// zero margins of xsh squares on both sides, so the horizontal dilation
+	// needs no clamping (RangeIsBlocked clamps squares outside the map away)
+	const int rowStride = mapx + 2 * xsh;
+
+	// CheckCollisionQuery::UpdateElevationForPos puts the collider at
+	// max(groundHeight, -waterline), so only a waterline below the surface
+	// can ever put it in water
+	const bool canBeInWater = (md.waterline > 0.0f);
+
+	// per padded map row: which of the two masks have anything set, so the
+	// dilation passes can skip the (many) rows without structures
+	enum { ROW_HAS_STRUCT = 1, ROW_HAS_WATER = 2 };
+
+	// *Squares: one flag per map square, *Spans: the same after horizontal
+	// dilation, *Footprints: after vertical dilation, only for the band rows;
+	// no assign() here, the rows are cleared by the tasks that fill them
+	structSquares.resize(numPadRows * rowStride);
+	structSpans.resize(numPadRows * rowStride);
+	waterSquares.resize(numPadRows * rowStride);
+	waterSpans.resize(numPadRows * rowStride);
+	rowFlags.resize(numPadRows);
+	structFootprints.resize((sqEnd - sqStart) * mapx);
+	waterFootprints.resize((sqEnd - sqStart) * mapx);
+
+	// horizontal footprint dilation of one row with the sampling of
+	// RangeIsBlocked: every other square from max(x - xsh, 0) to
+	// min(x + xsh, mapx - 1); <src> and <dst> point at column 0 of rows
+	// that have <xsh> zeroed squares on either side
+	const auto dilateRow = [&](const uint8_t* src, uint8_t* dst) {
+		std::memset(dst - xsh, 0, rowStride);
+
+		// interior: reading past either end lands in the zero margins,
+		// which is what clamping the range end to the map does
+		for (int dx = -xsh; dx <= xsh; dx += 2) {
+			const uint8_t* s = src + dx;
+
+			for (int x = xsh; x < mapx; ++x) {
+				dst[x] |= s[x];
+			}
+		}
+
+		// left border: clamping the range *start* to 0 changes which
+		// squares get sampled, so these columns are done explicitly
+		for (int x = 0, xn = std::min(xsh, mapx); x < xn; ++x) {
+			const int xmax = std::min(x + xsh, mapx - 1);
+			uint8_t v = 0;
+
+			for (int sx = 0; sx <= xmax; sx += 2) {
+				v |= src[sx];
+			}
+
+			dst[x] = v;
+		}
+	};
+
+	// pass 1: per map row, flag the squares holding a structure that blocks
+	// this MoveDef and dilate the flags horizontally
+	{
+		ZoneScopedN("CPathTexture::UpdateMoveDefView::Squares");
+
+		const std::vector<uint32_t>& cellBits = groundBlockingObjectMap.GetCellBits();
+
+		for_mt(padStart, padEnd, [&](const int z) {
+			// ObjectBlockType only looks at the collider position through the
+			// in-water exemptions of IsNonBlocking; a collider that is not in
+			// water (pos.y = 0 also enables the height checks, the query would
+			// otherwise take the pathfinder-estimator branch) gets the
+			// height-independent answer for every object
+			MoveTypes::CheckCollisionQuery dryCollider(&md);
+			dryCollider.pos.y = 0.0f;
+
+			const int rowOffset = (z - padStart) * rowStride + xsh;
+
+			uint8_t* structRow = &structSquares[rowOffset];
+			uint8_t* waterRow  = &waterSquares[rowOffset];
+			uint8_t  flags = 0;
+
+			std::memset(structRow - xsh, 0, rowStride);
+			std::memset(waterRow  - xsh, 0, rowStride);
+
+			// only visit the non-empty cells, skipping over the empty
+			// ones 32 at a time through the bitmap
+			const unsigned int rowStart = z * mapx;
+			const unsigned int rowEnd   = rowStart + mapx;
+
+			for (unsigned int sqr = rowStart; sqr < rowEnd; ) {
+				const uint32_t bits = cellBits[sqr >> 5] >> (sqr & 31);
+
+				if (bits == 0) {
+					sqr += (32 - (sqr & 31));
+					continue;
+				}
+
+				if ((sqr += std::countr_zero(bits)) >= rowEnd)
+					break;
+
+				const int x = sqr - rowStart;
+				const auto cell = groundBlockingObjectMap.GetCellUnsafeConst(sqr);
+
+				for (size_t i = 0, n = cell.size(); i < n; i++) {
+					const CSolidObject* collidee = cell[i];
+
+					if ((CMoveMath::ObjectBlockType(collidee, &dryCollider) & CMoveMath::BLOCK_STRUCTURE) == 0)
+						continue;
+
+					if (canBeInWater && collidee->IsInWater()) {
+						waterRow[x] = 1;
+						flags |= ROW_HAS_WATER;
+					} else {
+						structRow[x] = 1;
+						flags |= ROW_HAS_STRUCT;
 					}
-				} else {
-					status = TERRAINBLOCKED;
 				}
 
-				infoTexMem[idx] = GetBuildColor(status);
+				sqr += 1;
 			}
-		});
-	} else if (md != nullptr) {
-		for_mt(start, updateProcess, [&](const int y) {
-			int thread = ThreadPool::GetThreadNum();
-			for (int x = 0; x < texSize.x; ++x) {
-				const int2 sq = int2(x << 1, y << 1);
-				const int idx = y * texSize.x + x;
 
-				float scale = 1.0f;
+			rowFlags[z - padStart] = flags;
 
-				if (losFullView || losHandler->InLos(SquareToFloat3(sq), gu->myAllyTeam)) {
-					if (CMoveMath::IsBlocked(*md, sq.x,     sq.y    , nullptr, thread) & CMoveMath::BLOCK_STRUCTURE) { scale -= 0.25f; }
-					if (CMoveMath::IsBlocked(*md, sq.x + 1, sq.y    , nullptr, thread) & CMoveMath::BLOCK_STRUCTURE) { scale -= 0.25f; }
-					if (CMoveMath::IsBlocked(*md, sq.x,     sq.y + 1, nullptr, thread) & CMoveMath::BLOCK_STRUCTURE) { scale -= 0.25f; }
-					if (CMoveMath::IsBlocked(*md, sq.x + 1, sq.y + 1, nullptr, thread) & CMoveMath::BLOCK_STRUCTURE) { scale -= 0.25f; }
-				}
-
-				// NOTE: raw speedmods are not necessarily clamped to [0, 1]
-				const float sm = CMoveMath::GetPosSpeedMod(*md, sq.x, sq.y);
-				infoTexMem[idx] = GetSpeedModColor(sm * scale);
-			}
+			if (flags & ROW_HAS_STRUCT)
+				dilateRow(structRow, &structSpans[rowOffset]);
+			if (flags & ROW_HAS_WATER)
+				dilateRow(waterRow, &waterSpans[rowOffset]);
 		});
 	}
 
-	auto binding = texture.ScopedBind();
-	texture.UploadSubImage(infoTexMem.data() + elemOfft, 0, start, texSize.x, updateProcess - start);
+	// pass 2: per texel row, dilate vertically and color the texels
+	{
+		ZoneScopedN("CPathTexture::UpdateMoveDefView::Texels");
 
-	isCleared = false;
+		//FIXME make global func
+		const bool losFullView = ((gu->spectating && gu->spectatingFullView) || losHandler->GetGlobalLOS(gu->myAllyTeam));
+
+		for_mt(texStart, texEnd, [&](const int y) {
+			const int thread = ThreadPool::GetThreadNum();
+			const int sqz = y * 2;
+
+			// the two map rows covered by this texel row; vertical dilation
+			// samples every other row like RangeIsBlocked (see dilateRow)
+			uint8_t* structRows[2];
+			uint8_t* waterRows[2];
+
+			for (int i = 0; i < 2; ++i) {
+				const int z = sqz + i;
+
+				structRows[i] = &structFootprints[(z - sqStart) * mapx];
+				waterRows[i]  = &waterFootprints[(z - sqStart) * mapx];
+
+				std::memset(structRows[i], 0, mapx);
+				std::memset(waterRows[i],  0, mapx);
+
+				const int zFirst = (z >= zsh) ? (z - zsh) : 0;
+				const int zLast  = std::min(z + zsh, mapy - 1);
+
+				for (int sz = zFirst; sz <= zLast; sz += 2) {
+					const int rowOffset = (sz - padStart) * rowStride + xsh;
+					const uint8_t flags = rowFlags[sz - padStart];
+
+					if (flags & ROW_HAS_STRUCT) {
+						const uint8_t* spans = &structSpans[rowOffset];
+
+						for (int x = 0; x < mapx; ++x) {
+							structRows[i][x] |= spans[x];
+						}
+					}
+					if (flags & ROW_HAS_WATER) {
+						const uint8_t* spans = &waterSpans[rowOffset];
+
+						for (int x = 0; x < mapx; ++x) {
+							waterRows[i][x] |= spans[x];
+						}
+					}
+				}
+			}
+
+			// same result as (CMoveMath::IsBlocked(md, x, z, nullptr, thread) & BLOCK_STRUCTURE)
+			const auto isBlocked = [&](int x, int z, float speedMod) -> bool {
+				if (speedMod == 0.0f)
+					return true; // BLOCK_IMPASSABLE
+
+				const int i = z - sqz;
+
+				if (structRows[i][x])
+					return true;
+				if (!waterRows[i][x])
+					return false;
+
+				// a structure standing in water is inside the footprint, whether
+				// IsNonBlocking exempts it depends on the height at <x, z>
+				return ((CMoveMath::IsBlockedNoSpeedModCheck(md, x, z, nullptr, thread) & CMoveMath::BLOCK_STRUCTURE) != 0);
+			};
+
+			SColor* texels = &sweepTexels[y * texSize.x];
+			bool changed = false;
+
+			for (int x = 0; x < texSize.x; ++x) {
+				const int2 sq = int2(x << 1, y << 1);
+
+				// NOTE: raw speedmods are not necessarily clamped to [0, 1]
+				float sm;
+				float scale = 1.0f;
+
+				if (losFullView || losHandler->InLos(SquareToFloat3(sq), gu->myAllyTeam)) {
+					float sms[4];
+					CMoveMath::GetPosSpeedMod2x2(md, sq.x, sq.y, sms);
+
+					sm = sms[0];
+
+					if (isBlocked(sq.x,     sq.y    , sms[0])) { scale -= 0.25f; }
+					if (isBlocked(sq.x + 1, sq.y    , sms[1])) { scale -= 0.25f; }
+					if (isBlocked(sq.x,     sq.y + 1, sms[2])) { scale -= 0.25f; }
+					if (isBlocked(sq.x + 1, sq.y + 1, sms[3])) { scale -= 0.25f; }
+				} else {
+					sm = CMoveMath::GetPosSpeedMod(md, sq.x, sq.y);
+				}
+
+				const SColor texel = GetSpeedModColor(sm * scale);
+
+				changed |= (texels[x].i != texel.i);
+				texels[x] = texel;
+			}
+
+			if (changed || fadeAllRows)
+				rowFadeSteps[y] = FADE_STEPS;
+		});
+	}
 }

--- a/rts/Rendering/Map/InfoTexture/Modern/Path.h
+++ b/rts/Rendering/Map/InfoTexture/Modern/Path.h
@@ -3,8 +3,12 @@
 #ifndef _PATH_TEXTURE_H
 #define _PATH_TEXTURE_H
 
+#include <cstdint>
+#include <vector>
+
 #include "ModernInfoTexture.h"
 #include "Rendering/GL/FBO.h"
+#include "System/Color.h"
 #include "System/Misc/SpringTime.h"
 
 
@@ -30,14 +34,45 @@ private:
 	const MoveDef* GetSelectedMoveDef();
 	const UnitDef* GetCurrentBuildCmdUnitDef();
 
+	void BeginSweep(bool allRows) { updateProcess = 0; restUpdates = 0; fadeAllRows = allRows; }
+	void RestartSweep() { BeginSweep(true); }
+	int AdvanceSweep(int texelsPerUpdate);
+
+	void UpdateBuildView(const UnitDef* ud, int texStart, int texEnd);
+	void UpdateMoveDefView(const MoveDef& md, int texStart, int texEnd);
+	bool FadeRows();
+
 private:
 	bool isCleared;
 //	int updateFrame;
-	int updateProcess;
+	int updateProcess; // next texel row to compute, texSize.y when the sweep is complete
+	int restUpdates;   // updates since the MoveDef sweep completed (see Update)
 	unsigned int lastSelectedPathType;
 	int forcedPathType;
 	int forcedUnitDef;
 	spring_time lastUsage;
+
+	// CPU mirror of <texture>; the build view writes into it band by band,
+	// the MoveDef view fills <sweepTexels> band by band and fades the rows
+	// that changed into it (see Update)
+	std::vector<SColor> shownTexels;
+	std::vector<SColor> sweepTexels;
+
+	// per texel row: fade steps left until it shows <sweepTexels> (0 = settled)
+	std::vector<uint8_t> rowFadeSteps;
+	std::vector<uint8_t> rowTouched;
+	// first sweep after a view change: every computed row fades in
+	bool fadeAllRows;
+
+	// MoveDef view scratch buffers (per map row flags, their horizontal and
+	// their full footprint dilation), see UpdateMoveDefView
+	std::vector<uint8_t> structSquares;
+	std::vector<uint8_t> structSpans;
+	std::vector<uint8_t> structFootprints;
+	std::vector<uint8_t> waterSquares;
+	std::vector<uint8_t> waterSpans;
+	std::vector<uint8_t> waterFootprints;
+	std::vector<uint8_t> rowFlags;
 };
 
 #endif // _PATH_TEXTURE_H

--- a/rts/Sim/Misc/GroundBlockingObjectMap.cpp
+++ b/rts/Sim/Misc/GroundBlockingObjectMap.cpp
@@ -28,7 +28,9 @@ CR_BIND(CGroundBlockingObjectMap, )
 CR_REG_METADATA(CGroundBlockingObjectMap, (
 	CR_MEMBER(arrCells),
 	CR_MEMBER(vecCells),
-	CR_MEMBER(vecIndcs)
+	CR_MEMBER(vecIndcs),
+	CR_IGNORED(cellBits),
+	CR_POSTLOAD(PostLoad)
 ))
 
 
@@ -266,6 +268,18 @@ bool CGroundBlockingObjectMap::CheckYard(const CSolidObject* yardUnit, const Yar
 }
 
 
+// cellBits is derived from arrCells and not serialized, rebuild it
+void CGroundBlockingObjectMap::PostLoad()
+{
+	cellBits.assign((arrCells.size() + 31) / 32, 0);
+
+	for (unsigned int i = 0; i < arrCells.size(); ++i) {
+		if (!arrCells[i].Empty())
+			cellBits[i >> 5] |= (1u << (i & 31));
+	}
+}
+
+
 unsigned int CGroundBlockingObjectMap::CalcChecksum() const
 {
 	RECOIL_DETAILED_TRACY_ZONE;
@@ -288,8 +302,11 @@ bool CGroundBlockingObjectMap::CellInsertUnique(unsigned int sqr, CSolidObject* 
 
 	if (ac.Contains(o))
 		return false;
-	if (ac.Insert(o))
+	if (ac.Insert(o)) {
+		// first object in this cell (spill-over into the vector part implies a full array part)
+		cellBits[sqr >> 5] |= (1u << (sqr & 31));
 		return true;
+	}
 
 	// array-cell is full, spill over
 	if ((vc = &GetVecCell(sqr)) == &vecCells[0]) {
@@ -312,8 +329,13 @@ bool CGroundBlockingObjectMap::CellErase(unsigned int sqr, CSolidObject* o) {
 	VecCell* vc = nullptr;
 
 	if (ac.Erase(o)) {
-		if (ac.GetVecIndx() == 0)
+		if (ac.GetVecIndx() == 0) {
+			// no vector part to refill from, the cell may have become empty
+			if (ac.Empty())
+				cellBits[sqr >> 5] &= ~(1u << (sqr & 31));
+
 			return true;
+		}
 
 		// never allow a hole between array and vector parts
 		assert(!vecCells[ac.GetVecIndx()].empty());

--- a/rts/Sim/Misc/GroundBlockingObjectMap.h
+++ b/rts/Sim/Misc/GroundBlockingObjectMap.h
@@ -3,7 +3,9 @@
 #ifndef GROUNDBLOCKINGOBJECTMAP_H
 #define GROUNDBLOCKINGOBJECTMAP_H
 
+#include <algorithm>
 #include <array>
+#include <cstdint>
 #include <vector>
 
 #include "Sim/Objects/SolidObject.h"
@@ -99,6 +101,7 @@ public:
 
 	void Init(unsigned int numSquares) {
 		arrCells.resize(numSquares);
+		cellBits.assign((numSquares + 31) / 32, 0);
 		vecCells.reserve(32);
 		vecIndcs.reserve(32);
 
@@ -117,7 +120,10 @@ public:
 		}
 
 		vecIndcs.clear();
+		std::fill(cellBits.begin(), cellBits.end(), 0u);
 	}
+
+	void PostLoad();
 
 	unsigned int CalcChecksum() const;
 
@@ -171,6 +177,11 @@ public:
 		return {GetArrCell(mapSquare), vecCells.data()};
 	}
 
+	// one bit per map-square, set iff the cell holds any object; lets scans
+	// over many cells skip the empty ones without touching the cells
+	bool CellIsEmpty(unsigned int mapSquare) const { return (((cellBits[mapSquare >> 5] >> (mapSquare & 31)) & 1u) == 0); }
+	const std::vector<uint32_t>& GetCellBits() const { return cellBits; }
+
 private:
 	bool CheckYard(const CSolidObject* yardUnit, const YardMapStatus& mask) const;
 
@@ -186,6 +197,7 @@ private:
 	std::vector<ArrCell> arrCells;
 	std::vector<VecCell> vecCells;
 	std::vector<uint32_t> vecIndcs;
+	std::vector<uint32_t> cellBits;
 };
 
 extern CGroundBlockingObjectMap groundBlockingObjectMap;

--- a/rts/Sim/MoveTypes/MoveMath/MoveMath.cpp
+++ b/rts/Sim/MoveTypes/MoveMath/MoveMath.cpp
@@ -104,6 +104,40 @@ float CMoveMath::GetPosSpeedMod(const MoveDef& moveDef, unsigned xSquare, unsign
 	return 0.0f;
 }
 
+// NOTE: must produce exactly what GetPosSpeedMod produces per square (same
+// lookups, same class functions, same final multiply), keep the two in sync
+void CMoveMath::GetPosSpeedMod2x2(const MoveDef& moveDef, unsigned xSquare, unsigned zSquare, float speedMods[4])
+{
+	RECOIL_DETAILED_TRACY_ZONE;
+	assert((xSquare & 1) == 0 && (zSquare & 1) == 0);
+
+	if ((xSquare + 1) >= mapDims.mapx || (zSquare + 1) >= mapDims.mapy) {
+		for (unsigned int i = 0; i < 4; i++) {
+			speedMods[i] = GetPosSpeedMod(moveDef, xSquare + (i & 1), zSquare + (i >> 1));
+		}
+
+		return;
+	}
+
+	const int square = (xSquare >> 1) + ((zSquare >> 1) * mapDims.hmapx);
+	const int squareTerrType = readMap->GetTypeMapSynced()[square];
+
+	const float* heights = readMap->GetMaxHeightMapSynced() + (xSquare + (zSquare * mapDims.mapx));
+	const float  slope   = readMap->GetSlopeMapSynced()[square];
+
+	const CMapInfo::TerrainType& tt = mapInfo->terrainTypes[squareTerrType];
+
+	const float height[4] = {heights[0], heights[1], heights[mapDims.mapx], heights[mapDims.mapx + 1]};
+
+	switch (moveDef.speedModClass) {
+		case MoveDef::Tank:  { for (int i = 0; i < 4; i++) { speedMods[i] = (GroundSpeedMod(moveDef, height[i], slope) * tt.tankSpeed ); } } break;
+		case MoveDef::KBot:  { for (int i = 0; i < 4; i++) { speedMods[i] = (GroundSpeedMod(moveDef, height[i], slope) * tt.kbotSpeed ); } } break;
+		case MoveDef::Hover: { for (int i = 0; i < 4; i++) { speedMods[i] = ( HoverSpeedMod(moveDef, height[i], slope) * tt.hoverSpeed); } } break;
+		case MoveDef::Ship:  { for (int i = 0; i < 4; i++) { speedMods[i] = (  ShipSpeedMod(moveDef, height[i], slope) * tt.shipSpeed ); } } break;
+		default:             { for (int i = 0; i < 4; i++) { speedMods[i] = 0.0f; } } break;
+	}
+}
+
 float CMoveMath::GetPosSpeedMod(const MoveDef& moveDef, unsigned xSquare, unsigned zSquare, float3 moveDir)
 {
 	RECOIL_DETAILED_TRACY_ZONE;

--- a/rts/Sim/MoveTypes/MoveMath/MoveMath.h
+++ b/rts/Sim/MoveTypes/MoveMath/MoveMath.h
@@ -80,6 +80,10 @@ public:
 		return (GetPosSpeedMod(moveDef, pos.x / SQUARE_SIZE, pos.z / SQUARE_SIZE, moveDir));
 	}
 	static float GetPosSpeedMod(const MoveDef& moveDef, unsigned squareIndex);
+	// speed-modifiers of the 2x2 block of squares with top-left corner <xSquare, zSquare>
+	// (both even) in row-major order; same values as four GetPosSpeedMod calls, but the
+	// half-resolution type- and slope-map lookups are shared
+	static void GetPosSpeedMod2x2(const MoveDef& moveDef, unsigned xSquare, unsigned zSquare, float speedMods[4]);
 
 	// tells whether a position is blocked (inaccessible for a given object's MoveDef)
 	static inline BlockType IsBlocked(const MoveDef& moveDef, const float3& pos, const CSolidObject* collider, int thread);


### PR DESCRIPTION
# Path traversability info texture: much cheaper MoveDef view, identical output, smooth refresh

## Summary

`/showpathtype` (the "path" info texture) recomputed the
footprint-blocking test for every map square from scratch, four times per texel, and swept the
texture in hard-edged row bands. This PR

- rewrites the MoveDef view of `CPathTexture` so one pass over the blocking map serves the
  whole band: per-square structure flags, dilated by the footprint with exactly the sampling
  `CMoveMath::RangeIsBlocked` uses. Main-thread cost per texel drops from ~36-58 ns to ~3 ns,
  a full refresh of the texture from 15-24 ms to 1.5-2.1 ms of main-thread time, and the
  refresh completes in 0.37 s instead of 0.87 s (numbers below). The converged texture is
  bit-identical to the old code, verified by texel dumps.
- replaces the visible band-by-band sweep with a per-row fade: rows fade in as their band is
  computed, unchanged rows cost nothing, and deselecting fades to the clear colour instead of
  popping.
- fixes `/showpathtype <name>` being silently ignored (it showed the selected unit's MoveDef
  instead) whenever the path texture had not been drawn in the previous two seconds.
- adds a non-empty-cell bitmap to `CGroundBlockingObjectMap` (derived data, not serialized) and
  a `CMoveMath::GetPosSpeedMod2x2` helper; both are additions, no existing function changes.

The build view (`/showpathtype <unitdefname>`, or F2 while placing a building) is untouched
apart from writing through the same CPU mirror.

## Motivation

`CPathTexture::Update()` coloured each texel (a 2x2 block of map squares) from the terrain
speed-modifier and darkened it by a quarter for every square of the block for which
`CMoveMath::IsBlocked(...) & BLOCK_STRUCTURE` was set. `IsBlocked` walks the MoveDef footprint
(every other square) in `groundBlockingObjectMap`, so the work per square is O(footprint area)
and neighbouring squares re-read the same 72-byte cells: for the largest BAR footprint (9) that
is 100 cell visits per call, 400 per texel. On a 640x640 texture (Tempest_V3) an update of
128x128 texels took 0.35-0.95 ms on the main thread with 8 worker threads, 26 such updates were
needed per sweep (0.87 s at the 30 Hz info-texture rate), and the sweep front was visible as a
hard edge moving down the map.

## Behaviour changes

- Once settled, the MoveDef view texture is identical to the old one, texel for texel.
- New content no longer wipes in with a hard row edge over 0.87 s; it fades in band by band
  from the top over ~0.2 s after a view change (two 512x512 updates plus four fade steps), and
  later changes on the map (new building, wreck) fade in over four updates instead of popping.
- Deselecting fades to the "nothing selected" colour over four updates instead of an instant
  clear. (With the engine's default `infoPath.lua` that colour renders as bright purple; that is
  unchanged, only the transition is.)
- The MoveDef view refreshes every 11 updates (0.37 s) instead of every 26 (0.87 s).
- A view that went unused for more than 2 s restarts its sweep from the top when it is drawn
  again instead of continuing a stale one.
- `/showpathtype <movedef|id|unitdef>` now actually shows the requested view (bug fix above).
- Build view: unchanged (128x128 texels per update, progressive upload, same cost).
- Memory: two extra CPU copies of the path texture (hmapx*hmapy*4 bytes each; 1.6 MB each on a
  10 km map, 16 MB each on a 32x32 map) plus band-sized scratch buffers; 200 KB for the
  blocking-map bitmap.
- Savegames: `cellBits` is rebuilt in `PostLoad`, so the save format does not change.
- Tracy: `ZoneScopedN` zones for the update, both passes and the fade replace the previous
  `RECOIL_DETAILED_TRACY_ZONE` in `Update()`.

## Benchmarks

Setup: Tempest_V3 (10240x10240 elmos, 1280x1280 squares, 640x640 texture), BAR, ~850 units
including a dense base, structures in shallow and deep water and buildings against all four map
borders; local player (LOS applies); Ryzen 9 7950X3D, `WorkerThreadCount = 8`, RelWithDebInfo
build (Tracy on, detailed zoning off). Times are main-thread wall time of `CPathTexture::Update`
from temporary `SCOPED_TIMER`s read through `Spring.GetProfilerTimeRecord` with `/debug` on,
averaged over 150 sim frames per view (one update per sim frame), each view forced via
`/showpathtype`. Frame time was ~6.3 ms in both cases (GPU/other bound), so the difference does
not show in fps; the timers measure what the main thread pays.

Per update (old: 128x128 texels; new: average over the 11-update cycle of 7 sweep updates of
256x256 texels and 4 rest updates):

| view (MoveDef) | old ms/update | new ms/update | old ms per full refresh (26 updates) | new ms per full refresh (11 updates) |
|---|---|---|---|---|
| bot2 (footprint 2) | 0.57 | 0.135 | 14.8 | 1.5 |
| htank4 (4) | 0.76 | 0.131 | 19.8 | 1.4 |
| hbot7 (7) | 0.93 | 0.145 | 24.2 | 1.6 |
| hover3 | 0.68 | 0.115 | 17.7 | 1.3 |
| boat3 | 0.24 | 0.126 | 6.2 | 1.4 |
| boat9 (9) | 0.36 | 0.173 | 9.4 | 1.9 |
| uboat4 (submarine) | 0.27 | 0.139 | 7.0 | 1.5 |
| commanderbot (auto view) | 0.76 | 0.149 | 19.8 | 1.6 |
| build view armsolar / armfus | 1.43 / 1.60 | 1.38 / 1.53 | unchanged | unchanged |

Old cost scaled with the footprint (2.4x from bot2 to hbot7); the new cost is flat. Ships were
cheap before only because most of this map is land where the speed-modifier is zero and
`IsBlocked` returned early; on a water map they behaved like the land views. Per texel of
main-thread time: old 36-58 ns (land views), new ~3.3 ns including the fade share.

## Verification

A temporary widget forced each view, waited 8 s (several refresh cycles), copied `$info:path`
1:1 into an RGBA8 FBO and saved it losslessly with `gl.SaveImage`. Old and new engine dumps
were compared per texel for ten views (bot2, htank4, hbot7, hover3, boat3, boat9, uboat4, the
auto view, armsolar and armfus build views) on two scenes: the base with structures in
shallow/deep water (exercises the in-water fallback), and the same plus buildings against all
map borders (exercises the clamped-start sampling). Every comparison: 0 of 409,600 texels differ.
This was re-run after each optimisation step. Build-view dumps are included to confirm that
path is unaffected.


## Possible Follow-ups (not in this PR)

- The build view still costs ~1.4-1.5 ms per update (`TestUnitBuildSquare` per texel); making it
  cheap needs a per-square restructuring of `TestBuildSquare` (sliding-window height min/max,
  per-square depth/slope/mask/blocker flags, footprint dilation) with the same kind of dump
  verification.
- `cellBits` could let `RangeIsBlockedMt`, `RangeIsBlockedHashedMt` and `FloodFillRangeIsBlocked`
  skip empty cells with a bit test instead of a 72-byte cell read; that is synced pathfinding code
  and deserves its own measurement.




## Changes

### `Rendering/Map/InfoTexture/Modern/Path.{h,cpp}`

**MoveDef view (`UpdateMoveDefView`).** For the band of texel rows updated this frame:

1. Scan the corresponding map rows plus a footprint-sized margin once. Empty cells are skipped
   32 at a time through the new blocking-map bitmap; for each object in a non-empty cell,
   `CMoveMath::ObjectBlockType` is evaluated with a "dry" `CheckCollisionQuery` (see notes) and
   squares holding a structure-blocking object are flagged. Objects with `IsInWater()` go into a
   second mask (only when the MoveDef can be in water at all, i.e. `waterline > 0`).
2. Dilate the flags horizontally, then vertically, by the footprint half-sizes, sampling every
   other square exactly like `RangeIsBlocked` does, including the parity change it gets from
   clamping the range start at the left/top map border. Both passes are plain byte-ORs over rows.
3. Per texel: the same LOS test as before, the four speed-modifiers of the block via
   `GetPosSpeedMod2x2` (one lookup instead of four, same math), and the dilated masks. A square
   whose sampled footprint reaches an in-water structure falls back to the original
   `IsBlockedNoSpeedModCheck`, because only there does the result depend on the height at the
   queried square.

Scratch rows are cleared by the `for_mt` tasks that fill them; both passes and the fade run on
the thread pool.

**Presentation (`Update`, `FadeRows`).** `shownTexels` is a CPU mirror of the GL texture. The
MoveDef view computes into `sweepTexels` (256x256 texels per update, 512x512 for the first sweep
after a view change) without uploading; rows whose texels changed are marked (compare-on-write)
and fade into `shownTexels` over `FADE_STEPS = 4` updates with a fixed-point lerp whose last step
is an exact copy. Only the touched row runs are uploaded. A refresh cycle is the sweep plus
`FADE_STEPS` rest updates (11 updates here), so a quiet map costs the same as a changing one.
Clearing (nothing selected) fades to the clear colour the same way; the texture is cleared once
in the constructor so mirror and GPU agree from the start.

**Forced view fix.** `IsUpdateNeeded()` drops `forcedPathType/forcedUnitDef` when `lastUsage`
is older than 2 s, and it runs before the combiner binds the texture (iteration order of the
handler's `unordered_map`). So `/showpathtype bot2` from a state where the overlay was not
recently drawn reset itself on the first update and the view of the *selected unit's* MoveDef
was shown instead. `ShowMoveDef/ShowUnitDef` now refresh `lastUsage`.

### `Sim/Misc/GroundBlockingObjectMap.{h,cpp}`

`std::vector<uint32_t> cellBits`: one bit per map square, set iff the cell holds any object.
Maintained in `CellInsertUnique` (set when the first object goes into the array part; a spill
into the vector part implies the array part is full, so the bit is already set) and `CellErase`
(cleared when the array part becomes empty and there is no vector part to refill from). Sized
in `Init`, zeroed in `Kill`, `CR_IGNORED` with a `PostLoad` that rebuilds it from `arrCells`.
Accessors `CellIsEmpty(sqr)` and `GetCellBits()`. Cost: mapx*mapy/8 bytes (200 KB on this map)
and one bit-op per insert/erase. Nothing else uses it yet (see follow-ups).

### `Sim/MoveTypes/MoveMath/MoveMath.{h,cpp}`

`GetPosSpeedMod2x2(moveDef, x, z, out[4])`: the speed-modifiers of the 2x2 block with even
top-left corner. The type-map and slope-map are half resolution, so the four squares share one
entry; the helper reads it once and calls the unchanged `GroundSpeedMod/HoverSpeedMod/
ShipSpeedMod` per height with the same final multiply, producing exactly what four
`GetPosSpeedMod` calls produce. Falls back to four calls at the map edge.

---
This was all made by Claude Fable 5.1