### PR TITLE
Updated EnTT to v3.16.0

### DIFF
--- a/doc/pr-changelogs/3335.md
+++ b/doc/pr-changelogs/3335.md
@@ -1,0 +1,1 @@
+* updated EnTT library from v3.10.2 to v3.16.0

--- a/rts/Sim/Ecs/SaveLoadUtils.cpp
+++ b/rts/Sim/Ecs/SaveLoadUtils.cpp
@@ -44,7 +44,7 @@ void serialize(Archive &ar, float3 &c) { ar(c.x, c.y, c.z); }
 
 template<class S, class T>
 void ProcessComponents(T&& archive, S&& snapshot) {
-    snapshot.entities(archive);
+    snapshot.template get<entt::entity>(archive);
 
     MoveTypes::serializeComponents(archive, snapshot);
 }
@@ -55,14 +55,18 @@ void SaveLoadUtils::LoadComponents(std::stringstream &iss) {
     systemUtils.NotifyPreLoad();
 
     auto archive = cereal::BinaryInputArchive{iss};
-    LOG_L(L_DEBUG, "%s: Entities before clear is %d", __func__, (int)registry.alive());
-    registry.each([this](entt::entity entity) { registry.destroy(entity); });
+    LOG_L(L_DEBUG, "%s: Entities before clear is %d", __func__,
+        (int)registry.storage<entt::entity>().free_list());
 
-    assert(registry.alive() == 0);
+    registry.clear();
 
-    LOG_L(L_DEBUG, "%s: Entities after clear is %d (%d)", __func__, (int)registry.alive(), (int)iss.tellg());
+    assert(registry.storage<entt::entity>().free_list() == 0);
+
+    LOG_L(L_DEBUG, "%s: Entities after clear is %d (%d)", __func__,
+        (int)registry.storage<entt::entity>().free_list(), (int)iss.tellg());
     {ProcessComponents<entt::snapshot_loader>(archive, entt::snapshot_loader{registry});}
-    LOG_L(L_DEBUG, "%s: Entities after load is %d (%d)", __func__, (int)registry.alive(), (int)iss.tellg());
+    LOG_L(L_DEBUG, "%s: Entities after load is %d (%d)", __func__,
+        (int)registry.storage<entt::entity>().free_list(), (int)iss.tellg());
 
     {
         archive(systemGlobals);
@@ -72,7 +76,8 @@ void SaveLoadUtils::LoadComponents(std::stringstream &iss) {
 
 void SaveLoadUtils::SaveComponents(std::stringstream &oss) {
     auto archive = cereal::BinaryOutputArchive{oss};
-    LOG_L(L_DEBUG, "%s: Entities before save is %d (%d)", __func__, (int)registry.alive(), (int)oss.tellp());
+    LOG_L(L_DEBUG, "%s: Entities before save is %d (%d)", __func__,
+        (int)registry.storage<entt::entity>().free_list(), (int)oss.tellp());
     {ProcessComponents<entt::snapshot>(archive, entt::snapshot{registry});}
     LOG_L(L_DEBUG, "%s: Save bytes writen %d", __func__, (int)oss.tellp());
 

--- a/rts/Sim/MoveTypes/Components/MoveTypesComponents.h
+++ b/rts/Sim/MoveTypes/Components/MoveTypesComponents.h
@@ -35,9 +35,10 @@ void serialize(Archive &ar, UnitTrapCheck &c) { ar(c.type, c.id); }
 
 template<class Archive, class Snapshot>
 void serializeComponents(Archive &archive, Snapshot &snapshot) {
-    snapshot.template component
-        < GeneralMoveType, GroundMoveType, UnitTrapCheck
-        >(archive);
+    snapshot
+        .template get<GeneralMoveType>(archive)
+        .template get<GroundMoveType>(archive)
+        .template get<UnitTrapCheck>(archive);
 }
 
 struct YardmapTrapCheckSystemComponent {

--- a/rts/Sim/MoveTypes/Systems/GroundMoveSystem.cpp
+++ b/rts/Sim/MoveTypes/Systems/GroundMoveSystem.cpp
@@ -36,7 +36,7 @@ void GroundMoveSystem::Update() {
 		SCOPED_TIMER("Sim::Unit::MoveType::1::UpdateTraversalPlan");
         auto view = Sim::registry.view<GroundMoveType>();
         for_mt(0, view.size(), [&view](const int i){
-            auto entity = view.storage<GroundMoveType>()[i];
+            auto entity = (*view.storage<GroundMoveType>())[i];
             auto unitId = view.get<GroundMoveType>(entity);
 
             CUnit* unit = unitHandler.GetUnit(unitId.value);
@@ -80,7 +80,7 @@ void GroundMoveSystem::Update() {
 	{
         auto view = Sim::registry.view<GroundMoveType>();
         for_mt(0, view.size(), [&view](const int i){
-            auto entity = view.storage<GroundMoveType>()[i];
+            auto entity = (*view.storage<GroundMoveType>())[i];
             auto unitId = view.get<GroundMoveType>(entity);
 
             CUnit* unit = unitHandler.GetUnit(unitId.value);
@@ -108,7 +108,7 @@ void GroundMoveSystem::Update() {
         auto view = Sim::registry.view<GroundMoveType>();
         //size_t count = view.storage<GroundMoveType>().size();
         for_mt(0, view.size(), [&view](const int i){
-            auto entity = view.storage<GroundMoveType>()[i];
+            auto entity = (*view.storage<GroundMoveType>())[i];
             assert( Sim::registry.valid(entity) );
             assert( Sim::registry.all_of<GroundMoveType>(entity) );
             assert( !Sim::registry.all_of<GeneralMoveType>(entity) );

--- a/rts/Sim/MoveTypes/Systems/UnitTrapCheckSystem.cpp
+++ b/rts/Sim/MoveTypes/Systems/UnitTrapCheckSystem.cpp
@@ -108,7 +108,7 @@ void UnitTrapCheckSystem::Update() {
         TagUnitsThatMayBeStuck(curList, object, curThread);
     });
 
-    view.each([](entt::entity entity){ Sim::registry.remove<UnitTrapCheck>(entity); });
+    Sim::registry.clear<UnitTrapCheck>();
 }
 
 void UnitTrapCheckSystem::Shutdown() {

--- a/rts/Sim/Path/HAPFS/PathManager.cpp
+++ b/rts/Sim/Path/HAPFS/PathManager.cpp
@@ -417,11 +417,11 @@ void CPathManager::DeletePath(unsigned int pathID, bool /* force ignored*/) {
 
 		PathSearch* existingSearch = nullptr;
 		auto searchView = registry.view<PathSearch>();
-		searchView.each([&searchView, pathID](entt::entity entity){
+		for ( entt::entity entity : searchView ) {
 			auto& search = searchView.get<PathSearch>(entity);
 			if (search.pathId == pathID)
 				registry.destroy(entity);
-		});
+		};
 	}
 }
 
@@ -849,7 +849,7 @@ void CPathManager::Update()
 		});
 
 		// Clear out the search entities.
-		pathSearchView.each([](entt::entity ent){ registry.destroy(ent); });
+		for ( entt::entity entity : pathSearchView ) { registry.destroy(entity); }
 	}
 }
 

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -177,7 +177,7 @@ QTPFS::PathManager::PathManager() {
 	UnsyncedPathSearch::InitStatic();
 	ExternallyManagedPathSearch::InitStatic();
 
-	assert(registry.alive() == 0);
+	assert(registry.storage<entt::entity>().free_list() == 0);
 
 	// reserve entity 0 so it can't be used picked up by a path by accident.
 	systemEntity = registry.create();
@@ -198,7 +198,7 @@ QTPFS::PathManager::~PathManager() {
 
 	// print out and clear anything still left in the registry
 	// due to delayed path deletion there may be some entities still around.
-	registry.each([this](auto entity) {
+	for ( auto& entity : registry.storage<QTPFS::entity>() ) {
 		bool isPath = registry.all_of<IPath>(entity);
 		bool isUnsyncedPath = registry.all_of<UnsyncedIPath>(entity);
 		bool isExternallyManagedSyncedPath = registry.all_of<ExternallyManagedSyncedIPath>(entity);
@@ -231,7 +231,7 @@ QTPFS::PathManager::~PathManager() {
 			LOG("%s: ExternallyManagedPathSearch %x still active!", __func__, entt::to_integral(entity));
 			DestroyPathSearchEntity(entity);
 		}
-	});
+	};
 
 	nodeLayerUpdatePriorityOrder.clear();
 	for (unsigned int layerNum = 0; layerNum < nodeLayers.size(); layerNum++) {
@@ -267,9 +267,9 @@ QTPFS::PathManager::~PathManager() {
 	// make sure this is destroyed last to ensure entity 0 will be first picked up next time.
 	registry.destroy(systemEntity);
 
-	LOG("%s: %d entities still active!", __func__, int(registry.alive()));
+	LOG("%s: %d entities still active!", __func__, int(registry.storage<entt::entity>().free_list()));
 
-	assert(registry.alive() == 0);
+	assert(registry.storage<entt::entity>().free_list() == 0);
 
 	registry.clear();
 }

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -198,7 +198,7 @@ QTPFS::PathManager::~PathManager() {
 
 	// print out and clear anything still left in the registry
 	// due to delayed path deletion there may be some entities still around.
-	for ( auto& entity : registry.storage<QTPFS::entity>() ) {
+	for ( auto entity : registry.storage<QTPFS::entity>() ) {
 		bool isPath = registry.all_of<IPath>(entity);
 		bool isUnsyncedPath = registry.all_of<UnsyncedIPath>(entity);
 		bool isExternallyManagedSyncedPath = registry.all_of<ExternallyManagedSyncedIPath>(entity);

--- a/rts/Sim/Path/QTPFS/Registry.h
+++ b/rts/Sim/Path/QTPFS/Registry.h
@@ -17,17 +17,16 @@
 #include "System/Ecs/Utils/SystemUtils.h"
 
 namespace QTPFS {
-    using entity = std::int32_t;
+    enum class entity : std::uint32_t {};
 }
 
 // Create a special entity type which allows for all paths to be used from Lua.
 // Lua is using floats, which allows for 23 bits mantissa. So we can shave excess bits off of the entity version number.
 template<>
 struct entt::internal::entt_traits<QTPFS::entity> {
-    using entity_type = QTPFS::entity;
+    using value_type = QTPFS::entity;
+    using entity_type = std::uint32_t;
     using version_type = std::uint8_t;
-
-    using difference_type = std::int32_t;
 
     static constexpr entity_type entity_mask = 0xFFFFF;
     static constexpr entity_type version_mask = 0x7;

--- a/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
+++ b/rts/Sim/Path/QTPFS/Systems/PathSpeedModInfoSystem.cpp
@@ -46,7 +46,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
 
     // Initialization
     if (frameModulus <= 0) {
-        layersView.each([&layersView, pm](QTPFS::entity entity){
+        for ( QTPFS::entity entity : layersView ) {
                 auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
                 auto& nodeLayer = pm->GetNodeLayer(layer.layerNum);
                 layer.updateCurMaxSpeed = (-std::numeric_limits<float>::infinity());
@@ -54,13 +54,13 @@ void ScanForPathSpeedModInfo(int frameModulus) {
                 layer.updateInProgress = true;
                 layer.updateCurSumSpeed = 0.f;
                 layer.updateNumLeafNodes = 0.f;
-            });
+            };
         dataChunk = 0;
     }
     
     // One thread per layer: get maximum speed mod from the nodes walked thus far.
     for_mt(0, layersView.size(), [&layersView, &comp, dataChunk, pm](int idx){
-        QTPFS::entity entity = layersView.storage<NodeLayerSpeedInfoSweep>()[idx];
+        QTPFS::entity entity = (*layersView.storage<NodeLayerSpeedInfoSweep>())[idx];
         auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
 
         const int idxBeg = ((dataChunk + 0) * layer.updateMaxNodes) / comp.refreshTimeInFrames;
@@ -89,7 +89,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
 
     // Finished search
     if (dataChunk == comp.refreshTimeInFrames + (-1))
-        layersView.each([&comp, &layersView](QTPFS::entity entity){
+        for ( QTPFS::entity entity : layersView ) {
             auto& layer = layersView.get<NodeLayerSpeedInfoSweep>(entity);
             comp.relSpeedModinfos[layer.layerNum].max = layer.updateCurMaxSpeed;
             comp.relSpeedModinfos[layer.layerNum].mean = layer.updateCurSumSpeed / layer.updateNumLeafNodes;
@@ -98,7 +98,7 @@ void ScanForPathSpeedModInfo(int frameModulus) {
             // if (layer.layerNum == 2) {
             //     LOG("Finished Search - result is %f", comp.relSpeedModinfos[layer.layerNum]);
             // }
-            });
+            };
 }
 
 // #ifdef __GNUC__
@@ -182,6 +182,6 @@ void PathSpeedModInfoSystem::Shutdown() {
     RECOIL_DETAILED_TRACY_ZONE;
     systemUtils.OnUpdate().disconnect<&PathSpeedModInfoSystem::Update>();
 
-    registry.view<NodeLayerSpeedInfoSweep>()
-            .each([](QTPFS::entity entity){ registry.destroy(entity); });
+    auto view = registry.view<NodeLayerSpeedInfoSweep>();
+    for ( QTPFS::entity entity : view ) { registry.destroy(entity); }
 }

--- a/rts/System/Ecs/Utils/SystemUtils.h
+++ b/rts/System/Ecs/Utils/SystemUtils.h
@@ -21,15 +21,15 @@ public:
         postLoad.publish();
     }
 
-    [[nodiscard]] auto OnUpdate() ENTT_NOEXCEPT {
+    [[nodiscard]] auto OnUpdate() noexcept {
         return entt::sink{update};
     }
 
-    [[nodiscard]] auto OnPreLoad() ENTT_NOEXCEPT {
+    [[nodiscard]] auto OnPreLoad() noexcept {
         return entt::sink{preLoad};
     }
 
-    [[nodiscard]] auto OnPostLoad() ENTT_NOEXCEPT {
+    [[nodiscard]] auto OnPostLoad() noexcept {
         return entt::sink{postLoad};
     }
 


### PR DESCRIPTION
The update to C++23 was triggering many warnings against EnTT, which have since been addressed in later versions of EnTT. Applied the latest v3.x version of EnTT to address the C++23 warnings.

Tested build locally with AI in two matches without any issues coming up.