### PR TITLE
Fix death dependencies for inserted commands

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1183,6 +1183,8 @@ void CCommandAI::ExecuteInsert(const Command& c, bool fromSynced)
 		}
 	}
 
+	AddCommandDependency(newCmd);
+
 	if (facBuildQueue) {
 		facCAI->InsertBuildCommand(insertIt, newCmd);
 


### PR DESCRIPTION
Commands queued through `CMD.INSERT` skip `GiveAllowedCommand`'s dependency registration. When a target is deleted, inserted object commands can remain queued until a later slow update instead of being removed by `DependentDied`.

Register the embedded command's dependency in `ExecuteInsert`, after command and insertion-position validation and before either insertion branch. This also covers factory rally commands. Existing dependency deduplication and cleanup handle the lifetime.

Found during replay comparisons for beyond-all-reason/Beyond-All-Reason#8935, whose compact target-list controller inserts attacks.

Validation: built the unchanged `8c6f5e1725` checkout and the patched checkout with the Linux Podman `engine-headless` target. A synced BAR gadget on Quicksilver Remake 1.24 queued commands at frame 30, destroyed their targets at frame 40, and checked queues in `GameFramePost` on the actual deletion frame (41). The baseline retained inserted Attack, Repair, and factory rally Attack commands; the patched build passed all six scenarios (native Attack control, inserted Attack/Guard/Repair, factory rally Attack, and active inserted Attack followed by Move). Unrelated successor commands remained queued. `git diff --check` passes. Replay parity was not rerun.

Manual reproduction: queue Wait, insert a single-target Attack behind it using `CMD.INSERT {-1, CMD.ATTACK, 0, targetID}` with outer `alt`, then queue Move. Destroy the target and inspect `Spring.GetUnitCommands` in the first `GameFramePost` where `Spring.ValidUnitID(targetID)` is false. The Attack should already be gone and Wait/Move should remain. Repeat with a native shift-queued Attack as a control.

AI assistance: OpenAI Codex inspected the code, implemented the fix, wrote and ran the local regression gadget, and drafted this PR. Draft pending human verification and maintainer acceptance; no matching accepted engine issue was found.
