### PR TITLE
Let consecutive order completions re-enter SlowUpdate within one frame

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -68,6 +68,7 @@ CR_REG_METADATA(CCommandAI, (
 	CR_MEMBER(lastUserCommand),
 	CR_MEMBER(selfDCountdown),
 	CR_MEMBER(lastFinishCommand),
+	CR_MEMBER(finishCommandBudget),
 
 	CR_MEMBER(owner),
 
@@ -87,6 +88,7 @@ CCommandAI::CCommandAI():
 	lastUserCommand(-1000),
 	selfDCountdown(0),
 	lastFinishCommand(0),
+	finishCommandBudget(0),
 	owner(NULL),
 	orderTarget(0),
 	targetDied(false),
@@ -101,6 +103,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 	lastUserCommand(-1000),
 	selfDCountdown(0),
 	lastFinishCommand(0),
+	finishCommandBudget(0),
 	owner(owner),
 	orderTarget(0),
 	targetDied(false),
@@ -1687,11 +1690,18 @@ void CCommandAI::FinishCommand()
 		eventHandler.UnitIdle(owner);
 	}
 
-	// avoid infinite loops
-	if (lastFinishCommand == gs->frameNum)
+	// avoid infinite loops: allow as many re-entries per frame as there were
+	// orders queued when the first one finished, so a run of orders that end
+	// as soon as they start (dead or crashing targets) is worked through in
+	// one update, while repeat orders re-pushing themselves still terminate
+	if (lastFinishCommand != gs->frameNum) {
+		lastFinishCommand = gs->frameNum;
+		finishCommandBudget = static_cast<int>(commandQue.size());
+	} else if (finishCommandBudget <= 0) {
 		return;
-
-	lastFinishCommand = gs->frameNum;
+	} else {
+		finishCommandBudget--;
+	}
 
 	if (owner->IsStunned())
 		return;

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -124,6 +124,8 @@ public:
 	int lastUserCommand;
 	int selfDCountdown;
 	int lastFinishCommand;
+	// how many more FinishCommand calls may re-enter SlowUpdate this frame
+	int finishCommandBudget;
 
 	CUnit* owner;
 	CUnit* orderTarget;


### PR DESCRIPTION
Fixes #3351

## Issue

If the engine skips more than two queued orders, e.g. due to it being attack orders on crashing aircraft,  the next order is delayed one SlowUpdate. 

In large fights with hundreds of aircraft this might cause a short delay of target acquisition when multiple aircraft die at the same time.

## Work done

`CCommandAI::FinishCommand` re-entered `SlowUpdate` at most once per frame (`lastFinishCommand == gs->frameNum`, "avoid infinite loops"). When two or more consecutive queued orders end as soon as they start executing (a target that is already gone, or a crashing aircraft with #3348), the unit finishes them all in the same update, but the first executable order behind them stays uninitialised until the unit's next SlowUpdate, up to 16 frames later. The automatic target selection after a queue runs empty is delayed the same way.

This replaces the once-per-frame rule with a budget: on the first `FinishCommand` of a frame the budget is set to the number of orders still queued, and every further `FinishCommand` in that frame consumes one before re-entering `SlowUpdate`. A run of unservable orders is worked through in one update; repeat orders that push themselves back to the queue still terminate after one pass over the queue. `finishCommandBudget` is added to the creg members.

## Context

Found while comparing native Attack queues with the compact target lists of beyond-all-reason/Beyond-All-Reason#8935 (600 fighters vs 200 bombers): with #3348 applied the native queue still fell one SlowUpdate behind the Lua controller whenever two consecutive queued targets were crashing. With this change on top, master and the PR are bit-identical in that scenario until the end phase where all remaining bombers are crashing at once.

## Verification

Headless BAR test on a build of #3348 plus this change: fighter with queued Attacks [A, B, C, D], B and C crashing, A made neutral and crashing while attacked. Without this change B and C are finished in one frame but D is only attacked at the next SlowUpdate; with it D is attacked in the same frame. Built and run together with #3348; the change itself touches only `CommandAI.cpp/.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)