### PR TITLE
AI Intent system

### DIFF
--- a/AI/Interfaces/C/src/Interface.cpp
+++ b/AI/Interfaces/C/src/Interface.cpp
@@ -173,6 +173,21 @@ sharedLib_t CInterface::LoadSkirmishAILib(
 		reportInterfaceFunctionError(libFilePath, funcName);
 	}
 
+
+	funcName = "handleIntent";
+	funcAddr = sharedLib_findAddress(sharedLib, funcName.c_str());
+
+	skirmishAILibrary->handleIntent = (int (CALLING_CONV *)(
+		int skirmishAIId,
+		int topicId,
+		const void* data
+	)) funcAddr;
+
+	if (skirmishAILibrary->handleIntent == nullptr) {
+		// do nothing: it is not a requirement to handle game intents
+		//reportInterfaceFunctionError(libFilePath, funcName);
+	}
+
 	return sharedLib;
 }
 

--- a/rts/ExternalAI/AIInterfaceLibrary.cpp
+++ b/rts/ExternalAI/AIInterfaceLibrary.cpp
@@ -175,6 +175,7 @@ SSkirmishAILibrary CAIInterfaceLibrary::EmptyInterfaceLib()
 	sLibEmpty.init = nullptr;
 	sLibEmpty.release = nullptr;
 	sLibEmpty.handleEvent = handleEvent_empty;
+	sLibEmpty.handleIntent = nullptr;
 
 	return sLibEmpty;
 }

--- a/rts/ExternalAI/EngineOutHandler.cpp
+++ b/rts/ExternalAI/EngineOutHandler.cpp
@@ -519,6 +519,57 @@ bool CEngineOutHandler::SendLuaMessages(int aiTeam, const char* inData, std::vec
 }
 
 
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, int value) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, value), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, float value) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, value), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<int>& data) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<float>& data) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<char>& data) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<VariantWrapper>& data) {
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId,
+	const std::vector<int>& keys, const std::vector<int>& values)
+{
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, keys, values), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId,
+	const std::vector<int>& keys, const std::vector<float>& values)
+{
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, keys, values), teamId);
+}
+
+void CEngineOutHandler::Intent(int teamId, int topic, int objId,
+	const std::vector<int>& keys, const std::vector<VariantWrapper>& values)
+{
+	AI_SCOPED_TIMER();
+	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, keys, values), teamId);
+}
+
 
 void CEngineOutHandler::CreateSkirmishAI(const uint8_t skirmishAIId, bool savedGame) {
 	SCOPED_TIMER("AI");
@@ -587,4 +638,3 @@ void CEngineOutHandler::DestroySkirmishAI(const uint8_t skirmishAIId) {
 	// will trigger SkirmishAIHandler::RemoveSkirmishAI
 	clientNet->Send(CBaseNetProtocol::Get().SendAIStateChanged(gu->myPlayerNum, skirmishAIId, SKIRMAISTATE_DEAD));
 }
-

--- a/rts/ExternalAI/EngineOutHandler.cpp
+++ b/rts/ExternalAI/EngineOutHandler.cpp
@@ -539,16 +539,6 @@ void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vect
 	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
 }
 
-void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<char>& data) {
-	AI_SCOPED_TIMER();
-	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
-}
-
-void CEngineOutHandler::Intent(int teamId, int topic, int objId, const std::vector<VariantWrapper>& data) {
-	AI_SCOPED_TIMER();
-	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, data), teamId);
-}
-
 void CEngineOutHandler::Intent(int teamId, int topic, int objId,
 	const std::vector<int>& keys, const std::vector<int>& values)
 {
@@ -558,13 +548,6 @@ void CEngineOutHandler::Intent(int teamId, int topic, int objId,
 
 void CEngineOutHandler::Intent(int teamId, int topic, int objId,
 	const std::vector<int>& keys, const std::vector<float>& values)
-{
-	AI_SCOPED_TIMER();
-	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, keys, values), teamId);
-}
-
-void CEngineOutHandler::Intent(int teamId, int topic, int objId,
-	const std::vector<int>& keys, const std::vector<VariantWrapper>& values)
 {
 	AI_SCOPED_TIMER();
 	DO_FOR_TEAM_SKIRMISH_AIS(Intent(topic, objId, keys, values), teamId);

--- a/rts/ExternalAI/EngineOutHandler.h
+++ b/rts/ExternalAI/EngineOutHandler.h
@@ -80,6 +80,16 @@ public:
 	/// send a raw string from unsynced Lua to one or all active skirmish AI's
 	bool SendLuaMessages(int aiTeam, const char* inData, std::vector<const char*>& outData);
 
+	void Intent(int teamId, int topic, int objId, int value);
+	void Intent(int teamId, int topic, int objId, float value);
+	void Intent(int teamId, int topic, int objId, const std::vector<int>& data);
+	void Intent(int teamId, int topic, int objId, const std::vector<float>& data);
+	void Intent(int teamId, int topic, int objId, const std::vector<char>& data);
+	void Intent(int teamId, int topic, int objId, const std::vector<VariantWrapper>& data);
+	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<int>& values);
+	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<float>& values);
+	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<VariantWrapper>& values);
+
 
 	// Skirmish AI stuff
 	void CreateSkirmishAI(const uint8_t skirmishAIId, bool savedGame);

--- a/rts/ExternalAI/EngineOutHandler.h
+++ b/rts/ExternalAI/EngineOutHandler.h
@@ -84,11 +84,8 @@ public:
 	void Intent(int teamId, int topic, int objId, float value);
 	void Intent(int teamId, int topic, int objId, const std::vector<int>& data);
 	void Intent(int teamId, int topic, int objId, const std::vector<float>& data);
-	void Intent(int teamId, int topic, int objId, const std::vector<char>& data);
-	void Intent(int teamId, int topic, int objId, const std::vector<VariantWrapper>& data);
 	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<int>& values);
 	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<float>& values);
-	void Intent(int teamId, int topic, int objId, const std::vector<int>& keys, const std::vector<VariantWrapper>& values);
 
 
 	// Skirmish AI stuff

--- a/rts/ExternalAI/Interface/AISIntents.h
+++ b/rts/ExternalAI/Interface/AISIntents.h
@@ -1,0 +1,166 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef AI_S_INTENTS_H
+#define AI_S_INTENTS_H
+
+// IMPORTANT NOTE: unlike AISEvents.h external systems do not parse this file.
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+// NOTE structs should not be empty (C90), so add a useless member if needed
+
+/**
+ * Each intent type can be identified through a unique ID,
+ * which we call intent topic.
+ * Intents are sent from the game to AIs.
+ *
+ * Note: Do NOT change the values assigned to these topics,
+ * as this would be bad for inter-version compatibility.
+ * You should always append new intent topics at the end of this list,
+ * and adjust NUM_INTENTS.
+ *
+ * @see SSkirmishAILibrary.handleIntent()
+ */
+enum IntentTopic {
+	INTENT_NULL                        =  0,
+	INTENT_INT                         =  1,
+	INTENT_FLOAT                       =  2,
+	INTENT_ARRAY_INT                   =  3,
+	INTENT_ARRAY_FLOAT                 =  4,
+	INTENT_ARRAY_CHAR                  =  5,
+	INTENT_ARRAY_VARIANT               =  6,
+	INTENT_DICT_INT                    =  7,
+	INTENT_DICT_FLOAT                  =  8,
+	INTENT_DICT_VARIANT                =  9,
+};
+const int NUM_INTENTS = 10;
+
+
+#define AIINTERFACE_INTENTS_ABI_VERSION     ( \
+		  sizeof(struct SIntIntent) \
+		+ sizeof(struct SFloatIntent) \
+		+ sizeof(struct SArrayCharIntent) \
+		+ sizeof(struct SArrayIntIntent) \
+		+ sizeof(struct SArrayFloatIntent) \
+		+ sizeof(struct SArrayVariantIntent) \
+		+ sizeof(struct SDictIntIntent) \
+		+ sizeof(struct SDictFloatIntent) \
+		+ sizeof(struct SDictVariantIntent) \
+		)
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SIntIntent {
+	int topic;
+	int objId;
+	int value;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SFloatIntent {
+	int topic;
+	int objId;
+	float value;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SArrayCharIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const char* data;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SArrayIntIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const int* data;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SArrayFloatIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const float* data;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SDictIntIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const int* keys;
+	const int* values;
+};
+
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SDictFloatIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const int* keys;
+	const float* values;
+};
+
+enum EValueType {
+	TYPE_ERROR,
+	TYPE_INT,
+	TYPE_FLOAT,
+	TYPE_STRING,
+};
+struct SVariant {
+	enum EValueType type;
+	union UValue {
+		int i_val;
+		float f_val;
+		const char* s_val;
+	} data;
+
+	SVariant() : type(TYPE_ERROR) {}
+	SVariant(int val) : type(TYPE_INT), data(UValue{.i_val = val}) {}
+	SVariant(float val) : type(TYPE_FLOAT), data(UValue{.f_val = val}) {}
+	SVariant(const char* val) : type(TYPE_STRING), data(UValue{.s_val = val}) {}
+};
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SArrayVariantIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const SVariant* data;
+};
+/**
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SDictVariantIntent {
+	int topic;
+	int objId;
+	unsigned int size;
+	const int* keys;
+	const SVariant* values;
+};
+
+#ifdef	__cplusplus
+} // extern "C"
+#endif
+
+#endif // AI_S_INTENTS_H

--- a/rts/ExternalAI/Interface/AISIntents.h
+++ b/rts/ExternalAI/Interface/AISIntents.h
@@ -34,8 +34,9 @@ enum IntentTopic {
 	INTENT_DICT_INT                    =  7,
 	INTENT_DICT_FLOAT                  =  8,
 	INTENT_DICT_VARIANT                =  9,
+	INTENT_ALL_IN                      = 10,
 };
-const int NUM_INTENTS = 10;
+const int NUM_INTENTS = 11;
 
 
 #define AIINTERFACE_INTENTS_ABI_VERSION     ( \
@@ -48,6 +49,7 @@ const int NUM_INTENTS = 10;
 		+ sizeof(struct SDictIntIntent) \
 		+ sizeof(struct SDictFloatIntent) \
 		+ sizeof(struct SDictVariantIntent) \
+		+ sizeof(struct SIntent) \
 		)
 
 /**
@@ -157,6 +159,23 @@ struct SDictVariantIntent {
 	unsigned int size;
 	const int* keys;
 	const SVariant* values;
+};
+
+/**
+ * All-in-one struct.
+ * Receiver must know which fields to use
+ * according to topic.
+ * Sent by a Lua widget or unsynced gadget.
+ */
+struct SIntent {
+	int topic;
+	int objId;
+	int iValue;
+	float fValue;
+	unsigned int sizeKeys;
+	unsigned int sizeValues;
+	const int* keys;
+	const float* values;
 };
 
 #ifdef	__cplusplus

--- a/rts/ExternalAI/Interface/AISIntents.h
+++ b/rts/ExternalAI/Interface/AISIntents.h
@@ -29,27 +29,19 @@ enum IntentTopic {
 	INTENT_FLOAT                       =  2,
 	INTENT_ARRAY_INT                   =  3,
 	INTENT_ARRAY_FLOAT                 =  4,
-	INTENT_ARRAY_CHAR                  =  5,
-	INTENT_ARRAY_VARIANT               =  6,
-	INTENT_DICT_INT                    =  7,
-	INTENT_DICT_FLOAT                  =  8,
-	INTENT_DICT_VARIANT                =  9,
-	INTENT_ALL_IN                      = 10,
+	INTENT_DICT_INT                    =  5,
+	INTENT_DICT_FLOAT                  =  6,
 };
-const int NUM_INTENTS = 11;
+const int NUM_INTENTS = 7;
 
 
 #define AIINTERFACE_INTENTS_ABI_VERSION     ( \
 		  sizeof(struct SIntIntent) \
 		+ sizeof(struct SFloatIntent) \
-		+ sizeof(struct SArrayCharIntent) \
 		+ sizeof(struct SArrayIntIntent) \
 		+ sizeof(struct SArrayFloatIntent) \
-		+ sizeof(struct SArrayVariantIntent) \
 		+ sizeof(struct SDictIntIntent) \
 		+ sizeof(struct SDictFloatIntent) \
-		+ sizeof(struct SDictVariantIntent) \
-		+ sizeof(struct SIntent) \
 		)
 
 /**
@@ -68,16 +60,6 @@ struct SFloatIntent {
 	int topic;
 	int objId;
 	float value;
-};
-
-/**
- * Sent by a Lua widget or unsynced gadget.
- */
-struct SArrayCharIntent {
-	int topic;
-	int objId;
-	unsigned int size;
-	const char* data;
 };
 
 /**
@@ -118,62 +100,6 @@ struct SDictFloatIntent {
 	int topic;
 	int objId;
 	unsigned int size;
-	const int* keys;
-	const float* values;
-};
-
-enum EValueType {
-	TYPE_ERROR,
-	TYPE_INT,
-	TYPE_FLOAT,
-	TYPE_STRING,
-};
-struct SVariant {
-	enum EValueType type;
-	union UValue {
-		int i_val;
-		float f_val;
-		const char* s_val;
-	} data;
-
-	SVariant() : type(TYPE_ERROR) {}
-	SVariant(int val) : type(TYPE_INT), data(UValue{.i_val = val}) {}
-	SVariant(float val) : type(TYPE_FLOAT), data(UValue{.f_val = val}) {}
-	SVariant(const char* val) : type(TYPE_STRING), data(UValue{.s_val = val}) {}
-};
-/**
- * Sent by a Lua widget or unsynced gadget.
- */
-struct SArrayVariantIntent {
-	int topic;
-	int objId;
-	unsigned int size;
-	const SVariant* data;
-};
-/**
- * Sent by a Lua widget or unsynced gadget.
- */
-struct SDictVariantIntent {
-	int topic;
-	int objId;
-	unsigned int size;
-	const int* keys;
-	const SVariant* values;
-};
-
-/**
- * All-in-one struct.
- * Receiver must know which fields to use
- * according to topic.
- * Sent by a Lua widget or unsynced gadget.
- */
-struct SIntent {
-	int topic;
-	int objId;
-	int iValue;
-	float fValue;
-	unsigned int sizeKeys;
-	unsigned int sizeValues;
 	const int* keys;
 	const float* values;
 };

--- a/rts/ExternalAI/Interface/SSkirmishAILibrary.h
+++ b/rts/ExternalAI/Interface/SSkirmishAILibrary.h
@@ -214,6 +214,22 @@ struct SSkirmishAILibrary {
 	 */
 	int (CALLING_CONV *handleEvent)(int skirmishAIId, int topicId,
 			const void* data);
+
+	/**
+	 * Through this function, the AI receives events from the engine.
+	 * For details about events that may arrive here, see file AISEvents.h.
+	 *
+	 * @param skirmishAIId  the AI instance the event is addressed to
+	 * @param topicId       unique identifier of a message
+	 *                      (see INTENT_* defines in AIIntents.h)
+	 * @param data          an topic specific struct, which contains the data
+	 *                      associatedwith the event
+	 *                      (see structs in AIIntents.h)
+	 * @return     0: ok
+	 *          != 0: error
+	 */
+	int (CALLING_CONV *handleIntent)(int skirmishAIId, int topicId,
+			const void* data);
 };
 
 #ifdef __cplusplus

--- a/rts/ExternalAI/Interface/SSkirmishAILibrary.h
+++ b/rts/ExternalAI/Interface/SSkirmishAILibrary.h
@@ -207,7 +207,7 @@ struct SSkirmishAILibrary {
 	 * @param topicId       unique identifier of a message
 	 *                      (see EVENT_* defines in AISEvents.h)
 	 * @param data          an topic specific struct, which contains the data
-	 *                      associatedwith the event
+	 *                      associated with the event
 	 *                      (see S*Event structs in AISEvents.h)
 	 * @return     0: ok
 	 *          != 0: error
@@ -216,15 +216,15 @@ struct SSkirmishAILibrary {
 			const void* data);
 
 	/**
-	 * Through this function, the AI receives events from the engine.
-	 * For details about events that may arrive here, see file AISEvents.h.
+	 * Through this function, the AI receives intents from the game.
+	 * For details about intents that may arrive here, see file AISIntents.h.
 	 *
-	 * @param skirmishAIId  the AI instance the event is addressed to
+	 * @param skirmishAIId  the AI instance the intent is addressed to
 	 * @param topicId       unique identifier of a message
-	 *                      (see INTENT_* defines in AIIntents.h)
+	 *                      (see INTENT_* defines in AISIntents.h)
 	 * @param data          an topic specific struct, which contains the data
-	 *                      associatedwith the event
-	 *                      (see structs in AIIntents.h)
+	 *                      associated with the intent
+	 *                      (see S*Intent structs in AISIntents.h)
 	 * @return     0: ok
 	 *          != 0: error
 	 */

--- a/rts/ExternalAI/Interface/aidefines.h
+++ b/rts/ExternalAI/Interface/aidefines.h
@@ -43,6 +43,7 @@
 	+ sizeof(struct SAIInterfaceCallback) \
 	+ AIINTERFACE_EVENTS_ABI_VERSION \
 	+ AIINTERFACE_COMMANDS_ABI_VERSION \
+	+ AIINTERFACE_INTENTS_ABI_VERSION \
 	+ __archBits__   * 10000 \
 	+ sizeof(int)    * 1001 \
 	+ sizeof(char)   * 1002 \

--- a/rts/ExternalAI/SAIInterfaceCallbackImpl.cpp
+++ b/rts/ExternalAI/SAIInterfaceCallbackImpl.cpp
@@ -13,6 +13,7 @@
 #include "ExternalAI/Interface/ELevelOfSupport.h"     // for ABI version
 #include "ExternalAI/Interface/AISEvents.h"           // for ABI version
 #include "ExternalAI/Interface/AISCommands.h"         // for ABI version
+#include "ExternalAI/Interface/AISIntents.h"          // for ABI version
 #include "ExternalAI/Interface/SSkirmishAILibrary.h"  // for ABI version
 #include "ExternalAI/Interface/SAIInterfaceLibrary.h" // for ABI version and AI_INTERFACE_PROPERTY_*
 #include "System/SafeCStrings.h"

--- a/rts/ExternalAI/SkirmishAILibrary.cpp
+++ b/rts/ExternalAI/SkirmishAILibrary.cpp
@@ -103,3 +103,23 @@ int CSkirmishAILibrary::HandleEvent(int skirmishAIId, int topic, const void* dat
 	return ret;
 }
 
+int CSkirmishAILibrary::HandleIntent(int skirmishAIId, int topic, const void* data) const
+{
+	if (aiLib.handleIntent == nullptr)
+		return 0;
+
+	skirmishAIHandler.SetCurrentAIID(skirmishAIId);
+	const int ret = aiLib.handleIntent(skirmishAIId, topic, data);
+	skirmishAIHandler.SetCurrentAIID(MAX_AIS);
+
+	if (ret == 0)
+		return ret;
+
+	// intent handling failed!
+	const int teamId = skirmishAIHandler.GetSkirmishAI(skirmishAIId)->team;
+	const char* errorStr = "AI for team %d (ID: %d) failed handling intent with topic %d, error: %d";
+
+	LOG_L(L_WARNING, errorStr, teamId, skirmishAIId, topic, ret);
+
+	return ret;
+}

--- a/rts/ExternalAI/SkirmishAILibrary.h
+++ b/rts/ExternalAI/SkirmishAILibrary.h
@@ -34,6 +34,7 @@ public:
 	bool Init(int skirmishAIId, const SSkirmishAICallback* c_callback) const;
 	bool Release(int skirmishAIId) const;
 	int HandleEvent(int skirmishAIId, int topic, const void* data) const;
+	int HandleIntent(int skirmishAIId, int topic, const void* data) const;
 
 private:
 	SSkirmishAILibrary aiLib;

--- a/rts/ExternalAI/SkirmishAIWrapper.cpp
+++ b/rts/ExternalAI/SkirmishAIWrapper.cpp
@@ -457,6 +457,17 @@ void CSkirmishAIWrapper::SeismicPing(
 void CSkirmishAIWrapper::Intent(int topic, int objId, int value) {
 	const SIntIntent intent = {topic, objId, value};
 	HandleIntent(INTENT_INT, &intent);
+	// const SIntent intent = {
+	// 	.topic = topic,
+	// 	.objId = objId,
+	// 	.iVal = value,
+	// 	.fVal = 0.f,
+	// 	.sizeKeys = 0,
+	// 	.sizeValues = 0,
+	// 	.keys = nullptr,
+	// 	.values = nullptr
+	// };
+	// HandleIntent(INTENT_ALL_IN, &intent);
 }
 
 void CSkirmishAIWrapper::Intent(int topic, int objId, float value) {
@@ -466,7 +477,7 @@ void CSkirmishAIWrapper::Intent(int topic, int objId, float value) {
 
 void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<int>& data) {
 	const SArrayIntIntent intent = {topic, objId, (unsigned int)data.size(), data.data()};
-	HandleIntent(INTENT_FLOAT, &intent);
+	HandleIntent(INTENT_ARRAY_INT, &intent);
 }
 
 void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<float>& data) {

--- a/rts/ExternalAI/SkirmishAIWrapper.cpp
+++ b/rts/ExternalAI/SkirmishAIWrapper.cpp
@@ -457,17 +457,6 @@ void CSkirmishAIWrapper::SeismicPing(
 void CSkirmishAIWrapper::Intent(int topic, int objId, int value) {
 	const SIntIntent intent = {topic, objId, value};
 	HandleIntent(INTENT_INT, &intent);
-	// const SIntent intent = {
-	// 	.topic = topic,
-	// 	.objId = objId,
-	// 	.iVal = value,
-	// 	.fVal = 0.f,
-	// 	.sizeKeys = 0,
-	// 	.sizeValues = 0,
-	// 	.keys = nullptr,
-	// 	.values = nullptr
-	// };
-	// HandleIntent(INTENT_ALL_IN, &intent);
 }
 
 void CSkirmishAIWrapper::Intent(int topic, int objId, float value) {
@@ -485,31 +474,6 @@ void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<float>& 
 	HandleIntent(INTENT_ARRAY_FLOAT, &intent);
 }
 
-void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<char>& data) {
-	const SArrayCharIntent intent = {topic, objId, (unsigned int)data.size(), data.data()};
-	HandleIntent(INTENT_ARRAY_CHAR, &intent);
-}
-
-SVariant ConvertToC(const VariantWrapper& var) {
-	if (std::holds_alternative<int>(var)) {
-		return SVariant(std::get<int>(var));
-	} else if (std::holds_alternative<float>(var)) {
-		return SVariant(std::get<float>(var));
-	} else if (std::holds_alternative<std::string>(var)) {
-		return SVariant(std::get<std::string>(var).c_str());
-	}
-	return SVariant();
-}
-void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<VariantWrapper>& data) {
-	std::vector<SVariant> cData;
-	cData.reserve(data.size());
-	for (auto var : data) {
-		cData.push_back(ConvertToC(var));
-	}
-	const SArrayVariantIntent intent = {topic, objId, (unsigned int)cData.size(), cData.data()};
-	HandleIntent(INTENT_DICT_VARIANT, &intent);
-}
-
 void CSkirmishAIWrapper::Intent(int topic, int objId,
 	const std::vector<int>& keys, const std::vector<int>& values)
 {
@@ -522,18 +486,6 @@ void CSkirmishAIWrapper::Intent(int topic, int objId,
 {
 	const SDictFloatIntent intent = {topic, objId, (unsigned int)keys.size(), keys.data(), values.data()};
 	HandleIntent(INTENT_DICT_FLOAT, &intent);
-}
-
-void CSkirmishAIWrapper::Intent(int topic, int objId,
-	const std::vector<int>& keys, const std::vector<VariantWrapper>& values)
-{
-	std::vector<SVariant> cValues;
-	cValues.reserve(values.size());
-	for (auto var : values) {
-		cValues.push_back(ConvertToC(var));
-	}
-	const SDictVariantIntent intent = {topic, objId, (unsigned int)keys.size(), keys.data(), cValues.data()};
-	HandleIntent(INTENT_DICT_VARIANT, &intent);
 }
 
 

--- a/rts/ExternalAI/SkirmishAIWrapper.cpp
+++ b/rts/ExternalAI/SkirmishAIWrapper.cpp
@@ -11,6 +11,7 @@
 
 #include "Interface/AISEvents.h"
 #include "Interface/AISCommands.h"
+#include "Interface/AISIntents.h"
 #include "Interface/SSkirmishAILibrary.h"
 
 #include "Sim/Units/Unit.h"
@@ -453,6 +454,77 @@ void CSkirmishAIWrapper::SeismicPing(
 	HandleEvent(EVENT_SEISMIC_PING, &evtData);
 }
 
+void CSkirmishAIWrapper::Intent(int topic, int objId, int value) {
+	const SIntIntent intent = {topic, objId, value};
+	HandleIntent(INTENT_INT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId, float value) {
+	const SFloatIntent intent = {topic, objId, value};
+	HandleIntent(INTENT_FLOAT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<int>& data) {
+	const SArrayIntIntent intent = {topic, objId, (unsigned int)data.size(), data.data()};
+	HandleIntent(INTENT_FLOAT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<float>& data) {
+	const SArrayFloatIntent intent = {topic, objId, (unsigned int)data.size(), data.data()};
+	HandleIntent(INTENT_ARRAY_FLOAT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<char>& data) {
+	const SArrayCharIntent intent = {topic, objId, (unsigned int)data.size(), data.data()};
+	HandleIntent(INTENT_ARRAY_CHAR, &intent);
+}
+
+SVariant ConvertToC(const VariantWrapper& var) {
+	if (std::holds_alternative<int>(var)) {
+		return SVariant(std::get<int>(var));
+	} else if (std::holds_alternative<float>(var)) {
+		return SVariant(std::get<float>(var));
+	} else if (std::holds_alternative<std::string>(var)) {
+		return SVariant(std::get<std::string>(var).c_str());
+	}
+	return SVariant();
+}
+void CSkirmishAIWrapper::Intent(int topic, int objId, const std::vector<VariantWrapper>& data) {
+	std::vector<SVariant> cData;
+	cData.reserve(data.size());
+	for (auto var : data) {
+		cData.push_back(ConvertToC(var));
+	}
+	const SArrayVariantIntent intent = {topic, objId, (unsigned int)cData.size(), cData.data()};
+	HandleIntent(INTENT_DICT_VARIANT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId,
+	const std::vector<int>& keys, const std::vector<int>& values)
+{
+	const SDictIntIntent intent = {topic, objId, (unsigned int)keys.size(), keys.data(), values.data()};
+	HandleIntent(INTENT_DICT_INT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId,
+	const std::vector<int>& keys, const std::vector<float>& values)
+{
+	const SDictFloatIntent intent = {topic, objId, (unsigned int)keys.size(), keys.data(), values.data()};
+	HandleIntent(INTENT_DICT_FLOAT, &intent);
+}
+
+void CSkirmishAIWrapper::Intent(int topic, int objId,
+	const std::vector<int>& keys, const std::vector<VariantWrapper>& values)
+{
+	std::vector<SVariant> cValues;
+	cValues.reserve(values.size());
+	for (auto var : values) {
+		cValues.push_back(ConvertToC(var));
+	}
+	const SDictVariantIntent intent = {topic, objId, (unsigned int)keys.size(), keys.data(), cValues.data()};
+	HandleIntent(INTENT_DICT_VARIANT, &intent);
+}
+
 
 int CSkirmishAIWrapper::HandleEvent(int topic, const void* data) const {
 	ScopedTimer timer(GetTimerNameHash());
@@ -464,3 +536,12 @@ int CSkirmishAIWrapper::HandleEvent(int topic, const void* data) const {
 	return 0;
 }
 
+
+int CSkirmishAIWrapper::HandleIntent(int topic, const void* data) const {
+	ScopedTimer timer(GetTimerNameHash());
+
+	if (!blockEvents)
+		return library->HandleIntent(skirmishAIId, topic, data);
+
+	return 0;
+}

--- a/rts/ExternalAI/SkirmishAIWrapper.h
+++ b/rts/ExternalAI/SkirmishAIWrapper.h
@@ -5,15 +5,11 @@
 
 #include "SkirmishAIKey.h"
 
-#include <variant>
-
 class CSkirmishAILibrary;
 struct SSkirmishAICallback;
 
 struct Command;
 class float3;
-
-using VariantWrapper = std::variant<int, float, std::string>;
 
 
 /**
@@ -86,11 +82,8 @@ public:
 	void Intent(int topic, int objId, float value);
 	void Intent(int topic, int objId, const std::vector<int>& data);
 	void Intent(int topic, int objId, const std::vector<float>& data);
-	void Intent(int topic, int objId, const std::vector<char>& data);
-	void Intent(int topic, int objId, const std::vector<VariantWrapper>& data);
 	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<int>& values);
 	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<float>& values);
-	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<VariantWrapper>& values);
 
 	int GetSkirmishAIID() const { return skirmishAIId; }
 	int GetTeamId() const { return teamId; }

--- a/rts/ExternalAI/SkirmishAIWrapper.h
+++ b/rts/ExternalAI/SkirmishAIWrapper.h
@@ -5,11 +5,15 @@
 
 #include "SkirmishAIKey.h"
 
+#include <variant>
+
 class CSkirmishAILibrary;
 struct SSkirmishAICallback;
 
 struct Command;
 class float3;
+
+using VariantWrapper = std::variant<int, float, std::string>;
 
 
 /**
@@ -78,6 +82,16 @@ public:
 	void CommandFinished(int unitId, int commandId, int commandTopicId);
 	void SeismicPing(int allyTeam, int unitId, const float3& pos, float strength);
 
+	void Intent(int topic, int objId, int value);
+	void Intent(int topic, int objId, float value);
+	void Intent(int topic, int objId, const std::vector<int>& data);
+	void Intent(int topic, int objId, const std::vector<float>& data);
+	void Intent(int topic, int objId, const std::vector<char>& data);
+	void Intent(int topic, int objId, const std::vector<VariantWrapper>& data);
+	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<int>& values);
+	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<float>& values);
+	void Intent(int topic, int objId, const std::vector<int>& keys, const std::vector<VariantWrapper>& values);
+
 	int GetSkirmishAIID() const { return skirmishAIId; }
 	int GetTeamId() const { return teamId; }
 
@@ -110,6 +124,7 @@ private:
 	 * CAUTION: takes C AI Interface events, not engine C++ ones!
 	 */
 	int HandleEvent(int topic, const void* data) const;
+	int HandleIntent(int topic, const void* data) const;
 
 	uint32_t GetTimerNameHash() const { return *reinterpret_cast<const uint32_t*>(&timerName[0]); }
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4436,7 +4436,7 @@ int LuaUnsyncedCtrl::AiIntentFloat(lua_State* L) {
 
 	const int teamID = luaL_checkint(L, 1);
 	const int topic = luaL_checkint(L, 2);
-	const int objID = lua_israwnumber(L, 3) ? lua_toint(L, 3) : lua_isboolean(L, 4) ? lua_toboolean(L, 4) : -1;
+	const int objID = lua_israwnumber(L, 3) ? lua_toint(L, 3) : lua_isboolean(L, 3) ? lua_toboolean(L, 3) : -1;
 	const float value = lua_isnoneornil(L, 4) ? 0.f : lua_isboolean(L, 4) ? lua_toboolean(L, 4) : luaL_checkfloat(L, 4);
 
 	eoh->Intent(teamID, topic, objID, value);

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -309,10 +309,10 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(ForceTesselationUpdate);
 
 	REGISTER_LUA_CFUNC(SendSkirmishAIMessage);
-	REGISTER_LUA_CFUNC(AIIntentFloat);
-	REGISTER_LUA_CFUNC(AIIntentArray);
-	REGISTER_LUA_CFUNC(AIIntentDict);
-	REGISTER_LUA_CFUNC(AIIntentUnitDefs);
+	REGISTER_LUA_CFUNC(AiIntentFloat);
+	REGISTER_LUA_CFUNC(AiIntentArray);
+	REGISTER_LUA_CFUNC(AiIntentDict);
+	REGISTER_LUA_CFUNC(AiIntentUnitDefs);
 
 	REGISTER_LUA_CFUNC(SetLogSectionFilterLevel);
 
@@ -4423,14 +4423,14 @@ int LuaUnsyncedCtrl::SendSkirmishAIMessage(lua_State* L) {
 	return 2;
 }
 
-/*** @function Spring.AIIntentFloat
+/*** @function Spring.AiIntentFloat
  * @param teamID number
  * @param topic number
  * @param objID number?
  * @param value number?|boolean?
  * @return nil
  */
-int LuaUnsyncedCtrl::AIIntentFloat(lua_State* L) {
+int LuaUnsyncedCtrl::AiIntentFloat(lua_State* L) {
 	if (CLuaHandle::GetHandleSynced(L))
 		return 0;
 
@@ -4444,14 +4444,14 @@ int LuaUnsyncedCtrl::AIIntentFloat(lua_State* L) {
 	return 0;
 }
 
-/*** @function Spring.AIIntentArray
+/*** @function Spring.AiIntentArray
  * @param teamID number
  * @param topic number
  * @param objID number
  * @param values table
  * @return nil
  */
-int LuaUnsyncedCtrl::AIIntentArray(lua_State* L) {
+int LuaUnsyncedCtrl::AiIntentArray(lua_State* L) {
 	if (CLuaHandle::GetHandleSynced(L))
 		return 0;
 
@@ -4480,14 +4480,14 @@ int LuaUnsyncedCtrl::AIIntentArray(lua_State* L) {
 	return 0;
 }
 
-/*** @function Spring.AIIntentDict
+/*** @function Spring.AiIntentDict
  * @param teamID number
  * @param topic number
  * @param objID number
  * @param keyValues table
  * @return nil
  */
-int LuaUnsyncedCtrl::AIIntentDict(lua_State* L) {
+int LuaUnsyncedCtrl::AiIntentDict(lua_State* L) {
 	if (CLuaHandle::GetHandleSynced(L))
 		return 0;
 
@@ -4525,14 +4525,14 @@ int LuaUnsyncedCtrl::AIIntentDict(lua_State* L) {
 	return 0;
 }
 
-/*** @function Spring.AIIntentUnitDefs
+/*** @function Spring.AiIntentUnitDefs
  * @param teamID number
  * @param topic number
  * @param objID number
  * @param unitDefToValue table
  * @return nil
  */
-int LuaUnsyncedCtrl::AIIntentUnitDefs(lua_State* L) {
+int LuaUnsyncedCtrl::AiIntentUnitDefs(lua_State* L) {
 	if (CLuaHandle::GetHandleSynced(L))
 		return 0;
 

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -312,6 +312,7 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(AIIntentFloat);
 	REGISTER_LUA_CFUNC(AIIntentArray);
 	REGISTER_LUA_CFUNC(AIIntentDict);
+	REGISTER_LUA_CFUNC(AIIntentUnitDefs);
 
 	REGISTER_LUA_CFUNC(SetLogSectionFilterLevel);
 
@@ -4425,8 +4426,8 @@ int LuaUnsyncedCtrl::SendSkirmishAIMessage(lua_State* L) {
 /*** @function Spring.AIIntentFloat
  * @param teamID number
  * @param topic number
- * @param objID number
- * @param value number|boolean
+ * @param objID number?
+ * @param value number?|boolean?
  * @return nil
  */
 int LuaUnsyncedCtrl::AIIntentFloat(lua_State* L) {
@@ -4434,9 +4435,9 @@ int LuaUnsyncedCtrl::AIIntentFloat(lua_State* L) {
 		return 0;
 
 	const int teamID = luaL_checkint(L, 1);
-	const int topic = luaL_checkint(L, 2);
-	const int objID = luaL_checkint(L, 3);
-	const float value = lua_isboolean(L, 4) ? lua_toboolean(L, 4) : luaL_checkfloat(L, 4);
+	const int topic = lua_israwnumber(L, 2) ? lua_toint(L, 2) : -1;
+	const int objID = lua_israwnumber(L, 3) ? lua_toint(L, 3) : -1;
+	const float value = lua_isnoneornil(L, 4) ? 0.f : lua_isboolean(L, 4) ? lua_toboolean(L, 4) : luaL_checkfloat(L, 4);
 
 	eoh->Intent(teamID, topic, objID, value);
 
@@ -4520,6 +4521,66 @@ int LuaUnsyncedCtrl::AIIntentDict(lua_State* L) {
 	}
 
 	eoh->Intent(teamID, topic, objID, keys, values);
+
+	return 0;
+}
+
+/*** @function Spring.AIIntentUnitDefs
+ * @param teamID number
+ * @param topic number
+ * @param objID number
+ * @param unitDefToValue table
+ * @return nil
+ */
+int LuaUnsyncedCtrl::AIIntentUnitDefs(lua_State* L) {
+	if (CLuaHandle::GetHandleSynced(L))
+		return 0;
+
+	const int aiTeam = luaL_checkint(L, 1);
+	const int topic = luaL_checkint(L, 2);
+	const int waveId = luaL_checkint(L, 3);
+
+	luaL_checktype(L, 4, LUA_TTABLE);
+
+	std::vector<int> unitDefs;
+	std::vector<float> weights;
+
+	for (lua_pushnil(L); lua_next(L, 4) != 0; lua_pop(L, 1)) {
+
+		const UnitDef* unitDef = nullptr;
+
+		if (lua_israwstring(L, LUA_TABLE_KEY_INDEX)) {
+			unitDef = unitDefHandler->GetUnitDefByName(lua_tostring(L, LUA_TABLE_KEY_INDEX));
+		} else if (lua_israwnumber(L, LUA_TABLE_KEY_INDEX)) {
+			unitDef = unitDefHandler->GetUnitDefByID(lua_toint(L, LUA_TABLE_KEY_INDEX));
+		} else {
+			luaL_error(L, "[%s()] incorrect unitDef type", __func__);
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		if (unitDef == nullptr) {
+			if (lua_israwstring(L, LUA_TABLE_KEY_INDEX)) {
+				luaL_error(L, "[%s()]: bad unitDef name: %s", __func__, lua_tostring(L, LUA_TABLE_KEY_INDEX));
+			} else {
+				luaL_error(L, "[%s()]: bad unitDef ID: %d", __func__, lua_toint(L, LUA_TABLE_KEY_INDEX));
+			}
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+			luaL_error(L, "[%s()] incorrect weight type", __func__);
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		const float weight = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		unitDefs.push_back(unitDef->id);
+		weights.push_back(weight);
+	}
+
+	eoh->Intent(aiTeam, topic, waveId, unitDefs, weights);
 
 	return 0;
 }

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -309,6 +309,9 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(ForceTesselationUpdate);
 
 	REGISTER_LUA_CFUNC(SendSkirmishAIMessage);
+	REGISTER_LUA_CFUNC(AIIntentFloat);
+	REGISTER_LUA_CFUNC(AIIntentArray);
+	REGISTER_LUA_CFUNC(AIIntentDict);
 
 	REGISTER_LUA_CFUNC(SetLogSectionFilterLevel);
 
@@ -673,12 +676,12 @@ int LuaUnsyncedCtrl::SendMessage(lua_State* L)
 
 /*** @function Spring.SendMessageToSpectators
  * @param message string ``"`<PLAYER#>`"`` where `#` is a player ID.
- * 
+ *
  * This will be replaced with the player's name. e.g.
  * ```lua
  * Spring.SendMessage("`<PLAYER1>` did something") -- "ProRusher did something"
  * ```
- * 
+ *
  * @return nil
  */
 int LuaUnsyncedCtrl::SendMessageToSpectators(lua_State* L)
@@ -1276,7 +1279,7 @@ int LuaUnsyncedCtrl::SetCameraOffset(lua_State* L)
  * @function Spring.SetCameraState
  *
  * @param cameraState CameraState The fields must be consistent with the name/mode and current/new camera mode.
- * 
+ *
  * @param transitionTime number? (Default: `0`) in nanoseconds
  *
  * @param transitionTimeFactor number?
@@ -1380,7 +1383,7 @@ int LuaUnsyncedCtrl::SetDollyCameraPosition(lua_State* L)
  *
  * @class ControlPoint
  * @x_helper
- * 
+ *
  * @field [1] number x
  * @field [2] number y
  * @field [3] number z
@@ -2247,12 +2250,12 @@ int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
  */
 int LuaUnsyncedCtrl::SetMiniMapRotation(lua_State* L)
 {
-	
+
 	const float radians = luaL_checkfloat(L, 1);
-	
+
 	if (minimap == nullptr)
 		return 0;
-	
+
 	if (minimap->minimapCanFlip)
 		return 0;
 
@@ -4419,6 +4422,107 @@ int LuaUnsyncedCtrl::SendSkirmishAIMessage(lua_State* L) {
 	return 2;
 }
 
+/*** @function Spring.AIIntentFloat
+ * @param teamID number
+ * @param topic number
+ * @param objID number
+ * @param value number|boolean
+ * @return nil
+ */
+int LuaUnsyncedCtrl::AIIntentFloat(lua_State* L) {
+	if (CLuaHandle::GetHandleSynced(L))
+		return 0;
+
+	const int teamID = luaL_checkint(L, 1);
+	const int topic = luaL_checkint(L, 2);
+	const int objID = luaL_checkint(L, 3);
+	const float value = lua_isboolean(L, 4) ? lua_toboolean(L, 4) : luaL_checkfloat(L, 4);
+
+	eoh->Intent(teamID, topic, objID, value);
+
+	return 0;
+}
+
+/*** @function Spring.AIIntentArray
+ * @param teamID number
+ * @param topic number
+ * @param objID number
+ * @param values table
+ * @return nil
+ */
+int LuaUnsyncedCtrl::AIIntentArray(lua_State* L) {
+	if (CLuaHandle::GetHandleSynced(L))
+		return 0;
+
+	const int teamID = luaL_checkint(L, 1);
+	const int topic = luaL_checkint(L, 2);
+	const int objID = luaL_checkint(L, 3);
+
+	luaL_checktype(L, 4, LUA_TTABLE);
+
+	std::vector<float> values;
+
+	for (lua_pushnil(L); lua_next(L, 4) != 0; lua_pop(L, 1)) {
+
+		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+			luaL_error(L, "[%s()] incorrect value type", __func__);
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		const float value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		values.push_back(value);
+	}
+
+	eoh->Intent(teamID, topic, objID, values);
+
+	return 0;
+}
+
+/*** @function Spring.AIIntentDict
+ * @param teamID number
+ * @param topic number
+ * @param objID number
+ * @param keyValues table
+ * @return nil
+ */
+int LuaUnsyncedCtrl::AIIntentDict(lua_State* L) {
+	if (CLuaHandle::GetHandleSynced(L))
+		return 0;
+
+	const int teamID = luaL_checkint(L, 1);
+	const int topic = luaL_checkint(L, 2);
+	const int objID = luaL_checkint(L, 3);
+
+	luaL_checktype(L, 4, LUA_TTABLE);
+
+	std::vector<int> keys;
+	std::vector<float> values;
+
+	for (lua_pushnil(L); lua_next(L, 4) != 0; lua_pop(L, 1)) {
+
+		if (!lua_israwnumber(L, LUA_TABLE_KEY_INDEX)) {
+			luaL_error(L, "[%s()] incorrect key type", __func__);
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+			luaL_error(L, "[%s()] incorrect value type", __func__);
+			lua_pop(L, 2);
+			return 0;
+		}
+
+		const int key = lua_toint(L, LUA_TABLE_KEY_INDEX);
+		const float value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		keys.push_back(key);
+		values.push_back(value);
+	}
+
+	eoh->Intent(teamID, topic, objID, keys, values);
+
+	return 0;
+}
 
 /******************************************************************************
  * Developers

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -4435,8 +4435,8 @@ int LuaUnsyncedCtrl::AiIntentFloat(lua_State* L) {
 		return 0;
 
 	const int teamID = luaL_checkint(L, 1);
-	const int topic = lua_israwnumber(L, 2) ? lua_toint(L, 2) : -1;
-	const int objID = lua_israwnumber(L, 3) ? lua_toint(L, 3) : -1;
+	const int topic = luaL_checkint(L, 2);
+	const int objID = lua_israwnumber(L, 3) ? lua_toint(L, 3) : lua_isboolean(L, 4) ? lua_toboolean(L, 4) : -1;
 	const float value = lua_isnoneornil(L, 4) ? 0.f : lua_isboolean(L, 4) ? lua_toboolean(L, 4) : luaL_checkfloat(L, 4);
 
 	eoh->Intent(teamID, topic, objID, value);
@@ -4465,13 +4465,16 @@ int LuaUnsyncedCtrl::AiIntentArray(lua_State* L) {
 
 	for (lua_pushnil(L); lua_next(L, 4) != 0; lua_pop(L, 1)) {
 
-		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+		float value;
+		if (lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+			value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		} else if (lua_isboolean(L, LUA_TABLE_VALUE_INDEX)) {
+			value = lua_toboolean(L, LUA_TABLE_VALUE_INDEX);
+		} else {
 			luaL_error(L, "[%s()] incorrect value type", __func__);
 			lua_pop(L, 2);
 			return 0;
 		}
-
-		const float value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
 		values.push_back(value);
 	}
 
@@ -4508,14 +4511,18 @@ int LuaUnsyncedCtrl::AiIntentDict(lua_State* L) {
 			return 0;
 		}
 
-		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+		float value;
+		if (lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
+			value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		} else if (lua_isboolean(L, LUA_TABLE_VALUE_INDEX)) {
+			value = lua_toboolean(L, LUA_TABLE_VALUE_INDEX);
+		} else {
 			luaL_error(L, "[%s()] incorrect value type", __func__);
 			lua_pop(L, 2);
 			return 0;
 		}
 
 		const int key = lua_toint(L, LUA_TABLE_KEY_INDEX);
-		const float value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
 		keys.push_back(key);
 		values.push_back(value);
 	}
@@ -4538,12 +4545,12 @@ int LuaUnsyncedCtrl::AiIntentUnitDefs(lua_State* L) {
 
 	const int aiTeam = luaL_checkint(L, 1);
 	const int topic = luaL_checkint(L, 2);
-	const int waveId = luaL_checkint(L, 3);
+	const int objId = luaL_checkint(L, 3);
 
 	luaL_checktype(L, 4, LUA_TTABLE);
 
-	std::vector<int> unitDefs;
-	std::vector<float> weights;
+	std::vector<int> keys;
+	std::vector<float> values;
 
 	for (lua_pushnil(L); lua_next(L, 4) != 0; lua_pop(L, 1)) {
 
@@ -4570,17 +4577,17 @@ int LuaUnsyncedCtrl::AiIntentUnitDefs(lua_State* L) {
 		}
 
 		if (!lua_israwnumber(L, LUA_TABLE_VALUE_INDEX)) {
-			luaL_error(L, "[%s()] incorrect weight type", __func__);
+			luaL_error(L, "[%s()] incorrect value type", __func__);
 			lua_pop(L, 2);
 			return 0;
 		}
 
-		const float weight = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
-		unitDefs.push_back(unitDef->id);
-		weights.push_back(weight);
+		const float value = lua_tonumber(L, LUA_TABLE_VALUE_INDEX);
+		keys.push_back(unitDef->id);
+		values.push_back(value);
 	}
 
-	eoh->Intent(aiTeam, topic, waveId, unitDefs, weights);
+	eoh->Intent(aiTeam, topic, objId, keys, values);
 
 	return 0;
 }

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -205,6 +205,7 @@ class LuaUnsyncedCtrl {
 		static int AIIntentFloat(lua_State* L);
 		static int AIIntentArray(lua_State* L);
 		static int AIIntentDict(lua_State* L);
+		static int AIIntentUnitDefs(lua_State* L);
 
 		static int SetLogSectionFilterLevel(lua_State* L);
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -202,6 +202,9 @@ class LuaUnsyncedCtrl {
 		static int ForceTesselationUpdate(lua_State* L);
 
 		static int SendSkirmishAIMessage(lua_State* L);
+		static int AIIntentFloat(lua_State* L);
+		static int AIIntentArray(lua_State* L);
+		static int AIIntentDict(lua_State* L);
 
 		static int SetLogSectionFilterLevel(lua_State* L);
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -202,10 +202,10 @@ class LuaUnsyncedCtrl {
 		static int ForceTesselationUpdate(lua_State* L);
 
 		static int SendSkirmishAIMessage(lua_State* L);
-		static int AIIntentFloat(lua_State* L);
-		static int AIIntentArray(lua_State* L);
-		static int AIIntentDict(lua_State* L);
-		static int AIIntentUnitDefs(lua_State* L);
+		static int AiIntentFloat(lua_State* L);
+		static int AiIntentArray(lua_State* L);
+		static int AiIntentDict(lua_State* L);
+		static int AiIntentUnitDefs(lua_State* L);
 
 		static int SetLogSectionFilterLevel(lua_State* L);
 


### PR DESCRIPTION
### Work done
The AI ​​Intent interface is modeled after the event sent via the `Spring.SendSkirmishAIMessage` method.
Concept difference:
* Event is invoked by Engine directed to AI.
* Intent is invoked by Lua/Game directed to AI.

`SLuaMessageEvent` exists, but it actually violates the rule of "Event is engine's responsibility" and works only with strings.
The Intent system offers a binary interface for Lua, implemented via the following functions:
```
Spring.AiIntentFloat(teadmID, topic, objID, value)
Spring.AiIntentArray(teadmID, topic, objID, table)  -- table is an array of floats
Spring.AiIntentDict(teadmID, topic, objID, table)  -- table is a dictionary with integer keys and float values

Spring.AiIntentUnitDefs(teadmID, topic, objID, table)  -- AiIntentDict wrapper to translate string keys into integer IDs.
```