### PR TITLE
fix endianness of stats in demos produced on Linux

### DIFF
--- a/rts/System/Platform/byteorder.h
+++ b/rts/System/Platform/byteorder.h
@@ -27,6 +27,7 @@
 
 #if defined(__linux__)
 
+	#include <endian.h>
 	#include <string.h> // for memcpy
 	#include <byteswap.h>
 


### PR DESCRIPTION
On Linux hosts only, the game statistics stored in the replay/demo files are incorrectly written using big-endian instead of little-endian. Most of the replay/demo files available online are generated by dedicated servers running Linux, so this bug affects lots of files.

### Cause

When writing demo data, [the DemoRecorder calls the swab function on the statistics](https://github.com/beyond-all-reason/RecoilEngine/blob/05c054cbe2249feda3637cabfe122b75241113e9/rts/System/LoadSave/DemoRecorder.cpp#L265) to change the endianness of the data to little-endian, in case the host uses big-endian natively. On little-endian systems, [the swab function](https://github.com/beyond-all-reason/RecoilEngine/blob/05c054cbe2249feda3637cabfe122b75241113e9/rts/Game/Players/PlayerStatistics.cpp#L26) is supposed to be a no-op, because it calls the `swabDWordInPlace` macro, which does nothing [as long as swabDWord is not defined](https://github.com/beyond-all-reason/RecoilEngine/blob/05c054cbe2249feda3637cabfe122b75241113e9/rts/System/Platform/byteorder.h#L107). On Linux hosts, `swabDWord` is [defined only if __BYTE_ORDER == __BIG_ENDIAN](https://github.com/beyond-all-reason/RecoilEngine/blob/05c054cbe2249feda3637cabfe122b75241113e9/rts/System/Platform/byteorder.h#L35), so at first sight all is ok here.

The problem is that if both `__BYTE_ORDER` and `__BIG_ENDIAN` are not defined, they are replaced by `0` by the preprocessor and thus the condition is `true`. That means a Linux system is considered as big-endian in the `byteorder.h` file if both the `__BYTE_ORDER` and `__BIG_ENDIAN` macros aren't defined.

These macros are almost always defined, because just a `#include <string>` for instance triggers an indirect load of the `endian.h` header that defines them. However, in Recoil case, there are two components for which these macros aren't defined during compilation: `TeamStatistics` and `PlayerStatistics`. This is because the corresponding sources have very basic include chains that don't trigger the automatic definition of `__BYTE_ORDER` and `__BIG_ENDIAN`.

### Proposed fix

The proposed fix is to always ensure these macros are defined on Linux hosts, by including the required header `endian.h` in the `byteorder.h` file, just before using the macros.
A more modern and portable approach (but less conservative regarding existing code) would consist in using `#include <bit>` and comparing `std::endian::native` with `std::endian::little` to detect host endianness.

(fix #3357)

### Tests

This fix has been tested on a Linux host running dedicated engine with two Windows clients connecting to it and playing a game that lasted a few minutes. The stats sections of the demo files coming from Linux and Windows have been compared, they are exactly the same once the fix is applied.