### PR TITLE
faster unit command acquisition when not acting

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1546,9 +1546,8 @@ void CCommandAI::SlowUpdate()
 	RECOIL_DETAILED_TRACY_ZONE;
 	if (gs->paused) // Commands issued may invoke SlowUpdate when paused
 		return;
-	if (commandQue.empty()) {
+	if (commandQue.empty())
 		return;
-	}
 
 	Command& c = commandQue.front();
 
@@ -1589,6 +1588,24 @@ void CCommandAI::SlowUpdate()
 		return;
 
 	FinishCommand();
+}
+
+
+// The intent here is for units to call this each frame in Unit::Update(). SlowUpdate() is run before Update(), so
+// this is not expected to impact the existing behaviour of unit SlowUpdate().
+void CCommandAI::CheckForAndAttemptNewCommand() {
+
+	// Infinite loop protection.
+	if (lastFinishCommand == gs->frameNum)
+		return;
+
+	// If we don't have a command and there's one in the queue then try and start it.
+	if (inCommand == CMD_STOP) {
+		// Only try to process a new command once per frame. Letting this get set by FinishCommand() will cause
+		// SlowUpdate() to trigger twice in a single frame.
+		lastFinishCommand = gs->frameNum;
+		SlowUpdate();
+	}
 }
 
 

--- a/rts/Sim/Units/CommandAI/CommandAI.h
+++ b/rts/Sim/Units/CommandAI/CommandAI.h
@@ -50,6 +50,7 @@ public:
 	virtual bool CanWeaponAutoTarget(const CWeapon* weapon) const { return true; }
 	virtual int GetDefaultCmd(const CUnit* pointed, const CFeature* feature);
 	virtual void SlowUpdate();
+	void CheckForAndAttemptNewCommand();
 	virtual void GiveCommandReal(const Command& c, bool fromSynced = true);
 	virtual void FinishCommand();
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -691,6 +691,8 @@ void CUnit::Update()
 		return;
 	}
 
+	commandAI->CheckForAndAttemptNewCommand();
+
 	restTime += 1;
 }
 


### PR DESCRIPTION
Unit AI try each frame to pickup new command if unit is currently stopped.

An alternative approach to https://github.com/beyond-all-reason/RecoilEngine/pull/3350; though, it is also targeting a slightly different issue.