### PR TITLE
Fix resistance calculations to use maximumSpeed after applying terrain modifiers

### DIFF
--- a/doc/pr-changelogs/3336.md
+++ b/doc/pr-changelogs/3336.md
@@ -1,0 +1,1 @@
+ * fixed terrain speed bonuses (e.g. typemap ice) being cancelled by overspeed drag that used the unit's base max speed instead of the terrain-modified effective max speed.

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -131,6 +131,7 @@ CR_REG_METADATA(CGroundMoveType, (
 	CR_MEMBER(wantedSpeed),
 	CR_MEMBER(currentSpeed),
 	CR_MEMBER(deltaSpeed),
+	CR_MEMBER(terrainSpeedMod),
 
 	CR_MEMBER(currWayPointDist),
 	CR_MEMBER(prevWayPointDist),
@@ -449,11 +450,12 @@ static float3 CalcSpeedVectorExclGravity(const CUnit* owner, const CGroundMoveTy
 	else {
 		float vel = owner->speed.w;
 		float maxSpeed = owner->moveType->GetMaxSpeed();
-		if (vel > maxSpeed) {
+		const float effectiveMaxSpeed = maxSpeed * mt->GetTerrainSpeedMod();
+		if (vel > effectiveMaxSpeed) {
 			// Once a unit is travelling faster than their maximum speed, their engine power is no longer sufficient to counteract
 			// the drag from air and rolling resistance. So reduce their velocity by these forces until a return to maximum speed.
 			float rollingResistanceCoeff = owner->unitDef->rollingResistanceCoefficient;
-			vel = std::max(maxSpeed,
+			vel = std::max(effectiveMaxSpeed,
 				(owner->speed +
 				owner->GetDragAccelerationVec(
 					mapInfo->atmosphere.fluidDensity,
@@ -1315,6 +1317,8 @@ void CGroundMoveType::ChangeSpeed(float newWantedSpeed, bool wantReverse, bool f
 			// trying to release ourselves towards a passable square
 			if (groundSpeedMod == 0.0f)
 				groundSpeedMod = CMoveMath::GetPosSpeedMod(*md, owner->pos + flatFrontDir * SQUARE_SIZE, flatFrontDir);
+
+			terrainSpeedMod = groundSpeedMod;
 
 			const float curGoalDistSq = (owner->pos - goalPos).SqLength2D();
 			const float minGoalDistSq = Square(BrakingDistance(currentSpeed, decRate));

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -113,6 +113,7 @@ public:
 	float GetWantedSpeed() const { return wantedSpeed; }
 	float GetCurrentSpeed() const { return currentSpeed; }
 	float GetDeltaSpeed() const { return deltaSpeed; }
+	float GetTerrainSpeedMod() const { return terrainSpeedMod; }
 
 	float GetCurrWayPointDist() const { return currWayPointDist; }
 	float GetPrevWayPointDist() const { return prevWayPointDist; }
@@ -253,6 +254,7 @@ private:
 	float wantedSpeed = 0.0f;
 	float currentSpeed = 0.0f;
 	float deltaSpeed = 0.0f;
+	float terrainSpeedMod = 1.0f; /// last groundSpeedMod from ChangeSpeed (typemap × slope/depth)
 
 	float currWayPointDist = 0.0f;
 	float prevWayPointDist = 0.0f;


### PR DESCRIPTION
Currently there are multiple resistance factors that cause the unit to lose speed when exceeding their maximumSpeed. This includes rollingResistanceCoefficient, atmosphericDragCoefficient. The maximumSpeed considered for these resistance factors is the base maximumSpeed of the unit and not the maximumSpeed after terrain modifications. 

As a result, any increase in speed by terrain (such as by ice) or slope was effectively cancelled out. 

This PR saves the effective terrain speed modifier when calculated in ChangeSpeed and uses it to calculate the effectiveMaxSpeed to calculate when drag should apply instead of using the base maximum speed for the unit. 

As a result, terrain speed modifiers above 100% now function properly. (Roughly simulated a race between hovers at 140% speed on ice vs on land)

<img width="1459" height="990" alt="image" src="https://github.com/user-attachments/assets/d0562162-a19b-4502-a2c0-6394ddb53dc6" />

Previously, they had moved at effectively the same rate. Below is what it looks like on 07.04 release right now
<img width="1517" height="1122" alt="image" src="https://github.com/user-attachments/assets/aecad7d6-b7dc-4984-95a6-dfcd243619b8" />





AI: Cursor used, manual review & testing