### PR TITLE
Fix attack orders dropped after an automatic target dies

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1000,6 +1000,7 @@ void CCommandAI::GiveAllowedCommand(const Command& c, bool fromSynced)
 		ClearTargetLock((commandQue.empty())? Command(CMD_STOP): commandQue.front());
 		ClearCommandDependencies();
 		SetOrderTarget(nullptr);
+		targetDied = false;
 
 		// if c is an attack command, the actual order-target
 		// gets set via ExecuteAttack (called from SlowUpdate


### PR DESCRIPTION
Fixes #3345.

After an automatic attack target dies, replacing its order with a non-Shift Move can leave `targetDied` set. A subsequent Attack on a living enemy then finishes immediately, making A + click appear to do nothing.

Clear `targetDied` when `GiveAllowedCommand` discards the old queue and order target, matching the reset already performed when an active order finishes or is interrupted by a front insertion. This also covers a direct replacement Attack and ground Attack.

The bug was found in traces of these BAR replays on engine `2026.07.04` (times are simulation time at 30 frames/s):

- **Supreme Isthmus v2.1**, replay `ef77a16af457b067f28c9b91602765c6`: unit **5300** (`cormort`), frame **44647** (~**24:48**). Its automatic target 15292 dies at frame 44496, followed by non-Shift Moves from 44497 onward. The Attack on **18227** is accepted and completed in frame 44647; frame 44648 shows an automatic Attack on **24535** instead.
- **Comet Catcher Remake 1.8**, replay `1c95a16a3014f31a85859136bac2fb88`: units **3286** and **18263**, frame **31568** (~**17:32**). Automatic target **12278** is deleted that frame. A non-Shift Attack on **24004**, sent by a widget, is accepted and completed in the same frame; frame 31569 shows an automatic Attack on **31305** instead.

Validation: built Linux `engine-headless` with Podman on unchanged `694e9df7cf` and with this one-line change. Ran the same synced BAR gadget on Quicksilver Remake 1.24 in isolated data directories. It waited for the automatic Attack to execute before deleting its target, then checked replacement orders in the actual deletion frame. The baseline dropped the first direct Attack, the Attack after 20 frames of repeated Moves, and the ground Attack; the patched build passed all 20 assertions across those three cases and a Stop-then-Attack control. Second Attacks succeeded on both builds. `git diff --check` passes. The original replays were not rerun.

Manual reproduction: let a mobile unit automatically attack T; delete T and, before the next command-AI slow update, replace the order with a non-Shift Move. Before the Move finishes, attack a living U without Shift. The Attack should remain active. Issue #3345 has the two original replay examples and exact frames.

AI assistance: OpenAI Codex inspected the code, implemented the fix, wrote and ran the local regression gadget, and drafted this PR. Human gameplay verification is still pending.
