### PR TITLE
Sim: avoid UB in float-to-short heading casts

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -3318,8 +3318,9 @@ bool CGroundMoveType::UpdateDirectControl()
 		ChangeSpeed(0.0f, false, true);
 	}
 
-	if (unitCon.left ) { ChangeHeading(TAAngleToShort(owner->heading + turnRate)); turnSign =  1.0f; }
-	if (unitCon.right) { ChangeHeading(TAAngleToShort(owner->heading - turnRate)); turnSign = -1.0f; }
+	const short unitTurnRate = FloatToHeading(turnRate);
+	if (unitCon.left ) { ChangeHeading(owner->heading + unitTurnRate); turnSign =  1.0f; }
+	if (unitCon.right) { ChangeHeading(owner->heading - unitTurnRate); turnSign = -1.0f; }
 
 	// local client is controlling us
 	if (selfCon.GetControllee() == owner)

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -3318,9 +3318,8 @@ bool CGroundMoveType::UpdateDirectControl()
 		ChangeSpeed(0.0f, false, true);
 	}
 
-	// via int, a direct float->short is UB once out of range (#3075)
-	if (unitCon.left ) { ChangeHeading(short(int(owner->heading + turnRate))); turnSign =  1.0f; }
-	if (unitCon.right) { ChangeHeading(short(int(owner->heading - turnRate))); turnSign = -1.0f; }
+	if (unitCon.left ) { ChangeHeading(TAAngleToShort(owner->heading + turnRate)); turnSign =  1.0f; }
+	if (unitCon.right) { ChangeHeading(TAAngleToShort(owner->heading - turnRate)); turnSign = -1.0f; }
 
 	// local client is controlling us
 	if (selfCon.GetControllee() == owner)

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -3318,8 +3318,9 @@ bool CGroundMoveType::UpdateDirectControl()
 		ChangeSpeed(0.0f, false, true);
 	}
 
-	if (unitCon.left ) { ChangeHeading(owner->heading + turnRate); turnSign =  1.0f; }
-	if (unitCon.right) { ChangeHeading(owner->heading - turnRate); turnSign = -1.0f; }
+	// via int, a direct float->short is UB once out of range (#3075)
+	if (unitCon.left ) { ChangeHeading(short(int(owner->heading + turnRate))); turnSign =  1.0f; }
+	if (unitCon.right) { ChangeHeading(short(int(owner->heading - turnRate))); turnSign = -1.0f; }
 
 	// local client is controlling us
 	if (selfCon.GetControllee() == owner)

--- a/rts/Sim/Path/IPathController.cpp
+++ b/rts/Sim/Path/IPathController.cpp
@@ -79,8 +79,7 @@ short GMTDefaultPathController::GetDeltaHeading(
 	// add lookahead term to avoid overshooting target heading
 	// note that turnBrakeDist is always positive
 	const short brakeDistFactor = (absTurnSpeed >= maxTurnAccel);
-	// via int, a direct float->short is UB once out of range (#3075)
-	const short stopTurnHeading = short(int(oldHeading + (turnBrakeDist * Sign(curTurnSpeed) * brakeDistFactor)));
+	const short stopTurnHeading = TAAngleToShort(oldHeading + (turnBrakeDist * Sign(curTurnSpeed) * brakeDistFactor));
 	const short curDeltaHeading = newHeading - stopTurnHeading;
 
 	if (brakeDistFactor == 0) {

--- a/rts/Sim/Path/IPathController.cpp
+++ b/rts/Sim/Path/IPathController.cpp
@@ -79,7 +79,8 @@ short GMTDefaultPathController::GetDeltaHeading(
 	// add lookahead term to avoid overshooting target heading
 	// note that turnBrakeDist is always positive
 	const short brakeDistFactor = (absTurnSpeed >= maxTurnAccel);
-	const short stopTurnHeading = TAAngleToShort(oldHeading + (turnBrakeDist * Sign(curTurnSpeed) * brakeDistFactor));
+	const short brakeDist = FloatToHeading(turnBrakeDist * Sign(curTurnSpeed));
+	const short stopTurnHeading = oldHeading + (brakeDist * brakeDistFactor);
 	const short curDeltaHeading = newHeading - stopTurnHeading;
 
 	if (brakeDistFactor == 0) {

--- a/rts/Sim/Path/IPathController.cpp
+++ b/rts/Sim/Path/IPathController.cpp
@@ -79,7 +79,8 @@ short GMTDefaultPathController::GetDeltaHeading(
 	// add lookahead term to avoid overshooting target heading
 	// note that turnBrakeDist is always positive
 	const short brakeDistFactor = (absTurnSpeed >= maxTurnAccel);
-	const short stopTurnHeading = oldHeading + (turnBrakeDist * Sign(curTurnSpeed) * brakeDistFactor);
+	// via int, a direct float->short is UB once out of range (#3075)
+	const short stopTurnHeading = short(int(oldHeading + (turnBrakeDist * Sign(curTurnSpeed) * brakeDistFactor)));
 	const short curDeltaHeading = newHeading - stopTurnHeading;
 
 	if (brakeDistFactor == 0) {

--- a/rts/System/SpringMath.h
+++ b/rts/System/SpringMath.h
@@ -52,7 +52,7 @@ short int GetHeadingFromFacing(const int facing) _pure _warn_unused_result;
 int GetFacingFromHeading(const short int heading) _pure _warn_unused_result;
 float GetHeadingFromVectorF(const float dx, const float dz) _pure _warn_unused_result;
 short int GetHeadingFromVector(const float dx, const float dz) _pure _warn_unused_result;
-short int TAAngleToShort(const float angle) _pure _warn_unused_result;
+short int FloatToHeading(const float angle) _pure _warn_unused_result;
 shortint2 GetHAndPFromVector(const float3 vec) _pure _warn_unused_result; // vec should be normalized
 float2 GetHAndPFromVectorF(const float3 vec) _pure _warn_unused_result; // vec should be normalized
 float3 GetVectorFromHeading(const short int heading) _pure _warn_unused_result;

--- a/rts/System/SpringMath.h
+++ b/rts/System/SpringMath.h
@@ -52,6 +52,7 @@ short int GetHeadingFromFacing(const int facing) _pure _warn_unused_result;
 int GetFacingFromHeading(const short int heading) _pure _warn_unused_result;
 float GetHeadingFromVectorF(const float dx, const float dz) _pure _warn_unused_result;
 short int GetHeadingFromVector(const float dx, const float dz) _pure _warn_unused_result;
+short int TAAngleToShort(const float angle) _pure _warn_unused_result;
 shortint2 GetHAndPFromVector(const float3 vec) _pure _warn_unused_result; // vec should be normalized
 float2 GetHAndPFromVectorF(const float3 vec) _pure _warn_unused_result; // vec should be normalized
 float3 GetVectorFromHeading(const short int heading) _pure _warn_unused_result;

--- a/rts/System/SpringMath.inl
+++ b/rts/System/SpringMath.inl
@@ -22,6 +22,13 @@ inline short int GetHeadingFromFacing(const int facing)
 	}
 }
 
+// headings are circular 16-bit TA angles, so a float sum past a half turn is meant
+// to wrap; truncate to int first, a direct float->short is UB once out of range
+inline short int TAAngleToShort(const float angle)
+{
+	return static_cast<short int>(static_cast<int>(angle));
+}
+
 inline int GetFacingFromHeading(const short int heading)
 {
 	if (heading >= 0) {

--- a/rts/System/SpringMath.inl
+++ b/rts/System/SpringMath.inl
@@ -22,11 +22,15 @@ inline short int GetHeadingFromFacing(const int facing)
 	}
 }
 
-// headings are circular 16-bit TA angles, so a float sum past a half turn is meant
-// to wrap; truncate to int first, a direct float->short is UB once out of range
-inline short int TAAngleToShort(const float angle)
+// headings are circular 16-bit integer angles, so sums of them are meant to wrap.
+// float->short is UB once out of range, so the float side has to be in range
+// already; the assert catches a caller that is not in debug builds.
+inline short int FloatToHeading(const float angle)
 {
-	return static_cast<short int>(static_cast<int>(angle));
+	assert(angle >= static_cast<float>(std::numeric_limits<short int>::min())
+		&& angle <= static_cast<float>(std::numeric_limits<short int>::max()));
+
+	return static_cast<short int>(angle);
 }
 
 inline int GetFacingFromHeading(const short int heading)


### PR DESCRIPTION
Follow-up to #3075. Two more sites cast a float heading sum straight to short: `CGroundMoveType::UpdateDirectControl` passes `owner->heading + turnRate` to `ChangeHeading(short)`, and the brake lookahead in `GMTDefaultPathController::GetDeltaHeading` stores `oldHeading + turnBrakeDist` in a short. Close to a heading of +-32767 the sum leaves short's range and the conversion is undefined, the same arm64/x86 split as in #3075

Same fix, go through int first so the narrowing is the intended 16-bit wrap on every arch. The remaining `short(turnRate)` casts in the move types are bounded by the unit's turn rate and left alone