### PR TITLE
Fix the audio output being closed when a device is added

### DIFF
--- a/rts/System/Sound/ISound.h
+++ b/rts/System/Sound/ISound.h
@@ -55,7 +55,7 @@ public:
 	virtual bool Mute() = 0;
 	virtual bool IsMuted() const = 0;
 
-	virtual void DeviceChanged(uint32_t sdlDeviceIndex) = 0;
+	virtual void DeviceChanged(uint32_t sdlDeviceIndex, bool added) = 0;
 
 	///change current output device
 	static bool ChangeOutput(bool forceNullSound = false);

--- a/rts/System/Sound/Null/NullSound.h
+++ b/rts/System/Sound/Null/NullSound.h
@@ -35,7 +35,7 @@ public:
 	bool Mute() override { return true; }
 	bool IsMuted() const override { return true; }
 
-	void DeviceChanged(uint32_t sdlDeviceIndex) override {}
+	void DeviceChanged(uint32_t sdlDeviceIndex, bool added) override {}
 
 	void Iconified(bool state) override {}
 

--- a/rts/System/Sound/OpenAL/Sound.cpp
+++ b/rts/System/Sound/OpenAL/Sound.cpp
@@ -345,11 +345,15 @@ bool CSound::Mute()
 	return mute;
 }
 
-void CSound::DeviceChanged(uint32_t sdlDeviceIndex)
+void CSound::DeviceChanged(uint32_t sdlDeviceIndex, bool added)
 {
 	// handles SDL_AUDIODEVICEREMOVED and SDL_AUDIODEVICEADDED
 
-	if (!hasAlcSoftLoopBack || sdlDeviceIndex != sdlDeviceID)
+	if (!hasAlcSoftLoopBack)
+		return;
+
+	// sdlDeviceIndex is an instance id for REMOVED events but a device index for ADDED ones
+	if (added ? (sdlDeviceID != 0) : (sdlDeviceIndex != sdlDeviceID))
 		return;
 
 	LOG("[Sound::%s] SDL failed to handle device change, reopening", __func__);

--- a/rts/System/Sound/OpenAL/Sound.h
+++ b/rts/System/Sound/OpenAL/Sound.h
@@ -57,7 +57,7 @@ public:
 	bool Mute() override;
 	bool IsMuted() const override { return mute; }
 
-	void DeviceChanged(uint32_t sdlDeviceIndex) override;
+	void DeviceChanged(uint32_t sdlDeviceIndex, bool added) override;
 
 	void Iconified(bool state) override;
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -1233,11 +1233,11 @@ bool SpringApp::MainEventHandler(const SDL_Event& event)
 		} break;
 		case SDL_AUDIODEVICEREMOVED: {
 			LOG("[SpringApp::%s][SDL_AUDIODEVICEREMOVED][1] type=%u, which=%u, iscapture=%u", __func__, event.adevice.type, event.adevice.which, static_cast<uint32_t>(event.adevice.iscapture));
-			sound->DeviceChanged(event.adevice.which);
+			sound->DeviceChanged(event.adevice.which, false);
 		} break;
 		case SDL_AUDIODEVICEADDED: {
 			LOG("[SpringApp::%s][SDL_AUDIODEVICEADDED][1] type=%u, which=%u, iscapture=%u", __func__, event.adevice.type, event.adevice.which, static_cast<uint32_t>(event.adevice.iscapture));
-			sound->DeviceChanged(event.adevice.which);
+			sound->DeviceChanged(event.adevice.which, true);
 		} break;
 		case SDL_QUIT: {
 			gu->globalQuit = true;


### PR DESCRIPTION
`SDL_AudioDeviceEvent.which` is an instance id for `SDL_AUDIODEVICEREMOVED` but a device index for `SDL_AUDIODEVICEADDED`. `CSound::DeviceChanged` compared both against the open device id, so plugging in a device whose index happens to equal that id closed and reopened a working output mid-game

REMOVED keeps the id comparison, ADDED now only retries the reopen when no output is open