### PR TITLE
Fix EdgeMoveWidth=0 not disabling edge scrolling

### DIFF
--- a/doc/pr-changelogs/3341.md
+++ b/doc/pr-changelogs/3341.md
@@ -1,0 +1,1 @@
+ * Caveat: `EdgeMoveWidth=0` no longer pans at the very edge, to keep that behaviour set it to epsilon instead

--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -733,6 +733,9 @@ float3 CCamera::GetMoveVectorFromState(bool fromKeyState) const
 		return v;
 	}
 
+	if (edgeMoveWidth <= 0.0f)
+		return v;
+
 	const int windowW = globalRendering->winSizeX;
 	int mouseY = mouse->lasty;
 	int viewH;


### PR DESCRIPTION
`EdgeMoveWidth` declares `minimumValue(0.0f)`, but the band is `std::max<int>(1, windowW * edgeMoveWidth)`, so 0 gives a one pixel band instead of none and a pointer resting on the screen edge keeps scrolling the camera on its own

Return early for 0, the 0.02 default is untouched