### PR TITLE
Clear the Lua shader error log for each gl.CreateShader

### DIFF
--- a/rts/Lua/LuaShaders.cpp
+++ b/rts/Lua/LuaShaders.cpp
@@ -671,6 +671,8 @@ int LuaShaders::CreateShader(lua_State* L)
 	if (!graphicSrcEmpty && !computeSrcEmpty)
 		return 0;
 
+	CLuaHandle::GetActiveShaders(L).errorLog.clear();
+
 	bool success;
 	const GLuint vertObj = CompileObject(L, shdrDefs, vertSrcs, GL_VERTEX_SHADER, success);
 


### PR DESCRIPTION
`LuaShaders::errorLog` is one string with the last message, not a log that accumulates. every compiled stage overwrites it with the driver's info log, a failed link overwrites it again, and `gl.GetShaderLog` returns whatever is there. Nothing resets it when `gl.CreateShader` starts, so a call that returns nil before compiling anything leaves the previous call's message behind, and the widget asking `gl.GetShaderLog` why its shader failed gets the reason for a different shader. Clear it at the start of each call